### PR TITLE
Fix global_step when gradient accumulation > 1

### DIFF
--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -426,7 +426,9 @@ class TrainerTrainLoopMixin(ABC):
                 # logs user requested information to logger
                 self.log_metrics(batch_step_metrics, grad_norm_dic)
 
-            self.global_step += 1
+            # progress global step according to grads progress
+            if (self.batch_idx + 1) % self.accumulate_grad_batches == 0:
+                self.global_step += 1
             self.total_batch_idx += 1
 
             # end epoch early


### PR DESCRIPTION
# Before submitting

- [X] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [X] Did you make sure to update the docs?   
- [X] Did you write any new necessary tests?  

## What does this PR do?
Fix `global_step` update when gradient accumulation is > 1. 
`global_step` will be updated only after all parts of the batch are done.
Fixes #831

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.