### PR TITLE
Allow Trainer's `gpus` arg type to be subclass of currently accepted types

### DIFF
--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -566,7 +566,7 @@ def check_gpus_data_type(gpus):
     :return: return unmodified gpus variable
     """
 
-    if gpus is not None and type(gpus) not in (int, str, list):
+    if gpus is not None and not isinstance(gpus, (int, str, list)):
         raise MisconfigurationException("GPUs must be int, string or list of ints or None.")
 
 

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -566,7 +566,7 @@ def check_gpus_data_type(gpus):
     :return: return unmodified gpus variable
     """
 
-    if gpus is not None and (not isinstance(gpus, (int, str, list) or isinstance(gpus, bool)):
+    if gpus is not None and (not isinstance(gpus, (int, str, list)) or isinstance(gpus, bool)):
         raise MisconfigurationException("GPUs must be int, string or list of ints or None.")
 
 

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -566,7 +566,7 @@ def check_gpus_data_type(gpus):
     :return: return unmodified gpus variable
     """
 
-    if gpus is not None and not isinstance(gpus, (int, str, list)):
+    if gpus is not None and (not isinstance(gpus, (int, str, list) or isinstance(gpus, bool)):
         raise MisconfigurationException("GPUs must be int, string or list of ints or None.")
 
 


### PR DESCRIPTION
Fixes #1388 
