### PR TITLE
Add automatic GPU choice to trainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [unreleased] - YYYY-MM-DD
+
+### Added
+
+- Added `gpu_choice` to trainer which can enable automatically picking the first available GPU on exclusive mode systems.
+
 ## [0.7.3] - 2020-04-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- Added `gpu_choice` to trainer which can enable automatically picking the first available GPU on exclusive mode systems.
+- Added `auto_select_gpus` flag to trainer that enables automatic selection of available GPUs on exclusive mode systems.
 
 ## [0.7.3] - 2020-04-09
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -90,7 +90,7 @@ class Trainer(
             process_position: int = 0,
             num_nodes: int = 1,
             gpus: Optional[Union[List[int], str, int]] = None,
-            gpu_choice: str = 'manual',
+            auto_select_gpus: bool = False,
             num_tpu_cores: Optional[int] = None,
             log_gpu_memory: Optional[str] = None,
             progress_bar_refresh_rate: int = 1,
@@ -164,13 +164,12 @@ class Trainer(
 
             gpus: Which GPUs to train on.
 
-            gpu_choice: 'manual' (default) or 'auto'.
+            auto_select_gpus:
 
-                If 'auto' and `gpus` is an integer, pick the first
-                available gpus automatically. This is especially
-                useful when GPUs are configured to be in "exclusive
-                mode", which means that only one process at a time can
-                use them.
+                If enabled and `gpus` is an integer, pick available
+                gpus automatically. This is especially useful when
+                GPUs are configured to be in "exclusive mode", such
+                that only one process at a time can access them.
 
             num_tpu_cores: How many TPU cores to train on (1 or 8).
 
@@ -399,7 +398,7 @@ class Trainer(
         self.configure_accumulated_gradients(accumulate_grad_batches)
 
         # for gpus allow int, string and gpu list
-        if gpu_choice == "auto" and isinstance(gpus, int):
+        if auto_select_gpus and isinstance(gpus, int):
             self.gpus = pick_multiple_gpus(gpus)
         else:
             self.gpus = gpus

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -685,3 +685,18 @@ def test_gradient_clipping(tmpdir):
     model.prev_called_batch_idx = 0
 
     trainer.fit(model)
+
+
+def test_gpu_choice(tmpdir):
+    trainer_options = dict(
+        default_save_path=tmpdir,
+    )
+    # Only run if CUDA is available
+    if not torch.cuda.is_available():
+        return
+
+    num_gpus = torch.cuda.device_count()
+    Trainer(**trainer_options, gpus=num_gpus, gpu_choice="auto")
+
+    with pytest.raises(RuntimeError, match=r'.*No GPUs available.*'):
+        Trainer(**trainer_options, gpus=num_gpus + 1, gpu_choice="auto")

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -696,7 +696,7 @@ def test_gpu_choice(tmpdir):
         return
 
     num_gpus = torch.cuda.device_count()
-    Trainer(**trainer_options, gpus=num_gpus, gpu_choice="auto")
+    Trainer(**trainer_options, gpus=num_gpus, auto_select_gpus=True)
 
     with pytest.raises(RuntimeError, match=r'.*No GPUs available.*'):
-        Trainer(**trainer_options, gpus=num_gpus + 1, gpu_choice="auto")
+        Trainer(**trainer_options, gpus=num_gpus + 1, auto_select_gpus=True)


### PR DESCRIPTION
This commit adds the `gpu_choice` parameter to Trainer. By default,
this parameter is set to 'manual' which causes no observable
difference in behavior.

When `gpu_choice` is set to "auto" and `gpus` is an int, then the
trainer will automatically allocate the first available GPU.
This is especially useful when GPUs are configured to be in "exclusive
mode", which means that only one process at a time can use them.

# Before submitting

- [x] Was this discussed/approved via a Github issue? #951 
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?


## What does this PR do?
Fixes #951 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

*Comments*: 

1. I am not sure if the `pick_gpu` functions should be placed in `distrib_parts.py`. I chose this because determine_root_gpu_device` is defined there.
2. What is the idiomatic way to you specify that a test should only run when CUDA is available?
3. I am unsure what possible interactions with distributed training there are and if so how I should handle them. 
4. I added a docstring, does that count as adding docs? 

## Did you have fun?
Make sure you had fun coding 🙃
