### PR TITLE
docs: training_epoch_end return value fix

### DIFF
--- a/docs/source/experiment_reporting.rst
+++ b/docs/source/experiment_reporting.rst
@@ -44,7 +44,7 @@ To plot metrics into whatever logger you passed in (tensorboard, comet, neptune,
       ...
 
       logs = {'train_loss': loss}
-      results = {'log': logs}
+      results = {'loss': loss, 'log': logs}
       return results
 
    def validation_epoch_end(self, outputs):


### PR DESCRIPTION
## What does this PR do?
Fixes issue #1175.

I.e., updates the docs for `training_epoch_end`.