### PR TITLE
Issue 1161

### DIFF
--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -96,9 +96,6 @@ class TrainerDataLoadingMixin(ABC):
 
             dl_args['sampler'] = sampler
             dataloader = DataLoader(**dl_args)
-        # else:
-        #     sampler = SequentialSampler(dataloader.dataset)
-        #     dl_args['sampler'] = sampler
 
         return dataloader
 

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -91,15 +91,15 @@ class TrainerDataLoadingMixin(ABC):
                 )
                 dl_args['shuffle'] = False
             else:
-                if train:
-                    sampler = DistributedSampler(dataloader.dataset)
-                    dl_args['shuffle'] = False
-                else:
-                    sampler = SequentialSampler(dataloader.dataset)
+                sampler = DistributedSampler(dataloader.dataset)
+                dl_args['shuffle'] = False
 
             dl_args['sampler'] = sampler
-
             dataloader = DataLoader(**dl_args)
+        # else:
+        #     sampler = SequentialSampler(dataloader.dataset)
+        #     dl_args['sampler'] = sampler
+
         return dataloader
 
     def reset_train_dataloader(self, model: LightningModule) -> None:


### PR DESCRIPTION
Fix for issue 1161: when using ddp/ddpd2, the validation and training loops run the full respective dataset on each gpu. This costs time, and changes batch counts for any statistics being collected.

The fix just makes sure the for ddp and ddp2, `auto_add_sampler()` createes a `DistributedSampler` for each data set.

This passes all the tests on my machine except for slurm and apex related as I do not have either. I don't think this needs any doc changes. I can look into writing a test for this ... if needed. Let me know.