### PR TITLE
Relax hparams in model loading

### DIFF
--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -26,3 +26,21 @@ class LightningTestModel(LightningValidationMixin, LightningTestMixin, Lightning
 
     def on_training_metrics(self, logs):
         logs['some_tensor_to_test'] = torch.rand(1)
+
+
+class LightningTestModelWithoutHyperparametersArg(LightningTestModel):
+    """ without hparams argument in constructor """
+
+    def __init__(self):
+        import tests.models.utils as tutils
+
+        # the user loads the hparams in some other way
+        hparams = tutils.get_hparams()
+        super().__init__(hparams)
+
+
+class LightningTestModelWithUnusedHyperparametersArg(LightningTestModelWithoutHyperparametersArg):
+    """ has hparams argument in constructor but is not used """
+
+    def __init__(self, hparams):
+        super().__init__()


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Fixes #907. Changes model loading behaviour. Four cases:

- **Case 0:** Checkpoint has hparams key and user's LightningModule has hparams argument 
_no change_

- **Case1:** Checkpoint has hparams key and user's LightningModule is missing a hparams argument
_Before:_ raised exception but did not tell user what's wrong
_Now:_ raises exception reminding the user to add hparams. 

- **Case 2:** Checkpoint is missing hparams key and user's LightningModule is also missing it
_Before:_ raised an exception
_Now:_ Loads the model without hparams. This is the usecase in #907.

- **Case 3:** Checkpoint is missing hparams key but user's LightningModule has it.
_Before:_ raised an exception
_Now:_ Loads the model by passing in an empty Namespace and prints a warning.

All tests pass on my single gpu machine.
Some tests fail on my notebook (lazy_dataloader problem)

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
