### PR TITLE
reduce nb CI builds

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -1,6 +1,15 @@
 name: CI testing
 
-on: [push, pull_request]
+# https://help.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
## What does this PR do?
 with general CI, when we are working with root repo and making PR it triggers a double number of tests as one full set is for PR and another for regular push lol

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
