### PR TITLE
[Docs] Fix val_loss not referencing a variable

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -327,7 +327,7 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
 
                 # implement your own
                 out = self.forward(x)
-                loss = self.loss(out, y)
+                val_loss = self.loss(out, y)
 
                 # log 6 example images
                 # or generated text... or whatever


### PR DESCRIPTION
In validation step, the val_loss variable does not reference a declared variable in the example.