### PR TITLE
Fix examples that uses type_as

### DIFF
--- a/docs/source/multi_gpu.rst
+++ b/docs/source/multi_gpu.rst
@@ -38,7 +38,7 @@ This will make your code scale to any arbitrary number of GPUs or TPUs with Ligh
     # with lightning
     def forward(self, x):
         z = torch.Tensor(2, 3)
-        z = z.type_as(x.type())
+        z = z.type_as(x)
 
 Remove samplers
 ^^^^^^^^^^^^^^^

--- a/pytorch_lightning/core/__init__.py
+++ b/pytorch_lightning/core/__init__.py
@@ -228,7 +228,7 @@ When you init a new tensor in your code, just use type_as
 
         # put the z on the appropriate gpu or tpu core
         z = sample_noise()
-        z = z.type_as(x.type())
+        z = z.type_as(x)
 
 ----------
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
I think the latest Pytorch API `type_as` has changed since the documentations were last updated. Now `type_as` takes the tensor instead of tensor type.

Reference: [type_as](https://pytorch.org/docs/stable/tensors.html#torch.Tensor.type_as)


## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
