### PR TITLE
Fix requirements-extra.txt Trains package to release version

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,10 +233,12 @@ trainer.test()
 ## Visualization
 Lightning has out-of-the-box integration with the popular logging/visualizing frameworks
 
-- Tensorboard
-- MLFlow
-- Neptune.ai
-- Comet.ml
+- [Tensorboard](https://pytorch.org/docs/stable/tensorboard.html)
+- [MLFlow](https://mlflow.org/)
+- [Neptune.ai](https://neptune.ai/)
+- [Comet.ml](https://www.comet.ml/site/)
+- [Wandb](https://www.wandb.com/)
+- [Trains](https://github.com/allegroai/trains)
 - ...  
 
 ![tensorboard-support](docs/source/_images/general/tf_loss.png)

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -3,4 +3,4 @@ comet-ml>=1.0.56
 mlflow>=1.0.0
 test_tube>=0.7.5
 wandb>=0.8.21
-trains>=0.14.1rc0
+trains>=0.14.1


### PR DESCRIPTION
@Borda, Fixing [PR #1226](https://github.com/PyTorchLightning/pytorch-lightning/pull/1226)
Now re-based to master

Copied from PR 1226:

I noticed the requirements-extra.txt points to an RC version of Trains.
Since if in a requirements.txt the minimum version is an RC version, pip will always pull the latest pre-release version. I don't think this is what we want, especially with the CI :)
I fixed requirements-extra.txt to point to the latest released version.

Apologies for the mess (again) ...

EDIT:
For the sake of completeness, I also added a reference to Trains in the README visualization section