### PR TITLE
fix Github action

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -17,7 +17,7 @@ jobs:
     # https://stackoverflow.com/a/59076067/4521646
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -8,7 +8,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: ammaraskar/sphinx-action@master
       with:
         # git is requried to clone the docs theme


### PR DESCRIPTION
## What does this PR do?
The v1 has a problem with re-run failing test, it crashes while checkout repo, see https://github.com/actions/checkout/issues/23
original error:
```
git checkout --progress --force c6eed6899d8c459840ccd18f5a8dd51eed7af437
##[error]fatal: reference is not a tree: c6eed6899d8c459840ccd18f5a8dd51eed7af437
Removed matchers: 'checkout-git'
##[error]Git checkout failed with exit code: 128
##[error]Exit code 1 returned from process: file name '/home/runner/runners/2.165.2/bin/Runner.PluginHost', arguments 'action "GitHub.Runner.Plugins.Repository.v1_0.CheckoutTask, Runner.Plugins"'.
```

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
