### PR TITLE
for #330, use tqdm.auto in trainer

### DIFF
--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -127,7 +127,7 @@ import sys
 from abc import ABC, abstractmethod
 
 import torch
-import tqdm
+from tqdm.auto import tqdm
 
 from pytorch_lightning.utilities.debugging import MisconfigurationException
 
@@ -293,7 +293,7 @@ class TrainerEvaluationLoopMixin(ABC):
         # main progress bar will already be closed when testing so initial position is free
         position = 2 * self.process_position + (not test)
         desc = 'Testing' if test else 'Validating'
-        pbar = tqdm.tqdm(desc=desc, total=max_batches, leave=test, position=position,
+        pbar = tqdm(desc=desc, total=max_batches, leave=test, position=position,
                          disable=not self.show_progress_bar, dynamic_ncols=True,
                          unit='batch', file=sys.stdout)
         setattr(self, f'{"test" if test else "val"}_progress_bar', pbar)

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -294,8 +294,8 @@ class TrainerEvaluationLoopMixin(ABC):
         position = 2 * self.process_position + (not test)
         desc = 'Testing' if test else 'Validating'
         pbar = tqdm(desc=desc, total=max_batches, leave=test, position=position,
-                         disable=not self.show_progress_bar, dynamic_ncols=True,
-                         unit='batch', file=sys.stdout)
+                    disable=not self.show_progress_bar, dynamic_ncols=True,
+                    unit='batch', file=sys.stdout)
         setattr(self, f'{"test" if test else "val"}_progress_bar', pbar)
 
         # run evaluation

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -829,8 +829,8 @@ class Trainer(TrainerIOMixin,
 
         # init progress bar
         pbar = tqdm(leave=True, position=2 * self.process_position,
-                         disable=not self.show_progress_bar, dynamic_ncols=True, unit='batch',
-                         file=sys.stdout)
+                    disable=not self.show_progress_bar, dynamic_ncols=True, unit='batch',
+                    file=sys.stdout)
         self.main_progress_bar = pbar
 
         # clear cache before training

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -7,7 +7,7 @@ import logging
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
-import tqdm
+from tqdm.auto import tqdm
 from torch.optim.optimizer import Optimizer
 
 from pytorch_lightning.trainer.auto_mix_precision import TrainerAMPMixin
@@ -808,13 +808,13 @@ class Trainer(TrainerIOMixin,
         ref_model.on_train_start()
         if not self.disable_validation and self.num_sanity_val_steps > 0:
             # init progress bars for validation sanity check
-            pbar = tqdm.tqdm(desc='Validation sanity check',
+            pbar = tqdm(desc='Validation sanity check',
                              total=self.num_sanity_val_steps * len(self.get_val_dataloaders()),
                              leave=False, position=2 * self.process_position,
                              disable=not self.show_progress_bar, dynamic_ncols=True, unit='batch')
             self.main_progress_bar = pbar
             # dummy validation progress bar
-            self.val_progress_bar = tqdm.tqdm(disable=True)
+            self.val_progress_bar = tqdm(disable=True)
 
             eval_results = self.evaluate(model, self.get_val_dataloaders(),
                                          self.num_sanity_val_steps, False)
@@ -828,7 +828,7 @@ class Trainer(TrainerIOMixin,
                 self.early_stop_callback.check_metrics(callback_metrics)
 
         # init progress bar
-        pbar = tqdm.tqdm(leave=True, position=2 * self.process_position,
+        pbar = tqdm(leave=True, position=2 * self.process_position,
                          disable=not self.show_progress_bar, dynamic_ncols=True, unit='batch',
                          file=sys.stdout)
         self.main_progress_bar = pbar


### PR DESCRIPTION
for #330 

This will import the ipywidgets version of tqdm if available. This works nicely in notebooks by not filling up the log.

In the terminal it will use the same old tqdm.

We might also want to consider passing in the tqdm we want as an argument since there may be some edge cases where ipywidgets is available but the interface doesn't support it (e.g. vscode?) or isn't working. In which case people will get a warning message, but may want to configure it themselves.

------------------

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements) *https://github.com/PyTorchLightning/pytorch-lightning/issues/330#event-2979267744*
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?  *No options added*
- [ ] Did you write any new necessary tests?  *Not sure any extra ones are needed*

## What does this PR do?
*Fixes #330 (issue).*

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

*Especially @Borda*

## Did you have fun?
Make sure you had fun coding 🙃 
*:)*
