### PR TITLE
remove deprecated args to learning rate step function

### DIFF
--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -362,7 +362,7 @@ class TrainerTrainLoopMixin(ABC):
             # update LR schedulers
             if self.lr_schedulers is not None:
                 for lr_scheduler in self.lr_schedulers:
-                    lr_scheduler.step(epoch=self.current_epoch)
+                    lr_scheduler.step()
             if self.reduce_lr_on_plateau_scheduler is not None:
                 val_loss = self.callback_metrics.get('val_loss')
                 if val_loss is None:
@@ -370,7 +370,7 @@ class TrainerTrainLoopMixin(ABC):
                     m = f'ReduceLROnPlateau conditioned on metric val_loss ' \
                         f'which is not available. Available metrics are: {avail_metrics}'
                     raise MisconfigurationException(m)
-                self.reduce_lr_on_plateau_scheduler.step(val_loss, epoch=self.current_epoch)
+                self.reduce_lr_on_plateau_scheduler.step(val_loss)
 
             # early stopping
             met_min_epochs = epoch >= self.min_epochs - 1


### PR DESCRIPTION
# Before submitting

- [x ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [x ] Did you make sure to update the docs?   
- [x ] Did you write any new necessary tests?  
- [x ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/708.

Removing of the deprecated `epoch` argument in the `.step(...)` method of learning rate schedulers. Currently (pytorch 1.4) if the user give a `epoch` argument, an `DeprecationWarning` will be thrown. But looking at the pytorch master branch, the warning has been changed to `UserWarning` meaning that in the future, if the `epoch` argument is not removed, this will give an warning each time a model with a learning rate scheduler is trained. 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
