### PR TITLE
Fix broken `Trainer.test`

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1177,7 +1177,8 @@ class Trainer(TrainerIOMixin,
         self.testing = True
         if model is not None:
             self.fit(model)
-        self.run_evaluation(test_mode=True)
+        else:
+            self.run_evaluation(test_mode=True)
 
 
 class _PatchDataLoader(object):


### PR DESCRIPTION
Fixes #979 and #1007. Note that #770 claims to fix this problem as well (https://github.com/PyTorchLightning/pytorch-lightning/issues/1007#issuecomment-593436335), but includes other changes. 