### PR TITLE
Updates theme's Sphinx configuration

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,6 +97,7 @@ templates_path = ['_templates']
 # they should be run at build time.
 nbsphinx_execute = 'never'
 nbsphinx_allow_errors = True
+nbsphinx_requirejs_path = ''
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:


### PR DESCRIPTION
I am updating the project's Sphinx documentation to fix (#819). The issue is related to a library the Sphinx extension `nbsphinx` loads into the docs context (RequireJS). That library conflicts with other theme libraries, causing the latter to not be loaded. This results in several crashes (check the developer consoler), the most obvious of them the lack of anchors. See [this comment](https://github.com/readthedocs/readthedocs.org/issues/6661#issuecomment-588030590) for further details.

Luckily, the good folk from `nbsphinx` added an option to automatically _not load_ RequireJS. The drawback is that we can't use Jupyter Notebook widgets. I didn't see them anywhere in the docs, so I thought it was fine to disable the loading of RequireJS and let the theme's JS libraries be loaded instead.

The fix above solves all errors -- and now anchors work.

![Kapture 2020-02-18 at 23 31 32](https://user-images.githubusercontent.com/953118/74802687-953ce200-52a8-11ea-8841-fdb2d84d0ab0.gif)


# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?   
~- [ ] Did you write any new necessary tests?~
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
#819 which was closed but shouldn't have been because the issue persists.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃


cc @Borda 