### PR TITLE
remove extra whitespace from exception message

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1387,7 +1387,7 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
             else:
                 raise MisconfigurationException(
                     f"Checkpoint contains hyperparameters but {cls.__name__}'s __init__ "
-                    f"is missing the  argument 'hparams'. Are you loading the correct checkpoint?"
+                    f"is missing the argument 'hparams'. Are you loading the correct checkpoint?"
                 )
 
         # load the state_dict on the model automatically


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Fixes `tests/test_restore_models.py` for test `test_load_model_with_missing_hparams`. The test is expecting us to raise a `MisconfigurationException` which we do, but the expected pattern is not matched because there's an extra whitespace in the exception message. 

```
with pytest.raises(MisconfigurationException, match=r".*__init__ is missing the argument 'hparams'.*"):
        LightningTestModelWithoutHyperparametersArg.load_from_checkpoint(last_checkpoint)
```

versus

```
raise MisconfigurationException(
                    f"Checkpoint contains hyperparameters but {cls.__name__}'s __init__ "
                    f"is missing the  argument 'hparams'. Are you loading the correct checkpoint?"
                )
```

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
