### PR TITLE
Adding Intersphinx documentation links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -251,7 +251,6 @@ epub_exclude_files = ['search.html']
 
 # -- Options for intersphinx extension ---------------------------------------
 
-# Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
     'torch': ('https://pytorch.org/docs/stable/', None),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -252,7 +252,12 @@ epub_exclude_files = ['search.html']
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+    'torch': ('https://pytorch.org/docs/stable/', None),
+    'numpy': ('https://docs.scipy.org/doc/numpy/', None),
+    'PIL': ('https://pillow.readthedocs.io/en/stable/', None),
+}
 
 # -- Options for todo extension ----------------------------------------------
 


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Makes the html documentation pages link to external library documentation, like torch, numpy etc.
**Before:**
![before](https://user-images.githubusercontent.com/5495193/78417257-a8292d00-7630-11ea-94d3-b37bba6d8b09.jpg)

**After:**
![after1](https://user-images.githubusercontent.com/5495193/78417260-ad867780-7630-11ea-9b60-f37500f663a4.jpg)
(links to [Tensor](https://pytorch.org/docs/stable/tensors.html#torch.Tensor) docs on PyTorch website)

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
