### PR TITLE
docs - anchor links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -360,3 +360,5 @@ autodoc_default_options = {
 }
 
 html_add_permalinks = True
+# http://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html
+autosectionlabel_prefix_document = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -359,6 +359,15 @@ autodoc_default_options = {
     'private-members': True,
 }
 
+# Sphinx will add “permalinks” for each heading and description environment as paragraph signs that
+#  become visible when the mouse hovers over them.
+# This value determines the text for the permalink; it defaults to "¶". Set it to None or the empty
+#  string to disable permalinks.
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_add_permalinks
 html_add_permalinks = True
+
+# True to prefix each section label with the name of the document it is in, followed by a colon.
+#  For example, index:Introduction for a section called Introduction that appears in document index.rst.
+#  Useful for avoiding ambiguity when the same section heading appears in different documents.
 # http://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html
 autosectionlabel_prefix_document = True


### PR DESCRIPTION
## What does this PR do?
Fixes #819. Allow generating a permanent link to a heading next to the title...
![image](https://user-images.githubusercontent.com/6035284/74577211-5ea45600-4f8e-11ea-8790-276fbee7579c.png)

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.