### PR TITLE
WIP:removed unused Trainer kwargs from init

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -120,7 +120,6 @@ class Trainer(
             profiler: Optional[BaseProfiler] = None,
             benchmark: bool = False,
             reload_dataloaders_every_epoch: bool = False,
-            **kwargs
     ):
         r"""
 


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
discussed on slack
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?
current tests should cover this
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
It removes kwargs from Trainer which are not used.

My take on using kwargs on function:
All kwargs should have a consumer.
```
f_ok(a, b, **kwargs):
    # ok
     f2(**kwargs) 

f_ko(a, b, **kwargs):
    # kwargs are just for future convenience for future implementations/ for overriden functions
    # allows passing unsupported arguments and creates confusion that the args are supported
    # if the kwargs are not consumed
     f3(a, b)

f_also_ko(a, b, **kwargs):
     # same arguments as above - all kwargs needs to be consumed
     f4(a, b, kwargs['c'])
```

## Did you have fun?
 🙃
