### PR TITLE
Fix for incorrect run on the validation set with overwritten validation_epoch_end and test_end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed an issue where `val_percent_check=0` would not disable validation ([#1251](https://github.com/PyTorchLightning/pytorch-lightning/pull/1251))
 - Fixed average of incomplete `TensorRunningMean` ([#1309](https://github.com/PyTorchLightning/pytorch-lightning/pull/1309))
 - Fixed an issue with early stopping that would prevent it from monitoring training metrics when validation is disabled / not implemented ([#1235](https://github.com/PyTorchLightning/pytorch-lightning/pull/1235)). 
+- Fixed a bug that would cause `trainer.test()` to run on the validation set when overloading `validation_epoch_end ` and `test_end` ([#1353](https://github.com/PyTorchLightning/pytorch-lightning/pull/1353)).
 
 ## [0.7.1] - 2020-03-07
 

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -296,20 +296,25 @@ class TrainerEvaluationLoopMixin(ABC):
         if isinstance(model, (LightningDistributedDataParallel, LightningDataParallel)):
             model = model.module
 
-        # TODO: remove in v1.0.0
-        if test_mode and self.is_overriden('test_end', model=model):
-            eval_results = model.test_end(outputs)
-            warnings.warn('Method `test_end` was deprecated in 0.7.0 and will be removed 1.0.0.'
-                          ' Use `test_epoch_end` instead.', DeprecationWarning)
-        elif self.is_overriden('validation_end', model=model):
-            eval_results = model.validation_end(outputs)
-            warnings.warn('Method `validation_end` was deprecated in 0.7.0 and will be removed 1.0.0.'
-                          ' Use `validation_epoch_end` instead.', DeprecationWarning)
+        if test_mode:
+            if self.is_overriden('test_end', model=model):
+                # TODO: remove in v1.0.0
+                eval_results = model.test_end(outputs)
+                warnings.warn('Method `test_end` was deprecated in 0.7.0 and will be removed 1.0.0.'
+                              ' Use `test_epoch_end` instead.', DeprecationWarning)
 
-        if test_mode and self.is_overriden('test_epoch_end', model=model):
-            eval_results = model.test_epoch_end(outputs)
-        elif self.is_overriden('validation_epoch_end', model=model):
-            eval_results = model.validation_epoch_end(outputs)
+            elif self.is_overriden('test_epoch_end', model=model):
+                eval_results = model.test_epoch_end(outputs)
+
+        else:
+            if self.is_overriden('validation_end', model=model):
+                # TODO: remove in v1.0.0
+                eval_results = model.validation_end(outputs)
+                warnings.warn('Method `validation_end` was deprecated in 0.7.0 and will be removed 1.0.0.'
+                              ' Use `validation_epoch_end` instead.', DeprecationWarning)
+
+            elif self.is_overriden('validation_epoch_end', model=model):
+                eval_results = model.validation_epoch_end(outputs)
 
         # enable train mode again
         model.train()

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -555,8 +555,10 @@ def test_disabled_validation():
     # check that val_percent_check=0 turns off validation
     assert result == 1, 'training failed to complete'
     assert trainer.current_epoch == 1
-    assert not model.validation_step_invoked, '`validation_step` should not run when `val_percent_check=0`'
-    assert not model.validation_epoch_end_invoked, '`validation_epoch_end` should not run when `val_percent_check=0`'
+    assert not model.validation_step_invoked, \
+        '`validation_step` should not run when `val_percent_check=0`'
+    assert not model.validation_epoch_end_invoked, \
+        '`validation_epoch_end` should not run when `val_percent_check=0`'
 
     # check that val_percent_check has no influence when fast_dev_run is turned on
     model = CurrentModel(hparams)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -568,8 +568,10 @@ def test_disabled_validation():
 
     assert result == 1, 'training failed to complete'
     assert trainer.current_epoch == 0
-    assert model.validation_step_invoked, 'did not run `validation_step` with `fast_dev_run=True`'
-    assert model.validation_epoch_end_invoked, 'did not run `validation_end` with `fast_dev_run=True`'
+    assert model.validation_step_invoked, \
+        'did not run `validation_step` with `fast_dev_run=True`'
+    assert model.validation_epoch_end_invoked, \
+        'did not run `validation_epoch_end` with `fast_dev_run=True`'
 
 
 def test_nan_loss_detection(tmpdir):

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -528,15 +528,15 @@ def test_disabled_validation():
     class CurrentModel(LightTrainDataloader, LightValidationMixin, TestModelBase):
 
         validation_step_invoked = False
-        validation_end_invoked = False
+        validation_epoch_end_invoked = False
 
         def validation_step(self, *args, **kwargs):
             self.validation_step_invoked = True
             return super().validation_step(*args, **kwargs)
 
-        def validation_end(self, *args, **kwargs):
-            self.validation_end_invoked = True
-            return super().validation_end(*args, **kwargs)
+        def validation_epoch_end(self, *args, **kwargs):
+            self.validation_epoch_end_invoked = True
+            return super().validation_epoch_end(*args, **kwargs)
 
     hparams = tutils.get_default_hparams()
     model = CurrentModel(hparams)
@@ -556,7 +556,7 @@ def test_disabled_validation():
     assert result == 1, 'training failed to complete'
     assert trainer.current_epoch == 1
     assert not model.validation_step_invoked, '`validation_step` should not run when `val_percent_check=0`'
-    assert not model.validation_end_invoked, '`validation_end` should not run when `val_percent_check=0`'
+    assert not model.validation_epoch_end_invoked, '`validation_epoch_end` should not run when `val_percent_check=0`'
 
     # check that val_percent_check has no influence when fast_dev_run is turned on
     model = CurrentModel(hparams)
@@ -567,7 +567,7 @@ def test_disabled_validation():
     assert result == 1, 'training failed to complete'
     assert trainer.current_epoch == 0
     assert model.validation_step_invoked, 'did not run `validation_step` with `fast_dev_run=True`'
-    assert model.validation_end_invoked, 'did not run `validation_end` with `fast_dev_run=True`'
+    assert model.validation_epoch_end_invoked, 'did not run `validation_end` with `fast_dev_run=True`'
 
 
 def test_nan_loss_detection(tmpdir):


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs? (not needed)
- [x] Did you write any new necessary tests? (no new test, only fixing an old one related to this bug)
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Fixes #1262. 

- Fixed the bug described in the issue.
- Also fixed a test introduced in previous PR where the wrong method was tested. This was not possible to detect before because of the bug in #1262.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
