### PR TITLE
Add tags to the rendezvous calls for TPU. 

### DIFF
--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -233,7 +233,7 @@ class TrainerDataLoadingMixin(ABC):
                 self.get_val_dataloaders()
 
             # wait for all processes to catch up
-            torch_xla.core.xla_model.rendezvous()
+            torch_xla.core.xla_model.rendezvous("pl.TrainerDataLoadingMixin.get_dataloaders")
 
         # support IterableDataset for train data
         self.is_iterable_train_dataloader = (

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1002,7 +1002,7 @@ class Trainer(TrainerIOMixin,
         # wait for all models to restore weights
         if self.on_tpu and XLA_AVAILABLE:
             # wait for all processes to catch up
-            torch_xla.core.xla_model.rendezvous()
+            torch_xla.core.xla_model.rendezvous("pl.Trainer.run_pretrain_routine")
 
         # set up checkpoint callback
         self.configure_checkpoint_callback()

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -183,7 +183,7 @@ class TrainerIOMixin(ABC):
         # wait for all models to restore weights
         if self.on_tpu and XLA_AVAILABLE:
             # wait for all processes to catch up
-            torch_xla.core.xla_model.rendezvous()
+            torch_xla.core.xla_model.rendezvous("pl.TrainerIOMixin.restore_weights")
 
         # clear cache after restore
         if self.on_gpu:


### PR DESCRIPTION
According to the docs in XLA calls to `rendezvous` need to have a tag argument, i.e.
https://github.com/pytorch/xla/blob/d99ef16e523fa8376db75508ed5b09593964d112/torch_xla/core/xla_model.py#L495

Getting the following error without this:
```
Exception in device=TPU:0: rendezvous() missing 1 required positional argument: 'tag'
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/torch_xla/distributed/xla_multiprocessing.py", line 119, in _start_fn
    fn(gindex, *args)
  File "/usr/local/lib/python3.6/dist-packages/pytorch_lightning/trainer/distrib_parts.py", line 499, in tpu_train
    self.run_pretrain_routine(model)
  File "/usr/local/lib/python3.6/dist-packages/pytorch_lightning/trainer/trainer.py", line 1005, in run_pretrain_routine
    torch_xla.core.xla_model.rendezvous()
TypeError: rendezvous() missing 1 required positional argument: 'tag'
An exception has occurred, use %tb to see the full traceback.
```
