### PR TITLE
wandb logger 'global_step' affects other logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed Horovod distributed backend to set the `root_gpu` property ([#1669](https://github.com/PyTorchLightning/pytorch-lightning/pull/1669))
 
-- Fixed wandb logger `global_step` affects other loggers ([#1485](https://github.com/PyTorchLightning/pytorch-lightning/issues/1485))
+- Fixed wandb logger `global_step` affects other loggers ([#1492](https://github.com/PyTorchLightning/pytorch-lightning/issues/1485))
 
 ## [0.7.5] - 2020-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed Horovod distributed backend to set the `root_gpu` property ([#1669](https://github.com/PyTorchLightning/pytorch-lightning/pull/1669))
 
+- Fixed wandb logger `global_step` affects other loggers ([#1485](https://github.com/PyTorchLightning/pytorch-lightning/issues/1485))
 
 ## [0.7.5] - 2020-04-27
 
@@ -41,7 +42,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed ModelCheckpoint not being fixable ([#1632](https://github.com/PyTorchLightning/pytorch-lightning/pull/1632))
 - Fixed CPU DDP breaking change and DDP change ([#1635](https://github.com/PyTorchLightning/pytorch-lightning/pull/1635))
 - Tested pickling ([#1636](https://github.com/PyTorchLightning/pytorch-lightning/pull/1636))
-- Fixed wandb logger 'global_step' affects other loggers ([#1485](https://github.com/PyTorchLightning/pytorch-lightning/issues/1485))
 
 
 ## [0.7.4] - 2020-04-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed ModelCheckpoint not being fixable ([#1632](https://github.com/PyTorchLightning/pytorch-lightning/pull/1632))
 - Fixed CPU DDP breaking change and DDP change ([#1635](https://github.com/PyTorchLightning/pytorch-lightning/pull/1635))
 - Tested pickling ([#1636](https://github.com/PyTorchLightning/pytorch-lightning/pull/1636))
+- Fixed wandb logger 'global_step' affects other loggers ([#1485](https://github.com/PyTorchLightning/pytorch-lightning/issues/1485))
 
 
 ## [0.7.4] - 2020-04-26

--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -125,7 +125,7 @@ class LightningLoggerBase(ABC):
         """
         agg_step, metrics_to_log = self._aggregate_metrics(metrics=metrics, step=step)
 
-        if metrics_to_log is not None:
+        if metrics_to_log is not None and metrics_to_log != {}:
             self.log_metrics(metrics=metrics_to_log, step=agg_step)
 
     @abstractmethod

--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -125,7 +125,7 @@ class LightningLoggerBase(ABC):
         """
         agg_step, metrics_to_log = self._aggregate_metrics(metrics=metrics, step=step)
 
-        if metrics_to_log is not None and metrics_to_log != {}:
+        if metrics_to_log:
             self.log_metrics(metrics=metrics_to_log, step=agg_step)
 
     @abstractmethod

--- a/pytorch_lightning/loggers/wandb.py
+++ b/pytorch_lightning/loggers/wandb.py
@@ -119,8 +119,6 @@ class WandbLogger(LightningLoggerBase):
 
     @rank_zero_only
     def log_metrics(self, metrics: Dict[str, float], step: Optional[int] = None) -> None:
-        if step is not None:
-            metrics['global_step'] = step
         self.experiment.log(metrics)
 
     @property

--- a/pytorch_lightning/loggers/wandb.py
+++ b/pytorch_lightning/loggers/wandb.py
@@ -119,7 +119,7 @@ class WandbLogger(LightningLoggerBase):
 
     @rank_zero_only
     def log_metrics(self, metrics: Dict[str, float], step: Optional[int] = None) -> None:
-        self.experiment.log(metrics)
+        self.experiment.log(metrics, step=step)
 
     @property
     def name(self) -> str:

--- a/tests/loggers/test_wandb.py
+++ b/tests/loggers/test_wandb.py
@@ -16,11 +16,11 @@ def test_wandb_logger(wandb):
     logger = WandbLogger(anonymous=True, offline=True)
 
     logger.log_metrics({'acc': 1.0})
-    wandb.init().log.assert_called_once_with({'acc': 1.0})
+    wandb.init().log.assert_called_once_with({'acc': 1.0}, step=None)
 
     wandb.init().log.reset_mock()
-    logger.log_metrics({'acc': 1.0}, step=3)
-    wandb.init().log.assert_called_once_with({'global_step': 3, 'acc': 1.0})
+    logger.log_metrics({'acc': 1.0}, step=None)
+    wandb.init().log.assert_called_once_with({'acc': 1.0}, step=None)
 
     logger.log_hyperparams({'test': None})
     wandb.init().config.update.assert_called_once_with({'test': None}, allow_val_change=True)

--- a/tests/loggers/test_wandb.py
+++ b/tests/loggers/test_wandb.py
@@ -19,8 +19,8 @@ def test_wandb_logger(wandb):
     wandb.init().log.assert_called_once_with({'acc': 1.0}, step=None)
 
     wandb.init().log.reset_mock()
-    logger.log_metrics({'acc': 1.0}, step=None)
-    wandb.init().log.assert_called_once_with({'acc': 1.0}, step=None)
+    logger.log_metrics({'acc': 1.0}, step=3)
+    wandb.init().log.assert_called_once_with({'acc': 1.0}, step=3)
 
     logger.log_hyperparams({'test': None})
     wandb.init().config.update.assert_called_once_with({'test': None}, allow_val_change=True)


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs? Not needed just a fix...
- [x] Did you write any new necessary tests? Probably not necessary...
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

Should I make an changelog update or will a maintainer do this?

## What does this PR do?
Fixes #1485 .

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

Shortly discussed in #1485 with @Borda 

## Did you have fun?
Yes a lot! :D
