### PR TITLE
Allow reinits in sub procs

### DIFF
--- a/pytorch_lightning/loggers/wandb.py
+++ b/pytorch_lightning/loggers/wandb.py
@@ -62,10 +62,14 @@ class WandbLogger(LightningLoggerBase):
 
     def __getstate__(self):
         state = self.__dict__.copy()
+        # args needed to reload correct experiment
+        if self._experiment is not None:
+            state['_id'] = self._experiment.id
+        else:
+            state['_id'] = None
+
         # cannot be pickled
         state['_experiment'] = None
-        # args needed to reload correct experiment
-        state['_id'] = self.experiment.id
         return state
 
     @property
@@ -111,8 +115,14 @@ class WandbLogger(LightningLoggerBase):
 
     @property
     def name(self) -> str:
-        return self.experiment.project_name()
+        if self._experiment:
+            return self.experiment.project_name()
+        else:
+            return None
 
     @property
     def version(self) -> str:
-        return self.experiment.id
+        if self._experiment:
+            return self.experiment.id
+        else:
+            return None

--- a/pytorch_lightning/loggers/wandb.py
+++ b/pytorch_lightning/loggers/wandb.py
@@ -84,7 +84,7 @@ class WandbLogger(LightningLoggerBase):
                 os.environ['WANDB_MODE'] = 'dryrun'
             self._experiment = wandb.init(
                 name=self._name, dir=self._save_dir, project=self._project, anonymous=self._anonymous,
-                id=self._id, resume='allow', tags=self._tags, entity=self._entity)
+                reinit=True, id=self._id, resume='allow', tags=self._tags, entity=self._entity)
         return self._experiment
 
     def watch(self, model: nn.Module, log: str = 'gradients', log_freq: int = 100):

--- a/pytorch_lightning/loggers/wandb.py
+++ b/pytorch_lightning/loggers/wandb.py
@@ -115,14 +115,16 @@ class WandbLogger(LightningLoggerBase):
 
     @property
     def name(self) -> str:
+        # don't create an experiment if we don't have one
         if self._experiment:
-            return self.experiment.project_name()
+            return self._experiment.project_name()
         else:
             return None
 
     @property
     def version(self) -> str:
+        # don't create an experiment if we don't have one
         if self._experiment:
-            return self.experiment.id
+            return self._experiment.id
         else:
             return None

--- a/tests/loggers/test_wandb.py
+++ b/tests/loggers/test_wandb.py
@@ -64,6 +64,8 @@ def test_wandb_pickle(wandb):
     trainer_options = dict(max_epochs=1, logger=logger)
 
     trainer = Trainer(**trainer_options)
+    # Access the experiment to ensure it's created
+    trainer.logger.experiment
     pkl_bytes = pickle.dumps(trainer)
     trainer2 = pickle.loads(pkl_bytes)
 


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Fixes #981 

When using multiprocessing the default behavior of wandb is to return None for multiple calls to init.  Passing reinit=True ensure we always create an experiment.  This could lead to cases where a single experiment has multiple runs in wandb, but it's a much better default than throwing an exception.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
