### PR TITLE
Add support for logging hydra's hparams to TensorBoard.

### DIFF
--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -5,6 +5,10 @@ from abc import ABC, abstractmethod
 from argparse import Namespace
 from functools import wraps
 from typing import Union, Optional, Dict, Iterable, Any, Callable, List, Sequence, Mapping, Tuple
+try:
+    from omegaconf import OmegaConf, DictConfig
+except ImportError:
+    pass
 
 import numpy as np
 import torch
@@ -157,10 +161,12 @@ class LightningLoggerBase(ABC):
         pass
 
     @staticmethod
-    def _convert_params(params: Union[Dict[str, Any], Namespace]) -> Dict[str, Any]:
-        # in case converting from namespace
-        if isinstance(params, Namespace):
+    def _convert_params(params: Union[Dict[str, Any], Namespace, DictConfig]) -> Dict[str, Any]:
+        # in case converting from namespace or hydra config
+        if hasattr(params, "__dict__"):
             params = vars(params)
+        elif isinstance(params, DictConfig):
+            params = OmegaConf.to_container(params, resolve=True)
 
         if params is None:
             params = {}

--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -171,7 +171,7 @@ class LightningLoggerBase(ABC):
         # in case converting from Namespace or hydra's DictConfig
         if isinstance(params, Namespace):
             params = vars(params)
-        elif USING_HYDRA_CONF:
+        elif USING_HYDRA_CONF and isinstance(params, DictConfig):
             params = OmegaConf.to_container(params, resolve=True)
 
         if params is None:

--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -5,12 +5,16 @@ from abc import ABC, abstractmethod
 from argparse import Namespace
 from functools import wraps
 from typing import Union, Optional, Dict, Iterable, Any, Callable, List, Sequence, Mapping, Tuple
+
 try:
     from omegaconf import OmegaConf, DictConfig
 except ImportError:
     import logging
     logging.debug('Hydra is not installed. If you want to use Hydra for managing configuration,'
-                  'please install it with `pip install hydra_core`.')
+                  ' please install it with `pip install hydra_core`.')
+    USING_HYDRA_CONF = False
+else:
+    USING_HYDRA_CONF = True
 
 import numpy as np
 import torch
@@ -167,7 +171,7 @@ class LightningLoggerBase(ABC):
         # in case converting from Namespace or hydra's DictConfig
         if isinstance(params, Namespace):
             params = vars(params)
-        elif isinstance(params, DictConfig):
+        elif USING_HYDRA_CONF:
             params = OmegaConf.to_container(params, resolve=True)
 
         if params is None:

--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -9,7 +9,8 @@ try:
     from omegaconf import OmegaConf, DictConfig
 except ImportError:
     import logging
-    logging.debug('Hydra is not installed. If you want to use Hydra for managing configuration, please install it with `pip install hydra_core`.')
+    logging.debug('Hydra is not installed. If you want to use Hydra for managing configuration,'
+                  'please install it with `pip install hydra_core`.')
 
 import numpy as np
 import torch

--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -8,7 +8,8 @@ from typing import Union, Optional, Dict, Iterable, Any, Callable, List, Sequenc
 try:
     from omegaconf import OmegaConf, DictConfig
 except ImportError:
-    pass
+    import logging
+    logging.debug('Hydra is not installed. If you want to use Hydra for managing configuration, please install it with `pip install hydra_core`.')
 
 import numpy as np
 import torch

--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -162,8 +162,8 @@ class LightningLoggerBase(ABC):
 
     @staticmethod
     def _convert_params(params: Union[Dict[str, Any], Namespace, DictConfig]) -> Dict[str, Any]:
-        # in case converting from namespace or hydra config
-        if hasattr(params, "__dict__"):
+        # in case converting from Namespace or hydra's DictConfig
+        if isinstance(params, Namespace):
             params = vars(params)
         elif isinstance(params, DictConfig):
             params = OmegaConf.to_container(params, resolve=True)

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -7,4 +7,4 @@ test_tube>=0.7.5
 wandb>=0.8.21
 trains>=0.14.1
 matplotlib>=3.1.1
-hydra_core >=0.11.3
+hydra_core=0.11.3

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -7,3 +7,4 @@ test_tube>=0.7.5
 wandb>=0.8.21
 trains>=0.14.1
 matplotlib>=3.1.1
+hydra_core >=0.11.3

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -7,4 +7,4 @@ test_tube>=0.7.5
 wandb>=0.8.21
 trains>=0.14.1
 matplotlib>=3.1.1
-hydra_core=0.11.3
+hydra_core==0.11.3


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

## What does this PR do?
As discussed in #807, currently I can incorporate Hydra with Pytorch-Lightning easily. The only thing that's missing is hparams logging to Tensorboard.

Usage becomes: 
* in conf/config.yaml
```
data:
  - path: my_dataset/
model:
  - pretrained: albert-based-uncased
  - num_layers: 2
  - dropout: 0.5
optim:
  - lr: 3e-4
  - momentum: 0.99
  - scheduler: CosineLR

# Group all pytorch-lightning trainer args under this
trainer:
  - gpus: 1
  - val_percent_check: 0.1
  .... 
```

* in train.py
```
@hydra.main(config_file="conf/config.yaml")
def main(cfg: DictConfig):
    module = MyModule(hparams=cfg)
    trainer = Trainer(**OmegaConf.to_container(cfg.trainer, resolve=True))
    trainer.fit(module)
```

For this PR I think no document is needed, but if needed I can write up some minimal examples to use Hydra with Lightning.
