### PR TITLE
drop sklearn dependency

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -295,7 +295,7 @@ with open(os.path.join(PATH_ROOT, 'requirements.txt'), 'r') as fp:
             MOCK_REQUIRE_PACKAGES.append(pkg.rstrip())
 
 # TODO: better parse from package since the import name and package name may differ
-MOCK_MANUAL_PACKAGES = ['torch', 'torchvision', 'sklearn', 'test_tube', 'mlflow', 'comet_ml', 'wandb', 'neptune']
+MOCK_MANUAL_PACKAGES = ['torch', 'torchvision', 'test_tube', 'mlflow', 'comet_ml', 'wandb', 'neptune']
 autodoc_mock_imports = MOCK_REQUIRE_PACKAGES + MOCK_MANUAL_PACKAGES
 # for mod_name in MOCK_REQUIRE_PACKAGES:
 #     sys.modules[mod_name] = mock.Mock()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-scikit-learn>=0.20.2
 tqdm>=4.35.0
 numpy>=1.16.4
 torch>=1.1


### PR DESCRIPTION
## What does this PR do?
Attempt to drop `scikit-learn` from dependencies as it seems not to be used anywhere...
As proposed/discussed in https://pytorch-lightning.slack.com/archives/GR9G34QMS/p1579577591033700

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
