### PR TITLE
rename Test classes

### DIFF
--- a/benchmarks/test_trainer_parity.py
+++ b/benchmarks/test_trainer_parity.py
@@ -11,7 +11,7 @@ from torchvision import transforms
 import tests.base.utils as tutils
 
 from pytorch_lightning import Trainer, LightningModule
-from tests.base.datasets import TestingMNIST
+from tests.base.datasets import TrialMNIST
 
 
 class ParityMNIST(LightningModule):
@@ -42,10 +42,10 @@ class ParityMNIST(LightningModule):
         return torch.optim.Adam(self.parameters(), lr=0.02)
 
     def train_dataloader(self):
-        return DataLoader(TestingMNIST(train=True,
-                                       download=True,
-                                       num_samples=500,
-                                       digits=list(range(5))),
+        return DataLoader(TrialMNIST(train=True,
+                                     download=True,
+                                     num_samples=500,
+                                     digits=list(range(5))),
                           batch_size=128)
 
 

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -2,59 +2,41 @@
 
 import torch
 
-from tests.base.models import TestModelBase, DictHparamsModel
+from tests.base.models import TrialModelBase, DictHparamsModel
 from tests.base.mixins import (
-    LightEmptyTestStep,
-    LightValidationStepMixin,
-    LightValidationMixin,
-    LightValidationStepMultipleDataloadersMixin,
-    LightValidationMultipleDataloadersMixin,
-    LightTestStepMixin,
-    LightTestMixin,
-    LightTestStepMultipleDataloadersMixin,
-    LightTestMultipleDataloadersMixin,
-    LightTestFitSingleTestDataloadersMixin,
-    LightTestFitMultipleTestDataloadersMixin,
+    LightEmptyTstStep,
+    LightValStepMixin,
+    LightValMixin,
+    LightValStepMultipleDataloadersMixin,
+    LightValMultipleDataloadersMixin,
+    LightTstStepMixin,
+    LightTstMixin,
+    LightTstStepMultipleDataloadersMixin,
+    LightTstMultipleDataloadersMixin,
+    LightTstStepSingleTstDataloadersMixin,
+    LightTstStepMultipleTstDataloadersMixin,
     LightValStepFitSingleDataloaderMixin,
     LightValStepFitMultipleDataloadersMixin,
-    LightTrainDataloader,
-    LightValidationDataloader,
-    LightTestDataloader,
-    LightInfTrainDataloader,
+    LightTrnDataloader,
+    LightValDataloader,
+    LightTstDataloader,
+    LightInfTrnDataloader,
     LightInfValDataloader,
-    LightInfTestDataloader,
-    LightTestOptimizerWithSchedulingMixin,
-    LightTestMultipleOptimizersWithSchedulingMixin,
-    LightTestOptimizersWithMixedSchedulingMixin,
-    LightTestReduceLROnPlateauMixin,
-    LightTestNoneOptimizerMixin,
+    LightInfTstDataloader,
+    LightOptimizerWithSchedulingMixin,
+    LightMultipleOptimizersWithSchedulingMixin,
+    LightOptimizersWithMixedSchedulingMixin,
+    LightReduceLROnPlateauMixin,
+    LightNoneOptimizerMixin,
     LightZeroLenDataloader
 )
 
 
-class LightningTestModel(LightTrainDataloader,
-                         LightValidationMixin,
-                         LightTestMixin,
-                         TestModelBase):
+class LightningTrialModel(LightTrnDataloader,
+                          LightValMixin,
+                          LightTstMixin,
+                          TrialModelBase):
     """Most common test case. Validation and test dataloaders."""
 
     def on_training_metrics(self, logs):
         logs['some_tensor_to_test'] = torch.rand(1)
-
-
-class LightningTestModelWithoutHyperparametersArg(LightningTestModel):
-    """Without hparams argument in constructor """
-
-    def __init__(self):
-        import tests.base.utils as tutils
-
-        # the user loads the hparams in some other way
-        hparams = tutils.get_default_hparams()
-        super().__init__(hparams)
-
-
-class LightningTestModelWithUnusedHyperparametersArg(LightningTestModelWithoutHyperparametersArg):
-    """It has hparams argument in constructor but is not used."""
-
-    def __init__(self, hparams):
-        super().__init__()

--- a/tests/base/datasets.py
+++ b/tests/base/datasets.py
@@ -111,7 +111,7 @@ def normalize_tensor(tensor: Tensor, mean: float = 0.0, std: float = 1.0) -> Ten
     return tensor
 
 
-class TestingMNIST(MNIST):
+class TrialMNIST(MNIST):
     """Constrain image dataset
 
     Args:
@@ -127,7 +127,7 @@ class TestingMNIST(MNIST):
         digits: list selected MNIST digits/classes
 
     Examples:
-        >>> dataset = TestingMNIST(download=True)
+        >>> dataset = TrialMNIST(download=True)
         >>> len(dataset)
         300
         >>> sorted(set([d.item() for d in dataset.targets]))

--- a/tests/base/debug.py
+++ b/tests/base/debug.py
@@ -3,7 +3,7 @@ from torch.nn import functional as F
 from torch.utils.data import DataLoader
 
 import pytorch_lightning as pl
-from tests.base.datasets import TestingMNIST
+from tests.base.datasets import TrialMNIST
 
 
 # from test_models import assert_ok_test_acc, load_model, \
@@ -42,10 +42,10 @@ class CoolModel(pl.LightningModule):
         return [torch.optim.Adam(self.parameters(), lr=0.02)]
 
     def train_dataloader(self):
-        return DataLoader(TestingMNIST(train=True, num_samples=100), batch_size=16)
+        return DataLoader(TrialMNIST(train=True, num_samples=100), batch_size=16)
 
     def val_dataloader(self):
-        return DataLoader(TestingMNIST(train=False, num_samples=50), batch_size=16)
+        return DataLoader(TrialMNIST(train=False, num_samples=50), batch_size=16)
 
     def test_dataloader(self):
-        return DataLoader(TestingMNIST(train=False, num_samples=50), batch_size=16)
+        return DataLoader(TrialMNIST(train=False, num_samples=50), batch_size=16)

--- a/tests/base/mixins.py
+++ b/tests/base/mixins.py
@@ -4,7 +4,7 @@ import torch
 from torch import optim
 
 
-class LightValidationStepMixin:
+class LightValStepMixin:
     """
     Add val_dataloader and validation_step methods for the case
     when val_dataloader returns a single dataloader
@@ -53,7 +53,7 @@ class LightValidationStepMixin:
             return output
 
 
-class LightValidationMixin(LightValidationStepMixin):
+class LightValMixin(LightValStepMixin):
     """
     Add val_dataloader, validation_step, and validation_end methods for the case
     when val_dataloader returns a single dataloader
@@ -94,7 +94,7 @@ class LightValidationMixin(LightValidationStepMixin):
         return results
 
 
-class LightValidationStepMultipleDataloadersMixin:
+class LightValStepMultipleDataloadersMixin:
     """
     Add val_dataloader and validation_step methods for the case
     when val_dataloader returns multiple dataloaders
@@ -153,7 +153,7 @@ class LightValidationStepMultipleDataloadersMixin:
             return output
 
 
-class LightValidationMultipleDataloadersMixin(LightValidationStepMultipleDataloadersMixin):
+class LightValMultipleDataloadersMixin(LightValStepMultipleDataloadersMixin):
     """
     Add val_dataloader, validation_step, and validation_end methods for the case
     when val_dataloader returns multiple dataloaders
@@ -196,21 +196,21 @@ class LightValidationMultipleDataloadersMixin(LightValidationStepMultipleDataloa
         return result
 
 
-class LightTrainDataloader:
+class LightTrnDataloader:
     """Simple train dataloader."""
 
     def train_dataloader(self):
         return self._dataloader(train=True)
 
 
-class LightValidationDataloader:
+class LightValDataloader:
     """Simple validation dataloader."""
 
     def val_dataloader(self):
         return self._dataloader(train=False)
 
 
-class LightTestDataloader:
+class LightTstDataloader:
     """Simple test dataloader."""
 
     def test_dataloader(self):
@@ -238,7 +238,7 @@ class CustomInfDataloader:
             return next(self.iter)
 
 
-class LightInfTrainDataloader:
+class LightInfTrnDataloader:
     """Simple test dataloader."""
 
     def train_dataloader(self):
@@ -252,7 +252,7 @@ class LightInfValDataloader:
         return CustomInfDataloader(self._dataloader(train=False))
 
 
-class LightInfTestDataloader:
+class LightInfTstDataloader:
     """Simple test dataloader."""
 
     def test_dataloader(self):
@@ -269,14 +269,14 @@ class LightZeroLenDataloader:
         return dataloader
 
 
-class LightEmptyTestStep:
+class LightEmptyTstStep:
     """Empty test step."""
 
     def test_step(self, *args, **kwargs):
         return dict()
 
 
-class LightTestStepMixin(LightTestDataloader):
+class LightTstStepMixin(LightTstDataloader):
     """Test step mixin."""
 
     def test_step(self, batch, batch_idx, *args, **kwargs):
@@ -323,7 +323,7 @@ class LightTestStepMixin(LightTestDataloader):
             return output
 
 
-class LightTestMixin(LightTestStepMixin):
+class LightTstMixin(LightTstStepMixin):
     """Ritch test mixin."""
 
     def test_epoch_end(self, outputs):
@@ -360,7 +360,7 @@ class LightTestMixin(LightTestStepMixin):
         return result
 
 
-class LightTestStepMultipleDataloadersMixin:
+class LightTstStepMultipleDataloadersMixin:
     """Test step multiple dataloaders mixin."""
 
     def test_dataloader(self):
@@ -416,7 +416,7 @@ class LightTestStepMultipleDataloadersMixin:
             return output
 
 
-class LightTestFitSingleTestDataloadersMixin:
+class LightTstStepSingleTstDataloadersMixin:
     """Test fit single test dataloaders mixin."""
 
     def test_dataloader(self):
@@ -466,7 +466,7 @@ class LightTestFitSingleTestDataloadersMixin:
             return output
 
 
-class LightTestFitMultipleTestDataloadersMixin:
+class LightTstStepMultipleTstDataloadersMixin:
     """Test fit multiple test dataloaders mixin."""
 
     def test_step(self, batch, batch_idx, dataloader_idx, **kwargs):
@@ -617,7 +617,7 @@ class LightValStepFitMultipleDataloadersMixin:
             return output
 
 
-class LightTestMultipleDataloadersMixin(LightTestStepMultipleDataloadersMixin):
+class LightTstMultipleDataloadersMixin(LightTstStepMultipleDataloadersMixin):
 
     def test_epoch_end(self, outputs):
         """
@@ -656,7 +656,7 @@ class LightTestMultipleDataloadersMixin(LightTestStepMultipleDataloadersMixin):
         return result
 
 
-class LightTestOptimizerWithSchedulingMixin:
+class LightOptimizerWithSchedulingMixin:
     def configure_optimizers(self):
         if self.hparams.optimizer_name == 'lbfgs':
             optimizer = optim.LBFGS(self.parameters(), lr=self.hparams.learning_rate)
@@ -666,7 +666,7 @@ class LightTestOptimizerWithSchedulingMixin:
         return [optimizer], [lr_scheduler]
 
 
-class LightTestMultipleOptimizersWithSchedulingMixin:
+class LightMultipleOptimizersWithSchedulingMixin:
     def configure_optimizers(self):
         if self.hparams.optimizer_name == 'lbfgs':
             optimizer1 = optim.LBFGS(self.parameters(), lr=self.hparams.learning_rate)
@@ -680,7 +680,7 @@ class LightTestMultipleOptimizersWithSchedulingMixin:
         return [optimizer1, optimizer2], [lr_scheduler1, lr_scheduler2]
 
 
-class LightTestOptimizersWithMixedSchedulingMixin:
+class LightOptimizersWithMixedSchedulingMixin:
     def configure_optimizers(self):
         if self.hparams.optimizer_name == 'lbfgs':
             optimizer1 = optim.LBFGS(self.parameters(), lr=self.hparams.learning_rate)
@@ -695,7 +695,7 @@ class LightTestOptimizersWithMixedSchedulingMixin:
             [{'scheduler': lr_scheduler1, 'interval': 'step'}, lr_scheduler2]
 
 
-class LightTestReduceLROnPlateauMixin:
+class LightReduceLROnPlateauMixin:
     def configure_optimizers(self):
         if self.hparams.optimizer_name == 'lbfgs':
             optimizer = optim.LBFGS(self.parameters(), lr=self.hparams.learning_rate)
@@ -705,7 +705,7 @@ class LightTestReduceLROnPlateauMixin:
         return [optimizer], [lr_scheduler]
 
 
-class LightTestNoneOptimizerMixin:
+class LightNoneOptimizerMixin:
     def configure_optimizers(self):
         return None
 

--- a/tests/base/models.py
+++ b/tests/base/models.py
@@ -8,7 +8,7 @@ import torch.nn.functional as F
 from torch import optim
 from torch.utils.data import DataLoader
 
-from tests.base.datasets import TestingMNIST
+from tests.base.datasets import TrialMNIST
 
 try:
     from test_tube import HyperOptArgumentParser
@@ -38,10 +38,10 @@ class DictHparamsModel(LightningModule):
         return torch.optim.Adam(self.parameters(), lr=0.02)
 
     def train_dataloader(self):
-        return DataLoader(TestingMNIST(train=True, download=True), batch_size=16)
+        return DataLoader(TrialMNIST(train=True, download=True), batch_size=16)
 
 
-class TestModelBase(LightningModule):
+class TrialModelBase(LightningModule):
     """Base LightningModule for testing. Implements only the required interface."""
 
     def __init__(self, hparams, force_remove_distributed_sampler: bool = False):
@@ -137,11 +137,11 @@ class TestModelBase(LightningModule):
         return [optimizer], [scheduler]
 
     def prepare_data(self):
-        _ = TestingMNIST(root=self.hparams.data_root, train=True, download=True)
+        _ = TrialMNIST(root=self.hparams.data_root, train=True, download=True)
 
     def _dataloader(self, train):
         # init data generators
-        dataset = TestingMNIST(root=self.hparams.data_root, train=train, download=False)
+        dataset = TrialMNIST(root=self.hparams.data_root, train=train, download=False)
 
         # when using multi-node we need to add the datasampler
         batch_size = self.hparams.batch_size

--- a/tests/base/utils.py
+++ b/tests/base/utils.py
@@ -8,7 +8,7 @@ import torch
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import TestTubeLogger, TensorBoardLogger
-from tests.base import LightningTestModel
+from tests.base import LightningTrialModel
 from tests.base.datasets import PATH_DATASETS
 
 # generate a list of random seeds for each test
@@ -132,7 +132,7 @@ def get_default_model(lbfgs=False):
         setattr(hparams, 'optimizer_name', 'lbfgs')
         setattr(hparams, 'learning_rate', 0.002)
 
-    model = LightningTestModel(hparams)
+    model = LightningTrialModel(hparams)
 
     return model, hparams
 
@@ -161,7 +161,7 @@ def get_data_path(expt_logger, path_dir=None):
     return path_expt
 
 
-def load_model(exp, root_weights_dir, module_class=LightningTestModel, path_expt=None):
+def load_model(exp, root_weights_dir, module_class=LightningTrialModel, path_expt=None):
     # load trained model
     path_expt_dir = get_data_path(exp, path_dir=path_expt)
     tags_path = os.path.join(path_expt_dir, TensorBoardLogger.NAME_CSV_TAGS)
@@ -179,7 +179,7 @@ def load_model(exp, root_weights_dir, module_class=LightningTestModel, path_expt
     return trained_model
 
 
-def load_model_from_checkpoint(root_weights_dir, module_class=LightningTestModel):
+def load_model_from_checkpoint(root_weights_dir, module_class=LightningTrialModel):
     # load trained model
     checkpoints = [x for x in os.listdir(root_weights_dir) if '.ckpt' in x]
     weights_dir = os.path.join(root_weights_dir, checkpoints[0])

--- a/tests/loggers/test_all.py
+++ b/tests/loggers/test_all.py
@@ -7,7 +7,7 @@ import tests.base.utils as tutils
 from pytorch_lightning import Trainer
 from pytorch_lightning.loggers import (
     TensorBoardLogger, MLFlowLogger, NeptuneLogger, TestTubeLogger, CometLogger)
-from tests.base import LightningTestModel
+from tests.base import LightningTrialModel
 
 
 @pytest.mark.parametrize("logger_class", [
@@ -29,7 +29,7 @@ def test_loggers_fit_test(tmpdir, monkeypatch, logger_class):
     monkeypatch.setattr(atexit, 'register', lambda _: None)
 
     hparams = tutils.get_default_hparams()
-    model = LightningTestModel(hparams)
+    model = LightningTrialModel(hparams)
 
     class StoreHistoryLogger(logger_class):
         def __init__(self, *args, **kwargs):

--- a/tests/loggers/test_base.py
+++ b/tests/loggers/test_base.py
@@ -6,7 +6,7 @@ import numpy as np
 import tests.base.utils as tutils
 from pytorch_lightning import Trainer
 from pytorch_lightning.loggers import LightningLoggerBase, rank_zero_only, LoggerCollection
-from tests.base import LightningTestModel
+from tests.base import LightningTrialModel
 
 
 def test_logger_collection():
@@ -60,7 +60,7 @@ class CustomLogger(LightningLoggerBase):
 
 def test_custom_logger(tmpdir):
     hparams = tutils.get_default_hparams()
-    model = LightningTestModel(hparams)
+    model = LightningTrialModel(hparams)
 
     logger = CustomLogger()
 
@@ -81,7 +81,7 @@ def test_custom_logger(tmpdir):
 
 def test_multiple_loggers(tmpdir):
     hparams = tutils.get_default_hparams()
-    model = LightningTestModel(hparams)
+    model = LightningTrialModel(hparams)
 
     logger1 = CustomLogger()
     logger2 = CustomLogger()

--- a/tests/loggers/test_neptune.py
+++ b/tests/loggers/test_neptune.py
@@ -5,7 +5,7 @@ import torch
 import tests.base.utils as tutils
 from pytorch_lightning import Trainer
 from pytorch_lightning.loggers import NeptuneLogger
-from tests.base import LightningTestModel
+from tests.base import LightningTrialModel
 
 
 @patch('pytorch_lightning.loggers.neptune.neptune')
@@ -64,7 +64,7 @@ def test_neptune_leave_open_experiment_after_fit(tmpdir):
     tutils.reset_seed()
 
     hparams = tutils.get_default_hparams()
-    model = LightningTestModel(hparams)
+    model = LightningTrialModel(hparams)
 
     def _run_training(logger):
         logger._experiment = MagicMock()

--- a/tests/loggers/test_trains.py
+++ b/tests/loggers/test_trains.py
@@ -3,7 +3,7 @@ import pickle
 import tests.base.utils as tutils
 from pytorch_lightning import Trainer
 from pytorch_lightning.loggers import TrainsLogger
-from tests.base import LightningTestModel
+from tests.base import LightningTrialModel
 
 
 def test_trains_logger(tmpdir):
@@ -11,7 +11,7 @@ def test_trains_logger(tmpdir):
     tutils.reset_seed()
 
     hparams = tutils.get_default_hparams()
-    model = LightningTestModel(hparams)
+    model = LightningTrialModel(hparams)
     TrainsLogger.set_bypass_mode(True)
     TrainsLogger.set_credentials(api_host='http://integration.trains.allegro.ai:8008',
                                  files_host='http://integration.trains.allegro.ai:8081',
@@ -37,7 +37,7 @@ def test_trains_pickle(tmpdir):
     tutils.reset_seed()
 
     # hparams = tutils.get_default_hparams()
-    # model = LightningTestModel(hparams)
+    # model = LightningTrialModel(hparams)
     TrainsLogger.set_bypass_mode(True)
     TrainsLogger.set_credentials(api_host='http://integration.trains.allegro.ai:8008',
                                  files_host='http://integration.trains.allegro.ai:8081',

--- a/tests/models/test_amp.py
+++ b/tests/models/test_amp.py
@@ -7,7 +7,7 @@ import tests.base.utils as tutils
 from pytorch_lightning import Trainer
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.base import (
-    LightningTestModel,
+    LightningTrialModel,
 )
 
 
@@ -17,7 +17,7 @@ def test_amp_single_gpu(tmpdir):
     tutils.reset_seed()
 
     hparams = tutils.get_default_hparams()
-    model = LightningTestModel(hparams)
+    model = LightningTrialModel(hparams)
 
     trainer_options = dict(
         default_root_dir=tmpdir,
@@ -37,7 +37,7 @@ def test_no_amp_single_gpu(tmpdir):
     tutils.reset_seed()
 
     hparams = tutils.get_default_hparams()
-    model = LightningTestModel(hparams)
+    model = LightningTrialModel(hparams)
 
     trainer_options = dict(
         default_root_dir=tmpdir,
@@ -60,7 +60,7 @@ def test_amp_gpu_ddp(tmpdir):
     tutils.set_random_master_port()
 
     hparams = tutils.get_default_hparams()
-    model = LightningTestModel(hparams)
+    model = LightningTrialModel(hparams)
 
     trainer_options = dict(
         default_root_dir=tmpdir,
@@ -84,7 +84,7 @@ def test_amp_gpu_ddp_slurm_managed(tmpdir):
     os.environ['SLURM_LOCALID'] = str(0)
 
     hparams = tutils.get_default_hparams()
-    model = LightningTestModel(hparams)
+    model = LightningTrialModel(hparams)
 
     trainer_options = dict(
         max_epochs=1,

--- a/tests/models/test_cpu.py
+++ b/tests/models/test_cpu.py
@@ -5,14 +5,12 @@ import torch
 
 import tests.base.utils as tutils
 from pytorch_lightning import Trainer
-from pytorch_lightning.callbacks import (
-    EarlyStopping,
-)
+from pytorch_lightning.callbacks import EarlyStopping
 from tests.base import (
-    TestModelBase,
-    LightTrainDataloader,
-    LightningTestModel,
-    LightTestMixin,
+    TrialModelBase,
+    LightTrnDataloader,
+    LightningTrialModel,
+    LightTstMixin,
 )
 
 
@@ -84,7 +82,7 @@ def test_running_test_after_fitting(tmpdir):
     tutils.reset_seed()
 
     hparams = tutils.get_default_hparams()
-    model = LightningTestModel(hparams)
+    model = LightningTrialModel(hparams)
 
     # logger file to get meta
     logger = tutils.get_default_testtube_logger(tmpdir, False)
@@ -119,11 +117,11 @@ def test_running_test_without_val(tmpdir):
     """Verify `test()` works on a model with no `val_loader`."""
     tutils.reset_seed()
 
-    class CurrentTestModel(LightTrainDataloader, LightTestMixin, TestModelBase):
+    class CurrentModel(LightTrnDataloader, LightTstMixin, TrialModelBase):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # logger file to get meta
     logger = tutils.get_default_testtube_logger(tmpdir, False)
@@ -201,7 +199,7 @@ def test_simple_cpu(tmpdir):
     tutils.reset_seed()
 
     hparams = tutils.get_default_hparams()
-    model = LightningTestModel(hparams)
+    model = LightningTrialModel(hparams)
 
     # logger file to get meta
     trainer_options = dict(
@@ -276,7 +274,7 @@ def test_tbptt_cpu_model(tmpdir):
         def __len__(self):
             return 1
 
-    class BpttTestModel(LightTrainDataloader, TestModelBase):
+    class BpttModel(LightTrnDataloader, TrialModelBase):
         def __init__(self, hparams):
             super().__init__(hparams)
             self.test_hidden = None
@@ -322,7 +320,7 @@ def test_tbptt_cpu_model(tmpdir):
     hparams.hidden_dim = truncated_bptt_steps
     hparams.out_features = truncated_bptt_steps
 
-    model = BpttTestModel(hparams)
+    model = BpttModel(hparams)
 
     # fit model
     trainer = Trainer(**trainer_options)

--- a/tests/models/test_gpu.py
+++ b/tests/models/test_gpu.py
@@ -12,7 +12,7 @@ from pytorch_lightning.trainer.distrib_parts import (
     determine_root_gpu_device,
 )
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from tests.base import LightningTestModel
+from tests.base import LightningTrialModel
 
 PRETEND_N_OF_GPUS = 16
 
@@ -88,7 +88,7 @@ def test_cpu_slurm_save_load(tmpdir):
     tutils.reset_seed()
 
     hparams = tutils.get_default_hparams()
-    model = LightningTestModel(hparams)
+    model = LightningTrialModel(hparams)
 
     # logger file to get meta
     logger = tutils.get_default_testtube_logger(tmpdir, False)
@@ -138,7 +138,7 @@ def test_cpu_slurm_save_load(tmpdir):
         checkpoint_callback=ModelCheckpoint(tmpdir),
     )
     trainer = Trainer(**trainer_options)
-    model = LightningTestModel(hparams)
+    model = LightningTrialModel(hparams)
 
     # set the epoch start hook so we can predict before the model does the full training
     def assert_pred_same():

--- a/tests/models/test_gpu.py
+++ b/tests/models/test_gpu.py
@@ -213,7 +213,6 @@ def mocked_device_count_0(monkeypatch):
     monkeypatch.setattr(torch.cuda, 'device_count', device_count)
 
 
-@pytest.mark.gpus_param_tests
 @pytest.mark.parametrize(["gpus", "expected_num_gpus", "distributed_backend"], [
     pytest.param(None, 0, None, id="None - expect 0 gpu to use."),
     pytest.param(0, 0, None, id="Oth gpu, expect 1 gpu to use."),
@@ -226,7 +225,6 @@ def test_trainer_gpu_parse(mocked_device_count, gpus, expected_num_gpus, distrib
     assert Trainer(gpus=gpus, distributed_backend=distributed_backend).num_gpus == expected_num_gpus
 
 
-@pytest.mark.gpus_param_tests
 @pytest.mark.parametrize(["gpus", "expected_num_gpus", "distributed_backend"], [
     pytest.param(None, 0, None, id="None - expect 0 gpu to use."),
     pytest.param(None, 0, "ddp", id="None - expect 0 gpu to use."),
@@ -235,7 +233,6 @@ def test_trainer_num_gpu_0(mocked_device_count_0, gpus, expected_num_gpus, distr
     assert Trainer(gpus=gpus, distributed_backend=distributed_backend).num_gpus == expected_num_gpus
 
 
-@pytest.mark.gpus_param_tests
 @pytest.mark.parametrize(['gpus', 'expected_root_gpu', "distributed_backend"], [
     pytest.param(None, None, "ddp", id="None is None"),
     pytest.param(0, None, "ddp", id="O gpus, expect gpu root device to be None."),
@@ -248,9 +245,7 @@ def test_root_gpu_property(mocked_device_count, gpus, expected_root_gpu, distrib
     assert Trainer(gpus=gpus, distributed_backend=distributed_backend).root_gpu == expected_root_gpu
 
 
-@pytest.mark.gpus_param_tests
-@pytest.mark.parametrize([
-    'gpus', 'expected_root_gpu', "distributed_backend"], [
+@pytest.mark.parametrize(['gpus', 'expected_root_gpu', "distributed_backend"], [
     pytest.param(None, None, None, id="None is None"),
     pytest.param(None, None, "ddp", id="None is None"),
     pytest.param(0, None, "ddp", id="None is None"),
@@ -261,9 +256,7 @@ def test_root_gpu_property_0_passing(
 
 
 # Asking for a gpu when non are available will result in a MisconfigurationException
-@pytest.mark.gpus_param_tests
-@pytest.mark.parametrize([
-    'gpus', 'expected_root_gpu', "distributed_backend"], [
+@pytest.mark.parametrize(['gpus', 'expected_root_gpu', "distributed_backend"], [
     pytest.param(1, None, "ddp"),
     pytest.param(3, None, "ddp"),
     pytest.param(3, None, "ddp"),
@@ -278,7 +271,6 @@ def test_root_gpu_property_0_raising(
         Trainer(gpus=gpus, distributed_backend=distributed_backend).root_gpu
 
 
-@pytest.mark.gpus_param_tests
 @pytest.mark.parametrize(['gpus', 'expected_root_gpu'], [
     pytest.param(None, None, id="No gpus, expect gpu root device to be None"),
     pytest.param([0], 0, id="Oth gpu, expect gpu root device to be 0."),
@@ -290,7 +282,6 @@ def test_determine_root_gpu_device(gpus, expected_root_gpu):
     assert determine_root_gpu_device(gpus) == expected_root_gpu
 
 
-@pytest.mark.gpus_param_tests
 @pytest.mark.parametrize(['gpus', 'expected_gpu_ids'], [
     pytest.param(None, None),
     pytest.param(0, None),
@@ -308,7 +299,6 @@ def test_parse_gpu_ids(mocked_device_count, gpus, expected_gpu_ids):
     assert parse_gpu_ids(gpus) == expected_gpu_ids
 
 
-@pytest.mark.gpus_param_tests
 @pytest.mark.parametrize(['gpus'], [
     pytest.param(0.1),
     pytest.param(-2),
@@ -324,7 +314,6 @@ def test_parse_gpu_fail_on_unsupported_inputs(mocked_device_count, gpus):
         parse_gpu_ids(gpus)
 
 
-@pytest.mark.gpus_param_tests
 @pytest.mark.parametrize("gpus", [''])
 def test_parse_gpu_fail_on_empty_string(mocked_device_count, gpus):
     # This currently results in a ValueError instead of MisconfigurationException
@@ -332,20 +321,17 @@ def test_parse_gpu_fail_on_empty_string(mocked_device_count, gpus):
         parse_gpu_ids(gpus)
 
 
-@pytest.mark.gpus_param_tests
 @pytest.mark.parametrize("gpus", [[1, 2, 19], -1, '-1'])
 def test_parse_gpu_fail_on_non_existant_id(mocked_device_count_0, gpus):
     with pytest.raises(MisconfigurationException):
         parse_gpu_ids(gpus)
 
 
-@pytest.mark.gpus_param_tests
 def test_parse_gpu_fail_on_non_existant_id_2(mocked_device_count):
     with pytest.raises(MisconfigurationException):
         parse_gpu_ids([1, 2, 19])
 
 
-@pytest.mark.gpus_param_tests
 @pytest.mark.parametrize("gpus", [-1, '-1'])
 def test_parse_gpu_returns_None_when_no_devices_are_available(mocked_device_count_0, gpus):
     with pytest.raises(MisconfigurationException):

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -3,7 +3,7 @@
 from pytorch_lightning import Trainer
 
 import tests.base.utils as tutils
-from tests.base import TestModelBase, LightTrainDataloader, LightEmptyTestStep
+from tests.base import TrialModelBase, LightTrnDataloader, LightEmptyTstStep
 
 
 def test_tbd_remove_in_v0_8_0_module_imports():
@@ -70,7 +70,7 @@ def test_tbd_remove_in_v0_9_0_module_imports():
     from pytorch_lightning.profiler import SimpleProfiler, AdvancedProfiler  # noqa: F402
 
 
-class ModelVer0_6(LightTrainDataloader, LightEmptyTestStep, TestModelBase):
+class ModelVer0_6(LightTrnDataloader, LightEmptyTstStep, TrialModelBase):
 
     # todo: this shall not be needed while evaluate asks for dataloader explicitly
     def val_dataloader(self):
@@ -89,7 +89,7 @@ class ModelVer0_6(LightTrainDataloader, LightEmptyTestStep, TestModelBase):
         return {'test_loss': 0.6}
 
 
-class ModelVer0_7(LightTrainDataloader, LightEmptyTestStep, TestModelBase):
+class ModelVer0_7(LightTrnDataloader, LightEmptyTstStep, TrialModelBase):
 
     # todo: this shall not be needed while evaluate asks for dataloader explicitly
     def val_dataloader(self):

--- a/tests/trainer/test_callbacks.py
+++ b/tests/trainer/test_callbacks.py
@@ -3,32 +3,32 @@ from pytorch_lightning import Callback
 from pytorch_lightning import Trainer, LightningModule
 from pytorch_lightning.callbacks import EarlyStopping
 from tests.base import (
-    LightTrainDataloader,
-    LightTestMixin,
-    LightValidationMixin,
-    TestModelBase
+    LightTrnDataloader,
+    LightTstMixin,
+    LightValMixin,
+    TrialModelBase
 )
 
 
 def test_trainer_callback_system(tmpdir):
     """Test the callback system."""
 
-    class CurrentTestModel(
-        LightTrainDataloader,
-        LightTestMixin,
-        LightValidationMixin,
-        TestModelBase,
+    class CurrentModel(
+        LightTrnDataloader,
+        LightTstMixin,
+        LightValMixin,
+        TrialModelBase,
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     def _check_args(trainer, pl_module):
         assert isinstance(trainer, Trainer)
         assert isinstance(pl_module, LightningModule)
 
-    class TestCallback(Callback):
+    class MyCallback(Callback):
         def __init__(self):
             super().__init__()
             self.on_init_start_called = False
@@ -92,7 +92,7 @@ def test_trainer_callback_system(tmpdir):
             _check_args(trainer, pl_module)
             self.on_test_end_called = True
 
-    test_callback = TestCallback()
+    test_callback = MyCallback()
 
     trainer_options = {
         'callbacks': [test_callback],
@@ -157,7 +157,7 @@ def test_early_stopping_without_val_step(tmpdir):
     """Test that early stopping callback falls back to training metrics when no validation defined."""
     tutils.reset_seed()
 
-    class ModelWithoutValStep(LightTrainDataloader, TestModelBase):
+    class ModelWithoutValStep(LightTrnDataloader, TrialModelBase):
 
         def training_step(self, *args, **kwargs):
             output = super().training_step(*args, **kwargs)

--- a/tests/trainer/test_checks.py
+++ b/tests/trainer/test_checks.py
@@ -4,14 +4,14 @@ import tests.base.utils as tutils
 from pytorch_lightning import Trainer, LightningModule
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.base import (
-    TestModelBase,
-    LightValidationDataloader,
-    LightTestDataloader,
-    LightValidationStepMixin,
+    TrialModelBase,
+    LightValDataloader,
+    LightTstDataloader,
+    LightValStepMixin,
     LightValStepFitSingleDataloaderMixin,
-    LightTrainDataloader,
-    LightTestStepMixin,
-    LightTestFitMultipleTestDataloadersMixin,
+    LightTrnDataloader,
+    LightTstStepMixin,
+    LightTstStepMultipleTstDataloadersMixin,
 )
 
 
@@ -19,7 +19,7 @@ def test_error_on_no_train_step(tmpdir):
     """ Test that an error is thrown when no `training_step()` is defined """
     tutils.reset_seed()
 
-    class CurrentTestModel(LightningModule):
+    class CurrentModel(LightningModule):
         def forward(self, x):
             pass
 
@@ -27,7 +27,7 @@ def test_error_on_no_train_step(tmpdir):
     trainer = Trainer(**trainer_options)
 
     with pytest.raises(MisconfigurationException):
-        model = CurrentTestModel()
+        model = CurrentModel()
         trainer.fit(model)
 
 
@@ -36,14 +36,14 @@ def test_error_on_no_train_dataloader(tmpdir):
     tutils.reset_seed()
     hparams = tutils.get_default_hparams()
 
-    class CurrentTestModel(TestModelBase):
+    class CurrentModel(TrialModelBase):
         pass
 
     trainer_options = dict(default_root_dir=tmpdir, max_epochs=1)
     trainer = Trainer(**trainer_options)
 
     with pytest.raises(MisconfigurationException):
-        model = CurrentTestModel(hparams)
+        model = CurrentModel(hparams)
         trainer.fit(model)
 
 
@@ -51,7 +51,7 @@ def test_error_on_no_configure_optimizers(tmpdir):
     """ Test that an error is thrown when no `configure_optimizers()` is defined """
     tutils.reset_seed()
 
-    class CurrentTestModel(LightTrainDataloader, LightningModule):
+    class CurrentModel(LightTrnDataloader, LightningModule):
         def forward(self, x):
             pass
 
@@ -62,7 +62,7 @@ def test_error_on_no_configure_optimizers(tmpdir):
     trainer = Trainer(**trainer_options)
 
     with pytest.raises(MisconfigurationException):
-        model = CurrentTestModel()
+        model = CurrentModel()
         trainer.fit(model)
 
 
@@ -79,34 +79,34 @@ def test_warning_on_wrong_validation_settings(tmpdir):
     trainer_options = dict(default_root_dir=tmpdir, max_epochs=1)
     trainer = Trainer(**trainer_options)
 
-    class CurrentTestModel(LightTrainDataloader,
-                           LightValidationDataloader,
-                           TestModelBase):
+    class CurrentModel(LightTrnDataloader,
+                       LightValDataloader,
+                       TrialModelBase):
         pass
 
     # check val_dataloader -> val_step
     with pytest.raises(MisconfigurationException):
-        model = CurrentTestModel(hparams)
+        model = CurrentModel(hparams)
         trainer.fit(model)
 
-    class CurrentTestModel(LightTrainDataloader,
-                           LightValidationStepMixin,
-                           TestModelBase):
+    class CurrentModel(LightTrnDataloader,
+                       LightValStepMixin,
+                       TrialModelBase):
         pass
 
     # check val_dataloader + val_step -> val_epoch_end
     with pytest.warns(RuntimeWarning):
-        model = CurrentTestModel(hparams)
+        model = CurrentModel(hparams)
         trainer.fit(model)
 
-    class CurrentTestModel(LightTrainDataloader,
-                           LightValStepFitSingleDataloaderMixin,
-                           TestModelBase):
+    class CurrentModel(LightTrnDataloader,
+                       LightValStepFitSingleDataloaderMixin,
+                       TrialModelBase):
         pass
 
     # check val_step -> val_dataloader
     with pytest.raises(MisconfigurationException):
-        model = CurrentTestModel(hparams)
+        model = CurrentModel(hparams)
         trainer.fit(model)
 
 
@@ -123,32 +123,32 @@ def test_warning_on_wrong_test_settigs(tmpdir):
     trainer_options = dict(default_root_dir=tmpdir, max_epochs=1)
     trainer = Trainer(**trainer_options)
 
-    class CurrentTestModel(LightTrainDataloader,
-                           LightTestDataloader,
-                           TestModelBase):
+    class CurrentModel(LightTrnDataloader,
+                       LightTstDataloader,
+                       TrialModelBase):
         pass
 
     # check test_dataloader -> test_step
     with pytest.raises(MisconfigurationException):
-        model = CurrentTestModel(hparams)
+        model = CurrentModel(hparams)
         trainer.fit(model)
 
-    class CurrentTestModel(LightTrainDataloader,
-                           LightTestStepMixin,
-                           TestModelBase):
+    class CurrentModel(LightTrnDataloader,
+                       LightTstStepMixin,
+                       TrialModelBase):
         pass
 
     # check test_dataloader + test_step -> test_epoch_end
     with pytest.warns(RuntimeWarning):
-        model = CurrentTestModel(hparams)
+        model = CurrentModel(hparams)
         trainer.fit(model)
 
-    class CurrentTestModel(LightTrainDataloader,
-                           LightTestFitMultipleTestDataloadersMixin,
-                           TestModelBase):
+    class CurrentModel(LightTrnDataloader,
+                       LightTstStepMultipleTstDataloadersMixin,
+                       TrialModelBase):
         pass
 
     # check test_step -> test_dataloader
     with pytest.raises(MisconfigurationException):
-        model = CurrentTestModel(hparams)
+        model = CurrentModel(hparams)
         trainer.fit(model)

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -5,20 +5,20 @@ import tests.base.utils as tutils
 from pytorch_lightning import Trainer
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.base import (
-    TestModelBase,
-    LightningTestModel,
-    LightEmptyTestStep,
-    LightValidationMultipleDataloadersMixin,
-    LightTestMultipleDataloadersMixin,
-    LightTestFitSingleTestDataloadersMixin,
-    LightTestFitMultipleTestDataloadersMixin,
+    TrialModelBase,
+    LightningTrialModel,
+    LightEmptyTstStep,
+    LightValMultipleDataloadersMixin,
+    LightTstMultipleDataloadersMixin,
+    LightTstStepSingleTstDataloadersMixin,
+    LightTstStepMultipleTstDataloadersMixin,
     LightValStepFitMultipleDataloadersMixin,
     LightValStepFitSingleDataloaderMixin,
-    LightTrainDataloader,
-    LightValidationDataloader,
-    LightInfTrainDataloader,
+    LightTrnDataloader,
+    LightValDataloader,
+    LightInfTrnDataloader,
     LightInfValDataloader,
-    LightInfTestDataloader,
+    LightInfTstDataloader,
     LightZeroLenDataloader
 )
 
@@ -26,14 +26,14 @@ from tests.base import (
 def test_dataloader_config_errors(tmpdir):
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightTrainDataloader,
-        TestModelBase,
+    class CurrentModel(
+        LightTrnDataloader,
+        TrialModelBase,
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # percent check < 0
 
@@ -100,15 +100,15 @@ def test_multiple_val_dataloader(tmpdir):
     """Verify multiple val_dataloader."""
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightTrainDataloader,
-        LightValidationMultipleDataloadersMixin,
-        TestModelBase,
+    class CurrentModel(
+        LightTrnDataloader,
+        LightValMultipleDataloadersMixin,
+        TrialModelBase,
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # logger file to get meta
     trainer_options = dict(
@@ -138,16 +138,16 @@ def test_multiple_test_dataloader(tmpdir):
     """Verify multiple test_dataloader."""
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightTrainDataloader,
-        LightTestMultipleDataloadersMixin,
-        LightEmptyTestStep,
-        TestModelBase,
+    class CurrentModel(
+        LightTrnDataloader,
+        LightTstMultipleDataloadersMixin,
+        LightEmptyTstStep,
+        TrialModelBase,
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # logger file to get meta
     trainer_options = dict(
@@ -178,7 +178,7 @@ def test_train_dataloaders_passed_to_fit(tmpdir):
     """Verify that train dataloader can be passed to fit """
     tutils.reset_seed()
 
-    class CurrentTestModel(LightTrainDataloader, TestModelBase):
+    class CurrentModel(LightTrnDataloader, TrialModelBase):
         pass
 
     hparams = tutils.get_default_hparams()
@@ -192,7 +192,7 @@ def test_train_dataloaders_passed_to_fit(tmpdir):
     )
 
     # only train passed to fit
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
     trainer = Trainer(**trainer_options)
     fit_options = dict(train_dataloader=model._dataloader(train=True))
     result = trainer.fit(model, **fit_options)
@@ -204,10 +204,10 @@ def test_train_val_dataloaders_passed_to_fit(tmpdir):
     """ Verify that train & val dataloader can be passed to fit """
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightTrainDataloader,
+    class CurrentModel(
+        LightTrnDataloader,
         LightValStepFitSingleDataloaderMixin,
-        TestModelBase,
+        TrialModelBase,
     ):
         pass
 
@@ -222,7 +222,7 @@ def test_train_val_dataloaders_passed_to_fit(tmpdir):
     )
 
     # train, val passed to fit
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
     trainer = Trainer(**trainer_options)
     fit_options = dict(train_dataloader=model._dataloader(train=True),
                        val_dataloaders=model._dataloader(train=False))
@@ -237,12 +237,12 @@ def test_all_dataloaders_passed_to_fit(tmpdir):
     """Verify train, val & test dataloader can be passed to fit """
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightTrainDataloader,
+    class CurrentModel(
+        LightTrnDataloader,
         LightValStepFitSingleDataloaderMixin,
-        LightTestFitSingleTestDataloadersMixin,
-        LightEmptyTestStep,
-        TestModelBase,
+        LightTstStepSingleTstDataloadersMixin,
+        LightEmptyTstStep,
+        TrialModelBase,
     ):
         pass
 
@@ -257,7 +257,7 @@ def test_all_dataloaders_passed_to_fit(tmpdir):
     )
 
     # train, val and test passed to fit
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
     trainer = Trainer(**trainer_options)
     fit_options = dict(train_dataloader=model._dataloader(train=True),
                        val_dataloaders=model._dataloader(train=False))
@@ -278,10 +278,10 @@ def test_multiple_dataloaders_passed_to_fit(tmpdir):
     """Verify that multiple val & test dataloaders can be passed to fit."""
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightningTestModel,
+    class CurrentModel(
+        LightningTrialModel,
         LightValStepFitMultipleDataloadersMixin,
-        LightTestFitMultipleTestDataloadersMixin,
+        LightTstStepMultipleTstDataloadersMixin,
     ):
         pass
 
@@ -296,7 +296,7 @@ def test_multiple_dataloaders_passed_to_fit(tmpdir):
     )
 
     # train, multiple val and multiple test passed to fit
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
     trainer = Trainer(**trainer_options)
     fit_options = dict(train_dataloader=model._dataloader(train=True),
                        val_dataloaders=[model._dataloader(train=False),
@@ -317,16 +317,16 @@ def test_mixing_of_dataloader_options(tmpdir):
     """Verify that dataloaders can be passed to fit"""
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightTrainDataloader,
+    class CurrentModel(
+        LightTrnDataloader,
         LightValStepFitSingleDataloaderMixin,
-        LightTestFitSingleTestDataloadersMixin,
-        TestModelBase,
+        LightTstStepSingleTstDataloadersMixin,
+        TrialModelBase,
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # logger file to get meta
     trainer_options = dict(
@@ -359,14 +359,14 @@ def test_inf_train_dataloader(tmpdir):
     """Test inf train data loader (e.g. IterableDataset)"""
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightInfTrainDataloader,
-        LightningTestModel
+    class CurrentModel(
+        LightInfTrnDataloader,
+        LightningTrialModel
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # fit model
     with pytest.raises(MisconfigurationException):
@@ -401,14 +401,14 @@ def test_inf_val_dataloader(tmpdir):
     """Test inf val data loader (e.g. IterableDataset)"""
     tutils.reset_seed()
 
-    class CurrentTestModel(
+    class CurrentModel(
         LightInfValDataloader,
-        LightningTestModel
+        LightningTrialModel
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # fit model
     with pytest.raises(MisconfigurationException):
@@ -434,15 +434,15 @@ def test_inf_test_dataloader(tmpdir):
     """Test inf test data loader (e.g. IterableDataset)"""
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightInfTestDataloader,
-        LightningTestModel,
-        LightTestFitSingleTestDataloadersMixin
+    class CurrentModel(
+        LightInfTstDataloader,
+        LightningTrialModel,
+        LightTstStepSingleTstDataloadersMixin
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # fit model
     with pytest.raises(MisconfigurationException):
@@ -469,14 +469,14 @@ def test_error_on_zero_len_dataloader(tmpdir):
     """ Test that error is raised if a zero-length dataloader is defined """
     tutils.reset_seed()
 
-    class CurrentTestModel(
+    class CurrentModel(
         LightZeroLenDataloader,
-        LightningTestModel
+        LightningTrialModel
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # fit model
     with pytest.raises(ValueError):
@@ -492,17 +492,17 @@ def test_warning_with_few_workers(tmpdir):
     """ Test that error is raised if dataloader with only a few workers is used """
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightTrainDataloader,
+    class CurrentModel(
+        LightTrnDataloader,
         LightValStepFitSingleDataloaderMixin,
-        LightTestFitSingleTestDataloadersMixin,
-        LightEmptyTestStep,
-        TestModelBase,
+        LightTstStepSingleTstDataloadersMixin,
+        LightEmptyTstStep,
+        TrialModelBase,
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # logger file to get meta
     trainer_options = dict(

--- a/tests/trainer/test_lr_finder.py
+++ b/tests/trainer/test_lr_finder.py
@@ -5,9 +5,9 @@ import tests.base.utils as tutils
 from pytorch_lightning import Trainer
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.base import (
-    LightTrainDataloader,
-    TestModelBase,
-    LightTestMultipleOptimizersWithSchedulingMixin,
+    LightTrnDataloader,
+    TrialModelBase,
+    LightMultipleOptimizersWithSchedulingMixin,
 )
 
 
@@ -15,15 +15,15 @@ def test_error_on_more_than_1_optimizer(tmpdir):
     ''' Check that error is thrown when more than 1 optimizer is passed '''
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightTestMultipleOptimizersWithSchedulingMixin,
-        LightTrainDataloader,
-        TestModelBase,
+    class CurrentModel(
+        LightMultipleOptimizersWithSchedulingMixin,
+        LightTrnDataloader,
+        TrialModelBase,
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # logger file to get meta
     trainer = Trainer(
@@ -39,14 +39,14 @@ def test_model_reset_correctly(tmpdir):
     ''' Check that model weights are correctly reset after lr_find() '''
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightTrainDataloader,
-        TestModelBase,
+    class CurrentModel(
+        LightTrnDataloader,
+        TrialModelBase,
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # logger file to get meta
     trainer = Trainer(
@@ -69,14 +69,14 @@ def test_trainer_reset_correctly(tmpdir):
     ''' Check that all trainer parameters are reset correctly after lr_find() '''
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightTrainDataloader,
-        TestModelBase,
+    class CurrentModel(
+        LightTrnDataloader,
+        TrialModelBase,
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # logger file to get meta
     trainer = Trainer(
@@ -106,14 +106,14 @@ def test_trainer_reset_correctly(tmpdir):
 def test_trainer_arg_bool(tmpdir):
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightTrainDataloader,
-        TestModelBase,
+    class CurrentModel(
+        LightTrnDataloader,
+        TrialModelBase,
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
     before_lr = hparams.learning_rate
     # logger file to get meta
     trainer = Trainer(
@@ -131,15 +131,15 @@ def test_trainer_arg_bool(tmpdir):
 def test_trainer_arg_str(tmpdir):
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightTrainDataloader,
-        TestModelBase,
+    class CurrentModel(
+        LightTrnDataloader,
+        TrialModelBase,
     ):
         pass
 
     hparams = tutils.get_default_hparams()
     hparams.__dict__['my_fancy_lr'] = 1.0  # update with non-standard field
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
     before_lr = hparams.my_fancy_lr
     # logger file to get meta
     trainer = Trainer(
@@ -157,14 +157,14 @@ def test_trainer_arg_str(tmpdir):
 def test_call_to_trainer_method(tmpdir):
     tutils.reset_seed()
 
-    class CurrentTestModel(
-        LightTrainDataloader,
-        TestModelBase,
+    class CurrentModel(
+        LightTrnDataloader,
+        TrialModelBase,
     ):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
     before_lr = hparams.learning_rate
     # logger file to get meta
     trainer = Trainer(

--- a/tests/trainer/test_optimizers.py
+++ b/tests/trainer/test_optimizers.py
@@ -5,15 +5,15 @@ import tests.base.utils as tutils
 from pytorch_lightning import Trainer
 
 from tests.base import (
-    TestModelBase,
-    LightTrainDataloader,
-    LightValidationStepMixin,
-    LightValidationMixin,
-    LightTestOptimizerWithSchedulingMixin,
-    LightTestMultipleOptimizersWithSchedulingMixin,
-    LightTestOptimizersWithMixedSchedulingMixin,
-    LightTestReduceLROnPlateauMixin,
-    LightTestNoneOptimizerMixin
+    TrialModelBase,
+    LightTrnDataloader,
+    LightValStepMixin,
+    LightValMixin,
+    LightOptimizerWithSchedulingMixin,
+    LightMultipleOptimizersWithSchedulingMixin,
+    LightOptimizersWithMixedSchedulingMixin,
+    LightReduceLROnPlateauMixin,
+    LightNoneOptimizerMixin
 )
 
 
@@ -21,14 +21,14 @@ def test_optimizer_with_scheduling(tmpdir):
     """ Verify that learning rate scheduling is working """
     tutils.reset_seed()
 
-    class CurrentTestModel(
-            LightTestOptimizerWithSchedulingMixin,
-            LightTrainDataloader,
-            TestModelBase):
+    class CurrentModel(
+            LightOptimizerWithSchedulingMixin,
+            LightTrnDataloader,
+            TrialModelBase):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # logger file to get meta
     trainer_options = dict(
@@ -60,14 +60,14 @@ def test_multi_optimizer_with_scheduling(tmpdir):
     """ Verify that learning rate scheduling is working """
     tutils.reset_seed()
 
-    class CurrentTestModel(
-            LightTestMultipleOptimizersWithSchedulingMixin,
-            LightTrainDataloader,
-            TestModelBase):
+    class CurrentModel(
+            LightMultipleOptimizersWithSchedulingMixin,
+            LightTrnDataloader,
+            TrialModelBase):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # logger file to get meta
     trainer_options = dict(
@@ -103,14 +103,14 @@ def test_multi_optimizer_with_scheduling(tmpdir):
 def test_multi_optimizer_with_scheduling_stepping(tmpdir):
     tutils.reset_seed()
 
-    class CurrentTestModel(
-            LightTestOptimizersWithMixedSchedulingMixin,
-            LightTrainDataloader,
-            TestModelBase):
+    class CurrentModel(
+            LightOptimizersWithMixedSchedulingMixin,
+            LightTrnDataloader,
+            TrialModelBase):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # logger file to get meta
     trainer_options = dict(
@@ -150,16 +150,16 @@ def test_multi_optimizer_with_scheduling_stepping(tmpdir):
 def test_reduce_lr_on_plateau_scheduling(tmpdir):
     tutils.reset_seed()
 
-    class CurrentTestModel(
-            LightTestReduceLROnPlateauMixin,
-            LightTrainDataloader,
-            LightValidationMixin,
-            LightValidationStepMixin,
-            TestModelBase):
+    class CurrentModel(
+            LightReduceLROnPlateauMixin,
+            LightTrnDataloader,
+            LightValMixin,
+            LightValStepMixin,
+            TrialModelBase):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # logger file to get meta
     trainer_options = dict(
@@ -252,14 +252,14 @@ def test_none_optimizer_warning():
 def test_none_optimizer(tmpdir):
     tutils.reset_seed()
 
-    class CurrentTestModel(
-            LightTestNoneOptimizerMixin,
-            LightTrainDataloader,
-            TestModelBase):
+    class CurrentModel(
+            LightNoneOptimizerMixin,
+            LightTrnDataloader,
+            TrialModelBase):
         pass
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     # logger file to get meta
     trainer_options = dict(
@@ -282,7 +282,7 @@ def test_configure_optimizer_from_dict(tmpdir):
     `optimizer` field only.
     """
 
-    class CurrentTestModel(LightTrainDataloader, TestModelBase):
+    class CurrentModel(LightTrnDataloader, TrialModelBase):
         def configure_optimizers(self):
             config = {
                 'optimizer': torch.optim.SGD(params=self.parameters(), lr=1e-03)
@@ -290,7 +290,7 @@ def test_configure_optimizer_from_dict(tmpdir):
             return config
 
     hparams = tutils.get_default_hparams()
-    model = CurrentTestModel(hparams)
+    model = CurrentModel(hparams)
 
     trainer_options = dict(default_save_path=tmpdir, max_epochs=1)
 


### PR DESCRIPTION
## What does this PR do?
Rename test supporting classes to not contain "Test"
The problem with the TEs name si is that these classes are treated as unit tests and pytest complains that these classes do not contain any real test cases
If the test was used for test-step/dataloader/... renames to `tst`
otherwise renames to `Trial` 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
