### PR TITLE
Fix issue_703: backward compatibility with python3.6

### DIFF
--- a/pytorch_lightning/core/memory.py
+++ b/pytorch_lightning/core/memory.py
@@ -5,6 +5,7 @@ Generates a summary of a model's layers and dimensionality
 import gc
 import os
 import subprocess
+from subprocess import PIPE
 
 import numpy as np
 import pandas as pd
@@ -235,7 +236,8 @@ def get_gpu_memory_map():
             '--format=csv,nounits,noheader',
         ],
         encoding='utf-8',
-        capture_output=True,
+        # capture_output=True,          # valid for python version >=3.7
+        stdout=PIPE, stderr=PIPE,       # for backward compatibility with python version 3.6
         check=True)
     # Convert lines into a dictionary
     gpu_memory = [int(x) for x in result.stdout.strip().split(os.linesep)]


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
   - #703 (there are no comments)
- [x] Did you read the [contributor guideline](https://github.com/williamFalcon/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
   -  No visible changes
- [ ] Did you write any new necessary tests? 
   - About py.test -v
Distributed modes don't work on my machines.
`test_amp.py::test_amp_gpu_ddp`  freezes.
It is not related with pytorch-lightning, and it is not related with this PR (master branch freezed too, in pure pytorch too, other ML too).
So I can't run the tests and  I tested them manually (examples without distributed modes)


## What does this PR do?
Fixes #703 
Backward compatibility with python3.6
Fitting with log_gpu_memory=True in the Trainer fails in python3.6 version.
Reason:
`subprocess.run` is used with `capture_output`  which is valid only for the python >= 3.7
See also workaround to maintain python3.6:
https://stackoverflow.com/questions/53209127/

## PR review    
_Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged._

I'll wait.

