### PR TITLE
Add ddp_cpu backend for testing ddp without GPUs

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -948,10 +948,7 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
 
         root_node = self.trainer.resolve_root_node_address(root_node)
         os.environ['MASTER_ADDR'] = root_node
-        if self.trainer.on_gpu:
-            torch_backend = "nccl"
-        else:
-            torch_backend = "gloo"
+        torch_backend = "nccl" if self.trainer.on_gpu else "gloo"
         torch_distrib.init_process_group(torch_backend, rank=proc_rank, world_size=world_size)
 
     def configure_apex(

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -944,7 +944,7 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
         try:
             root_node = os.environ['SLURM_NODELIST'].split(' ')[0]
         except Exception:
-            root_node = '127.0.0.2'
+            root_node = '127.0.0.1'
 
         root_node = self.trainer.resolve_root_node_address(root_node)
         os.environ['MASTER_ADDR'] = root_node

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -948,7 +948,11 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
 
         root_node = self.trainer.resolve_root_node_address(root_node)
         os.environ['MASTER_ADDR'] = root_node
-        torch_distrib.init_process_group('nccl', rank=proc_rank, world_size=world_size)
+        if self.trainer.on_gpu:
+            torch_backend = "nccl"
+        else:
+            torch_backend = "gloo"
+        torch_distrib.init_process_group(torch_backend, rank=proc_rank, world_size=world_size)
 
     def configure_apex(
             self,

--- a/pytorch_lightning/overrides/data_parallel.py
+++ b/pytorch_lightning/overrides/data_parallel.py
@@ -99,7 +99,14 @@ class LightningDistributedDataParallel(DistributedDataParallel):
                 output = self.gather(outputs, self.output_device)
         else:
             # normal
-            output = self.module(*inputs, **kwargs)
+            # output = self.module(*inputs, **kwargs)
+            # lightning (ddp_cpu)
+            if self.module.training:
+                output = self.module.training_step(*inputs, **kwargs)
+            elif self.module.testing:
+                output = self.module.test_step(*inputs, **kwargs)
+            else:
+                output = self.module.validation_step(*inputs, **kwargs)
 
         if torch.is_grad_enabled():
             # We'll return the output object verbatim since it is a freeform

--- a/pytorch_lightning/trainer/__init__.py
+++ b/pytorch_lightning/trainer/__init__.py
@@ -251,6 +251,10 @@ The distributed backend to use.
 
 - (```dp```) is DataParallel (split batch among GPUs of same machine)
 - (```ddp```) is DistributedDataParallel (each gpu on each node trains, and syncs grads)
+- (```ddp_cpu```) is DistributedDataParallel on CPU (same as `ddp`, but does not use GPUs.
+  Useful for multi-node CPU training or single-node debugging. Note that this will **not** give
+  a speedup on a single node, since Torch already makes effient use of multiple CPUs on a single
+  machine.)
 - (```ddp2```) dp on node, ddp across nodes. Useful for things like increasing
     the number of negative samples
 
@@ -509,6 +513,21 @@ nb_gpu_nodes:
 .. warning:: .. deprecated:: 0.5.0
 
     Use `num_nodes` instead. Will remove 0.8.0.
+
+num_processes
+^^^^^^^^^^^^^
+
+Number of processes to train with. Automatically set to the number of GPUs
+when using ``distrbuted_backend="ddp"``. Set to a number greater than 1 when
+using ``distributed_backend="ddp_cpu"`` to mimic distributed training on a
+machine without GPUs. This is useful for debugging, but **will not** provide
+any speedup, since single-process Torch already makes effient use of multiple
+CPUs.
+
+Example::
+
+    # Simulate DDP for debugging on your GPU-less laptop
+    trainer = Trainer(distributed_backend="ddp_cpu", num_processes=2)
 
 num_sanity_val_steps
 ^^^^^^^^^^^^^^^^^^^^

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -297,7 +297,9 @@ class TrainerDDPMixin(ABC):
             self.node_rank = 0
 
         # show progressbar only on progress_rank 0
-        self.progress_bar_refresh_rate = self.progress_bar_refresh_rate if self.node_rank == 0 and process_idx == 0 else 0
+        self.progress_bar_refresh_rate = (
+            self.progress_bar_refresh_rate if self.node_rank == 0 and process_idx == 0 else 0
+        )
 
         # determine which process we are and world size
         if self.use_ddp:

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -182,7 +182,8 @@ class TrainerDDPMixin(ABC):
 
         if distributed_backend is None:
             if self.num_gpus == 0:
-                return
+                if self.num_nodes > 1 or self.num_processes > 1:
+                    self.use_ddp = True  # ddp_cpu
             elif self.num_gpus == 1:
                 self.single_gpu = True
             elif self.num_gpus > 1:
@@ -192,7 +193,7 @@ class TrainerDDPMixin(ABC):
                 self.use_dp = True
         elif distributed_backend == "dp":
             if self.num_gpus == 0:
-                return
+                pass
             elif self.num_gpus == 1:
                 self.single_gpu = True
                 self.use_dp = True
@@ -200,7 +201,8 @@ class TrainerDDPMixin(ABC):
                 self.use_dp = True
         elif distributed_backend == "ddp":
             if self.num_gpus == 0:
-                return
+                if self.num_nodes > 1 or self.num_processes > 1:
+                    self.use_ddp = True  # ddp_cpu
             elif self.num_gpus == 1:
                 self.single_gpu = True
                 self.use_ddp = True
@@ -209,10 +211,14 @@ class TrainerDDPMixin(ABC):
                 self.num_processes = self.num_gpus
         elif distributed_backend == "ddp2":
             if self.num_gpus == 0:
-                return
+                pass
             elif self.num_gpus >= 1:
                 self.use_ddp2 = True
         elif distributed_backend == "ddp_cpu":
+            if self.num_gpus > 0:
+                m = 'You requested one or more GPUs, but set the backend ' \
+                    'to ddp_cpu. Training will not use GPUs.'
+                warnings.warn(m)
             self.use_ddp = True
             self.data_parallel_device_ids = None
             self.on_gpu = False

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -274,7 +274,7 @@ class TrainerDDPMixin(ABC):
 
         log.info(f'VISIBLE GPUS: {os.environ["CUDA_VISIBLE_DEVICES"]}')
 
-    def ddp_train(self, gpu_idx, model):
+    def ddp_train(self, process_idx, model):
         """
         Entry point into a DP thread
         :param gpu_idx:
@@ -291,16 +291,16 @@ class TrainerDDPMixin(ABC):
             self.node_rank = 0
 
         # show progressbar only on progress_rank 0
-        self.progress_bar_refresh_rate = self.progress_bar_refresh_rate if self.node_rank == 0 and gpu_idx == 0 else 0
+        self.progress_bar_refresh_rate = self.progress_bar_refresh_rate if self.node_rank == 0 and process_idx == 0 else 0
 
         # determine which process we are and world size
         if self.use_ddp:
-            self.proc_rank = self.node_rank * self.num_gpus + gpu_idx
-            self.world_size = self.num_gpu_nodes * self.num_gpus
+            self.proc_rank = self.node_rank * self.num_processes + process_idx
+            self.world_size = self.num_nodes * self.num_processes
 
         elif self.use_ddp2:
             self.proc_rank = self.node_rank
-            self.world_size = self.num_gpu_nodes
+            self.world_size = self.num_nodes
         # set warning rank
         set_proc_rank(self.proc_rank)
 
@@ -320,15 +320,13 @@ class TrainerDDPMixin(ABC):
 
         # MODEL
         # copy model to each gpu
-        if self.distributed_backend == 'ddp':
-            torch.cuda.set_device(gpu_idx)
-        model.cuda(gpu_idx)
+        if self.on_gpu:
+            self.root_gpu = self.data_parallel_device_ids[process_idx]
+            torch.cuda.set_device(self.root_gpu)
+            model.cuda(self.root_gpu)
 
         # set model properties before going into wrapper
         self.copy_trainer_model_properties(model)
-
-        # override root GPU
-        self.root_gpu = gpu_idx
 
         # AMP
         # run through amp wrapper before going to distributed DP
@@ -339,10 +337,10 @@ class TrainerDDPMixin(ABC):
 
         # DDP2 uses all GPUs on the machine
         if self.distributed_backend == 'ddp':
-            device_ids = [gpu_idx]
+            device_ids = [self.root_gpu]
         elif self.use_ddp2:
             device_ids = self.data_parallel_device_ids
-        else:
+        else:  # includes ddp_cpu
             device_ids = None
 
         # allow user to configure ddp

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -216,9 +216,8 @@ class TrainerDDPMixin(ABC):
                 self.use_ddp2 = True
         elif distributed_backend == "ddp_cpu":
             if self.num_gpus > 0:
-                m = 'You requested one or more GPUs, but set the backend ' \
-                    'to ddp_cpu. Training will not use GPUs.'
-                warnings.warn(m)
+                warnings.warn('You requested one or more GPUs, but set the backend to `ddp_cpu`.'
+                              ' Training will not use GPUs.')
             self.use_ddp = True
             self.data_parallel_device_ids = None
             self.on_gpu = False

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -192,9 +192,8 @@ class TrainerDDPMixin(ABC):
                                ' Setting distributed_backend=dp for you.')
                 self.use_dp = True
         elif distributed_backend == "dp":
-            if self.num_gpus == 0:
-                pass
-            elif self.num_gpus == 1:
+            # do nothing if num_gpus == 0
+            if self.num_gpus == 1:
                 self.single_gpu = True
                 self.use_dp = True
             elif self.num_gpus > 1:
@@ -210,9 +209,8 @@ class TrainerDDPMixin(ABC):
                 self.use_ddp = True
                 self.num_processes = self.num_gpus
         elif distributed_backend == "ddp2":
-            if self.num_gpus == 0:
-                pass
-            elif self.num_gpus >= 1:
+            # do nothing if num_gpus == 0
+            if self.num_gpus >= 1:
                 self.use_ddp2 = True
         elif distributed_backend == "ddp_cpu":
             if self.num_gpus > 0:

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -214,8 +214,8 @@ class TrainerDDPMixin(ABC):
                 self.use_ddp2 = True
         elif distributed_backend == "ddp_cpu":
             if self.num_gpus > 0:
-                warnings.warn('You requested one or more GPUs, but set the backend to `ddp_cpu`.'
-                              ' Training will not use GPUs.')
+                rank_zero_warn('You requested one or more GPUs, but set the backend to `ddp_cpu`.'
+                               ' Training will not use GPUs.')
             self.use_ddp = True
             self.data_parallel_device_ids = None
             self.on_gpu = False

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -2,7 +2,6 @@ import distutils
 import inspect
 import os
 import sys
-import warnings
 from argparse import ArgumentParser
 from typing import Union, Optional, List, Dict, Tuple, Iterable, Any
 
@@ -321,7 +320,7 @@ class Trainer(
         assert num_tpu_cores in [1, 8, None], 'num_tpu_cores can only be 1 or 8'
 
         if num_processes != 1 and distributed_backend != "ddp_cpu":
-            warnings.warn(
+            rank_zero_warn(
                 "num_processes is only used for distributed_backend=\"ddp_cpu\". Ignoring it."
             )
         self.num_processes = num_processes

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -2,6 +2,7 @@ import distutils
 import inspect
 import os
 import sys
+import warnings
 from argparse import ArgumentParser
 from typing import Union, Optional, List, Dict, Tuple, Iterable, Any
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -92,6 +92,7 @@ class Trainer(
             gradient_clip_val: float = 0,
             process_position: int = 0,
             num_nodes: int = 1,
+            num_processes: int = 1,
             gpus: Optional[Union[List[int], str, int]] = None,
             auto_select_gpus: bool = False,
             num_tpu_cores: Optional[int] = None,
@@ -728,7 +729,7 @@ class Trainer(
                 self.model = model
 
                 # train
-                mp.spawn(self.ddp_train, nprocs=self.num_gpus, args=(model,))
+                mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model,))
 
                 # load weights if not interrupted
                 self.load_spawn_weights(model)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -320,7 +320,9 @@ class Trainer(
         assert num_tpu_cores in [1, 8, None], 'num_tpu_cores can only be 1 or 8'
 
         if num_processes != 1 and distributed_backend != "ddp_cpu":
-            warnings.warn("num_processes is only used for distributed_backend=\"ddp_cpu\". Ignoring it.")
+            warnings.warn(
+                "num_processes is only used for distributed_backend=\"ddp_cpu\". Ignoring it."
+            )
         self.num_processes = num_processes
 
         self.process_position = process_position

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -320,9 +320,7 @@ class Trainer(
         assert num_tpu_cores in [1, 8, None], 'num_tpu_cores can only be 1 or 8'
 
         if num_processes != 1 and distributed_backend != "ddp_cpu":
-            rank_zero_warn(
-                "num_processes is only used for distributed_backend=\"ddp_cpu\". Ignoring it."
-            )
+            rank_zero_warn("num_processes is only used for distributed_backend=\"ddp_cpu\". Ignoring it.")
         self.num_processes = num_processes
 
         self.process_position = process_position

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -318,6 +318,10 @@ class Trainer(
         self.num_tpu_cores = num_tpu_cores
         assert num_tpu_cores in [1, 8, None], 'num_tpu_cores can only be 1 or 8'
 
+        if num_processes != 1 and distributed_backend != "ddp_cpu":
+            warnings.warn("num_processes is only used for distributed_backend=\"ddp_cpu\". Ignoring it.")
+        self.num_processes = num_processes
+
         self.process_position = process_position
         self.weights_summary = weights_summary
 
@@ -437,12 +441,8 @@ class Trainer(
         self.tpu_global_core_rank = None
 
         # distributed backend choice
-        self.use_ddp = False
-        self.use_ddp2 = False
-        self.use_dp = False
-        self.single_gpu = False
         self.distributed_backend = distributed_backend
-        self.set_distributed_mode(distributed_backend, self.num_nodes)
+        self.set_distributed_mode(distributed_backend)
 
         # override dist backend when using tpus
         if self.on_tpu:

--- a/tests/models/test_cpu.py
+++ b/tests/models/test_cpu.py
@@ -3,6 +3,7 @@ import warnings
 
 import pytest
 import torch
+from packaging.version import parse as version_parse
 
 import tests.base.utils as tutils
 from pytorch_lightning import Trainer
@@ -43,6 +44,9 @@ def test_early_stopping_cpu_model(tmpdir):
 
 @pytest.mark.skipif(platform.system() == "Windows",
                     reason="Distributed training is not supported on Windows")
+@pytest.mark.skipif((platform.system() == "Darwin" and
+                     version_parse(torch.__version__) < version_parse("1.3.0")),
+                    reason="Distributed training is not supported on MacOS before Torch 1.3.0")
 def test_multi_cpu_model_ddp(tmpdir):
     """Make sure DDP works."""
     tutils.reset_seed()

--- a/tests/models/test_cpu.py
+++ b/tests/models/test_cpu.py
@@ -48,7 +48,7 @@ def test_multi_cpu_model_ddp(tmpdir):
     tutils.reset_seed()
     tutils.set_random_master_port()
 
-    model, hparams = tutils.get_model()
+    model, hparams = tutils.get_default_model()
     trainer_options = dict(
         default_save_path=tmpdir,
         show_progress_bar=False,

--- a/tests/models/test_cpu.py
+++ b/tests/models/test_cpu.py
@@ -1,3 +1,4 @@
+import platform
 import warnings
 
 import pytest
@@ -40,6 +41,8 @@ def test_early_stopping_cpu_model(tmpdir):
     model.unfreeze()
 
 
+@pytest.mark.skipif(platform.system() == "Windows",
+                    reason="Distributed training is not supported on Windows")
 def test_multi_cpu_model_ddp(tmpdir):
     """Make sure DDP works."""
     tutils.reset_seed()

--- a/tests/models/test_cpu.py
+++ b/tests/models/test_cpu.py
@@ -54,7 +54,7 @@ def test_multi_cpu_model_ddp(tmpdir):
 
     model, hparams = tutils.get_default_model()
     trainer_options = dict(
-        default_save_path=tmpdir,
+        default_root_dir=tmpdir,
         show_progress_bar=False,
         max_epochs=1,
         train_percent_check=0.4,

--- a/tests/models/test_cpu.py
+++ b/tests/models/test_cpu.py
@@ -40,6 +40,26 @@ def test_early_stopping_cpu_model(tmpdir):
     model.unfreeze()
 
 
+def test_multi_cpu_model_ddp(tmpdir):
+    """Make sure DDP works."""
+    tutils.reset_seed()
+    tutils.set_random_master_port()
+
+    model, hparams = tutils.get_model()
+    trainer_options = dict(
+        default_save_path=tmpdir,
+        show_progress_bar=False,
+        max_epochs=1,
+        train_percent_check=0.4,
+        val_percent_check=0.2,
+        gpus=None,
+        num_processes=2,
+        distributed_backend='ddp_cpu'
+    )
+
+    tutils.run_model_test(trainer_options, model, on_gpu=False)
+
+
 def test_lbfgs_cpu_model(tmpdir):
     """Test each of the trainer options."""
     tutils.reset_seed()

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -708,7 +708,9 @@ def test_trainer_config_cpu():
     assert trainer.use_ddp is False
     assert trainer.use_ddp2 is False
     assert trainer.num_gpus == 0
+    assert trainer.on_gpu is False
     assert trainer.single_gpu is False
+    assert trainer.num_processes == 1
 
 
 def test_trainer_config_nogpu_dp():
@@ -718,7 +720,9 @@ def test_trainer_config_nogpu_dp():
     assert trainer.use_ddp is False
     assert trainer.use_ddp2 is False
     assert trainer.num_gpus == 0
+    assert trainer.on_gpu is False
     assert trainer.single_gpu is False
+    assert trainer.num_processes == 1
 
 
 def test_trainer_config_nogpu_ddp():
@@ -728,7 +732,20 @@ def test_trainer_config_nogpu_ddp():
     assert trainer.use_ddp is False
     assert trainer.use_ddp2 is False
     assert trainer.num_gpus == 0
+    assert trainer.on_gpu is False
     assert trainer.single_gpu is False
+    assert trainer.num_processes == 1
+
+
+def test_trainer_config_nogpu_ddp_cpu():
+    trainer = Trainer(distributed_backend="ddp_cpu", num_processes=2, gpus=None)
+    assert trainer.use_dp is False
+    assert trainer.use_ddp is True
+    assert trainer.use_ddp2 is False
+    assert trainer.num_gpus == 0
+    assert trainer.on_gpu is False
+    assert trainer.single_gpu is False
+    assert trainer.num_processes == 2
 
 
 def test_trainer_config_nogpu_ddp2():
@@ -738,7 +755,9 @@ def test_trainer_config_nogpu_ddp2():
     assert trainer.use_ddp is False
     assert trainer.use_ddp2 is False
     assert trainer.num_gpus == 0
+    assert trainer.on_gpu is False
     assert trainer.single_gpu is False
+    assert trainer.num_processes == 1
 
 
 @pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
@@ -748,7 +767,9 @@ def test_trainer_config_single_gpu():
     assert trainer.use_ddp is False
     assert trainer.use_ddp2 is False
     assert trainer.num_gpus == 1
+    assert trainer.on_gpu is True
     assert trainer.single_gpu is True
+    assert trainer.num_processes == 1
 
 
 @pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
@@ -758,7 +779,9 @@ def test_trainer_config_single_gpu_dp():
     assert trainer.use_ddp is False
     assert trainer.use_ddp2 is False
     assert trainer.num_gpus == 1
+    assert trainer.on_gpu is True
     assert trainer.single_gpu is True
+    assert trainer.num_processes == 1
 
 
 @pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
@@ -768,7 +791,21 @@ def test_trainer_config_single_gpu_ddp():
     assert trainer.use_ddp is True
     assert trainer.use_ddp2 is False
     assert trainer.num_gpus == 1
+    assert trainer.on_gpu is True
     assert trainer.single_gpu is True
+    assert trainer.num_processes == 1
+
+
+@pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
+def test_trainer_config_single_gpu_ddp_cpu():
+    trainer = Trainer(distributed_backend="ddp_cpu", num_processes=2, gpus=1)
+    assert trainer.use_dp is False
+    assert trainer.use_ddp is True
+    assert trainer.use_ddp2 is False
+    assert trainer.num_gpus == 0
+    assert trainer.on_gpu is False
+    assert trainer.single_gpu is False
+    assert trainer.num_processes == 2
 
 
 @pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
@@ -778,7 +815,9 @@ def test_trainer_config_single_gpu_ddp2():
     assert trainer.use_ddp is False
     assert trainer.use_ddp2 is True
     assert trainer.num_gpus == 1
+    assert trainer.on_gpu is True
     assert trainer.single_gpu is False
+    assert trainer.num_processes == 1
 
 
 @pytest.mark.skipif(torch.cuda.device_count() > 2, reason="Multiple GPUs needed")
@@ -790,7 +829,9 @@ def test_trainer_config_multi_gpu():
     assert trainer.use_ddp is False
     assert trainer.use_ddp2 is False
     assert trainer.num_gpus == 2
+    assert trainer.on_gpu is True
     assert trainer.single_gpu is False
+    assert trainer.num_processes == 1
 
 
 @pytest.mark.skipif(torch.cuda.device_count() > 2, reason="Multiple GPUs needed")
@@ -800,7 +841,9 @@ def test_trainer_config_multi_gpu_dp():
     assert trainer.use_ddp is False
     assert trainer.use_ddp2 is False
     assert trainer.num_gpus == 2
+    assert trainer.on_gpu is True
     assert trainer.single_gpu is False
+    assert trainer.num_processes == 1
 
 
 @pytest.mark.skipif(torch.cuda.device_count() > 2, reason="Multiple GPUs needed")
@@ -811,6 +854,8 @@ def test_trainer_config_multi_gpu_ddp():
     assert trainer.use_ddp2 is False
     assert trainer.num_gpus == 2
     assert trainer.single_gpu is False
+    assert trainer.on_gpu is True
+    assert trainer.num_processes == 2
 
 
 @pytest.mark.skipif(torch.cuda.device_count() > 2, reason="Multiple GPUs needed")
@@ -821,3 +866,5 @@ def test_trainer_config_multi_gpu_ddp2():
     assert trainer.use_ddp2 is True
     assert trainer.num_gpus == 2
     assert trainer.single_gpu is False
+    assert trainer.on_gpu is True
+    assert trainer.num_processes == 1

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -659,6 +659,7 @@ def test_trainer_interrupted_flag(tmpdir):
     trainer.fit(model)
     assert trainer.interrupted
 
+
 def test_gradient_clipping(tmpdir):
     """
     Test gradient clipping

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -702,105 +702,85 @@ def test_gpu_choice(tmpdir):
         Trainer(**trainer_options, gpus=num_gpus + 1, auto_select_gpus=True)
 
 
-@pytest.mark.parametrize(
-    "trainer_kwargs,expected",
-    [
-        (
-            dict(distributed_backend=None, gpus=None),
-            dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0,
-                 on_gpu=False, single_gpu=False, num_processes=1)
-        ),
-        (
-            dict(distributed_backend="dp", gpus=None),
-            dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0,
-                 on_gpu=False, single_gpu=False, num_processes=1)
-        ),
-        (
-            dict(distributed_backend="dp", gpus=None),
-            dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0,
-                 on_gpu=False, single_gpu=False, num_processes=1)
-        ),
-        (
-            dict(distributed_backend="ddp", gpus=None),
-            dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0,
-                 on_gpu=False, single_gpu=False, num_processes=1)
-        ),
-        (
-            dict(distributed_backend="ddp", num_processes=2, gpus=None),
-            dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=0,
-                 on_gpu=False, single_gpu=False, num_processes=2)
-        ),
-        (
-            dict(distributed_backend="ddp", num_nodes=2, gpus=None),
-            dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=0,
-                 on_gpu=False, single_gpu=False, num_processes=1)
-        ),
-        (
-            dict(distributed_backend="ddp_cpu", num_processes=2, gpus=None),
-            dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=0,
-                 on_gpu=False, single_gpu=False, num_processes=2)
-        ),
-        (
-            dict(distributed_backend="ddp2", gpus=None),
-            dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0,
-                 on_gpu=False, single_gpu=False, num_processes=1)
-        ),
-        pytest.param(
-            dict(distributed_backend=None, gpus=1),
-            dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=1,
-                 on_gpu=True, single_gpu=True, num_processes=1),
-            marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
-        ),
-        pytest.param(
-            dict(distributed_backend="dp", gpus=1),
-            dict(use_dp=True, use_ddp=False, use_ddp2=False, num_gpus=1,
-                 on_gpu=True, single_gpu=True, num_processes=1),
-            marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
-        ),
-        pytest.param(
-            dict(distributed_backend="ddp", gpus=1),
-            dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=1,
-                 on_gpu=True, single_gpu=True, num_processes=1),
-            marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
-        ),
-        pytest.param(
-            dict(distributed_backend="ddp_cpu", num_processes=2, gpus=1),
-            dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=0,
-                 on_gpu=False, single_gpu=False, num_processes=2),
-            marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
-        ),
-        pytest.param(
-            dict(distributed_backend="ddp2", gpus=1),
-            dict(use_dp=False, use_ddp=False, use_ddp2=True, num_gpus=1,
-                 on_gpu=True, single_gpu=False, num_processes=1),
-            marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
-        ),
-        pytest.param(
-            dict(distributed_backend=None, gpus=2),
-            dict(use_dp=True, use_ddp=False, use_ddp2=False, num_gpus=2,
-                 on_gpu=True, single_gpu=False, num_processes=1),
-            marks=[pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")]
-        ),
-        pytest.param(
-            dict(distributed_backend="dp", gpus=2),
-            dict(use_dp=True, use_ddp=False, use_ddp2=False, num_gpus=2,
-                 on_gpu=True, single_gpu=False, num_processes=1),
-            marks=[pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")]
-        ),
-        pytest.param(
-            dict(distributed_backend="ddp", gpus=2),
-            dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=2,
-                 on_gpu=True, single_gpu=False, num_processes=2),
-            marks=[pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")]
-        ),
-        pytest.param(
-            dict(distributed_backend="ddp2", gpus=2),
-            dict(use_dp=False, use_ddp=False, use_ddp2=True, num_gpus=2,
-                 on_gpu=True, single_gpu=False, num_processes=1),
-            marks=[pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")]
-        ),
-    ]
-)
+@pytest.mark.parametrize("trainer_kwargs,expected", [
+    pytest.param(
+        dict(distributed_backend=None, gpus=None),
+        dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0, on_gpu=False, single_gpu=False, num_processes=1)
+    ),
+    pytest.param(
+        dict(distributed_backend="dp", gpus=None),
+        dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0, on_gpu=False, single_gpu=False, num_processes=1)
+    ),
+    pytest.param(
+        dict(distributed_backend="dp", gpus=None),
+        dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0, on_gpu=False, single_gpu=False, num_processes=1)
+    ),
+    pytest.param(
+        dict(distributed_backend="ddp", gpus=None),
+        dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0, on_gpu=False, single_gpu=False, num_processes=1)
+    ),
+    pytest.param(
+        dict(distributed_backend="ddp", num_processes=2, gpus=None),
+        dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=0, on_gpu=False, single_gpu=False, num_processes=2)
+    ),
+    pytest.param(
+        dict(distributed_backend="ddp", num_nodes=2, gpus=None),
+        dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=0, on_gpu=False, single_gpu=False, num_processes=1)
+    ),
+    pytest.param(
+        dict(distributed_backend="ddp_cpu", num_processes=2, gpus=None),
+        dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=0, on_gpu=False, single_gpu=False, num_processes=2)
+    ),
+    pytest.param(
+        dict(distributed_backend="ddp2", gpus=None),
+        dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0, on_gpu=False, single_gpu=False, num_processes=1)
+    ),
+    pytest.param(
+        dict(distributed_backend=None, gpus=1),
+        dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=1, on_gpu=True, single_gpu=True, num_processes=1),
+        marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
+    ),
+    pytest.param(
+        dict(distributed_backend="dp", gpus=1),
+        dict(use_dp=True, use_ddp=False, use_ddp2=False, num_gpus=1, on_gpu=True, single_gpu=True, num_processes=1),
+        marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
+    ),
+    pytest.param(
+        dict(distributed_backend="ddp", gpus=1),
+        dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=1, on_gpu=True, single_gpu=True, num_processes=1),
+        marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
+    ),
+    pytest.param(
+        dict(distributed_backend="ddp_cpu", num_processes=2, gpus=1),
+        dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=0, on_gpu=False, single_gpu=False, num_processes=2),
+        marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
+    ),
+    pytest.param(
+        dict(distributed_backend="ddp2", gpus=1),
+        dict(use_dp=False, use_ddp=False, use_ddp2=True, num_gpus=1, on_gpu=True, single_gpu=False, num_processes=1),
+        marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
+    ),
+    pytest.param(
+        dict(distributed_backend=None, gpus=2),
+        dict(use_dp=True, use_ddp=False, use_ddp2=False, num_gpus=2, on_gpu=True, single_gpu=False, num_processes=1),
+        marks=[pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")]
+    ),
+    pytest.param(
+        dict(distributed_backend="dp", gpus=2),
+        dict(use_dp=True, use_ddp=False, use_ddp2=False, num_gpus=2, on_gpu=True, single_gpu=False, num_processes=1),
+        marks=[pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")]
+    ),
+    pytest.param(
+        dict(distributed_backend="ddp", gpus=2),
+        dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=2, on_gpu=True, single_gpu=False, num_processes=2),
+        marks=[pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")]
+    ),
+    pytest.param(
+        dict(distributed_backend="ddp2", gpus=2),
+        dict(use_dp=False, use_ddp=False, use_ddp2=True, num_gpus=2, on_gpu=True, single_gpu=False, num_processes=1),
+        marks=[pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")]
+    ),
+])
 def test_trainer_config(trainer_kwargs, expected):
     trainer = Trainer(**trainer_kwargs)
     assert trainer.use_dp is expected["use_dp"]

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -737,6 +737,30 @@ def test_trainer_config_nogpu_ddp():
     assert trainer.num_processes == 1
 
 
+def test_trainer_config_nogpu_multiprocess_ddp():
+    """Fall back to ddp_cpu if num_processes is specified"""
+    trainer = Trainer(distributed_backend="ddp", num_processes=2, gpus=None)
+    assert trainer.use_dp is False
+    assert trainer.use_ddp is True
+    assert trainer.use_ddp2 is False
+    assert trainer.num_gpus == 0
+    assert trainer.on_gpu is False
+    assert trainer.single_gpu is False
+    assert trainer.num_processes == 2
+
+
+def test_trainer_config_nogpu_multinode_ddp():
+    """Fall back to ddp_cpu if num_nodes is >1"""
+    trainer = Trainer(distributed_backend="ddp", num_nodes=2, gpus=None)
+    assert trainer.use_dp is False
+    assert trainer.use_ddp is True
+    assert trainer.use_ddp2 is False
+    assert trainer.num_gpus == 0
+    assert trainer.on_gpu is False
+    assert trainer.single_gpu is False
+    assert trainer.num_processes == 1
+
+
 def test_trainer_config_nogpu_ddp_cpu():
     trainer = Trainer(distributed_backend="ddp_cpu", num_processes=2, gpus=None)
     assert trainer.use_dp is False
@@ -798,7 +822,8 @@ def test_trainer_config_single_gpu_ddp():
 
 @pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
 def test_trainer_config_single_gpu_ddp_cpu():
-    trainer = Trainer(distributed_backend="ddp_cpu", num_processes=2, gpus=1)
+    with pytest.warns(UserWarning):
+        trainer = Trainer(distributed_backend="ddp_cpu", num_processes=2, gpus=1)
     assert trainer.use_dp is False
     assert trainer.use_ddp is True
     assert trainer.use_ddp2 is False

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -809,15 +809,3 @@ def test_trainer_config(trainer_kwargs, expected):
     assert trainer.on_gpu is expected["on_gpu"]
     assert trainer.single_gpu is expected["single_gpu"]
     assert trainer.num_processes == expected["num_processes"]
-
-
-@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")
-def test_trainer_config_multi_gpu_ddp2():
-    trainer = Trainer(distributed_backend="ddp2", gpus=2)
-    assert trainer.use_dp is False
-    assert trainer.use_ddp is False
-    assert trainer.use_ddp2 is True
-    assert trainer.num_gpus == 2
-    assert trainer.single_gpu is False
-    assert trainer.on_gpu is True
-    assert trainer.num_processes == 1

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -700,3 +700,124 @@ def test_gpu_choice(tmpdir):
 
     with pytest.raises(RuntimeError, match=r'.*No GPUs available.*'):
         Trainer(**trainer_options, gpus=num_gpus + 1, auto_select_gpus=True)
+
+
+def test_trainer_config_cpu():
+    trainer = Trainer(distributed_backend=None, gpus=None)
+    assert trainer.use_dp is False
+    assert trainer.use_ddp is False
+    assert trainer.use_ddp2 is False
+    assert trainer.num_gpus == 0
+    assert trainer.single_gpu is False
+
+
+def test_trainer_config_nogpu_dp():
+    """Fall back to non-distributed training on CPU"""
+    trainer = Trainer(distributed_backend="dp", gpus=None)
+    assert trainer.use_dp is False
+    assert trainer.use_ddp is False
+    assert trainer.use_ddp2 is False
+    assert trainer.num_gpus == 0
+    assert trainer.single_gpu is False
+
+
+def test_trainer_config_nogpu_ddp():
+    """Fall back to non-distributed training on CPU"""
+    trainer = Trainer(distributed_backend="ddp", gpus=None)
+    assert trainer.use_dp is False
+    assert trainer.use_ddp is False
+    assert trainer.use_ddp2 is False
+    assert trainer.num_gpus == 0
+    assert trainer.single_gpu is False
+
+
+def test_trainer_config_nogpu_ddp2():
+    """Fall back to non-distributed training on CPU"""
+    trainer = Trainer(distributed_backend="ddp2", gpus=None)
+    assert trainer.use_dp is False
+    assert trainer.use_ddp is False
+    assert trainer.use_ddp2 is False
+    assert trainer.num_gpus == 0
+    assert trainer.single_gpu is False
+
+
+@pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
+def test_trainer_config_single_gpu():
+    trainer = Trainer(distributed_backend=None, gpus=1)
+    assert trainer.use_dp is False
+    assert trainer.use_ddp is False
+    assert trainer.use_ddp2 is False
+    assert trainer.num_gpus == 1
+    assert trainer.single_gpu is True
+
+
+@pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
+def test_trainer_config_single_gpu_dp():
+    trainer = Trainer(distributed_backend="dp", gpus=1)
+    assert trainer.use_dp is True
+    assert trainer.use_ddp is False
+    assert trainer.use_ddp2 is False
+    assert trainer.num_gpus == 1
+    assert trainer.single_gpu is True
+
+
+@pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
+def test_trainer_config_single_gpu_ddp():
+    trainer = Trainer(distributed_backend="ddp", gpus=1)
+    assert trainer.use_dp is False
+    assert trainer.use_ddp is True
+    assert trainer.use_ddp2 is False
+    assert trainer.num_gpus == 1
+    assert trainer.single_gpu is True
+
+
+@pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
+def test_trainer_config_single_gpu_ddp2():
+    trainer = Trainer(distributed_backend="ddp2", gpus=1)
+    assert trainer.use_dp is False
+    assert trainer.use_ddp is False
+    assert trainer.use_ddp2 is True
+    assert trainer.num_gpus == 1
+    assert trainer.single_gpu is False
+
+
+@pytest.mark.skipif(torch.cuda.device_count() > 2, reason="Multiple GPUs needed")
+def test_trainer_config_multi_gpu():
+    """Test fallback to DP if no distributed_backend specified"""
+    with pytest.warns(UserWarning):
+        trainer = Trainer(distributed_backend=None, gpus=2)
+    assert trainer.use_dp is True
+    assert trainer.use_ddp is False
+    assert trainer.use_ddp2 is False
+    assert trainer.num_gpus == 2
+    assert trainer.single_gpu is False
+
+
+@pytest.mark.skipif(torch.cuda.device_count() > 2, reason="Multiple GPUs needed")
+def test_trainer_config_multi_gpu_dp():
+    trainer = Trainer(distributed_backend="dp", gpus=2)
+    assert trainer.use_dp is True
+    assert trainer.use_ddp is False
+    assert trainer.use_ddp2 is False
+    assert trainer.num_gpus == 2
+    assert trainer.single_gpu is False
+
+
+@pytest.mark.skipif(torch.cuda.device_count() > 2, reason="Multiple GPUs needed")
+def test_trainer_config_multi_gpu_ddp():
+    trainer = Trainer(distributed_backend="ddp", gpus=2)
+    assert trainer.use_dp is False
+    assert trainer.use_ddp is True
+    assert trainer.use_ddp2 is False
+    assert trainer.num_gpus == 2
+    assert trainer.single_gpu is False
+
+
+@pytest.mark.skipif(torch.cuda.device_count() > 2, reason="Multiple GPUs needed")
+def test_trainer_config_multi_gpu_ddp2():
+    trainer = Trainer(distributed_backend="ddp2", gpus=2)
+    assert trainer.use_dp is False
+    assert trainer.use_ddp is False
+    assert trainer.use_ddp2 is True
+    assert trainer.num_gpus == 2
+    assert trainer.single_gpu is False

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -820,7 +820,7 @@ def test_trainer_config_single_gpu_ddp2():
     assert trainer.num_processes == 1
 
 
-@pytest.mark.skipif(torch.cuda.device_count() > 2, reason="Multiple GPUs needed")
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")
 def test_trainer_config_multi_gpu():
     """Test fallback to DP if no distributed_backend specified"""
     with pytest.warns(UserWarning):
@@ -834,7 +834,7 @@ def test_trainer_config_multi_gpu():
     assert trainer.num_processes == 1
 
 
-@pytest.mark.skipif(torch.cuda.device_count() > 2, reason="Multiple GPUs needed")
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")
 def test_trainer_config_multi_gpu_dp():
     trainer = Trainer(distributed_backend="dp", gpus=2)
     assert trainer.use_dp is True
@@ -846,7 +846,7 @@ def test_trainer_config_multi_gpu_dp():
     assert trainer.num_processes == 1
 
 
-@pytest.mark.skipif(torch.cuda.device_count() > 2, reason="Multiple GPUs needed")
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")
 def test_trainer_config_multi_gpu_ddp():
     trainer = Trainer(distributed_backend="ddp", gpus=2)
     assert trainer.use_dp is False
@@ -858,7 +858,7 @@ def test_trainer_config_multi_gpu_ddp():
     assert trainer.num_processes == 2
 
 
-@pytest.mark.skipif(torch.cuda.device_count() > 2, reason="Multiple GPUs needed")
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")
 def test_trainer_config_multi_gpu_ddp2():
     trainer = Trainer(distributed_backend="ddp2", gpus=2)
     assert trainer.use_dp is False

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -659,7 +659,6 @@ def test_trainer_interrupted_flag(tmpdir):
     trainer.fit(model)
     assert trainer.interrupted
 
-
 def test_gradient_clipping(tmpdir):
     """
     Test gradient clipping
@@ -702,185 +701,114 @@ def test_gpu_choice(tmpdir):
         Trainer(**trainer_options, gpus=num_gpus + 1, auto_select_gpus=True)
 
 
-def test_trainer_config_cpu():
-    trainer = Trainer(distributed_backend=None, gpus=None)
-    assert trainer.use_dp is False
-    assert trainer.use_ddp is False
-    assert trainer.use_ddp2 is False
-    assert trainer.num_gpus == 0
-    assert trainer.on_gpu is False
-    assert trainer.single_gpu is False
-    assert trainer.num_processes == 1
-
-
-def test_trainer_config_nogpu_dp():
-    """Fall back to non-distributed training on CPU"""
-    trainer = Trainer(distributed_backend="dp", gpus=None)
-    assert trainer.use_dp is False
-    assert trainer.use_ddp is False
-    assert trainer.use_ddp2 is False
-    assert trainer.num_gpus == 0
-    assert trainer.on_gpu is False
-    assert trainer.single_gpu is False
-    assert trainer.num_processes == 1
-
-
-def test_trainer_config_nogpu_ddp():
-    """Fall back to non-distributed training on CPU"""
-    trainer = Trainer(distributed_backend="ddp", gpus=None)
-    assert trainer.use_dp is False
-    assert trainer.use_ddp is False
-    assert trainer.use_ddp2 is False
-    assert trainer.num_gpus == 0
-    assert trainer.on_gpu is False
-    assert trainer.single_gpu is False
-    assert trainer.num_processes == 1
-
-
-def test_trainer_config_nogpu_multiprocess_ddp():
-    """Fall back to ddp_cpu if num_processes is specified"""
-    trainer = Trainer(distributed_backend="ddp", num_processes=2, gpus=None)
-    assert trainer.use_dp is False
-    assert trainer.use_ddp is True
-    assert trainer.use_ddp2 is False
-    assert trainer.num_gpus == 0
-    assert trainer.on_gpu is False
-    assert trainer.single_gpu is False
-    assert trainer.num_processes == 2
-
-
-def test_trainer_config_nogpu_multinode_ddp():
-    """Fall back to ddp_cpu if num_nodes is >1"""
-    trainer = Trainer(distributed_backend="ddp", num_nodes=2, gpus=None)
-    assert trainer.use_dp is False
-    assert trainer.use_ddp is True
-    assert trainer.use_ddp2 is False
-    assert trainer.num_gpus == 0
-    assert trainer.on_gpu is False
-    assert trainer.single_gpu is False
-    assert trainer.num_processes == 1
-
-
-def test_trainer_config_nogpu_ddp_cpu():
-    trainer = Trainer(distributed_backend="ddp_cpu", num_processes=2, gpus=None)
-    assert trainer.use_dp is False
-    assert trainer.use_ddp is True
-    assert trainer.use_ddp2 is False
-    assert trainer.num_gpus == 0
-    assert trainer.on_gpu is False
-    assert trainer.single_gpu is False
-    assert trainer.num_processes == 2
-
-
-def test_trainer_config_nogpu_ddp2():
-    """Fall back to non-distributed training on CPU"""
-    trainer = Trainer(distributed_backend="ddp2", gpus=None)
-    assert trainer.use_dp is False
-    assert trainer.use_ddp is False
-    assert trainer.use_ddp2 is False
-    assert trainer.num_gpus == 0
-    assert trainer.on_gpu is False
-    assert trainer.single_gpu is False
-    assert trainer.num_processes == 1
-
-
-@pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
-def test_trainer_config_single_gpu():
-    trainer = Trainer(distributed_backend=None, gpus=1)
-    assert trainer.use_dp is False
-    assert trainer.use_ddp is False
-    assert trainer.use_ddp2 is False
-    assert trainer.num_gpus == 1
-    assert trainer.on_gpu is True
-    assert trainer.single_gpu is True
-    assert trainer.num_processes == 1
-
-
-@pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
-def test_trainer_config_single_gpu_dp():
-    trainer = Trainer(distributed_backend="dp", gpus=1)
-    assert trainer.use_dp is True
-    assert trainer.use_ddp is False
-    assert trainer.use_ddp2 is False
-    assert trainer.num_gpus == 1
-    assert trainer.on_gpu is True
-    assert trainer.single_gpu is True
-    assert trainer.num_processes == 1
-
-
-@pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
-def test_trainer_config_single_gpu_ddp():
-    trainer = Trainer(distributed_backend="ddp", gpus=1)
-    assert trainer.use_dp is False
-    assert trainer.use_ddp is True
-    assert trainer.use_ddp2 is False
-    assert trainer.num_gpus == 1
-    assert trainer.on_gpu is True
-    assert trainer.single_gpu is True
-    assert trainer.num_processes == 1
-
-
-@pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
-def test_trainer_config_single_gpu_ddp_cpu():
-    with pytest.warns(UserWarning):
-        trainer = Trainer(distributed_backend="ddp_cpu", num_processes=2, gpus=1)
-    assert trainer.use_dp is False
-    assert trainer.use_ddp is True
-    assert trainer.use_ddp2 is False
-    assert trainer.num_gpus == 0
-    assert trainer.on_gpu is False
-    assert trainer.single_gpu is False
-    assert trainer.num_processes == 2
-
-
-@pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")
-def test_trainer_config_single_gpu_ddp2():
-    trainer = Trainer(distributed_backend="ddp2", gpus=1)
-    assert trainer.use_dp is False
-    assert trainer.use_ddp is False
-    assert trainer.use_ddp2 is True
-    assert trainer.num_gpus == 1
-    assert trainer.on_gpu is True
-    assert trainer.single_gpu is False
-    assert trainer.num_processes == 1
-
-
-@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")
-def test_trainer_config_multi_gpu():
-    """Test fallback to DP if no distributed_backend specified"""
-    with pytest.warns(UserWarning):
-        trainer = Trainer(distributed_backend=None, gpus=2)
-    assert trainer.use_dp is True
-    assert trainer.use_ddp is False
-    assert trainer.use_ddp2 is False
-    assert trainer.num_gpus == 2
-    assert trainer.on_gpu is True
-    assert trainer.single_gpu is False
-    assert trainer.num_processes == 1
-
-
-@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")
-def test_trainer_config_multi_gpu_dp():
-    trainer = Trainer(distributed_backend="dp", gpus=2)
-    assert trainer.use_dp is True
-    assert trainer.use_ddp is False
-    assert trainer.use_ddp2 is False
-    assert trainer.num_gpus == 2
-    assert trainer.on_gpu is True
-    assert trainer.single_gpu is False
-    assert trainer.num_processes == 1
-
-
-@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")
-def test_trainer_config_multi_gpu_ddp():
-    trainer = Trainer(distributed_backend="ddp", gpus=2)
-    assert trainer.use_dp is False
-    assert trainer.use_ddp is True
-    assert trainer.use_ddp2 is False
-    assert trainer.num_gpus == 2
-    assert trainer.single_gpu is False
-    assert trainer.on_gpu is True
-    assert trainer.num_processes == 2
+@pytest.mark.parametrize(
+    "trainer_kwargs,expected",
+    [
+        (
+            dict(distributed_backend=None, gpus=None),
+            dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0,
+                 on_gpu=False, single_gpu=False, num_processes=1)
+        ),
+        (
+            dict(distributed_backend="dp", gpus=None),
+            dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0,
+                 on_gpu=False, single_gpu=False, num_processes=1)
+        ),
+        (
+            dict(distributed_backend="dp", gpus=None),
+            dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0,
+                 on_gpu=False, single_gpu=False, num_processes=1)
+        ),
+        (
+            dict(distributed_backend="ddp", gpus=None),
+            dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0,
+                 on_gpu=False, single_gpu=False, num_processes=1)
+        ),
+        (
+            dict(distributed_backend="ddp", num_processes=2, gpus=None),
+            dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=0,
+                 on_gpu=False, single_gpu=False, num_processes=2)
+        ),
+        (
+            dict(distributed_backend="ddp", num_nodes=2, gpus=None),
+            dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=0,
+                 on_gpu=False, single_gpu=False, num_processes=1)
+        ),
+        (
+            dict(distributed_backend="ddp_cpu", num_processes=2, gpus=None),
+            dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=0,
+                 on_gpu=False, single_gpu=False, num_processes=2)
+        ),
+        (
+            dict(distributed_backend="ddp2", gpus=None),
+            dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=0,
+                 on_gpu=False, single_gpu=False, num_processes=1)
+        ),
+        pytest.param(
+            dict(distributed_backend=None, gpus=1),
+            dict(use_dp=False, use_ddp=False, use_ddp2=False, num_gpus=1,
+                 on_gpu=True, single_gpu=True, num_processes=1),
+            marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
+        ),
+        pytest.param(
+            dict(distributed_backend="dp", gpus=1),
+            dict(use_dp=True, use_ddp=False, use_ddp2=False, num_gpus=1,
+                 on_gpu=True, single_gpu=True, num_processes=1),
+            marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
+        ),
+        pytest.param(
+            dict(distributed_backend="ddp", gpus=1),
+            dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=1,
+                 on_gpu=True, single_gpu=True, num_processes=1),
+            marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
+        ),
+        pytest.param(
+            dict(distributed_backend="ddp_cpu", num_processes=2, gpus=1),
+            dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=0,
+                 on_gpu=False, single_gpu=False, num_processes=2),
+            marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
+        ),
+        pytest.param(
+            dict(distributed_backend="ddp2", gpus=1),
+            dict(use_dp=False, use_ddp=False, use_ddp2=True, num_gpus=1,
+                 on_gpu=True, single_gpu=False, num_processes=1),
+            marks=[pytest.mark.skipif(torch.cuda.device_count() == 0, reason="GPU needed")]
+        ),
+        pytest.param(
+            dict(distributed_backend=None, gpus=2),
+            dict(use_dp=True, use_ddp=False, use_ddp2=False, num_gpus=2,
+                 on_gpu=True, single_gpu=False, num_processes=1),
+            marks=[pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")]
+        ),
+        pytest.param(
+            dict(distributed_backend="dp", gpus=2),
+            dict(use_dp=True, use_ddp=False, use_ddp2=False, num_gpus=2,
+                 on_gpu=True, single_gpu=False, num_processes=1),
+            marks=[pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")]
+        ),
+        pytest.param(
+            dict(distributed_backend="ddp", gpus=2),
+            dict(use_dp=False, use_ddp=True, use_ddp2=False, num_gpus=2,
+                 on_gpu=True, single_gpu=False, num_processes=2),
+            marks=[pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")]
+        ),
+        pytest.param(
+            dict(distributed_backend="ddp2", gpus=2),
+            dict(use_dp=False, use_ddp=False, use_ddp2=True, num_gpus=2,
+                 on_gpu=True, single_gpu=False, num_processes=1),
+            marks=[pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")]
+        ),
+    ]
+)
+def test_trainer_config(trainer_kwargs, expected):
+    trainer = Trainer(**trainer_kwargs)
+    assert trainer.use_dp is expected["use_dp"]
+    assert trainer.use_ddp is expected["use_ddp"]
+    assert trainer.use_ddp2 is expected["use_ddp2"]
+    assert trainer.num_gpus == expected["num_gpus"]
+    assert trainer.on_gpu is expected["on_gpu"]
+    assert trainer.single_gpu is expected["single_gpu"]
+    assert trainer.num_processes == expected["num_processes"]
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Multiple GPUs needed")


### PR DESCRIPTION
New feature: DDP on CPU. This can be used for distributed training with out GPUs, or to test/debug DDP on single machine without GPUs.. Since PyTorch already makes good use of multiple cores under the hood, this *will not* provide any speedup over normal CPU training if you're only using a single node.

API changes:

* New distributed backend: `distributed_backend="ddp_cpu"`
* New `Trainer` argument: `num_processes`. Controls the number or processes per node. Is currently only used by `ddp_cpu`.

Still need to update the documentation, but I wanted to get some eyes on this before I got too far. Right now everything if functional as far as I can tell, and I've added a new test that covers this feature.