### PR TITLE
Add warning for few workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added model configuration checking ([#1199](https://github.com/PyTorchLightning/pytorch-lightning/pull/1199))
 - Added support for optimizer frequencies through `LightningModule.configure_optimizers()` ([#1269](https://github.com/PyTorchLightning/pytorch-lightning/pull/1269))
 - Added option to run without an optimizer by returning `None` from `configure_optimizers`. ([#1279](https://github.com/PyTorchLightning/pytorch-lightning/pull/1279))
+- Added a warning when the number of data loader workers is small. ([#1378](https://github.com/PyTorchLightning/pytorch-lightning/pull/1378))
 
 ### Changed
 

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -75,12 +75,10 @@ class TrainerDataLoadingMixin(ABC):
             raise ValueError(msg)
 
     def _worker_check(self, dataloader: DataLoader, name: str) -> None:
-        msg = f'The dataloader, {name}, does not have many workers which may be a bottleneck. `' \
-              f'Consider increasing the value of the `num_workers` argument in the `' \
-              f'`DataLoader` init to improve performance.'
-
         if isinstance(dataloader, DataLoader) and dataloader.num_workers <= 2:
-            warnings.warn(msg)
+            warnings.warn(f'The dataloader, {name}, does not have many workers which may be a bottleneck. `'
+                          'Consider increasing the value of the `num_workers` argument in the `' \
+                          `DataLoader` init to improve performance.')
 
     def auto_add_sampler(self, dataloader: DataLoader, train: bool) -> DataLoader:
 

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -76,9 +76,9 @@ class TrainerDataLoadingMixin(ABC):
 
     def _worker_check(self, dataloader: DataLoader, name: str) -> None:
         if isinstance(dataloader, DataLoader) and dataloader.num_workers <= 2:
-            warnings.warn(f'The dataloader, {name}, does not have many workers which may be a bottleneck. `'
-                          'Consider increasing the value of the `num_workers` argument in the `' \
-                          `DataLoader` init to improve performance.')
+            warnings.warn(f'The dataloader, {name}, does not have many workers which may be a bottleneck.'
+                          ' Consider increasing the value of the `num_workers` argument`'
+                          ' in the `DataLoader` init to improve performance.')
 
     def auto_add_sampler(self, dataloader: DataLoader, train: bool) -> DataLoader:
 

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -1,8 +1,9 @@
+import warnings
 from abc import ABC, abstractmethod
 from typing import Union, List, Tuple, Callable
 
 import torch.distributed as torch_distrib
-from torch.utils.data import SequentialSampler, DataLoader
+from torch.utils.data import DataLoader
 from torch.utils.data.distributed import DistributedSampler
 
 from pytorch_lightning.core import LightningModule
@@ -73,6 +74,14 @@ class TrainerDataLoadingMixin(ABC):
         if not 0. <= value <= 1.:
             raise ValueError(msg)
 
+    def _worker_check(self, dataloader: DataLoader, name: str) -> None:
+        msg = f'The dataloader, {name}, does not have many workers which may be a bottleneck. `' \
+              f'Consider increasing the value of the `num_workers` argument in the `' \
+              f'`DataLoader` init to improve performance.'
+
+        if isinstance(dataloader, DataLoader) and dataloader.num_workers <= 2:
+            warnings.warn(msg)
+
     def auto_add_sampler(self, dataloader: DataLoader, train: bool) -> DataLoader:
 
         # don't do anything if it's not a dataloader
@@ -112,11 +121,13 @@ class TrainerDataLoadingMixin(ABC):
             model: The current `LightningModule`
         """
         self.train_dataloader = self.request_dataloader(model.train_dataloader)
+
         self.num_training_batches = 0
 
         # automatically add samplers
         self.train_dataloader = self.auto_add_sampler(self.train_dataloader, train=True)
 
+        self._worker_check(self.train_dataloader, 'train dataloader')
         self._percent_range_check('train_percent_check')
 
         if not _has_len(self.train_dataloader):
@@ -176,10 +187,10 @@ class TrainerDataLoadingMixin(ABC):
         # determine number of batches
         # datasets could be none, 1 or 2+
         if len(dataloaders) != 0:
-            for dataloader in dataloaders:
+            for i, dataloader in enumerate(dataloaders):
+                self._worker_check(dataloader, f'{mode} dataloader {i}')
                 if not _has_len(dataloader):
                     num_batches = float('inf')
-                    break
 
             percent_check = getattr(self, f'{mode}_percent_check')
 

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -517,7 +517,8 @@ def test_warning_with_few_workers(tmpdir):
     trainer = Trainer(**trainer_options)
 
     # fit model
-    with pytest.warns(UserWarning, match='train dataloader') and pytest.warns(UserWarning, match='val dataloader'):
+    with pytest.warns(UserWarning, match='train dataloader') and \
+         pytest.warns(UserWarning, match='val dataloader'):
         trainer.fit(model, **fit_options)
 
     with pytest.warns(UserWarning, match='test dataloader'):

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -517,11 +517,13 @@ def test_warning_with_few_workers(tmpdir):
     trainer = Trainer(**trainer_options)
 
     # fit model
-    with pytest.warns(UserWarning, match='train dataloader') and \
-         pytest.warns(UserWarning, match='val dataloader'):
+    with pytest.warns(UserWarning, match='train'):
         trainer.fit(model, **fit_options)
 
-    with pytest.warns(UserWarning, match='test dataloader'):
+    with pytest.warns(UserWarning, match='val'):
+        trainer.fit(model, **fit_options)
+
+    with pytest.warns(UserWarning, match='test'):
         trainer.test()
 
 


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
Fixes #1322 

- adds a warning when a data loader with only a few (<= 2) workers is used. Could potentially use a higher number?  or just warn when num workers is zero?

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
