### PR TITLE
Fix failing GPU tests

### DIFF
--- a/pytorch_lightning/logging/test_tube.py
+++ b/pytorch_lightning/logging/test_tube.py
@@ -135,8 +135,9 @@ class TestTubeLogger(LightningLoggerBase):
     def close(self):
         # TODO: HACK figure out where this is being set to true
         self.experiment.debug = self.debug
-        exp = self.experiment
-        exp.close()
+        if not self.debug:
+            exp = self.experiment
+            exp.close()
 
     @property
     def rank(self):

--- a/tests/test_gpu_models.py
+++ b/tests/test_gpu_models.py
@@ -183,7 +183,7 @@ def test_multi_gpu_none_backend(tmpdir):
         gpus='-1'
     )
 
-    with pytest.raises(MisconfigurationException):
+    with pytest.warns(UserWarning):
         tutils.run_model_test(trainer_options, model)
 
 


### PR DESCRIPTION
* Fix `test_multi_gpu_none_backend`. Test was expecting an exception, but this has been changed to a warning in the code. Updated test to reflect this.
* Fix `TestTubeLogger` so that `close` doesn't get called when `debug=True`

With these fixes, all tests are passing for me.