### PR TITLE
Change min max gpu memory to be on their own plots

### DIFF
--- a/pytorch_lightning/core/memory.py
+++ b/pytorch_lightning/core/memory.py
@@ -246,7 +246,7 @@ def get_memory_profile(mode: str) -> Union[Dict[str, int], Dict[int, int]]:
         min_index, min_memory = min(memory_map.items(), key=lambda item: item[1])
         max_index, max_memory = max(memory_map.items(), key=lambda item: item[1])
 
-        memory_map = {min_index: min_memory, max_index: max_memory}
+        memory_map = {'min_gpu_mem': min_memory, 'max_gpu_mem': max_memory}
 
     return memory_map
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
The original min_max gpu memory functionality has unexpected behavior where the min and max memory is plotted in the gpu_{gpu_index} plot. This doesn't make sense when the min and max gpu usage switches between GPUs during training as the plot is uninterpretable. It's also a waste of space having a gpu_{gpu_index} plot for each master node gpu when only the gpus that have the max and min memory have data points. 

This PR changes the logger to have two plots: "min_gpu_mem", "max_gpu_mem", which contain the min and max gpu memory plots respectively.