### PR TITLE
Fix comet logger to log after train

### DIFF
--- a/pytorch_lightning/loggers/comet.py
+++ b/pytorch_lightning/loggers/comet.py
@@ -178,6 +178,14 @@ class CometLogger(LightningLoggerBase):
 
     @rank_zero_only
     def finalize(self, status):
+        r"""
+        When calling self.experiment.end(), that experiment won't log any more data to Comet. That's why, if you need
+        to log any more data you need to create an ExistingCometExperiment. For example, to log data when testing your
+        model after training, because when training is finalized CometLogger.finalize is called.
+
+        This happens automatically in the CometLogger.experiment property, when self._experiment is set to None
+        i.e. self.reset_experiment().
+        """
         self.experiment.end()
         self.reset_experiment()
 


### PR DESCRIPTION
## What does this PR do?
Fixes issue #760.

Updates the `CometLogger` class for it to support logging data after the training is done. For this an `ExistingCometExperiment` is created inside the `CometLogger` object once the training is finalized. When this happens, `CometExperiment.end` is called, which makes this object not to log any more data. 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

