### PR TITLE
Logging gradients with tensor's names

### DIFF
--- a/pytorch_lightning/core/grads.py
+++ b/pytorch_lightning/core/grads.py
@@ -10,7 +10,7 @@ class GradInformation(nn.Module):
     def grad_norm(self, norm_type):
         results = {}
         total_norm = 0
-        for i, p in enumerate(self.parameters()):
+        for name, p in self.named_parameters():
             if p.requires_grad:
                 try:
                     param_norm = p.grad.data.norm(norm_type)
@@ -18,7 +18,7 @@ class GradInformation(nn.Module):
                     norm = param_norm ** (1 / norm_type)
 
                     grad = round(norm.data.cpu().numpy().flatten()[0], 3)
-                    results['grad_{}_norm_{}'.format(norm_type, i)] = grad
+                    results['grad_{}_norm_{}'.format(norm_type, name)] = grad
                 except Exception:
                     # this param had no grad
                     pass


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   Not needed
- [ ] Did you write any new necessary tests?  Not needed

## What does this PR do?
Current gradient logging (when enabled) provides no information about the names of the parameters of interest, providing only raw values of gradient norms. With PyTorch's named_parameters() method we can access the names of our parameters - this is now used to name the individual gradient norm.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
