### PR TITLE
updated fast training docs with latest usage

### DIFF
--- a/docs/source/fast_training.rst
+++ b/docs/source/fast_training.rst
@@ -21,7 +21,7 @@ It can be useful to force training for a minimum number of epochs or limit to a 
 .. code-block:: python
 
     # DEFAULT
-    trainer = Trainer(min_nb_epochs=1, max_nb_epochs=1000)
+    trainer = Trainer(min_epochs=1, max_epochs=1000)
 
 
 Set validation check frequency within 1 training epoch


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Updated [fast training docs](https://pytorch-lightning.readthedocs.io/en/latest/fast_training.html) to use the correct parameters (`min_epochs` and `max_epochs`) instead of the deprecated ones (`min_nb_epochs` and `max_nb_epochs`).

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     