### PR TITLE
Fix load_from_checkpoint docs

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1168,15 +1168,6 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
                 def __init__(self, hparams):
                     self.learning_rate = hparams.learning_rate
 
-            # --------------
-            # Case 2
-            # when using a dict
-            model = MyModel({'learning_rate': 0.1})
-
-            class MyModel(LightningModule):
-                def __init__(self, hparams):
-                    self.learning_rate = hparams['learning_rate']
-
         Args:
             checkpoint_path (str): Path to checkpoint.
             map_location (dict | str | torch.device | function):


### PR DESCRIPTION
We don't (yet) support storing hparams a a dict. It *must*
be an `argparse.Namespace` for checkpoint saving and
loading to work.

Also opened #977 to start supporting this, but lets fix the docs for now.