### PR TITLE
Fix default ckpt path when logger exists

### DIFF
--- a/pytorch_lightning/trainer/callback_config.py
+++ b/pytorch_lightning/trainer/callback_config.py
@@ -23,8 +23,11 @@ class TrainerCallbackConfigMixin(ABC):
         if self.checkpoint_callback is True:
             # init a default one
             if self.logger is not None:
+                save_dir = (getattr(self.logger, 'save_dir', None) or
+                            getattr(self.logger, '_save_dir', None) or
+                            self.default_save_path)
                 ckpt_path = os.path.join(
-                    self.default_save_path,
+                    save_dir,
                     self.logger.name,
                     f'version_{self.logger.version}',
                     "checkpoints"


### PR DESCRIPTION
Fixes #734

But it looks like not all loggers have `save_dir`, in such a case checkpoints will be saved under `default_save_path` as before.