### PR TITLE
handle keyboard interrupt for ddp .test()

### DIFF
--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -371,6 +371,8 @@ class TrainerDDPMixin(ABC):
         # remove ddp weights
         os.remove(path)
 
+        return loaded_model
+
     def resolve_root_node_address(self, root_node):
         if '[' in root_node:
             name = root_node.split('[')[0]

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -351,10 +351,8 @@ class TrainerDDPMixin(ABC):
         :return:
         """
         if self.proc_rank == 0:
-            print('-' * 100)
             path = os.path.join(self.default_save_path, '__temp_weight_ddp_end.ckpt')
             self.save_checkpoint(path)
-            print('saved checkpoint!!')
 
     def load_spawn_weights(self, original_model):
         """
@@ -372,7 +370,6 @@ class TrainerDDPMixin(ABC):
 
         # remove ddp weights
         os.remove(path)
-        print('loaded checkpoint!!')
 
     def resolve_root_node_address(self, root_node):
         if '[' in root_node:

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -339,7 +339,10 @@ class TrainerDDPMixin(ABC):
         model = model.configure_ddp(model, device_ids)
 
         # continue training routine
-        self.run_pretrain_routine(model)
+        try:
+            self.run_pretrain_routine(model)
+        except KeyboardInterrupt:
+            print('keyboard pressed...')
 
         # when ddp ends, we save the model
         self.save_spawn_weights(model)

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -353,8 +353,9 @@ class TrainerDDPMixin(ABC):
         :param model:
         :return:
         """
-        path = os.path.join(self.default_save_path, '__temp_weight_ddp_end.ckpt')
-        self.save_checkpoint(path)
+        if self.proc_rank == 0:
+            path = os.path.join(self.default_save_path, '__temp_weight_ddp_end.ckpt')
+            self.save_checkpoint(path)
 
     def load_spawn_weights(self, original_model):
         """

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -372,6 +372,7 @@ class TrainerDDPMixin(ABC):
 
         # remove ddp weights
         os.remove(path)
+        print('loaded checkpoint!!')
 
     def resolve_root_node_address(self, root_node):
         if '[' in root_node:

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -354,6 +354,7 @@ class TrainerDDPMixin(ABC):
             print('-' * 100)
             path = os.path.join(self.default_save_path, '__temp_weight_ddp_end.ckpt')
             self.save_checkpoint(path)
+            print('saved checkpoint!!')
 
     def load_spawn_weights(self, original_model):
         """

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -350,8 +350,8 @@ class TrainerDDPMixin(ABC):
         :param model:
         :return:
         """
-        print('-' * 100)
         if self.proc_rank == 0:
+            print('-' * 100)
             path = os.path.join(self.default_save_path, '__temp_weight_ddp_end.ckpt')
             self.save_checkpoint(path)
 

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -339,10 +339,7 @@ class TrainerDDPMixin(ABC):
         model = model.configure_ddp(model, device_ids)
 
         # continue training routine
-        try:
-            self.run_pretrain_routine(model)
-        except KeyboardInterrupt:
-            print('keyboard pressed...')
+        self.run_pretrain_routine(model)
 
         # when ddp ends, we save the model
         self.save_spawn_weights(model)
@@ -353,6 +350,7 @@ class TrainerDDPMixin(ABC):
         :param model:
         :return:
         """
+        print('-' * 100)
         if self.proc_rank == 0:
             path = os.path.join(self.default_save_path, '__temp_weight_ddp_end.ckpt')
             self.save_checkpoint(path)

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -337,6 +337,7 @@ Here lightning distributes parts of your module across available GPUs to optimiz
 from abc import ABC, abstractmethod
 import logging as log
 import os
+import signal
 
 import torch
 
@@ -494,6 +495,13 @@ class TrainerDPMixin(ABC):
         m = f'INIT TPU local core: {self.tpu_local_core_rank}, ' \
             f'global rank: {self.tpu_global_core_rank}'
         log.info(m)
+
+        def signal_handle(_signal, frame):
+            print(frame)
+            print('*' * 100)
+            self.save_spawn_weights(model)
+
+        signal.signal(signal.SIGINT, signal_handle)
 
         # continue training routine
         self.run_pretrain_routine(model)

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -496,16 +496,10 @@ class TrainerDPMixin(ABC):
             f'global rank: {self.tpu_global_core_rank}'
         log.info(m)
 
-        def signal_handle(_signal, frame):
-            self.save_spawn_weights(model)
-
-        if self.proc_rank == 0:
-            signal.signal(signal.SIGINT, signal_handle)
-
         # continue training routine
         self.run_pretrain_routine(model)
 
-        # self.save_spawn_weights(model)
+        self.save_spawn_weights(model)
 
     def dp_train(self, model):
 

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -497,11 +497,10 @@ class TrainerDPMixin(ABC):
         log.info(m)
 
         def signal_handle(_signal, frame):
-            print(frame)
-            print('*' * 100)
             self.save_spawn_weights(model)
 
-        signal.signal(signal.SIGINT, signal_handle)
+        if self.proc_rank == 0:
+            signal.signal(signal.SIGINT, signal_handle)
 
         # continue training routine
         self.run_pretrain_routine(model)

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -506,7 +506,7 @@ class TrainerDPMixin(ABC):
         # continue training routine
         self.run_pretrain_routine(model)
 
-        self.save_spawn_weights(model)
+        # self.save_spawn_weights(model)
 
     def dp_train(self, model):
 

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -496,10 +496,7 @@ class TrainerDPMixin(ABC):
         log.info(m)
 
         # continue training routine
-        try:
-            self.run_pretrain_routine(model)
-        except KeyboardInterrupt:
-            print('keyboard pressed...')
+        self.run_pretrain_routine(model)
 
         self.save_spawn_weights(model)
 

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -494,7 +494,12 @@ class TrainerDPMixin(ABC):
         m = f'INIT TPU local core: {self.tpu_local_core_rank}, ' \
             f'global rank: {self.tpu_global_core_rank}'
         log.info(m)
-        self.run_pretrain_routine(model)
+
+        # continue training routine
+        try:
+            self.run_pretrain_routine(model)
+        except KeyboardInterrupt:
+            print('keyboard pressed...')
 
         self.save_spawn_weights(model)
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1217,7 +1217,6 @@ class Trainer(TrainerIOMixin,
             if os.path.exists(path):
                 self.load_spawn_weights(self.model)
 
-            import pdb; pdb.set_trace()
             self.fit(self.model)
         else:
             self.run_evaluation(test_mode=True)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -978,7 +978,6 @@ class Trainer(TrainerIOMixin,
             #  COLAB_GPU is an env var available by default in Colab environments.
             start_method = 'fork' if os.getenv('COLAB_GPU') else 'spawn'
             xmp.spawn(self.tpu_train, args=(model,), nprocs=self.num_tpu_cores, start_method=start_method)
-            print('0' * 100)
             self.load_spawn_weights(model)
             self.model = model
 
@@ -1194,12 +1193,18 @@ class Trainer(TrainerIOMixin,
             trainer = Trainer()
             trainer.test(model)
         """
+
         self.testing = True
-        import pdb; pdb.set_trace()
         if model is not None:
             self.model = model
             self.fit(model)
-        elif self.model is not None and (self.use_ddp or self.use_tpu):
+        elif self.use_ddp or self.use_tpu:
+            import pdb; pdb.set_trace()
+            # attempt to load weights from a ddp process
+            path = os.path.join(self.default_save_path, '__temp_weight_ddp_end.ckpt')
+            if os.path.exists(path):
+                self.load_spawn_weights(self.model)
+
             self.fit(self.model)
         else:
             self.run_evaluation(test_mode=True)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1214,6 +1214,7 @@ class Trainer(TrainerIOMixin,
         elif self.use_ddp or self.use_tpu:
             # attempt to load weights from a spawn
             path = os.path.join(self.default_save_path, '__temp_weight_ddp_end.ckpt')
+            test_model = self.model
             if os.path.exists(path):
                 test_model = self.load_spawn_weights(self.model)
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1215,9 +1215,9 @@ class Trainer(TrainerIOMixin,
             # attempt to load weights from a spawn
             path = os.path.join(self.default_save_path, '__temp_weight_ddp_end.ckpt')
             if os.path.exists(path):
-                self.load_spawn_weights(self.model)
+                test_model = self.load_spawn_weights(self.model)
 
-            self.fit(self.model)
+            self.fit(test_model)
         else:
             self.run_evaluation(test_mode=True)
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1217,9 +1217,6 @@ class Trainer(TrainerIOMixin,
             if os.path.exists(path):
                 self.load_spawn_weights(self.model)
 
-            # TODO: allow test to run on all cores. 1 core only that works now
-            self.num_tpu_cores = 1
-
             self.fit(self.model)
         else:
             self.run_evaluation(test_mode=True)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -959,8 +959,14 @@ class Trainer(TrainerIOMixin,
                 self.ddp_train(task, model)
             else:
                 self.__set_random_port()
+
+                # track for predict
+                self.model = model
+
+                # train
                 mp.spawn(self.ddp_train, nprocs=self.num_gpus, args=(model,))
-                print('0'*100)
+
+                # load weights if not interrupted
                 self.load_spawn_weights(model)
                 self.model = model
 
@@ -977,7 +983,14 @@ class Trainer(TrainerIOMixin,
 
             #  COLAB_GPU is an env var available by default in Colab environments.
             start_method = 'fork' if os.getenv('COLAB_GPU') else 'spawn'
+
+            # track for predict
+            self.model = model
+
+            # train
             xmp.spawn(self.tpu_train, args=(model,), nprocs=self.num_tpu_cores, start_method=start_method)
+
+            # load weights if not interrupted
             self.load_spawn_weights(model)
             self.model = model
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1195,6 +1195,7 @@ class Trainer(TrainerIOMixin,
             trainer.test(model)
         """
         self.testing = True
+        import pdb; pdb.set_trace()
         if model is not None:
             self.model = model
             self.fit(model)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -978,6 +978,7 @@ class Trainer(TrainerIOMixin,
             #  COLAB_GPU is an env var available by default in Colab environments.
             start_method = 'fork' if os.getenv('COLAB_GPU') else 'spawn'
             xmp.spawn(self.tpu_train, args=(model,), nprocs=self.num_tpu_cores, start_method=start_method)
+            print('0' * 100)
             self.load_spawn_weights(model)
             self.model = model
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -960,6 +960,7 @@ class Trainer(TrainerIOMixin,
             else:
                 self.__set_random_port()
                 mp.spawn(self.ddp_train, nprocs=self.num_gpus, args=(model,))
+                print('0'*100)
                 self.load_spawn_weights(model)
                 self.model = model
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1212,12 +1212,12 @@ class Trainer(TrainerIOMixin,
             self.model = model
             self.fit(model)
         elif self.use_ddp or self.use_tpu:
-            import pdb; pdb.set_trace()
             # attempt to load weights from a ddp process
             path = os.path.join(self.default_save_path, '__temp_weight_ddp_end.ckpt')
             if os.path.exists(path):
                 self.load_spawn_weights(self.model)
 
+            import pdb; pdb.set_trace()
             self.fit(self.model)
         else:
             self.run_evaluation(test_mode=True)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1212,10 +1212,13 @@ class Trainer(TrainerIOMixin,
             self.model = model
             self.fit(model)
         elif self.use_ddp or self.use_tpu:
-            # attempt to load weights from a ddp process
+            # attempt to load weights from a spawn
             path = os.path.join(self.default_save_path, '__temp_weight_ddp_end.ckpt')
             if os.path.exists(path):
                 self.load_spawn_weights(self.model)
+
+            # TODO: allow test to run on all cores. 1 core only that works now
+            self.num_tpu_cores = 1
 
             self.fit(self.model)
         else:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1238,21 +1238,6 @@ class _PatchDataLoader(object):
         return self.dataloader
 
 
-class _PatchDataLoader(object):
-    r'''
-    Callable object for patching dataloaders passed into trainer.fit().
-    Use this class to override model.*_dataloader() and be pickle-compatible.
-
-    Args:
-        dataloader: Dataloader object to return when called.
-    '''
-    def __init__(self, dataloader: Union[List[DataLoader], DataLoader]):
-        self.dataloader = dataloader
-
-    def __call__(self) -> Union[List[DataLoader], DataLoader]:
-        return self.dataloader
-
-
 def _set_dataloader(model, dataloader, attribute):
     r'''
     Check dataloaders passed to .fit() method if they are pytorch DataLoader

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -236,8 +236,9 @@ class TrainerIOMixin(ABC):
         model = self.get_model()
 
         if self.on_tpu:
-            tpu_model = deepcopy(model).cpu()
-            checkpoint['state_dict'] = tpu_model.state_dict()
+            xm.save(model, 'tmp_tpu_tensors.pt')
+            tpu_tensors = torch.load('tmp_tpu_tensors.pt')
+            checkpoint['state_dict'] = tpu_tensors.state_dict()
         else:
             checkpoint['state_dict'] = model.state_dict()
 

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -236,7 +236,7 @@ class TrainerIOMixin(ABC):
         model = self.get_model()
 
         if self.on_tpu:
-            xm.save(model, 'tmp_tpu_tensors.pt')
+            xm.save(model.state_dict(), 'tmp_tpu_tensors.pt')
             tpu_tensors = torch.load('tmp_tpu_tensors.pt')
             os.remove('tmp_tpu_tensors.pt')
 

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -6,6 +6,7 @@ import warnings
 from abc import ABC
 from subprocess import call
 from typing import Union
+from copy import deepcopy
 
 import torch
 import torch.distributed as dist
@@ -235,7 +236,8 @@ class TrainerIOMixin(ABC):
         model = self.get_model()
 
         if self.on_tpu:
-            checkpoint['state_dict'] = model.cpu().state_dict()
+            tpu_model = deepcopy(model).cpu()
+            checkpoint['state_dict'] = tpu_model.state_dict()
         else:
             checkpoint['state_dict'] = model.state_dict()
 

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -233,7 +233,12 @@ class TrainerIOMixin(ABC):
 
         # add the hparams and state_dict from the model
         model = self.get_model()
-        checkpoint['state_dict'] = model.state_dict()
+
+        if self.on_tpu:
+            checkpoint['state_dict'] = model.cpu().state_dict()
+        else:
+            checkpoint['state_dict'] = model.state_dict()
+
         if hasattr(model, "hparams"):
             checkpoint['hparams'] = vars(model.hparams)
         else:

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -238,6 +238,8 @@ class TrainerIOMixin(ABC):
         if self.on_tpu:
             xm.save(model, 'tmp_tpu_tensors.pt')
             tpu_tensors = torch.load('tmp_tpu_tensors.pt')
+            os.remove('tmp_tpu_tensors.pt')
+
             checkpoint['state_dict'] = tpu_tensors.state_dict()
         else:
             checkpoint['state_dict'] = model.state_dict()

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -235,14 +235,7 @@ class TrainerIOMixin(ABC):
         # add the hparams and state_dict from the model
         model = self.get_model()
 
-        if self.on_tpu:
-            xm.save(model.state_dict(), 'tmp_tpu_tensors.pt')
-            tpu_tensors = torch.load('tmp_tpu_tensors.pt')
-            os.remove('tmp_tpu_tensors.pt')
-
-            checkpoint['state_dict'] = tpu_tensors.state_dict()
-        else:
-            checkpoint['state_dict'] = model.state_dict()
+        checkpoint['state_dict'] = model.state_dict()
 
         if hasattr(model, "hparams"):
             checkpoint['hparams'] = vars(model.hparams)


### PR DESCRIPTION
When keyboard interrupt stops training, model doesn't get to save and load state to exit spawn.

In the .test() we see if there was a spawn checkpoint saved.
solves the DDP problem but not TPU.

Also doesn't solve the problem of returning the weights to the user once training is done without calling .test() (only a problem on colab).

```
-- Process 0 terminated with the following error:
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/torch/multiprocessing/spawn.py", line 20, in _wrap
    fn(i, *args)
  File "/usr/local/lib/python3.6/dist-packages/torch_xla/distributed/xla_multiprocessing.py", line 116, in _start_fn
    _setup_replication()
  File "/usr/local/lib/python3.6/dist-packages/torch_xla/distributed/xla_multiprocessing.py", line 109, in _setup_replication
    xm.set_replication(str(device), [str(device)])
  File "/usr/local/lib/python3.6/dist-packages/torch_xla/core/xla_model.py", line 199, in set_replication
    replication_devices = xla_replication_devices(devices)
  File "/usr/local/lib/python3.6/dist-packages/torch_xla/core/xla_model.py", line 186, in xla_replication_devices
    .format(len(local_devices), len(kind_devices)))
RuntimeError: Cannot replicate if number of devices (1) is different from 8
```

@dlibenzi any thoughts?