### PR TITLE
Use callable object for patching dataloaders

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1191,7 +1191,7 @@ class _PatchDataLoader(object):
     def __init__(self, dataloader: Union[List[DataLoader], DataLoader]):
         self.dataloader = dataloader
 
-    def __call__(self):
+    def __call__(self) -> Union[List[DataLoader], DataLoader]:
         return self.dataloader
 
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1188,7 +1188,7 @@ class _PatchDataLoader(object):
     Args:
         dataloader: Dataloader object to return when called.
     '''
-    def __init__(self, dataloader):
+    def __init__(self, dataloader: Union[List[DataLoader], DataLoader]):
         self.dataloader = dataloader
 
     def __call__(self):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1002,30 +1002,21 @@ class Trainer(TrainerIOMixin,
                 m = 'You called .fit() with a train_dataloader but did not define training_step()'
                 raise MisconfigurationException(m)
 
-            def patch_train_dataloader():
-                return train_dataloader
-
-            model.train_dataloader = patch_train_dataloader
+            model.train_dataloader = _PatchDataLoader(train_dataloader)
 
         if val_dataloaders is not None:
             if not self.is_overriden('validation_step', model):
                 m = 'You called .fit() with a val_dataloaders but did not define validation_step()'
                 raise MisconfigurationException(m)
 
-            def patch_val_dataloader():
-                return val_dataloaders
-
-            model.val_dataloader = patch_val_dataloader
+            model.val_dataloader = _PatchDataLoader(val_dataloaders)
 
         if test_dataloaders is not None:
             if not self.is_overriden('test_step', model):
                 m = 'You called .fit() with a test_dataloaders but did not define test_step()'
                 raise MisconfigurationException(m)
 
-            def patch_test_dataloader():
-                return test_dataloaders
-
-            model.test_dataloader = patch_test_dataloader
+            model.test_dataloader = _PatchDataLoader(test_dataloaders)
 
     def init_optimizers(
             self,
@@ -1187,6 +1178,21 @@ class Trainer(TrainerIOMixin,
         if model is not None:
             self.fit(model)
         self.run_evaluation(test_mode=True)
+
+
+class _PatchDataLoader(object):
+    r'''
+    Callable object for patching dataloaders passed into trainer.fit().
+    Use this class to override model.*_dataloader() and be pickle-compatible.
+
+    Args:
+        dataloader: Dataloader object to return when called.
+    '''
+    def __init__(self, dataloader):
+        self.dataloader = dataloader
+
+    def __call__(self):
+        return self.dataloader
 
 
 def _set_dataloader(model, dataloader, attribute):

--- a/tests/test_gpu_models.py
+++ b/tests/test_gpu_models.py
@@ -66,6 +66,31 @@ def test_multi_gpu_model_ddp(tmpdir):
     tutils.run_model_test(trainer_options, model)
 
 
+def test_ddp_all_dataloaders_passed_to_fit(tmpdir):
+    """Make sure DDP works with dataloaders passed to fit()"""
+    if not tutils.can_run_gpu_test():
+        return
+
+    tutils.reset_seed()
+    tutils.set_random_master_port()
+
+    model, hparams = tutils.get_model()
+    trainer_options = dict(default_save_path=tmpdir,
+                           show_progress_bar=False,
+                           max_epochs=1,
+                           train_percent_check=0.4,
+                           val_percent_check=0.2,
+                           gpus=[0, 1],
+                           distributed_backend='ddp')
+
+    fit_options = dict(train_dataloader=model.train_dataloader(),
+                       val_dataloaders=model.val_dataloader())
+
+    trainer = Trainer(**trainer_options)
+    result = trainer.fit(model, **fit_options)
+    assert result == 1, "DDP doesn't work with dataloaders passed to fit()."
+
+
 def test_optimizer_return_options():
     tutils.reset_seed()
 


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
    - not sure if there's anywhere I need to
- [x] Did you write any new necessary tests?  
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Fixes #968 .

Changes how we patch dataloaders when passed to `trainer.fit()` so that it's pickleable

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
