### PR TITLE
Add Support for Non-primitive types in TensorboardLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added type hints to `pytorch_lightning.core` ([#946](https://github.com/PyTorchLightning/pytorch-lightning/pull/946))
 - Added support for IterableDataset in validation and testing ([#1104](https://github.com/PyTorchLightning/pytorch-lightning/pull/1104))
+- Added support for non-primitive types in hparams for TensorboardLogger ([#1130](https://github.com/PyTorchLightning/pytorch-lightning/pull/1130))
+
 
 ### Changed
 

--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -1,9 +1,10 @@
 import argparse
-import torch
 from abc import ABC, abstractmethod
 from argparse import Namespace
 from functools import wraps
 from typing import Union, Optional, Dict, Iterable, Any, Callable, List
+
+import torch
 
 
 def rank_zero_only(fn: Callable):

--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -67,7 +67,8 @@ class LightningLoggerBase(ABC):
         ...         "layer": torch.nn.BatchNorm1d}
         >>> OrderedDict(LightningLoggerBase._sanitize_params(params))
         OrderedDict([('float', 0.3), ('int', 1), ('string', 'abc'), ('bool', True),\
- ('list', '[1, 2, 3]'), ('namespace', 'Namespace(foo=3)'), ('layer', "<class 'torch.nn.modules.batchnorm.BatchNorm1d'>")])
+ ('list', '[1, 2, 3]'), ('namespace', 'Namespace(foo=3)'),\
+ ('layer', "<class 'torch.nn.modules.batchnorm.BatchNorm1d'>")])
         """
         return {k: v if type(v) in [bool, int, float, str, torch.Tensor] else str(v) for k, v in params.items()}
 

--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -58,17 +58,23 @@ class LightningLoggerBase(ABC):
     @staticmethod
     def _sanitize_params(params: Dict[str, Any]) -> Dict[str, Any]:
         """Returns params with non-primitvies converted to strings for logging
+
         >>> params = {"float": 0.3,
-        ...         "int": 1,
-        ...         "string": "abc",
-        ...         "bool": True,
-        ...         "list": [1, 2, 3],
-        ...         "namespace": Namespace(foo=3),
-        ...         "layer": torch.nn.BatchNorm1d}
-        >>> OrderedDict(LightningLoggerBase._sanitize_params(params))
-        OrderedDict([('float', 0.3), ('int', 1), ('string', 'abc'), ('bool', True),\
- ('list', '[1, 2, 3]'), ('namespace', 'Namespace(foo=3)'),\
- ('layer', "<class 'torch.nn.modules.batchnorm.BatchNorm1d'>")])
+        ...           "int": 1,
+        ...           "string": "abc",
+        ...           "bool": True,
+        ...           "list": [1, 2, 3],
+        ...           "namespace": Namespace(foo=3),
+        ...           "layer": torch.nn.BatchNorm1d}
+        >>> import pprint
+        >>> pprint.pprint(LightningLoggerBase._sanitize_params(params))  # doctest: +NORMALIZE_WHITESPACE
+        {'bool': True,
+         'float': 0.3,
+         'int': 1,
+         'layer': "<class 'torch.nn.modules.batchnorm.BatchNorm1d'>",
+         'list': '[1, 2, 3]',
+         'namespace': 'Namespace(foo=3)',
+         'string': 'abc'}
         """
         return {k: v if type(v) in [bool, int, float, str, torch.Tensor] else str(v) for k, v in params.items()}
 

--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -45,7 +45,7 @@ class LightningLoggerBase(ABC):
         pass
 
     @staticmethod
-    def _convert_params(self, params: Union[Dict[str, Any], Namespace]) -> Dict[str, Any]:
+    def _convert_params(params: Union[Dict[str, Any], Namespace]) -> Dict[str, Any]:
         # in case converting from namespace
         if isinstance(params, Namespace):
             params = vars(params)
@@ -66,8 +66,8 @@ class LightningLoggerBase(ABC):
         ...         "namespace": Namespace(foo=3),
         ...         "layer": torch.nn.BatchNorm1d}
         >>> OrderedDict(LightningLoggerBase._sanitize_params(params))
-        OrderedDict([('float', 0.3), ('int', 1), ('string', 'abc'), ('bool', True), ('list', '[1, 2, 3]'),\
- ('namespace', 'Namespace(foo=3)'), ('layer', "<class 'torch.nn.modules.batchnorm.BatchNorm1d'>")])
+        OrderedDict([('float', 0.3), ('int', 1), ('string', 'abc'), ('bool', True),\
+ ('list', '[1, 2, 3]'), ('namespace', 'Namespace(foo=3)'), ('layer', "<class 'torch.nn.modules.batchnorm.BatchNorm1d'>")])
         """
         return {k: v if type(v) in [bool, int, float, str, torch.Tensor] else str(v) for k, v in params.items()}
 

--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -2,7 +2,6 @@ import argparse
 import torch
 from abc import ABC, abstractmethod
 from argparse import Namespace
-from collections import OrderedDict
 from functools import wraps
 from typing import Union, Optional, Dict, Iterable, Any, Callable, List
 

--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -187,3 +187,4 @@ class TensorBoardLogger(LightningLoggerBase):
                 out_dict[k] = v
 
         return out_dict
+    

--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -187,4 +187,3 @@ class TensorBoardLogger(LightningLoggerBase):
                 out_dict[k] = v
 
         return out_dict
-    

--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -175,15 +175,3 @@ class TensorBoardLogger(LightningLoggerBase):
             return 0
 
         return max(existing_versions) + 1
-
-    def _sanitize_params(self, params):
-        native_types = [int, bool, float, str, torch.Tensor]
-        out_dict = {}
-
-        for k, v in params.items():
-            if type(v) not in native_types:
-                out_dict[k] = repr(v)
-            else:
-                out_dict[k] = v
-
-        return out_dict

--- a/tests/loggers/test_tensorboard.py
+++ b/tests/loggers/test_tensorboard.py
@@ -1,4 +1,5 @@
 import pickle
+from argparse import Namespace
 
 import pytest
 import torch
@@ -9,7 +10,6 @@ from pytorch_lightning.loggers import (
     TensorBoardLogger
 )
 from tests.models import LightningTestModel
-from argparse import Namespace
 
 
 def test_tensorboard_logger(tmpdir):

--- a/tests/loggers/test_tensorboard.py
+++ b/tests/loggers/test_tensorboard.py
@@ -9,6 +9,7 @@ from pytorch_lightning.loggers import (
     TensorBoardLogger
 )
 from tests.models import LightningTestModel
+from argparse import Namespace
 
 
 def test_tensorboard_logger(tmpdir):
@@ -108,6 +109,9 @@ def test_tensorboard_log_hyperparams(tmpdir):
         "float": 0.3,
         "int": 1,
         "string": "abc",
-        "bool": True
+        "bool": True,
+        "list": [1, 2, 3],
+        "namespace": Namespace(foo=3),
+        "layer": torch.nn.BatchNorm1d
     }
     logger.log_hyperparams(hparams)


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Implements suggestions from #1095 . Specifically makes it so TensoboardLogger converts non-primitive types to strings before logging, and maintains original types in hparams.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
