### PR TITLE
Create single file in TensorBoardLogger

### DIFF
--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -6,6 +6,7 @@ from pkg_resources import parse_version
 import torch
 import csv
 from torch.utils.tensorboard import SummaryWriter
+from torch.utils.tensorboard.summary import hparams
 
 from .base import LightningLoggerBase, rank_zero_only
 
@@ -84,8 +85,11 @@ class TensorBoardLogger(LightningLoggerBase):
                 " hyperparameter logging."
             )
         else:
-            # `add_hparams` requires both - hparams and metric
-            self.experiment.add_hparams(hparam_dict=params, metric_dict={})
+            exp, ssi, sei = hparams(params, {})
+            writer = self.experiment._get_file_writer()
+            writer.add_summary(exp)
+            writer.add_summary(ssi)
+            writer.add_summary(sei)
         # some alternative should be added
         self.tags.update(params)
 

--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -6,7 +6,6 @@ from pkg_resources import parse_version
 import torch
 import csv
 from torch.utils.tensorboard import SummaryWriter
-from torch.utils.tensorboard.summary import hparams
 
 from .base import LightningLoggerBase, rank_zero_only
 
@@ -85,6 +84,7 @@ class TensorBoardLogger(LightningLoggerBase):
                 " hyperparameter logging."
             )
         else:
+            from torch.utils.tensorboard.summary import hparams
             exp, ssi, sei = hparams(params, {})
             writer = self.experiment._get_file_writer()
             writer.add_summary(exp)


### PR DESCRIPTION

## What does this PR do?
Fixes #740 

The idea is to hack into `add_hparams` method and instead of creating new tfevents file use existing one.
