### PR TITLE
fixing Win failed import

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -2,8 +2,8 @@ name: Automatic Rebase
 # https://github.com/marketplace/actions/automatic-rebase
 
 on:
-  issue_comment:
-    types: [created]
+  - pull_request
+
 jobs:
   rebase:
     name: Rebase

--- a/pytorch_lightning/__init__.py
+++ b/pytorch_lightning/__init__.py
@@ -1,6 +1,6 @@
 """Root package info."""
 
-__version__ = '0.7.1'
+__version__ = '0.7.2-dev'
 __author__ = 'William Falcon et al.'
 __author_email__ = 'waf2107@columbia.edu'
 __license__ = 'Apache-2.0'

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -22,10 +22,10 @@ from torch.optim.optimizer import Optimizer
 
 try:
     from apex import amp
-
-    APEX_AVAILABLE = True
 except ImportError:
     APEX_AVAILABLE = False
+else:
+    APEX_AVAILABLE = True
 
 
 class ModelHooks(torch.nn.Module):

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 from torch import Tensor
-from torch.distributed import init_process_group
+import torch.distributed as torch_distrib
 from torch.nn.parallel import DistributedDataParallel
 from torch.optim import Adam
 from torch.optim.optimizer import Optimizer
@@ -24,10 +24,10 @@ from pytorch_lightning.utilities.debugging import MisconfigurationException
 
 try:
     import torch_xla.core.xla_model as xm
-    XLA_AVAILABLE = True
-
 except ImportError:
     XLA_AVAILABLE = False
+else:
+    XLA_AVAILABLE = True
 
 
 class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
@@ -859,7 +859,7 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
 
         root_node = self.trainer.resolve_root_node_address(root_node)
         os.environ['MASTER_ADDR'] = root_node
-        init_process_group('nccl', rank=proc_rank, world_size=world_size)
+        torch_distrib.init_process_group('nccl', rank=proc_rank, world_size=world_size)
 
     def configure_apex(
             self,

--- a/pytorch_lightning/trainer/auto_mix_precision.py
+++ b/pytorch_lightning/trainer/auto_mix_precision.py
@@ -1,13 +1,12 @@
-
+import logging as log
 from abc import ABC
 
 try:
     from apex import amp
-
-    APEX_AVAILABLE = True
 except ImportError:
     APEX_AVAILABLE = False
-import logging as log
+else:
+    APEX_AVAILABLE = True
 
 
 class TrainerAMPMixin(ABC):

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Union, List, Tuple, Callable
 
-import torch.distributed as dist
+import torch.distributed as torch_distrib
 from torch.utils.data import SequentialSampler, DataLoader
 from torch.utils.data.distributed import DistributedSampler
 
@@ -224,7 +224,7 @@ class TrainerDataLoadingMixin(ABC):
         # get the function we'll use to get data
         if self.use_ddp or self.use_ddp2:
             # all processes wait until data download has happened
-            dist.barrier()
+            torch_distrib.barrier()
 
         # data download/load on TPU
         elif self.use_tpu and XLA_AVAILABLE:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -8,7 +8,7 @@ from typing import Union, Optional, List, Dict, Tuple, Iterable
 
 import torch
 from torch import optim
-import torch.distributed as dist
+import torch.distributed as torch_distrib
 import torch.multiprocessing as mp
 from torch.optim.optimizer import Optimizer
 from torch.utils.data import DataLoader
@@ -748,7 +748,7 @@ class Trainer(
             self.logger.save()
 
         if self.use_ddp or self.use_ddp2:
-            dist.barrier()
+            torch_distrib.barrier()
 
         # wait for all models to restore weights
         if self.on_tpu and XLA_AVAILABLE:

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -100,7 +100,7 @@ from subprocess import call
 from typing import Union
 
 import torch
-import torch.distributed as dist
+import torch.distributed as torch_distrib
 
 from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.loggers import LightningLoggerBase
@@ -177,7 +177,7 @@ class TrainerIOMixin(ABC):
         # wait for all models to restore weights
         if self.use_ddp or self.use_ddp2:
             # wait for all processes to catch up
-            dist.barrier()
+            torch_distrib.barrier()
 
         # wait for all models to restore weights
         if self.on_tpu and XLA_AVAILABLE:


### PR DESCRIPTION
## What does this PR do?
Fixing the failing imports on Windows, see:
```
c:\hostedtoolcache\windows\python\3.6.8\x64\lib\site-packages\py\_path\local.py:701: in pyimport
    __import__(modname)
pytorch_lightning\__init__.py:27: in <module>
    from .core import LightningModule
pytorch_lightning\core\__init__.py:316: in <module>
    from .lightning import LightningModule
pytorch_lightning\core\lightning.py:12: in <module>
    from torch.distributed import init_process_group
E   ImportError: cannot import name 'init_process_group'
```
minor: Reduce nb calling rebase actions and also state version as develop

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
