### PR TITLE
Fix fast_dev_run running validation twice

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -331,10 +331,10 @@ class Trainer(
 
         self.fast_dev_run = fast_dev_run
         if self.fast_dev_run:
-            self.num_sanity_val_steps = 1
+            self.num_sanity_val_steps = 0
             self.max_epochs = 1
             log.info('Running in fast_dev_run mode: will run a full train,'
-                     ' val loop using a single batch')
+                     ' val and test loop using a single batch')
 
         # set default save path if user didn't provide one
         self.default_save_path = default_save_path


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
At the moment, when using fast_dev_run, the validation step is run twice. This is because validation_sanity_check is set to 1 so the sanity check is run on validation and then later it's run again because fast_dev_run is run again.