### PR TITLE
added initial semantic segmentation example

### DIFF
--- a/pl_examples/full_examples/semantic_segmentation/semseg.py
+++ b/pl_examples/full_examples/semantic_segmentation/semseg.py
@@ -111,6 +111,18 @@ class KITTI(Dataset):
 
 
 class SegModel(pl.LightningModule):
+    '''
+    Semantic Segmentation Module
+
+    This is a basic semantic segmentation module implemented with Lightning.
+    It uses CrossEntropyLoss as the default loss function. May be replaced with
+    other loss functions as required.
+    It is specific to KITTI dataset i.e. dataloaders are for KITTI
+    and Normalize transform uses the mean and standard deviation of this dataset.
+    It uses the FCN ResNet50 model as an example.
+
+    Adam optimizer is used along with Cosine Annealing learning rate scheduler.
+    '''
     def __init__(self, hparams):
         super(SegModel, self).__init__()
         self.root_path = hparams.root
@@ -160,9 +172,7 @@ def main(hparams):
     # 2 INIT TRAINER
     # ------------------------
     trainer = pl.Trainer(
-        gpus=hparams.gpus,
-        max_nb_epochs=5,
-        early_stop_callback=None
+        gpus=hparams.gpus
     )
 
     # ------------------------

--- a/pl_examples/full_examples/semantic_segmentation/semseg.py
+++ b/pl_examples/full_examples/semantic_segmentation/semseg.py
@@ -134,9 +134,7 @@ def main(hparams):
     # ------------------------
     # 3 START TRAINING
     # ------------------------
-    # trainer.fit(model)
-
-    trainer.test(model)
+    trainer.fit(model)
 
 
 if __name__ == '__main__':

--- a/pl_examples/full_examples/semantic_segmentation/semseg.py
+++ b/pl_examples/full_examples/semantic_segmentation/semseg.py
@@ -116,10 +116,13 @@ class SegModel(pl.LightningModule):
         self.root_path = hparams.root
         self.batch_size = hparams.batch_size
         self.learning_rate = hparams.lr
-        self.net = torchvision.models.segmentation.fcn_resnet50(pretrained=False, progress=True, num_classes=19)
+        self.net = torchvision.models.segmentation.fcn_resnet50(pretrained=False,
+                                                                progress=True,
+                                                                num_classes=19)
         self.transform = transforms.Compose([
             transforms.ToTensor(),
-            transforms.Normalize(mean=[0.35675976, 0.37380189, 0.3764753], std=[0.32064945, 0.32098866, 0.32325324])
+            transforms.Normalize(mean=[0.35675976, 0.37380189, 0.3764753],
+                                 std=[0.32064945, 0.32098866, 0.32325324])
         ])
         self.trainset = KITTI(self.root_path, split='train', transform=self.transform)
         self.testset = KITTI(self.root_path, split='test', transform=self.transform)

--- a/pl_examples/full_examples/semantic_segmentation/semseg.py
+++ b/pl_examples/full_examples/semantic_segmentation/semseg.py
@@ -1,0 +1,152 @@
+import os
+from argparse import ArgumentParser
+from collections import OrderedDict
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torchvision
+import torchvision.transforms as transforms
+from torch.utils.data import DataLoader, Dataset
+from torchvision.models.segmentation import fcn_resnet50
+
+from PIL import Image
+import pytorch_lightning as pl
+
+class KITTI(Dataset):
+    def __init__(self, root_path, split = 'test', img_size = (1242, 376), transform = None):
+        self.img_size = img_size
+        self.void_labels = [0, 1, 2, 3, 4, 5, 6, 9, 10, 14, 15, 16, 18, 29, 30, -1]
+        self.valid_labels = [7, 8, 11, 12, 13, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 31, 32, 33]
+        self.ignore_index = 250
+        self.class_map = dict(zip(self.valid_labels, range(19)))
+        self.split = split
+        self.root = root_path
+        if self.split == 'train':
+            self.img_path = os.path.join(self.root, 'training/image_2')    
+            self.mask_path = os.path.join(self.root, 'training/semantic')
+        else : 
+            self.img_path = os.path.join(self.root, 'testing/image_2')
+            self.mask_path = None
+
+        self.transform = transform
+        
+        self.img_list = self.get_filenames(self.img_path)
+        if self.split == 'train':
+            self.mask_list = self.get_filenames(self.mask_path)
+        else :
+            self.mask_list = None
+        
+    def __len__(self):
+        return(len(self.img_list))
+    
+    def __getitem__(self, idx):
+        img = Image.open(self.img_list[idx])
+        img = img.resize(self.img_size)
+        img = np.array(img)
+        
+        if self.split == 'train' : 
+            mask = Image.open(self.mask_list[idx]).convert('L')
+            mask = mask.resize(self.img_size)
+            mask = np.array(mask)
+            mask = self.encode_segmap(mask)
+        
+        if self.transform :
+            img = self.transform(img)
+            
+        if self.split == 'train' :
+            return img, mask
+        else :
+            return img
+    
+    def encode_segmap(self, mask):
+        '''
+        Sets void classes to zero so they won't be considered for training
+        '''
+        for voidc in self.void_labels :
+            mask[mask == voidc] = self.ignore_index
+        for validc in self.valid_labels :
+            mask[mask == validc] = self.class_map[validc]
+        return mask
+    
+    def get_filenames(self, path):
+        files_list = list()
+        for filename in os.listdir(path):
+            files_list.append(os.path.join(path, filename))
+        return files_list
+    
+class SegModel(pl.LightningModule):
+    def __init__(self, hparams):
+        super(SegModel, self).__init__()
+        self.hparams = hparams
+#         self.root_path = '/home/akshay/Projects/pl-sem-seg/'
+        self.root_path = hparams.root
+        self.batch_size = hparams.batch_size
+        self.learning_rate = hparams.lr
+        self.net = torchvision.models.segmentation.fcn_resnet50(pretrained = False, progress = True, num_classes = 19)
+        self.transform = transforms.Compose([
+            transforms.ToTensor(),
+            transforms.Normalize(mean = [0.35675976, 0.37380189, 0.3764753], std = [0.32064945, 0.32098866, 0.32325324])
+        ])
+        self.trainset = KITTI(self.root_path, split = 'train', transform = self.transform)
+        self.testset = KITTI(self.root_path, split = 'test', transform = self.transform)
+        
+    def forward(self, x):
+        return self.net(x)
+    
+    def training_step(self, batch, batch_nb) :
+        img, mask = batch
+        img = img.float()
+        mask = mask.long()
+        out = self.forward(img)
+        loss_val = F.cross_entropy(out['out'], mask, ignore_index = 250)
+        return {'loss' : loss_val}
+    
+#     def test_step(self, batch, batch_nb):
+#         print('-----------------testing-----------------')
+#         img = batch
+#         # log sampled images
+#         masks = self.net(img)
+#         grid = torchvision.utils.make_grid(masks)
+#         self.logger.experiment.add_image(f'generated_images', grid, self.current_epoch)
+    
+    def configure_optimizers(self):
+        opt = torch.optim.Adam(self.net.parameters(), lr = self.learning_rate)
+        sch = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max = 10)
+        return [opt], [sch]
+    
+    def train_dataloader(self):
+        return DataLoader(self.trainset, batch_size = self.batch_size, shuffle = True)
+    
+    def test_dataloader(self):
+        return DataLoader(self.testset, batch_size = 1, shuffle = True)
+    
+def main(hparams):
+    # ------------------------
+    # 1 INIT LIGHTNING MODEL
+    # ------------------------
+    model = SegModel(hparams)
+
+    # ------------------------
+    # 2 INIT TRAINER
+    # ------------------------
+    trainer = pl.Trainer(
+        gpus = hparams.gpus
+    )
+
+    # ------------------------
+    # 3 START TRAINING
+    # ------------------------
+    trainer.fit(model)
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument("--root", type = str, help = "path where dataset is stored")
+    parser.add_argument("--gpus", type = int, help = "number of available GPUs")
+    parser.add_argument("--batch_size", type = int, default = 4, help = "size of the batches")
+    parser.add_argument("--lr", type = float, default = 0.001, help = "adam: learning rate")
+
+    hparams = parser.parse_args()
+
+    main(hparams)

--- a/pl_examples/full_examples/semantic_segmentation/semseg.py
+++ b/pl_examples/full_examples/semantic_segmentation/semseg.py
@@ -80,7 +80,6 @@ class SegModel(pl.LightningModule):
     def __init__(self, hparams):
         super(SegModel, self).__init__()
         self.hparams = hparams
-#         self.root_path = '/home/akshay/Projects/pl-sem-seg/'
         self.root_path = hparams.root
         self.batch_size = hparams.batch_size
         self.learning_rate = hparams.lr

--- a/pl_examples/full_examples/semantic_segmentation/semseg.py
+++ b/pl_examples/full_examples/semantic_segmentation/semseg.py
@@ -14,8 +14,9 @@ from torchvision.models.segmentation import fcn_resnet50
 from PIL import Image
 import pytorch_lightning as pl
 
+
 class KITTI(Dataset):
-    def __init__(self, root_path, split = 'test', img_size = (1242, 376), transform = None):
+    def __init__(self, root_path, split='test', img_size=(1242, 376), transform=None):
         self.img_size = img_size
         self.void_labels = [0, 1, 2, 3, 4, 5, 6, 9, 10, 14, 15, 16, 18, 29, 30, -1]
         self.valid_labels = [7, 8, 11, 12, 13, 17, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 31, 32, 33]
@@ -24,103 +25,99 @@ class KITTI(Dataset):
         self.split = split
         self.root = root_path
         if self.split == 'train':
-            self.img_path = os.path.join(self.root, 'training/image_2')    
+            self.img_path = os.path.join(self.root, 'training/image_2')
             self.mask_path = os.path.join(self.root, 'training/semantic')
-        else : 
+        else:
             self.img_path = os.path.join(self.root, 'testing/image_2')
             self.mask_path = None
 
         self.transform = transform
-        
+
         self.img_list = self.get_filenames(self.img_path)
         if self.split == 'train':
             self.mask_list = self.get_filenames(self.mask_path)
-        else :
+        else:
             self.mask_list = None
-        
+
     def __len__(self):
         return(len(self.img_list))
-    
+
     def __getitem__(self, idx):
         img = Image.open(self.img_list[idx])
         img = img.resize(self.img_size)
         img = np.array(img)
-        
-        if self.split == 'train' : 
+
+        if self.split == 'train':
             mask = Image.open(self.mask_list[idx]).convert('L')
             mask = mask.resize(self.img_size)
             mask = np.array(mask)
             mask = self.encode_segmap(mask)
-        
-        if self.transform :
+
+        if self.transform:
             img = self.transform(img)
-            
-        if self.split == 'train' :
+
+        if self.split == 'train':
             return img, mask
-        else :
+        else:
             return img
-    
+
     def encode_segmap(self, mask):
         '''
         Sets void classes to zero so they won't be considered for training
         '''
-        for voidc in self.void_labels :
+        for voidc in self.void_labels:
             mask[mask == voidc] = self.ignore_index
-        for validc in self.valid_labels :
+        for validc in self.valid_labels:
             mask[mask == validc] = self.class_map[validc]
         return mask
-    
+
     def get_filenames(self, path):
+        '''
+        Returns a list of absolute paths to images inside given `path`
+        '''
         files_list = list()
         for filename in os.listdir(path):
             files_list.append(os.path.join(path, filename))
         return files_list
-    
+
+
 class SegModel(pl.LightningModule):
     def __init__(self, hparams):
         super(SegModel, self).__init__()
-        self.hparams = hparams
         self.root_path = hparams.root
         self.batch_size = hparams.batch_size
         self.learning_rate = hparams.lr
-        self.net = torchvision.models.segmentation.fcn_resnet50(pretrained = False, progress = True, num_classes = 19)
+        self.net = torchvision.models.segmentation.fcn_resnet50(pretrained=False, progress=True, num_classes=19)
         self.transform = transforms.Compose([
             transforms.ToTensor(),
-            transforms.Normalize(mean = [0.35675976, 0.37380189, 0.3764753], std = [0.32064945, 0.32098866, 0.32325324])
+            transforms.Normalize(mean=[0.35675976, 0.37380189, 0.3764753], std=[0.32064945, 0.32098866, 0.32325324])
         ])
-        self.trainset = KITTI(self.root_path, split = 'train', transform = self.transform)
-        self.testset = KITTI(self.root_path, split = 'test', transform = self.transform)
-        
+        self.trainset = KITTI(self.root_path, split='train', transform=self.transform)
+        self.testset = KITTI(self.root_path, split='test', transform=self.transform)
+
     def forward(self, x):
         return self.net(x)
-    
-    def training_step(self, batch, batch_nb) :
+
+    def training_step(self, batch, batch_nb):
         img, mask = batch
         img = img.float()
         mask = mask.long()
         out = self.forward(img)
-        loss_val = F.cross_entropy(out['out'], mask, ignore_index = 250)
-        return {'loss' : loss_val}
-    
-#     def test_step(self, batch, batch_nb):
-#         print('-----------------testing-----------------')
-#         img = batch
-#         # log sampled images
-#         masks = self.net(img)
-#         grid = torchvision.utils.make_grid(masks)
-#         self.logger.experiment.add_image(f'generated_images', grid, self.current_epoch)
-    
+        loss_val = F.cross_entropy(out['out'], mask, ignore_index=250)
+        return {'loss': loss_val}
+
     def configure_optimizers(self):
-        opt = torch.optim.Adam(self.net.parameters(), lr = self.learning_rate)
-        sch = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max = 10)
+        opt = torch.optim.Adam(self.net.parameters(), lr=self.learning_rate)
+        sch = torch.optim.lr_scheduler.CosineAnnealingLR(opt, T_max=10)
         return [opt], [sch]
-    
+
     def train_dataloader(self):
-        return DataLoader(self.trainset, batch_size = self.batch_size, shuffle = True)
-    
+        return DataLoader(self.trainset, batch_size=self.batch_size, shuffle=True)
+
     def test_dataloader(self):
-        return DataLoader(self.testset, batch_size = 1, shuffle = True)
-    
+        return DataLoader(self.testset, batch_size=self.batch_size, shuffle=False)
+
+
 def main(hparams):
     # ------------------------
     # 1 INIT LIGHTNING MODEL
@@ -131,20 +128,23 @@ def main(hparams):
     # 2 INIT TRAINER
     # ------------------------
     trainer = pl.Trainer(
-        gpus = hparams.gpus
+        gpus=hparams.gpus
     )
 
     # ------------------------
     # 3 START TRAINING
     # ------------------------
-    trainer.fit(model)
+    # trainer.fit(model)
+
+    trainer.test(model)
+
 
 if __name__ == '__main__':
     parser = ArgumentParser()
-    parser.add_argument("--root", type = str, help = "path where dataset is stored")
-    parser.add_argument("--gpus", type = int, help = "number of available GPUs")
-    parser.add_argument("--batch_size", type = int, default = 4, help = "size of the batches")
-    parser.add_argument("--lr", type = float, default = 0.001, help = "adam: learning rate")
+    parser.add_argument("--root", type=str, help="path where dataset is stored")
+    parser.add_argument("--gpus", type=int, help="number of available GPUs")
+    parser.add_argument("--batch_size", type=int, default=4, help="size of the batches")
+    parser.add_argument("--lr", type=float, default=0.001, help="adam: learning rate")
 
     hparams = parser.parse_args()
 


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  

## What does this PR do?
Fixes #635 (Semantic Segmentation example).

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Some additional info
I tried to add a `test_step` in the `LightningModule` which logs the predicted segmentation output. Since the default logger is TensorBoard, I expected the images to show up when I use `tensorboard logdir=lightning_logs` (at the default save path). But, they don't show up. I couldn't find any example which uses the logger properly. So, if someone can point me to an example, then I'll finish that (right now it's commented out).

Also, I have kind of followed the GAN example as a template, so I have put all of the code in a single  file. If you prefer, then I can separate the `Dataset` class into another file. And I have added this as a `full_example`, so please let me know if you want it in `domain_examples` or something.

Also, I have used the [KITTI dataset](http://www.cvlibs.net/datasets/kitti/) (since it is small and enough for an example) but it is not available directly in `torchvision`. So, it needs to be downloaded separately and the path needs to be given in the `hparams`. Note that the segmentation datasets available in torchvision (like Pascal VOC) are too large for a simple example. 

Also, I couldn't figure out what documentation or tests are required, because none of the other examples have any documentation or tests (that I could find). Please point out if anything is required.