### PR TITLE
Error on zero length dataloaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for non-primitive types in `hparams` for `TensorboardLogger` ([#1130](https://github.com/PyTorchLightning/pytorch-lightning/pull/1130))
 - Added a check that stops the training when loss or weights contain `NaN` or `inf` values. ([#1097](https://github.com/PyTorchLightning/pytorch-lightning/pull/1097))
 - Updated references to self.forward() to instead use the `__call__` interface. ([#1211](https://github.com/PyTorchLightning/pytorch-lightning/pull/1211))
+- Added informative errors if user defined dataloader has zero length ([#1280](https://github.com/PyTorchLightning/pytorch-lightning/pull/1280))
 
 ### Changed
 

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -30,8 +30,7 @@ def _has_len(dataloader: DataLoader) -> bool:
     it is a finite dataloader or infinite dataloader """
     try:
         # try getting the length
-        val = len(dataloader)
-        if val == 0:
+        if len(dataloader) == 0:
             raise ValueError('Dataloader returned 0 length. Please make sure'
                              ' that your Dataloader atleast returns 1 batch')
         return True

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -26,9 +26,14 @@ else:
 
 
 def _has_len(dataloader: DataLoader) -> bool:
+    """ Checks if a given Dataloader has __len__ method implemented i.e. if
+    it is a finite dataloader or infinite dataloader """
     try:
         # try getting the length
-        _ = len(dataloader)
+        val = len(dataloader)
+        if val == 0:
+            raise ValueError('Dataloader returned 0 length. Please make sure'
+                             ' that your Dataloader atleast returns 1 batch')
         return True
     except TypeError:
         return False

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -25,7 +25,8 @@ from tests.base.mixins import (
     LightTestOptimizerWithSchedulingMixin,
     LightTestMultipleOptimizersWithSchedulingMixin,
     LightTestOptimizersWithMixedSchedulingMixin,
-    LightTestReduceLROnPlateauMixin
+    LightTestReduceLROnPlateauMixin,
+    LightZeroLenDataloader
 )
 
 

--- a/tests/base/mixins.py
+++ b/tests/base/mixins.py
@@ -255,6 +255,16 @@ class LightInfTestDataloader:
         return CustomInfDataloader(self._dataloader(train=False))
 
 
+class LightZeroLenDataloader:
+    """ Simple dataloader that has zero length. """
+
+    def train_dataloader(self):
+        dataloader = self._dataloader(train=True)
+        dataloader.dataset.data = dataloader.dataset.data[:0]
+        dataloader.dataset.targets = dataloader.dataset.targets[:0]
+        return dataloader
+
+
 class LightEmptyTestStep:
     """Empty test step."""
 

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -16,7 +16,8 @@ from tests.base import (
     LightTrainDataloader,
     LightInfTrainDataloader,
     LightInfValDataloader,
-    LightInfTestDataloader
+    LightInfTestDataloader,
+    LightZeroLenDataloader
 )
 
 
@@ -450,3 +451,26 @@ def test_inf_test_dataloader(tmpdir):
 
     # verify training completed
     assert result == 1
+
+
+def test_error_on_zero_len_dataloader(tmpdir):
+    """ Test that error is raised if a zero-length dataloader is defined """
+    tutils.reset_seed()
+
+    class CurrentTestModel(
+        LightZeroLenDataloader,
+        LightningTestModel
+    ):
+        pass
+
+    hparams = tutils.get_default_hparams()
+    model = CurrentTestModel(hparams)
+
+    # fit model
+    with pytest.raises(ValueError):
+        trainer = Trainer(
+            default_save_path=tmpdir,
+            max_epochs=1,
+            test_percent_check=0.5
+        )
+        trainer.fit(model)


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/1131.
Return a `ValueError` if user specified dataloaders has zero length (no batches). Current error returned are non-informative.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
