### PR TITLE
Print test results only if prog_bar_metrics is not empty

### DIFF
--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -379,10 +379,11 @@ class TrainerEvaluationLoopMixin(ABC):
         # log results of test
         if test_mode:
             if self.proc_rank == 0:
-                print('-' * 100)
-                print('TEST RESULTS')
-                pprint(prog_bar_metrics)
-                print('-' * 100)
+                if prog_bar_metrics:
+                    print('-' * 100)
+                    print('TEST RESULTS')
+                    pprint(prog_bar_metrics)
+                    print('-' * 100)
 
         # log metrics
         self.log_metrics(log_metrics, {})

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -377,13 +377,11 @@ class TrainerEvaluationLoopMixin(ABC):
         self.add_tqdm_metrics(prog_bar_metrics)
 
         # log results of test
-        if test_mode:
-            if self.proc_rank == 0:
-                if prog_bar_metrics:
-                    print('-' * 100)
-                    print('TEST RESULTS')
-                    pprint(prog_bar_metrics)
-                    print('-' * 100)
+        if test_mode and self.proc_rank == 0 and prog_bar_metrics:
+            print('-' * 80)
+            print('TEST RESULTS')
+            pprint(prog_bar_metrics)
+            print('-' * 80)
 
         # log metrics
         self.log_metrics(log_metrics, {})


### PR DESCRIPTION
## What does this PR do?
If prog_bar_metrics is empty, does not print TEST_RESULTS. 
Useful for aesthetics, if the user has another way of displaying results. 
