### PR TITLE
[blocked by #789] Fix/dataset check [wip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed a bug where the model checkpointer didn't write to the same directory as the logger ([#771](https://github.com/PyTorchLightning/pytorch-lightning/pull/771))
 - Fixed a bug where the `TensorBoardLogger` class would create an additional empty log file during fitting ([#777](https://github.com/PyTorchLightning/pytorch-lightning/pull/777))
 - Fixed a bug where `global_step` was advanced incorrectly when using `accumulate_grad_batches > 1` ([#832](https://github.com/PyTorchLightning/pytorch-lightning/pull/832))
-- Fixed a bug when using a `DataLoader` without a `dataset` attribute
-- Fixed a bug when using a `IterableDataset` inside the train `DataLoader`
+- Fixed a bug when using a `DataLoader` without a `dataset` attribute ([#883](https://github.com/PyTorchLightning/pytorch-lightning/pull/883))
+- Fixed a bug when using a `IterableDataset` inside the train `DataLoader` ([#883](https://github.com/PyTorchLightning/pytorch-lightning/pull/883))
 
 ## [0.6.0] - 2020-01-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed a bug where the model checkpointer didn't write to the same directory as the logger ([#771](https://github.com/PyTorchLightning/pytorch-lightning/pull/771))
 - Fixed a bug where the `TensorBoardLogger` class would create an additional empty log file during fitting ([#777](https://github.com/PyTorchLightning/pytorch-lightning/pull/777))
 - Fixed a bug where `global_step` was advanced incorrectly when using `accumulate_grad_batches > 1` ([#832](https://github.com/PyTorchLightning/pytorch-lightning/pull/832))
+- Fixed a bug when using a `DataLoader` without a `dataset` attribute
+- Fixed a bug when using a `IterableDataset` inside the train `DataLoader`
 
 ## [0.6.0] - 2020-01-21
 ### Added

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -56,8 +56,8 @@ class TrainerDataLoadingMixin(ABC):
 
         # determine number of training batches
         self.is_iterable_train_dataloader = (
-                EXIST_ITER_DATASET and hasattr(self.get_train_dataloader(), 'dataset')
-                and isinstance(self.get_train_dataloader().dataset, IterableDataset))
+            EXIST_ITER_DATASET and hasattr(self.get_train_dataloader(), 'dataset') and
+            isinstance(self.get_train_dataloader().dataset, IterableDataset))
         if self.is_iterable_train_dataloader:
             self.num_training_batches = float('inf')
         else:
@@ -65,7 +65,8 @@ class TrainerDataLoadingMixin(ABC):
 
             try:
                 self.num_training_batches = len(self.get_train_dataloader())
-                self.num_training_batches = int(self.num_training_batches * self.train_percent_check)
+                self.num_training_batches = int(self.num_training_batches *
+                                                self.train_percent_check)
             except TypeError as e:
                 # Assume infinite data loading if the dataloader doesn't implement __len__
                 if 'has no len' in str(e):

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -322,7 +322,7 @@ class TrainerTrainLoopMixin(ABC):
 
             # reset progress bar
             # .reset() doesn't work on disabled progress bar so we should check
-            if not self.main_progress_bar.disable:
+            if not self.main_progress_bar.disable and num_iterations != float('inf'):
                 self.main_progress_bar.reset(num_iterations)
             desc = f'Epoch {epoch + 1}' if not self.is_iterable_train_dataloader else ''
             self.main_progress_bar.set_description(desc)


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Fixes #840 - also touches part of #698 

- Changed Exception order so that MisconfigurationException will be called and given the correct error when using IterableDataset
- Removed dependency on `Dataloader.dataset` following #840 
- Changed TQDM call to prevent error when `num_training_batches == float('inf')`
- `num_training_batches =float('inf')` is now the default when train dataloader doesn't have `__len__` (in addition to when using an `IterableDataset`)
- Added test for training using an iterable

- Note that these only apply to the train dataloader, test / val using `IterableDataset` will still cause an error, but thought we should merge this first as stops a few annoying behaviours

## PR review
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
