### PR TITLE
Fix Configuring Learning Rate Schedulers

### DIFF
--- a/docs/source/optimizers.rst
+++ b/docs/source/optimizers.rst
@@ -19,6 +19,20 @@ Every optimizer you use can be paired with any `LearningRateScheduler <https://p
    def configure_optimizers(self):
       return [Adam(...), SGD(...)], [ReduceLROnPlateau(), LambdaLR()]
 
+   # Same as above with additional params passed to the first scheduler
+   def configure_optimizers(self):
+      optimizers = [Adam(...), SGD(...)]
+      schedulers = [
+         {
+            'scheduler': ReduceLROnPlateau(mode='max', patience=7),
+            'monitor': 'val_recall', # Default: val_loss
+            'interval': 'epoch',
+            'frequency': 1
+         },
+         LambdaLR()
+      ]
+      return optimizers, schedulers
+
 
 Use multiple optimizers (like GANs)
 -------------------------------------

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -944,34 +944,27 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
 
         Some things to note:
 
-            Lightning calls ``.backward()`` and ``.step()`` on each optimizer
-            and learning rate scheduler as needed.
+            - Lightning calls ``.backward()`` and ``.step()`` on each optimizer
+             and learning rate scheduler as needed.
+            - If you use 16-bit precision (``precision=16``), Lightning will automatically
+             handle the optimizers for you.
+            - If you use multiple optimizers, training_step will have an additional ``optimizer_idx`` parameter.
+            - If you use LBFGS lightning handles the closure function automatically for you.
+            - If you use multiple optimizers, gradients will be calculated only
+             for the parameters of current optimizer at each training step.
+            - If you need to control how often those optimizers step or override the
+             default .step() schedule, override the `optimizer_step` hook.
+            - If you only want to call a learning rate scheduler every `x` step or epoch,
+             or want to monitor a custom metric, you can specify these in a dictionary:
 
-            If you use 16-bit precision (``precision=16``), Lightning will automatically
-            handle the optimizers for you.
+                .. code-block:: python
 
-            If you use multiple optimizers, training_step will have an additional
-            ``optimizer_idx`` parameter.
-
-            If you use LBFGS lightning handles the closure function automatically for you.
-
-            If you use multiple optimizers, gradients will be calculated only
-            for the parameters of current optimizer at each training step.
-
-            If you need to control how often those optimizers step or override the
-            default .step() schedule, override the `optimizer_step` hook.
-
-            If you only want to call a learning rate scheduler every `x` step or epoch,
-            or want to monitor a custom metric, you can specify these in a dictionary:
-
-            .. code-block:: python
-
-                {
-                    'scheduler': lr_scheduler,
-                    'interval': 'step'  # or 'epoch'
-                    'monitor': 'val_f1',
-                    'frequency': x
-                }
+                    {
+                        'scheduler': lr_scheduler,
+                        'interval': 'step'  # or 'epoch'
+                        'monitor': 'val_f1',
+                        'frequency': x
+                    }
 
         """
         return Adam(self.parameters(), lr=1e-3)

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -942,28 +942,36 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
                     dis_sched = CosineAnnealing(discriminator_opt, T_max=10) # called every epoch
                     return [gen_opt, dis_opt], [gen_sched, dis_sched]
 
-        Some things to know
+        Some things to note:
 
-            - Lightning calls ``.backward()`` and ``.step()`` on each optimizer
+            Lightning calls ``.backward()`` and ``.step()`` on each optimizer
             and learning rate scheduler as needed.
 
-            - If you use 16-bit precision (``precision=16``), Lightning will automatically
+            If you use 16-bit precision (``precision=16``), Lightning will automatically
             handle the optimizers for you.
 
-            - If you use multiple optimizers, training_step will have an additional
+            If you use multiple optimizers, training_step will have an additional
             ``optimizer_idx`` parameter.
 
-            - If you use LBFGS lightning handles the closure function automatically for you
+            If you use LBFGS lightning handles the closure function automatically for you.
 
-            - If you use multiple optimizers, gradients will be calculated only
+            If you use multiple optimizers, gradients will be calculated only
             for the parameters of current optimizer at each training step.
 
-            - If you need to control how often those optimizers step or override the
+            If you need to control how often those optimizers step or override the
             default .step() schedule, override the `optimizer_step` hook.
 
-            - If you only want to call a learning rate scheduler every `x` step or epoch,
-            you can input this as 'frequency' key: dict(scheduler=lr_scheduler,
-                                                        interval='step' or 'epoch', frequency=x)
+            If you only want to call a learning rate scheduler every `x` step or epoch,
+            or want to monitor a custom metric, you can specify these in a dictionary:
+
+            .. code-block:: python
+
+                {
+                    'scheduler': lr_scheduler,
+                    'interval': 'step'  # or 'epoch'
+                    'monitor': 'val_f1',
+                    'frequency': x
+                }
 
         """
         return Adam(self.parameters(), lr=1e-3)

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -942,8 +942,7 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
                     dis_sched = CosineAnnealing(discriminator_opt, T_max=10) # called every epoch
                     return [gen_opt, dis_opt], [gen_sched, dis_sched]
 
-        Some things to note:
-
+        .. note:: Some things to note:
             - Lightning calls ``.backward()`` and ``.step()`` on each optimizer
              and learning rate scheduler as needed.
             - If you use 16-bit precision (``precision=16``), Lightning will automatically
@@ -956,7 +955,6 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
              default .step() schedule, override the `optimizer_step` hook.
             - If you only want to call a learning rate scheduler every `x` step or epoch,
              or want to monitor a custom metric, you can specify these in a dictionary:
-
                 .. code-block:: python
 
                     {


### PR DESCRIPTION
# Before submitting

- [x] Was this **discussed**/~~approved~~ via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Fixes #1157 Clarifies within the docs how and where to set scheduler parameters.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
This PR would have saved me an hour, so collectively, I hope it it savs many dev-hours.

At least two others [A](https://github.com/PyTorchLightning/pytorch-lightning/issues/1157), [B](https://github.com/PyTorchLightning/pytorch-lightning/issues/1156) similarly shared confusion about how best and where to set scheduler parameters.

Two places in the docs speak to configuring schedulers:

- [Common Use Cases](https://pytorch-lightning.readthedocs.io/en/0.7.1/optimizers.html#learning-rate-scheduling)
- [Core .configure_optimizers Docs](https://pytorch-lightning.readthedocs.io/en/latest/pytorch_lightning.core.html#pytorch_lightning.core.LightningModule.configure_optimizers)

Neither sufficiently instructs users the appropriate or intended manner of monitoring non-default values or what parameters pytorch searches for to manage schedulers. The functionality exist; it just needs better marketing / documentation =). This PR updates the appropriate .rst files to provide clarity how best to use this functionality.

Docs updated and PEP8 is still in effect.