### PR TITLE
change default logger to dedicated one

### DIFF
--- a/pl_examples/basic_examples/lightning_module_template.py
+++ b/pl_examples/basic_examples/lightning_module_template.py
@@ -1,7 +1,6 @@
 """
 Example template for defining a system
 """
-import logging as log
 import os
 from argparse import ArgumentParser
 from collections import OrderedDict
@@ -14,6 +13,7 @@ from torch import optim
 from torch.utils.data import DataLoader
 from torchvision.datasets import MNIST
 
+from pytorch_lightning import _logger as log
 from pytorch_lightning.core import LightningModule
 
 

--- a/pytorch_lightning/__init__.py
+++ b/pytorch_lightning/__init__.py
@@ -24,6 +24,9 @@ if __LIGHTNING_SETUP__:
     # We are not importing the rest of the scikit during the build
     # process, as it may not be compiled yet
 else:
+    from logging import getLogger
+    _logger = getLogger("lightning")
+
     from .core import LightningModule
     from .trainer import Trainer
     from .callbacks import Callback

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -5,12 +5,12 @@ Stop training when a monitored quantity has stopped improving.
 
 """
 
-import logging as log
 import warnings
 
 import numpy as np
 
 from .base import Callback
+from pytorch_lightning import _logger as log
 
 
 class EarlyStopping(Callback):

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -5,7 +5,6 @@ Model Checkpointing
 Automatically save model checkpoints during training.
 """
 
-import logging as log
 import os
 import shutil
 import warnings
@@ -14,6 +13,7 @@ import re
 import numpy as np
 
 from pytorch_lightning.callbacks.base import Callback
+from pytorch_lightning import _logger as log
 
 
 class ModelCheckpoint(Callback):

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1,6 +1,5 @@
 import collections
 import inspect
-import logging as log
 import os
 import warnings
 from abc import ABC, abstractmethod
@@ -15,6 +14,7 @@ from torch.optim import Adam
 from torch.optim.optimizer import Optimizer
 from torch.utils.data import DataLoader
 
+from pytorch_lightning import _logger as log
 from pytorch_lightning.core.grads import GradInformation
 from pytorch_lightning.core.hooks import ModelHooks
 from pytorch_lightning.core.memory import ModelSummary

--- a/pytorch_lightning/core/memory.py
+++ b/pytorch_lightning/core/memory.py
@@ -3,7 +3,6 @@ Generates a summary of a model's layers and dimensionality
 """
 
 import gc
-import logging as log
 import os
 import subprocess
 from subprocess import PIPE
@@ -14,6 +13,8 @@ import torch
 from torch.nn import Module
 
 import pytorch_lightning as pl
+
+from pytorch_lightning import _logger as log
 
 
 class ModelSummary(object):

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -1,8 +1,9 @@
 import csv
-import logging as log
 import os
 from argparse import Namespace
 from typing import Union, Dict, Any
+
+from pytorch_lightning import _logger as log
 
 
 class ModelIO(object):

--- a/pytorch_lightning/loggers/comet.py
+++ b/pytorch_lightning/loggers/comet.py
@@ -6,7 +6,6 @@ CometLogger
 -------------
 """
 
-import logging as log
 from argparse import Namespace
 from typing import Optional, Dict, Union, Any
 
@@ -27,8 +26,9 @@ except ImportError:
 import torch
 from torch import is_tensor
 
+from pytorch_lightning import _logger as log
+from pytorch_lightning.loggers.base import LightningLoggerBase, rank_zero_only
 from pytorch_lightning.utilities.debugging import MisconfigurationException
-from .base import LightningLoggerBase, rank_zero_only
 
 
 class CometLogger(LightningLoggerBase):

--- a/pytorch_lightning/loggers/mlflow.py
+++ b/pytorch_lightning/loggers/mlflow.py
@@ -23,7 +23,6 @@ Use the logger anywhere in you LightningModule as follows:
         self.logger.experiment.whatever_ml_flow_supports(...)
 
 """
-import logging as log
 from argparse import Namespace
 from time import time
 from typing import Optional, Dict, Any, Union
@@ -34,7 +33,8 @@ except ImportError:
     raise ImportError('You want to use `mlflow` logger which is not installed yet,'
                       ' install it with `pip install mlflow`.')
 
-from .base import LightningLoggerBase, rank_zero_only
+from pytorch_lightning import _logger as log
+from pytorch_lightning.loggers.base import LightningLoggerBase, rank_zero_only
 
 
 class MLFlowLogger(LightningLoggerBase):

--- a/pytorch_lightning/loggers/neptune.py
+++ b/pytorch_lightning/loggers/neptune.py
@@ -6,7 +6,6 @@ Log using `neptune-logger <https://neptune.ai>`_
 NeptuneLogger
 --------------
 """
-import logging as log
 from argparse import Namespace
 from typing import Optional, List, Dict, Any, Union, Iterable
 
@@ -20,6 +19,7 @@ except ImportError:
 import torch
 from torch import is_tensor
 
+from pytorch_lightning import _logger as log
 from pytorch_lightning.loggers.base import LightningLoggerBase, rank_zero_only
 
 

--- a/pytorch_lightning/loggers/trains.py
+++ b/pytorch_lightning/loggers/trains.py
@@ -24,7 +24,6 @@ Use the logger anywhere in you LightningModule as follows:
 
 """
 
-import logging as log
 from argparse import Namespace
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
@@ -38,7 +37,8 @@ except ImportError:
     raise ImportError('You want to use `TRAINS` logger which is not installed yet,'
                       ' install it with `pip install trains`.')
 
-from .base import LightningLoggerBase, rank_zero_only
+from pytorch_lightning import _logger as log
+from pytorch_lightning.loggers.base import LightningLoggerBase, rank_zero_only
 
 
 class TrainsLogger(LightningLoggerBase):

--- a/pytorch_lightning/profiler/profiler.py
+++ b/pytorch_lightning/profiler/profiler.py
@@ -1,6 +1,5 @@
 import cProfile
 import io
-import logging as log
 import pstats
 import time
 from abc import ABC, abstractmethod
@@ -8,6 +7,8 @@ from collections import defaultdict
 from contextlib import contextmanager
 
 import numpy as np
+
+from pytorch_lightning import _logger as log
 
 
 class BaseProfiler(ABC):

--- a/pytorch_lightning/trainer/auto_mix_precision.py
+++ b/pytorch_lightning/trainer/auto_mix_precision.py
@@ -1,5 +1,6 @@
-import logging as log
 from abc import ABC
+
+from pytorch_lightning import _logger as log
 
 try:
     from apex import amp

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -113,7 +113,6 @@ When the script starts again, Lightning will:
 
 """
 
-import logging as log
 import os
 import re
 import warnings
@@ -121,7 +120,7 @@ from abc import ABC, abstractmethod
 from typing import Union
 
 import torch
-
+from pytorch_lightning import _logger as log
 from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.utilities.debugging import MisconfigurationException
 

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -334,12 +334,12 @@ Here lightning distributes parts of your module across available GPUs to optimiz
 
 """
 
-import logging as log
 import os
 from abc import ABC, abstractmethod
 
 import torch
 
+from pytorch_lightning import _logger as log
 from pytorch_lightning.overrides.data_parallel import (
     LightningDistributedDataParallel,
     LightningDataParallel,

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1,5 +1,4 @@
 import inspect
-import logging as log
 import os
 import sys
 import warnings
@@ -14,8 +13,8 @@ from torch.optim.optimizer import Optimizer
 from torch.utils.data import DataLoader
 from tqdm.auto import tqdm
 
-from pytorch_lightning.callbacks import Callback
-from pytorch_lightning.callbacks import ModelCheckpoint, EarlyStopping
+from pytorch_lightning import _logger as log
+from pytorch_lightning.callbacks import ModelCheckpoint, EarlyStopping, Callback
 from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.profiler import Profiler, PassThroughProfiler
 from pytorch_lightning.profiler.profiler import BaseProfiler

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -89,7 +89,6 @@ At a rough level, here's what happens inside Trainer :py:mod:`pytorch_lightning.
 
 """
 
-import logging as log
 import os
 import re
 import signal
@@ -102,6 +101,7 @@ from typing import Union
 import torch
 import torch.distributed as torch_distrib
 
+from pytorch_lightning import _logger as log
 from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.overrides.data_parallel import (

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -122,7 +122,6 @@ When this flag is enabled each batch is split into sequences of size truncated_b
 """
 
 import copy
-import logging as log
 import warnings
 from abc import ABC, abstractmethod
 from typing import Callable
@@ -131,6 +130,7 @@ from typing import Union, List
 import numpy as np
 from torch.utils.data import DataLoader
 
+from pytorch_lightning import _logger as log
 from pytorch_lightning.callbacks.base import Callback
 from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.loggers import LightningLoggerBase

--- a/pytorch_lightning/trainer/training_tricks.py
+++ b/pytorch_lightning/trainer/training_tricks.py
@@ -1,9 +1,9 @@
-import logging as log
 import math
 from abc import ABC, abstractmethod
 
 import torch
 
+from pytorch_lightning import _logger as log
 from pytorch_lightning.callbacks import GradientAccumulationScheduler
 
 EPSILON = 1e-6


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Changed the default logger to `logging.getLogger("lightning")` as proposed here: https://github.com/PyTorchLightning/pytorch-lightning/issues/710#issuecomment-592973492
This modification won't make any difference to current users since the logging will propagate to root logger. However if the user want to distinguish the text log from pytorch-lightning from logs of other packages, they have an option now.

