### PR TITLE
Scheduler initialized after Apex

### DIFF
--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -163,6 +163,10 @@ class TrainerDDPMixin(ABC):
     def init_optimizers(self, *args):
         """Warning: this is just empty shell for code implemented in other class."""
 
+    @abstractmethod
+    def configure_schedulers(self, *args):
+        """Warning: this is just empty shell for code implemented in other class."""
+
     def init_tpu(self):
         # turn off all the GPU stuff
         self.distributed_backend = None
@@ -325,6 +329,7 @@ class TrainerDDPMixin(ABC):
             # An example
             model, optimizers = model.configure_apex(amp, model, self.optimizers, self.amp_level)
             self.optimizers = optimizers
+            self.lr_schedulers = self.configure_schedulers(self.lr_schedulers)
 
         # DDP2 uses all GPUs on the machine
         if self.distributed_backend == 'ddp':

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -390,6 +390,10 @@ class TrainerDPMixin(ABC):
     def init_optimizers(self, *args):
         """Warning: this is just empty shell for code implemented in other class."""
 
+    @abstractmethod
+    def configure_schedulers(self, *args):
+        """Warning: this is just empty shell for code implemented in other class."""
+
     def copy_trainer_model_properties(self, model):
         if isinstance(model, LightningDataParallel):
             ref_model = model.module
@@ -465,6 +469,7 @@ class TrainerDPMixin(ABC):
             # An example
             model, optimizers = model.configure_apex(amp, model, self.optimizers, self.amp_level)
             self.optimizers = optimizers
+            self.lr_schedulers = self.configure_schedulers(self.lr_schedulers)
 
         self.run_pretrain_routine(model)
 
@@ -520,6 +525,7 @@ class TrainerDPMixin(ABC):
                 raise MisconfigurationException(m)
             else:
                 model, optimizers = model.configure_apex(amp, model, self.optimizers, self.amp_level)
+                self.lr_schedulers = self.configure_schedulers(self.lr_schedulers)
 
         # create list of device ids
         device_ids = self.data_parallel_device_ids

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -770,7 +770,8 @@ class Trainer(
         # two lists, optimizer + lr schedulers
         elif len(optimizers) == 2 and isinstance(optimizers[0], list):
             optimizers, lr_schedulers = optimizers
-            lr_schedulers = self.configure_schedulers(lr_schedulers)
+            if not self.use_amp:
+                lr_schedulers = self.configure_schedulers(lr_schedulers)
             return optimizers, lr_schedulers
 
         # single list or tuple, multiple optimizer


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Fixes the following issues as discussed in issue #841.

Moved the initialization of learning rate schedulers to after the initialization of apex optimizers if use_amp is set to True.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
