### PR TITLE
Update Checkpointing.md

### DIFF
--- a/docs/Trainer/Checkpointing.md
+++ b/docs/Trainer/Checkpointing.md
@@ -16,7 +16,7 @@ from pytorch_lightning.callbacks import ModelCheckpoint
 
 # DEFAULTS used by the Trainer
 checkpoint_callback = ModelCheckpoint(
-    filepath=os.getcwd(),
+    filepath=os.path.join(os.getcwd(), os.path.join(lightning_logs, checkpoints)),
     save_top_k=1,
     verbose=True,
     monitor='val_loss',


### PR DESCRIPTION
os.getcwd() refers the current directory and if used that way, it just destructively removes everything including the source code. I think this is the default.
