### PR TITLE
build fix

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -469,7 +469,8 @@ class Trainer(TrainerIOMixin,
         # print model summary
         if self.proc_rank == 0 and self.weights_summary is not None:
             if self.weights_summary in ['full', 'top']:
-                ref_model.summarize(mode=self.weights_summary)
+                pass
+                # ref_model.summarize(mode=self.weights_summary)
             else:
                 m = "weights_summary can be None, 'full' or 'top'"
                 raise MisconfigurationException(m)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -470,7 +470,7 @@ class Trainer(TrainerIOMixin,
         if self.proc_rank == 0 and self.weights_summary is not None:
             if self.weights_summary in ['full', 'top']:
                 pass
-                # ref_model.summarize(mode=self.weights_summary)
+                ref_model.summarize(mode=self.weights_summary)
             else:
                 m = "weights_summary can be None, 'full' or 'top'"
                 raise MisconfigurationException(m)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -469,7 +469,6 @@ class Trainer(TrainerIOMixin,
         # print model summary
         if self.proc_rank == 0 and self.weights_summary is not None:
             if self.weights_summary in ['full', 'top']:
-                pass
                 ref_model.summarize(mode=self.weights_summary)
             else:
                 m = "weights_summary can be None, 'full' or 'top'"

--- a/tests/test_amp.py
+++ b/tests/test_amp.py
@@ -48,7 +48,7 @@ def test_no_amp_single_gpu(tmpdir):
         max_epochs=1,
         gpus=1,
         distributed_backend='dp',
-        use_amp=True
+        use_amp=False
     )
 
     with pytest.raises((MisconfigurationException, ModuleNotFoundError)):

--- a/tests/test_amp.py
+++ b/tests/test_amp.py
@@ -47,8 +47,8 @@ def test_no_amp_single_gpu(tmpdir):
         show_progress_bar=True,
         max_epochs=1,
         gpus=1,
-        distributed_backend='dp',
-        use_amp=False
+        distributed_backend=None,
+        use_amp=True
     )
 
     with pytest.raises((MisconfigurationException, ModuleNotFoundError)):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -144,6 +144,8 @@ def load_model(exp, root_weights_dir, module_class=LightningTemplateModel):
 
 
 def run_prediction(dataloader, trained_model, dp=False, min_acc=0.50):
+    trained_model.eval()
+
     # run prediction on 1 batch
     for batch in dataloader:
         break

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -159,7 +159,7 @@ def run_prediction(dataloader, trained_model, dp=False, min_acc=0.50):
         acc = torch.mean(acc).item()
 
     else:
-        y_hat = trained_model(x)
+        y_hat = trained_model(x, 0)
 
         # acc
         labels_hat = torch.argmax(y_hat, dim=1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -159,7 +159,7 @@ def run_prediction(dataloader, trained_model, dp=False, min_acc=0.50):
         acc = torch.mean(acc).item()
 
     else:
-        y_hat = trained_model(x, 0)
+        y_hat = trained_model(x)
 
         # acc
         labels_hat = torch.argmax(y_hat, dim=1)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -159,8 +159,6 @@ def run_prediction(dataloader, trained_model, dp=False, min_acc=0.50):
         acc = torch.mean(acc).item()
 
     else:
-        import pdb
-        pdb.set_trace()
         y_hat = trained_model(x)
 
         # acc

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -157,6 +157,8 @@ def run_prediction(dataloader, trained_model, dp=False, min_acc=0.50):
         acc = torch.mean(acc).item()
 
     else:
+        import pdb
+        pdb.set_trace()
         y_hat = trained_model(x)
 
         # acc


### PR DESCRIPTION
```
_______________________________________________________________________ test_running_test_pretrained_model _______________________________________________________________________

tmpdir = local('/tmp/pytest-of-waf251/pytest-7/test_running_test_pretrained_m1')

    def test_running_test_pretrained_model(tmpdir):
        tutils.reset_seed()

        """Verify test() on pretrained model"""
        hparams = tutils.get_hparams()
        model = LightningTestModel(hparams)

        # logger file to get meta
        logger = tutils.get_test_tube_logger(tmpdir, False)

        # logger file to get weights
        checkpoint = tutils.init_checkpoint_callback(logger)

        trainer_options = dict(
            show_progress_bar=False,
            max_epochs=4,
            train_percent_check=0.4,
            val_percent_check=0.2,
            checkpoint_callback=checkpoint,
            logger=logger
        )

        # fit model
        trainer = Trainer(**trainer_options)
>       result = trainer.fit(model)

tests/test_restore_models.py:85:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pytorch_lightning/trainer/trainer.py:403: in fit
    self.run_pretrain_routine(model)
pytorch_lightning/trainer/trainer.py:473: in run_pretrain_routine
    ref_model.summarize(mode=self.weights_summary)
pytorch_lightning/core/lightning.py:1022: in summarize
    model_summary = ModelSummary(self, mode=mode)
pytorch_lightning/core/memory.py:26: in __init__
    self.summarize()
pytorch_lightning/core/memory.py:174: in summarize
    self.get_variable_sizes()
pytorch_lightning/core/memory.py:75: in get_variable_sizes
    out = m(input_)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/module.py:547: in __call__
    result = self.forward(*input, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/linear.py:87: in forward
    return F.linear(input, self.weight, self.bias)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/functional.py:1369: in linear
    ret = torch.addmm(bias, input, weight.t())
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:21: in wrapper
    args[i] = utils.cached_cast(cast_fn, args[i], handle.cache)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cast_fn = <function maybe_half at 0x7f157a2e5d90>
x = Parameter containing:
tensor([ 3.4106e-02,  4.2996e-03,  1.2126e-02, -2.2040e-02,  1.8711e-02,
         5.9155e-03,  3...e-02,  1.8386e-02,
         2.9301e-02, -1.1740e-02,  2.4358e-02,  3.3718e-02, -2.5309e-02],
       requires_grad=True)
cache = {Parameter containing:
tensor([[ 0.0650,  0.0889,  0.0557,  ...,  0.0830,  0.0451,  0.0288],
        [ 0.0933,  0.0492...18,  0.1643, -0.1760,  0.2532, -0.1964, -0.0585,
         0.2620, -0.0264], device='cuda:0', dtype=torch.float16), ...}

    def cached_cast(cast_fn, x, cache):
        if is_nested(x):
            return type(x)([cached_cast(y) for y in x])
        if x in cache:
            cached_x = cache[x]
            if x.requires_grad and cached_x.requires_grad:
                # Make sure x is actually cached_x's autograd parent.
>               if cached_x.grad_fn.next_functions[1][0].variable is not x:
E               AttributeError: 'NoneType' object has no attribute 'next_functions'

../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/utils.py:97: AttributeError
________________________________________________________________________ test_load_model_from_checkpoint _________________________________________________________________________

tmpdir = local('/tmp/pytest-of-waf251/pytest-7/test_load_model_from_checkpoin0')

    def test_load_model_from_checkpoint(tmpdir):
        tutils.reset_seed()

        """Verify test() on pretrained model"""
        hparams = tutils.get_hparams()
        model = LightningTestModel(hparams)

        trainer_options = dict(
            show_progress_bar=False,
            max_epochs=1,
            train_percent_check=0.4,
            val_percent_check=0.2,
            checkpoint_callback=True,
            logger=False,
            default_save_path=tmpdir,
        )

        # fit model
        trainer = Trainer(**trainer_options)
>       result = trainer.fit(model)

tests/test_restore_models.py:119:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pytorch_lightning/trainer/trainer.py:403: in fit
    self.run_pretrain_routine(model)
pytorch_lightning/trainer/trainer.py:473: in run_pretrain_routine
    ref_model.summarize(mode=self.weights_summary)
pytorch_lightning/core/lightning.py:1022: in summarize
    model_summary = ModelSummary(self, mode=mode)
pytorch_lightning/core/memory.py:26: in __init__
    self.summarize()
pytorch_lightning/core/memory.py:174: in summarize
    self.get_variable_sizes()
pytorch_lightning/core/memory.py:75: in get_variable_sizes
    out = m(input_)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/module.py:547: in __call__
    result = self.forward(*input, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/linear.py:87: in forward
    return F.linear(input, self.weight, self.bias)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/functional.py:1369: in linear
    ret = torch.addmm(bias, input, weight.t())
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:21: in wrapper
    args[i] = utils.cached_cast(cast_fn, args[i], handle.cache)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cast_fn = <function maybe_half at 0x7f157a2e5d90>
x = Parameter containing:
tensor([ 0.0357, -0.0161,  0.0134, -0.0132,  0.0212, -0.0272, -0.0089, -0.0037,
         0.0202,...1, -0.0294,
         0.0063, -0.0313, -0.0126, -0.0145, -0.0328, -0.0348,  0.0205, -0.0167],
       requires_grad=True)
cache = {Parameter containing:
tensor([[ 0.0650,  0.0889,  0.0557,  ...,  0.0830,  0.0451,  0.0288],
        [ 0.0933,  0.0492...18,  0.1643, -0.1760,  0.2532, -0.1964, -0.0585,
         0.2620, -0.0264], device='cuda:0', dtype=torch.float16), ...}

    def cached_cast(cast_fn, x, cache):
        if is_nested(x):
            return type(x)([cached_cast(y) for y in x])
        if x in cache:
            cached_x = cache[x]
            if x.requires_grad and cached_x.requires_grad:
                # Make sure x is actually cached_x's autograd parent.
>               if cached_x.grad_fn.next_functions[1][0].variable is not x:
E               AttributeError: 'NoneType' object has no attribute 'next_functions'

../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/utils.py:97: AttributeError
_________________________________________________________________________________ test_dp_resume _________________________________________________________________________________

tmpdir = local('/tmp/pytest-of-waf251/pytest-7/test_dp_resume0')

    def test_dp_resume(tmpdir):
        """Make sure DP continues training correctly."""
        if not tutils.can_run_gpu_test():
            return

        tutils.reset_seed()

        hparams = tutils.get_hparams()
        model = LightningTestModel(hparams)

        trainer_options = dict(
            show_progress_bar=True,
            max_epochs=2,
            gpus=2,
            distributed_backend='dp',
        )

        # get logger
        logger = tutils.get_test_tube_logger(tmpdir, debug=False)

        # exp file to get weights
        # logger file to get weights
        checkpoint = tutils.init_checkpoint_callback(logger)

        # add these to the trainer options
        trainer_options['logger'] = logger
        trainer_options['checkpoint_callback'] = checkpoint

        # fit model
        trainer = Trainer(**trainer_options)
        trainer.is_slurm_managing_tasks = True
        result = trainer.fit(model)

        # track epoch before saving
        real_global_epoch = trainer.current_epoch

        # correct result and ok accuracy
        assert result == 1, 'amp + dp model failed to complete'

        # ---------------------------
        # HPC LOAD/SAVE
        # ---------------------------
        # save
        trainer.hpc_save(tmpdir, logger)

        # init new trainer
        new_logger = tutils.get_test_tube_logger(tmpdir, version=logger.version)
        trainer_options['logger'] = new_logger
        trainer_options['checkpoint_callback'] = ModelCheckpoint(tmpdir)
        trainer_options['train_percent_check'] = 0.2
        trainer_options['val_percent_check'] = 0.2
        trainer_options['max_epochs'] = 1
        new_trainer = Trainer(**trainer_options)

        # set the epoch start hook so we can predict before the model does the full training
        def assert_good_acc():
            assert new_trainer.current_epoch == real_global_epoch and new_trainer.current_epoch > 0

            # if model and state loaded correctly, predictions will be good even though we
            # haven't trained with the new loaded model
            dp_model = new_trainer.model
            dp_model.eval()

            dataloader = trainer.get_train_dataloader()
            tutils.run_prediction(dataloader, dp_model, dp=True)

        # new model
        model = LightningTestModel(hparams)
        model.on_train_start = assert_good_acc

        # fit new model which should load hpc weights
>       new_trainer.fit(model)

tests/test_restore_models.py:253:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pytorch_lightning/trainer/trainer.py:388: in fit
    self.dp_train(model)
pytorch_lightning/trainer/distrib_parts.py:471: in dp_train
    self.run_pretrain_routine(model)
pytorch_lightning/trainer/trainer.py:521: in run_pretrain_routine
    self.train()
pytorch_lightning/trainer/training_loop.py:360: in train
    self.logger.finalize("success")
pytorch_lightning/logging/base.py:14: in wrapped_fn
    fn(self, *args, **kwargs)
pytorch_lightning/logging/test_tube.py:95: in finalize
    self.close()
pytorch_lightning/logging/base.py:14: in wrapped_fn
    fn(self, *args, **kwargs)
pytorch_lightning/logging/test_tube.py:102: in close
    exp.close()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <test_tube.log.Experiment object at 0x7f15580f8828>

    def close(self):
>       if self.all_writers is None:
E       AttributeError: 'Experiment' object has no attribute 'all_writers'

../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/utils/tensorboard/writer.py:927: AttributeError
------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------
Epoch 2: 100%|██████████| 126/126 [00:06<00:00, 19.16batch/s, batch_idx=62, gpu=0, loss=0.575, some_val=0.177, v_num=0, val_acc=0.384, val_loss=280]
0batch [00:00, ?batch/s]
------------------------------------------------------------------------------ Captured stderr call ------------------------------------------------------------------------------
INFO:root:gpu available: True, used: True
INFO:root:VISIBLE GPUS: 0,1
INFO:root:
        Name         Type Params   In_sizes  Out_sizes
0       c_d1       Linear  785 K   [5, 784]  [5, 1000]
1    c_d1_bn  BatchNorm1d    2 K  [5, 1000]  [5, 1000]
2  c_d1_drop      Dropout    0    [5, 1000]  [5, 1000]
3       c_d2       Linear   10 K  [5, 1000]    [5, 10]
INFO:root:gpu available: True, used: True
INFO:root:VISIBLE GPUS: 0,1
INFO:root:
        Name         Type Params   In_sizes  Out_sizes
0       c_d1       Linear  785 K   [5, 784]  [5, 1000]
1    c_d1_bn  BatchNorm1d    2 K  [5, 1000]  [5, 1000]
2  c_d1_drop      Dropout    0    [5, 1000]  [5, 1000]
3       c_d2       Linear   10 K  [5, 1000]    [5, 10]
INFO:root:restored hpc model from: /tmp/pytest-of-waf251/pytest-7/test_dp_resume0/hpc_ckpt_1.ckpt

------------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------------
INFO     root:distrib_data_parallel.py:208 gpu available: True, used: True
INFO     root:distrib_data_parallel.py:256 VISIBLE GPUS: 0,1
INFO     root:lightning.py:1023
        Name         Type Params   In_sizes  Out_sizes
0       c_d1       Linear  785 K   [5, 784]  [5, 1000]
1    c_d1_bn  BatchNorm1d    2 K  [5, 1000]  [5, 1000]
2  c_d1_drop      Dropout    0    [5, 1000]  [5, 1000]
3       c_d2       Linear   10 K  [5, 1000]    [5, 10]
INFO     root:distrib_data_parallel.py:208 gpu available: True, used: True
INFO     root:distrib_data_parallel.py:256 VISIBLE GPUS: 0,1
INFO     root:lightning.py:1023
        Name         Type Params   In_sizes  Out_sizes
0       c_d1       Linear  785 K   [5, 784]  [5, 1000]
1    c_d1_bn  BatchNorm1d    2 K  [5, 1000]  [5, 1000]
2  c_d1_drop      Dropout    0    [5, 1000]  [5, 1000]
3       c_d2       Linear   10 K  [5, 1000]    [5, 10]
INFO     root:trainer_io.py:446 restored hpc model from: /tmp/pytest-of-waf251/pytest-7/test_dp_resume0/hpc_ckpt_1.ckpt
___________________________________________________________________________ test_cpu_restore_training ____________________________________________________________________________

tmpdir = local('/tmp/pytest-of-waf251/pytest-7/test_cpu_restore_training0')

    def test_cpu_restore_training(tmpdir):
        """Verify continue training session on CPU."""
        tutils.reset_seed()

        hparams = tutils.get_hparams()
        model = LightningTestModel(hparams)

        # logger file to get meta
        test_logger_version = 10
        logger = tutils.get_test_tube_logger(tmpdir, False, version=test_logger_version)

        trainer_options = dict(
            max_epochs=2,
            val_check_interval=0.50,
            val_percent_check=0.2,
            train_percent_check=0.2,
            logger=logger,
            checkpoint_callback=ModelCheckpoint(tmpdir)
        )

        # fit model
        trainer = Trainer(**trainer_options)
>       result = trainer.fit(model)

tests/test_restore_models.py:282:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pytorch_lightning/trainer/trainer.py:403: in fit
    self.run_pretrain_routine(model)
pytorch_lightning/trainer/trainer.py:473: in run_pretrain_routine
    ref_model.summarize(mode=self.weights_summary)
pytorch_lightning/core/lightning.py:1022: in summarize
    model_summary = ModelSummary(self, mode=mode)
pytorch_lightning/core/memory.py:26: in __init__
    self.summarize()
pytorch_lightning/core/memory.py:174: in summarize
    self.get_variable_sizes()
pytorch_lightning/core/memory.py:75: in get_variable_sizes
    out = m(input_)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/module.py:547: in __call__
    result = self.forward(*input, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/linear.py:87: in forward
    return F.linear(input, self.weight, self.bias)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/functional.py:1369: in linear
    ret = torch.addmm(bias, input, weight.t())
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:21: in wrapper
    args[i] = utils.cached_cast(cast_fn, args[i], handle.cache)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cast_fn = <function maybe_half at 0x7f157a2e5d90>
x = Parameter containing:
tensor([-1.0625e-02, -2.2733e-02, -2.9363e-02, -3.4656e-02,  2.7105e-04,
        -8.6701e-03, -3...e-02, -1.8353e-02,
        -3.2332e-02, -6.4804e-03, -6.3736e-03, -5.1361e-03, -7.7882e-03],
       requires_grad=True)
cache = {Parameter containing:
tensor([[ 0.0650,  0.0889,  0.0557,  ...,  0.0830,  0.0451,  0.0288],
        [ 0.0933,  0.0492...18,  0.1643, -0.1760,  0.2532, -0.1964, -0.0585,
         0.2620, -0.0264], device='cuda:0', dtype=torch.float16), ...}

    def cached_cast(cast_fn, x, cache):
        if is_nested(x):
            return type(x)([cached_cast(y) for y in x])
        if x in cache:
            cached_x = cache[x]
            if x.requires_grad and cached_x.requires_grad:
                # Make sure x is actually cached_x's autograd parent.
>               if cached_x.grad_fn.next_functions[1][0].variable is not x:
E               AttributeError: 'NoneType' object has no attribute 'next_functions'

../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/utils.py:97: AttributeError
___________________________________________________________________________ test_model_saving_loading ____________________________________________________________________________

tmpdir = local('/tmp/pytest-of-waf251/pytest-7/test_model_saving_loading0')

    def test_model_saving_loading(tmpdir):
        """Tests use case where trainer saves the model, and user loads it from tags independently."""
        tutils.reset_seed()

        hparams = tutils.get_hparams()
        model = LightningTestModel(hparams)

        # logger file to get meta
        logger = tutils.get_test_tube_logger(tmpdir, False)

        trainer_options = dict(
            max_epochs=1,
            logger=logger,
            checkpoint_callback=ModelCheckpoint(tmpdir)
        )

        # fit model
        trainer = Trainer(**trainer_options)
>       result = trainer.fit(model)

tests/test_restore_models.py:339:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pytorch_lightning/trainer/trainer.py:403: in fit
    self.run_pretrain_routine(model)
pytorch_lightning/trainer/trainer.py:473: in run_pretrain_routine
    ref_model.summarize(mode=self.weights_summary)
pytorch_lightning/core/lightning.py:1022: in summarize
    model_summary = ModelSummary(self, mode=mode)
pytorch_lightning/core/memory.py:26: in __init__
    self.summarize()
pytorch_lightning/core/memory.py:174: in summarize
    self.get_variable_sizes()
pytorch_lightning/core/memory.py:75: in get_variable_sizes
    out = m(input_)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/module.py:547: in __call__
    result = self.forward(*input, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/linear.py:87: in forward
    return F.linear(input, self.weight, self.bias)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/functional.py:1369: in linear
    ret = torch.addmm(bias, input, weight.t())
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:21: in wrapper
    args[i] = utils.cached_cast(cast_fn, args[i], handle.cache)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cast_fn = <function maybe_half at 0x7f157a2e5d90>
x = Parameter containing:
tensor([-1.8999e-02,  3.3154e-02,  1.2389e-02, -3.4414e-02, -5.8694e-03,
        -1.3161e-02, -2...e-03, -2.7175e-02,
        -3.0759e-02, -7.3475e-03, -1.2750e-02,  2.9525e-02,  6.2156e-04],
       requires_grad=True)
cache = {Parameter containing:
tensor([[ 0.0650,  0.0889,  0.0557,  ...,  0.0830,  0.0451,  0.0288],
        [ 0.0933,  0.0492...18,  0.1643, -0.1760,  0.2532, -0.1964, -0.0585,
         0.2620, -0.0264], device='cuda:0', dtype=torch.float16), ...}

    def cached_cast(cast_fn, x, cache):
        if is_nested(x):
            return type(x)([cached_cast(y) for y in x])
        if x in cache:
            cached_x = cache[x]
            if x.requires_grad and cached_x.requires_grad:
                # Make sure x is actually cached_x's autograd parent.
>               if cached_x.grad_fn.next_functions[1][0].variable is not x:
E               AttributeError: 'NoneType' object has no attribute 'next_functions'

../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/utils.py:97: AttributeError
_______________________________________________________________________________ test_no_val_module _______________________________________________________________________________

tmpdir = local('/tmp/pytest-of-waf251/pytest-7/test_no_val_module0')

    def test_no_val_module(tmpdir):
        """Tests use case where trainer saves the model, and user loads it from tags independently."""
        tutils.reset_seed()

        hparams = tutils.get_hparams()

        class CurrentTestModel(LightningTestModelBase):
            pass

        model = CurrentTestModel(hparams)

        # logger file to get meta
        logger = tutils.get_test_tube_logger(tmpdir, False)

        trainer_options = dict(
            max_epochs=1,
            logger=logger,
            checkpoint_callback=ModelCheckpoint(tmpdir)
        )

        # fit model
        trainer = Trainer(**trainer_options)
>       result = trainer.fit(model)

tests/test_trainer.py:44:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pytorch_lightning/trainer/trainer.py:403: in fit
    self.run_pretrain_routine(model)
pytorch_lightning/trainer/trainer.py:473: in run_pretrain_routine
    ref_model.summarize(mode=self.weights_summary)
pytorch_lightning/core/lightning.py:1022: in summarize
    model_summary = ModelSummary(self, mode=mode)
pytorch_lightning/core/memory.py:26: in __init__
    self.summarize()
pytorch_lightning/core/memory.py:174: in summarize
    self.get_variable_sizes()
pytorch_lightning/core/memory.py:75: in get_variable_sizes
    out = m(input_)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/module.py:547: in __call__
    result = self.forward(*input, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/linear.py:87: in forward
    return F.linear(input, self.weight, self.bias)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/functional.py:1369: in linear
    ret = torch.addmm(bias, input, weight.t())
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:21: in wrapper
    args[i] = utils.cached_cast(cast_fn, args[i], handle.cache)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cast_fn = <function maybe_half at 0x7f157a2e5d90>
x = Parameter containing:
tensor([-3.1078e-02, -2.8256e-02,  7.8388e-04,  1.2149e-02,  2.0855e-02,
        -1.2378e-02, -2...e-03,  9.5723e-03,
         9.0040e-03,  7.4463e-03,  3.3460e-02,  1.3761e-02, -2.1957e-03],
       requires_grad=True)
cache = {Parameter containing:
tensor([[ 0.0650,  0.0889,  0.0557,  ...,  0.0830,  0.0451,  0.0288],
        [ 0.0933,  0.0492...18,  0.1643, -0.1760,  0.2532, -0.1964, -0.0585,
         0.2620, -0.0264], device='cuda:0', dtype=torch.float16), ...}

    def cached_cast(cast_fn, x, cache):
        if is_nested(x):
            return type(x)([cached_cast(y) for y in x])
        if x in cache:
            cached_x = cache[x]
            if x.requires_grad and cached_x.requires_grad:
                # Make sure x is actually cached_x's autograd parent.
>               if cached_x.grad_fn.next_functions[1][0].variable is not x:
E               AttributeError: 'NoneType' object has no attribute 'next_functions'

../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/utils.py:97: AttributeError
_____________________________________________________________________________ test_no_val_end_module _____________________________________________________________________________

tmpdir = local('/tmp/pytest-of-waf251/pytest-7/test_no_val_end_module0')

    def test_no_val_end_module(tmpdir):
        """Tests use case where trainer saves the model, and user loads it from tags independently."""
        tutils.reset_seed()

        class CurrentTestModel(LightningValidationStepMixin, LightningTestModelBase):
            pass

        hparams = tutils.get_hparams()
        model = CurrentTestModel(hparams)

        # logger file to get meta
        logger = tutils.get_test_tube_logger(tmpdir, False)

        trainer_options = dict(
            max_epochs=1,
            logger=logger,
            checkpoint_callback=ModelCheckpoint(tmpdir)
        )

        # fit model
        trainer = Trainer(**trainer_options)
>       result = trainer.fit(model)

tests/test_trainer.py:82:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pytorch_lightning/trainer/trainer.py:403: in fit
    self.run_pretrain_routine(model)
pytorch_lightning/trainer/trainer.py:473: in run_pretrain_routine
    ref_model.summarize(mode=self.weights_summary)
pytorch_lightning/core/lightning.py:1022: in summarize
    model_summary = ModelSummary(self, mode=mode)
pytorch_lightning/core/memory.py:26: in __init__
    self.summarize()
pytorch_lightning/core/memory.py:174: in summarize
    self.get_variable_sizes()
pytorch_lightning/core/memory.py:75: in get_variable_sizes
    out = m(input_)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/module.py:547: in __call__
    result = self.forward(*input, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/linear.py:87: in forward
    return F.linear(input, self.weight, self.bias)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/functional.py:1369: in linear
    ret = torch.addmm(bias, input, weight.t())
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:21: in wrapper
    args[i] = utils.cached_cast(cast_fn, args[i], handle.cache)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cast_fn = <function maybe_half at 0x7f157a2e5d90>
x = Parameter containing:
tensor([ 3.2754e-02,  1.7449e-02,  1.5225e-02, -2.3287e-02,  3.1023e-02,
        -2.8604e-02, -2...e-03, -2.5877e-02,
         2.7885e-03, -1.2829e-03,  2.0791e-02,  2.3693e-02,  1.7682e-02],
       requires_grad=True)
cache = {Parameter containing:
tensor([[ 0.0650,  0.0889,  0.0557,  ...,  0.0830,  0.0451,  0.0288],
        [ 0.0933,  0.0492...18,  0.1643, -0.1760,  0.2532, -0.1964, -0.0585,
         0.2620, -0.0264], device='cuda:0', dtype=torch.float16), ...}

    def cached_cast(cast_fn, x, cache):
        if is_nested(x):
            return type(x)([cached_cast(y) for y in x])
        if x in cache:
            cached_x = cache[x]
            if x.requires_grad and cached_x.requires_grad:
                # Make sure x is actually cached_x's autograd parent.
>               if cached_x.grad_fn.next_functions[1][0].variable is not x:
E               AttributeError: 'NoneType' object has no attribute 'next_functions'

../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/utils.py:97: AttributeError
_____________________________________________________________________ test_gradient_accumulation_scheduling ______________________________________________________________________

tmpdir = local('/tmp/pytest-of-waf251/pytest-7/test_gradient_accumulation_sch0')

    def test_gradient_accumulation_scheduling(tmpdir):
        tutils.reset_seed()

        """
        Test grad accumulation by the freq of optimizer updates
        """
        # test incorrect configs
        with pytest.raises(IndexError):
            assert Trainer(accumulate_grad_batches={0: 3, 1: 4, 4: 6})
            assert Trainer(accumulate_grad_batches={-2: 3})

        with pytest.raises(TypeError):
            assert Trainer(accumulate_grad_batches={})
            assert Trainer(accumulate_grad_batches=[[2, 3], [4, 6]])
            assert Trainer(accumulate_grad_batches={1: 2, 3.: 4})
            assert Trainer(accumulate_grad_batches={1: 2.5, 3: 5})

        # test optimizer call freq matches scheduler
        def optimizer_step(self, epoch, batch_idx, optimizer, optimizer_idx, second_order_closure=None):
            # only test the first 12 batches in epoch
            if batch_idx < 12:
                if epoch == 0:
                    # reset counter when starting epoch
                    if batch_idx == 0:
                        self.prev_called_batch_idx = 0

                        # use this opportunity to test once
                        assert self.trainer.accumulate_grad_batches == 1

                    assert batch_idx == self.prev_called_batch_idx
                    self.prev_called_batch_idx += 1

                elif 1 <= epoch <= 2:
                    # reset counter when starting epoch
                    if batch_idx == 1:
                        self.prev_called_batch_idx = 1

                        # use this opportunity to test once
                        assert self.trainer.accumulate_grad_batches == 2

                    assert batch_idx == self.prev_called_batch_idx
                    self.prev_called_batch_idx += 2

                else:
                    if batch_idx == 3:
                        self.prev_called_batch_idx = 3

                        # use this opportunity to test once
                        assert self.trainer.accumulate_grad_batches == 4

                    assert batch_idx == self.prev_called_batch_idx
                    self.prev_called_batch_idx += 3

            optimizer.step()

            # clear gradients
            optimizer.zero_grad()

        hparams = tutils.get_hparams()
        model = LightningTestModel(hparams)
        schedule = {1: 2, 3: 4}

        trainer = Trainer(accumulate_grad_batches=schedule,
                          train_percent_check=0.1,
                          val_percent_check=0.1,
                          max_epochs=4,
                          default_save_path=tmpdir)

        # for the test
        trainer.optimizer_step = optimizer_step
        model.prev_called_batch_idx = 0

>       trainer.fit(model)

tests/test_trainer.py:171:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pytorch_lightning/trainer/trainer.py:403: in fit
    self.run_pretrain_routine(model)
pytorch_lightning/trainer/trainer.py:473: in run_pretrain_routine
    ref_model.summarize(mode=self.weights_summary)
pytorch_lightning/core/lightning.py:1022: in summarize
    model_summary = ModelSummary(self, mode=mode)
pytorch_lightning/core/memory.py:26: in __init__
    self.summarize()
pytorch_lightning/core/memory.py:174: in summarize
    self.get_variable_sizes()
pytorch_lightning/core/memory.py:75: in get_variable_sizes
    out = m(input_)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/module.py:547: in __call__
    result = self.forward(*input, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/linear.py:87: in forward
    return F.linear(input, self.weight, self.bias)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/functional.py:1369: in linear
    ret = torch.addmm(bias, input, weight.t())
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:21: in wrapper
    args[i] = utils.cached_cast(cast_fn, args[i], handle.cache)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cast_fn = <function maybe_half at 0x7f157a2e5d90>
x = Parameter containing:
tensor([ 2.0159e-02,  9.6993e-03,  1.8182e-02, -2.5544e-02, -2.5235e-02,
        -1.0433e-02, -3...e-03,  1.1901e-02,
         5.2050e-03, -1.3128e-02, -1.3827e-02, -8.1634e-03,  3.5227e-02],
       requires_grad=True)
cache = {Parameter containing:
tensor([[ 0.0650,  0.0889,  0.0557,  ...,  0.0830,  0.0451,  0.0288],
        [ 0.0933,  0.0492...18,  0.1643, -0.1760,  0.2532, -0.1964, -0.0585,
         0.2620, -0.0264], device='cuda:0', dtype=torch.float16), ...}

    def cached_cast(cast_fn, x, cache):
        if is_nested(x):
            return type(x)([cached_cast(y) for y in x])
        if x in cache:
            cached_x = cache[x]
            if x.requires_grad and cached_x.requires_grad:
                # Make sure x is actually cached_x's autograd parent.
>               if cached_x.grad_fn.next_functions[1][0].variable is not x:
E               AttributeError: 'NoneType' object has no attribute 'next_functions'

../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/utils.py:97: AttributeError
__________________________________________________________________________ test_multiple_val_dataloader __________________________________________________________________________

tmpdir = local('/tmp/pytest-of-waf251/pytest-7/test_multiple_val_dataloader0')

    def test_multiple_val_dataloader(tmpdir):
        """Verify multiple val_dataloader."""
        tutils.reset_seed()

        class CurrentTestModel(
            LightningValidationMultipleDataloadersMixin,
            LightningTestModelBase
        ):
            pass

        hparams = tutils.get_hparams()
        model = CurrentTestModel(hparams)

        # logger file to get meta
        trainer_options = dict(
            default_save_path=tmpdir,
            max_epochs=1,
            val_percent_check=0.1,
            train_percent_check=1.0,
        )

        # fit model
        trainer = Trainer(**trainer_options)
>       result = trainer.fit(model)

tests/test_trainer.py:364:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pytorch_lightning/trainer/trainer.py:403: in fit
    self.run_pretrain_routine(model)
pytorch_lightning/trainer/trainer.py:473: in run_pretrain_routine
    ref_model.summarize(mode=self.weights_summary)
pytorch_lightning/core/lightning.py:1022: in summarize
    model_summary = ModelSummary(self, mode=mode)
pytorch_lightning/core/memory.py:26: in __init__
    self.summarize()
pytorch_lightning/core/memory.py:174: in summarize
    self.get_variable_sizes()
pytorch_lightning/core/memory.py:75: in get_variable_sizes
    out = m(input_)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/module.py:547: in __call__
    result = self.forward(*input, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/linear.py:87: in forward
    return F.linear(input, self.weight, self.bias)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/functional.py:1369: in linear
    ret = torch.addmm(bias, input, weight.t())
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:21: in wrapper
    args[i] = utils.cached_cast(cast_fn, args[i], handle.cache)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cast_fn = <function maybe_half at 0x7f157a2e5d90>
x = Parameter containing:
tensor([-3.3585e-02,  1.5228e-03,  3.0550e-02, -4.9648e-04, -1.2231e-02,
        -1.2370e-02,  2...e-03,  1.3650e-02,
         1.1333e-02, -2.7724e-02,  3.0606e-02, -1.5910e-02, -3.4099e-02],
       requires_grad=True)
cache = {Parameter containing:
tensor([[ 0.0650,  0.0889,  0.0557,  ...,  0.0830,  0.0451,  0.0288],
        [ 0.0933,  0.0492...18,  0.1643, -0.1760,  0.2532, -0.1964, -0.0585,
         0.2620, -0.0264], device='cuda:0', dtype=torch.float16), ...}

    def cached_cast(cast_fn, x, cache):
        if is_nested(x):
            return type(x)([cached_cast(y) for y in x])
        if x in cache:
            cached_x = cache[x]
            if x.requires_grad and cached_x.requires_grad:
                # Make sure x is actually cached_x's autograd parent.
>               if cached_x.grad_fn.next_functions[1][0].variable is not x:
E               AttributeError: 'NoneType' object has no attribute 'next_functions'

../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/utils.py:97: AttributeError
_________________________________________________________________________ test_multiple_test_dataloader __________________________________________________________________________

tmpdir = local('/tmp/pytest-of-waf251/pytest-7/test_multiple_test_dataloader0')

    def test_multiple_test_dataloader(tmpdir):
        """Verify multiple test_dataloader."""
        tutils.reset_seed()

        class CurrentTestModel(
            LightningTestMultipleDataloadersMixin,
            LightningTestModelBase
        ):
            pass

        hparams = tutils.get_hparams()
        model = CurrentTestModel(hparams)

        # logger file to get meta
        trainer_options = dict(
            default_save_path=tmpdir,
            max_epochs=1,
            val_percent_check=0.1,
            train_percent_check=0.1,
        )

        # fit model
        trainer = Trainer(**trainer_options)
>       result = trainer.fit(model)

tests/test_trainer.py:401:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
pytorch_lightning/trainer/trainer.py:403: in fit
    self.run_pretrain_routine(model)
pytorch_lightning/trainer/trainer.py:473: in run_pretrain_routine
    ref_model.summarize(mode=self.weights_summary)
pytorch_lightning/core/lightning.py:1022: in summarize
    model_summary = ModelSummary(self, mode=mode)
pytorch_lightning/core/memory.py:26: in __init__
    self.summarize()
pytorch_lightning/core/memory.py:174: in summarize
    self.get_variable_sizes()
pytorch_lightning/core/memory.py:75: in get_variable_sizes
    out = m(input_)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/module.py:547: in __call__
    result = self.forward(*input, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/modules/linear.py:87: in forward
    return F.linear(input, self.weight, self.bias)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:28: in wrapper
    return orig_fn(*new_args, **kwargs)
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/nn/functional.py:1369: in linear
    ret = torch.addmm(bias, input, weight.t())
../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/wrap.py:21: in wrapper
    args[i] = utils.cached_cast(cast_fn, args[i], handle.cache)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cast_fn = <function maybe_half at 0x7f157a2e5d90>
x = Parameter containing:
tensor([ 7.0308e-03,  8.0707e-03, -2.9088e-02, -1.7069e-02, -1.6213e-02,
         2.0917e-02,  1...e-02, -1.1187e-02,
         1.4406e-02, -5.9742e-03, -2.4150e-02,  5.9858e-03, -1.5739e-02],
       requires_grad=True)
cache = {Parameter containing:
tensor([[ 0.0650,  0.0889,  0.0557,  ...,  0.0830,  0.0451,  0.0288],
        [ 0.0933,  0.0492...18,  0.1643, -0.1760,  0.2532, -0.1964, -0.0585,
         0.2620, -0.0264], device='cuda:0', dtype=torch.float16), ...}

    def cached_cast(cast_fn, x, cache):
        if is_nested(x):
            return type(x)([cached_cast(y) for y in x])
        if x in cache:
            cached_x = cache[x]
            if x.requires_grad and cached_x.requires_grad:
                # Make sure x is actually cached_x's autograd parent.
>               if cached_x.grad_fn.next_functions[1][0].variable is not x:
E               AttributeError: 'NoneType' object has no attribute 'next_functions'

../../media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/apex/amp/utils.py:97: AttributeError
================================================================================ warnings summary ================================================================================
/home/waf251/media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/past/translation/__init__.py:35
  /home/waf251/media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/past/translation/__init__.py:35: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

pytorch_lightning/core/model_saving.py:8
  /home/waf251/Developer/pytorch-lightning/pytorch_lightning/core/model_saving.py:8: DeprecationWarning: `model_saving` module has been renamed to `saving` since v0.5.3 and will be removed in v0.8.0
    " and will be removed in v0.8.0", DeprecationWarning)

pytorch_lightning/core/root_module.py:8
  /home/waf251/Developer/pytorch-lightning/pytorch_lightning/core/root_module.py:8: DeprecationWarning: `root_module` module has been renamed to `lightning` since v0.5.3 and will be removed in v0.8.0
    " and will be removed in v0.8.0", DeprecationWarning)

pytorch_lightning/logging/comet_logger.py:8
  /home/waf251/Developer/pytorch-lightning/pytorch_lightning/logging/comet_logger.py:8: DeprecationWarning: `comet_logger` module has been renamed to `comet` since v0.5.3 and will be removed in v0.8.0
    " and will be removed in v0.8.0", DeprecationWarning)

pytorch_lightning/logging/mlflow_logger.py:8
  /home/waf251/Developer/pytorch-lightning/pytorch_lightning/logging/mlflow_logger.py:8: DeprecationWarning: `mlflow_logger` module has been renamed to `mlflow` since v0.5.3 and will be removed in v0.8.0
    " and will be removed in v0.8.0", DeprecationWarning)

pytorch_lightning/logging/test_tube_logger.py:8
  /home/waf251/Developer/pytorch-lightning/pytorch_lightning/logging/test_tube_logger.py:8: DeprecationWarning: `test_tube_logger` module has been renamed to `test_tube` since v0.5.3 and will be removed in v0.8.0
    " and will be removed in v0.8.0", DeprecationWarning)

pytorch_lightning/overrides/override_data_parallel.py:9
  /home/waf251/Developer/pytorch-lightning/pytorch_lightning/overrides/override_data_parallel.py:9: DeprecationWarning: `override_data_parallel` module has been renamed to `data_parallel` since v0.5.3 and will be removed in v0.8.0
    " and will be removed in v0.8.0", DeprecationWarning)

pytorch_lightning/pt_overrides/__init__.py:8
  /home/waf251/Developer/pytorch-lightning/pytorch_lightning/pt_overrides/__init__.py:8: DeprecationWarning: `pt_overrides` package has been renamed to `overrides` since v0.5.3 and will be removed in v0.8.0
    " and will be removed in v0.8.0", DeprecationWarning)

pytorch_lightning/root_module/__init__.py:8
  /home/waf251/Developer/pytorch-lightning/pytorch_lightning/root_module/__init__.py:8: DeprecationWarning: `root_module` package has been renamed to `core` since v0.5.3 and will be removed in v0.8.0
    " and will be removed in v0.8.0", DeprecationWarning)

tests/test_amp.py::test_amp_gpu_dp
  /home/waf251/media/falcon_kcgscratch1/software/miniconda3/envs/pl3/lib/python3.6/site-packages/torch/optim/lr_scheduler.py:73: UserWarning: Seems like `optimizer.step()` has been overridden after learning rate scheduler initialization. Please, make sure to call `optimizer.step()` before `lr_scheduler.step()`. See more details at https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate
    "https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate", UserWarning)

tests/test_gpu_models.py::test_multi_gpu_none_backend
  /home/waf251/Developer/pytorch-lightning/pytorch_lightning/trainer/distrib_data_parallel.py:195: UserWarning: You requested multiple GPUs but did not specify a backendTrainer(distributed_backend=dp) (or ddp, ddp2)Setting distributed_backend=dp for you
    warnings.warn(m)

tests/test_logging.py::test_tensorboard_logger
tests/test_logging.py::test_tensorboard_log_hyperparams
  /home/waf251/Developer/pytorch-lightning/pytorch_lightning/logging/tensorboard.py:62: UserWarning: Hyperparameter logging is not available for Torch version 1.2.0. Skipping log_hyperparams. Upgrade to Torch 1.3.0 or above to enable hyperparameter logging.
    f"Hyperparameter logging is not available for Torch version {torch.__version__}."

tests/test_restore_models.py::test_dp_resume
  /home/waf251/Developer/pytorch-lightning/pytorch_lightning/callbacks/pt_callbacks.py:200: UserWarning: Checkpoint directory /tmp/pytest-of-waf251/pytest-7/test_dp_resume0 exists and is not empty with save_top_k != 0.All files in this directory will be deleted when a checkpoint is saved!
    f"Checkpoint directory {filepath} exists and is not empty with save_top_k != 0."

-- Docs: https://docs.pytest.org/en/latest/warnings.html
============================================================= 35 failed, 74 passed, 14 warnings in 376.79s (0:06:16) =============================================================
Name                                                    Stmts   Miss  Cover   Missing
```

@neggert @Borda @jeffling 