### PR TITLE
CI: Docs build preview in each PR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,10 @@ jobs:
     steps:
       - checkout
       - *make_docs
+      - store_artifacts:
+          # allows us to preview the generated html pages
+          path: docs/build/html/
+          destination: html
 
   Formatting:
     docker:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -120,6 +120,8 @@ make html
 ```
 and open `docs/build/html/index.html` in your browser.
 
+When you send a PR the continuous integration will run tests and build the docs. You can access a preview of the html pages in the 
+_Artifacts_ tab in CircleCI when you click on the task named _ci/circleci: Build-Docs_ at the bottom of the PR page.
 
 ### Testing
 


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
It works!
This allows us to preview the docs in every PR and make documentation updates easier to review as it does not require to pull the branch and build locally. The html pages are automatically stored in CircleCI. 

**1. Click on the details button for the **Build Docs** task:**
![image](https://user-images.githubusercontent.com/5495193/79279736-fb13a780-7eae-11ea-929b-89fab49dfa95.png)

**2. In CircleCi, click on the Artifacts tab:**
![docs-preview](https://user-images.githubusercontent.com/5495193/79279765-0d8de100-7eaf-11ea-8e3a-fcfd817d943a.jpg)

**3. Click on index.html to get to the home page!**


## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
