### PR TITLE
[WIP] [discussion] Re-raise logger import warnings when not installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ references:
       command: |
         virtualenv vEnv ; source vEnv/bin/activate
         pip install --editable . ; cd .. & python -c "import pytorch_lightning ; print(pytorch_lightning.__version__)"
+        pip install -r requirements-extra.txt --user
         deactivate ; rm -rf vEnv
 
   create_pkg: &create_pkg

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ references:
       name: Install package
       command: |
         virtualenv vEnv ; source vEnv/bin/activate
-        pip install -r requirements-extra.txt --user
+        pip install -r requirements-extra.txt
         pip install --editable . ; cd .. & python -c "import pytorch_lightning ; print(pytorch_lightning.__version__)"
         deactivate ; rm -rf vEnv
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,8 @@ references:
       name: Install package
       command: |
         virtualenv vEnv ; source vEnv/bin/activate
-        pip install --editable . ; cd .. & python -c "import pytorch_lightning ; print(pytorch_lightning.__version__)"
         pip install -r requirements-extra.txt --user
+        pip install --editable . ; cd .. & python -c "import pytorch_lightning ; print(pytorch_lightning.__version__)"
         deactivate ; rm -rf vEnv
 
   create_pkg: &create_pkg

--- a/pytorch_lightning/loggers/__init__.py
+++ b/pytorch_lightning/loggers/__init__.py
@@ -92,42 +92,42 @@ try:
     environ["COMET_DISABLE_AUTO_LOGGING"] = "1"
 
     from pytorch_lightning.loggers.comet import CometLogger
-except ImportError:  # pragma: no-cover
+except ImportError as e:  # pragma: no-cover
     del environ["COMET_DISABLE_AUTO_LOGGING"]  # pragma: no-cover
 else:
     __all__.append('CometLogger')
 
 try:
     from pytorch_lightning.loggers.mlflow import MLFlowLogger
-except ImportError:  # pragma: no-cover
-    pass  # pragma: no-cover
+except ImportError as e:  # pragma: no-cover
+    raise e  # pragma: no-cover
 else:
     __all__.append('MLFlowLogger')
 
 try:
     from pytorch_lightning.loggers.neptune import NeptuneLogger
-except ImportError:  # pragma: no-cover
-    pass  # pragma: no-cover
+except ImportError as e:  # pragma: no-cover
+    raise e  # pragma: no-cover
 else:
     __all__.append('NeptuneLogger')
 
 try:
     from pytorch_lightning.loggers.test_tube import TestTubeLogger
-except ImportError:  # pragma: no-cover
-    pass  # pragma: no-cover
+except ImportError as e:  # pragma: no-cover
+    raise e  # pragma: no-cover
 else:
     __all__.append('TestTubeLogger')
 
 try:
     from pytorch_lightning.loggers.wandb import WandbLogger
-except ImportError:  # pragma: no-cover
-    pass  # pragma: no-cover
+except ImportError as e:  # pragma: no-cover
+    raise e
 else:
     __all__.append('WandbLogger')
 
 try:
     from pytorch_lightning.loggers.trains import TrainsLogger
-except ImportError:  # pragma: no-cover
-    pass  # pragma: no-cover
+except ImportError as e:
+    raise e
 else:
     __all__.append('TrainsLogger')

--- a/pytorch_lightning/loggers/comet.py
+++ b/pytorch_lightning/loggers/comet.py
@@ -20,7 +20,7 @@ try:
         # For more information, see: https://www.comet.ml/docs/python-sdk/releases/#release-300
         from comet_ml.papi import API  # pragma: no-cover
 except ImportError:  # pragma: no-cover
-    raise ImportError('You want to use `comet_ml` logger which is not installed yet,'  # pragma: no-cover
+    raise ImportError('You want to use `comet-ml` logger which is not installed yet,'  # pragma: no-cover
                       ' install it with `pip install comet-ml`.')
 
 import torch

--- a/pytorch_lightning/loggers/test_tube.py
+++ b/pytorch_lightning/loggers/test_tube.py
@@ -4,7 +4,7 @@ from typing import Optional, Dict, Any, Union
 try:
     from test_tube import Experiment
 except ImportError:  # pragma: no-cover
-    raise ImportError('You want to use `test_tube` logger which is not installed yet,'  # pragma: no-cover
+    raise ImportError('You want to use `test-tube` logger which is not installed yet,'  # pragma: no-cover
                       ' install it with `pip install test-tube`.')
 
 from pytorch_lightning.loggers.base import LightningLoggerBase, rank_zero_only


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
When importing a logger this way
`from pytorch_lightning.loggers.wandb import WandbLogger`
an error message will be printed if the package is not installed. 
However, if we import from the top level module, i.e.,
`from pytorch_lightning.loggers import WandbLogger`
the error message is discarded.
This PR fixes that.

Probably what is happening in #1487. 


## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
