### PR TITLE
Fix backwards compatibility for optional logging dependencies

### DIFF
--- a/pytorch_lightning/logging/__init__.py
+++ b/pytorch_lightning/logging/__init__.py
@@ -9,3 +9,4 @@ warnings.warn("`logging` package has been renamed to `loggers` since v0.6.1"
               " The deprecated package name will be removed in v0.8.0.", DeprecationWarning)
 
 from pytorch_lightning.loggers import *  # noqa: F403
+from pytorch_lightning.loggers import base, tensorboard  # noqa: F403

--- a/pytorch_lightning/logging/comet.py
+++ b/pytorch_lightning/logging/comet.py
@@ -1,0 +1,5 @@
+"""
+.. warning:: `logging` package has been renamed to `loggers` since v0.6.1 and will be removed in v0.8.0
+"""
+
+from pytorch_lightning.loggers import comet  # noqa: F403

--- a/pytorch_lightning/logging/mlflow.py
+++ b/pytorch_lightning/logging/mlflow.py
@@ -1,0 +1,5 @@
+"""
+.. warning:: `logging` package has been renamed to `loggers` since v0.6.1 and will be removed in v0.8.0
+"""
+
+from pytorch_lightning.loggers import mlflow  # noqa: F403

--- a/pytorch_lightning/logging/neptune.py
+++ b/pytorch_lightning/logging/neptune.py
@@ -1,0 +1,5 @@
+"""
+.. warning:: `logging` package has been renamed to `loggers` since v0.6.1 and will be removed in v0.8.0
+"""
+
+from pytorch_lightning.loggers import neptune  # noqa: F403

--- a/pytorch_lightning/logging/test_tube.py
+++ b/pytorch_lightning/logging/test_tube.py
@@ -1,0 +1,5 @@
+"""
+.. warning:: `logging` package has been renamed to `loggers` since v0.6.1 and will be removed in v0.8.0
+"""
+
+from pytorch_lightning.loggers import test_tube  # noqa: F403

--- a/pytorch_lightning/logging/wandb.py
+++ b/pytorch_lightning/logging/wandb.py
@@ -1,0 +1,5 @@
+"""
+.. warning:: `logging` package has been renamed to `loggers` since v0.6.1 and will be removed in v0.8.0
+"""
+
+from pytorch_lightning.loggers import wandb  # noqa: F403


### PR DESCRIPTION
# Before submitting

- [X ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [X ] Did you make sure to update the docs?   
- [ X] Did you write any new necessary tests?  
- [ X] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Fixes #798, #799 and #815

There's other ways to fix this, but I felt that adding these redirect files was the simplest and easiest to understand. 