### PR TITLE
fixed memory leak from opt return

### DIFF
--- a/pl_examples/basic_examples/cpu_template.py
+++ b/pl_examples/basic_examples/cpu_template.py
@@ -28,7 +28,7 @@ def main(hparams):
     # ------------------------
     # 2 INIT TRAINER
     # ------------------------
-    trainer = pl.Trainer(max_epochs=hparams.epochs)
+    trainer = pl.Trainer(max_epochs=hparams.epochs, overfit_pct=0.01, early_stop_callback=True)
 
     # ------------------------
     # 3 START TRAINING

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -106,6 +106,9 @@ class EarlyStopping(Callback):
             return stop_training
 
         current = logs.get(self.monitor)
+        if not isinstance(current, torch.Tensor):
+            import pdb; pdb.set_trace()
+            current = torch.tensor(current)
         if self.monitor_op(current - self.min_delta, self.best):
             self.best = current
             self.wait = 0

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -59,10 +59,9 @@ class EarlyStopping(Callback):
         self.stopped_epoch = 0
 
         mode_dict = {
-            'min': (torch.lt, torch_inf, 'min'),
-            'max': (torch.gt, -torch_inf, 'max'),
-            'auto': (torch.gt, -torch_inf, 'max') if 'acc' in self.monitor or self.monitor.startswith('fmeasure')
-            else (torch.lt, torch_inf, 'min'),
+            'min': torch.lt,
+            'max': torch.gt,
+            'auto': torch.gt if 'acc' in self.monitor else torch.lt
         }
 
         if mode not in mode_dict:

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -107,8 +107,8 @@ class EarlyStopping(Callback):
 
         current = logs.get(self.monitor)
         if not isinstance(current, torch.Tensor):
-            import pdb; pdb.set_trace()
             current = torch.tensor(current)
+
         if self.monitor_op(current - self.min_delta, self.best):
             self.best = current
             self.wait = 0

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -13,6 +13,8 @@ from pytorch_lightning import _logger as log
 from pytorch_lightning.callbacks.base import Callback
 from pytorch_lightning.utilities import rank_zero_warn
 
+torch_inf = torch.tensor(np.Inf)
+
 
 class EarlyStopping(Callback):
     r"""
@@ -56,7 +58,6 @@ class EarlyStopping(Callback):
         self.wait = 0
         self.stopped_epoch = 0
 
-        torch_inf = torch.tensor(np.Inf)
         mode_dict = {
             'min': (torch.lt, torch_inf, 'min'),
             'max': (torch.gt, -torch_inf, 'max'),
@@ -70,7 +71,7 @@ class EarlyStopping(Callback):
             mode = 'auto'
 
         self.monitor_op = mode_dict[mode]
-        self.min_delta *= 1 if self.monitor_op == np.greater else -1
+        self.min_delta *= 1 if self.monitor_op == torch.gt else -1
 
     def _validate_condition_metric(self, logs):
         """
@@ -97,7 +98,7 @@ class EarlyStopping(Callback):
         # Allow instances to be re-used
         self.wait = 0
         self.stopped_epoch = 0
-        self.best = np.Inf if self.monitor_op == np.less else -np.Inf
+        self.best = torch_inf if self.monitor_op == torch.lt else -torch_inf
 
     def on_epoch_end(self, trainer, pl_module):
         logs = trainer.callback_metrics

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -46,13 +46,8 @@ class EarlyStopping(Callback):
         >>> trainer = Trainer(early_stop_callback=early_stopping)
     """
 
-    def __init__(self,
-                 monitor: str = 'val_loss',
-                 min_delta: float = 0.0,
-                 patience: int = 3,
-                 verbose: bool = False,
-                 mode: str = 'min',
-                 strict: bool = True):
+    def __init__(self, monitor: str = 'val_loss', min_delta: float = 0.0, patience: int = 3,
+                 verbose: bool = False, mode: str = 'auto', strict: bool = True):
         super().__init__()
 
         self.monitor = monitor

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -46,8 +46,13 @@ class EarlyStopping(Callback):
         >>> trainer = Trainer(early_stop_callback=early_stopping)
     """
 
-    def __init__(self, monitor: str = 'val_loss', min_delta: float = 0.0, patience: int = 0,
-                 verbose: bool = False, mode: str = 'auto', strict: bool = True):
+    def __init__(self,
+                 monitor: str = 'val_loss',
+                 min_delta: float = 0.0,
+                 patience: int = 3,
+                 verbose: bool = False,
+                 mode: str = 'min',
+                 strict: bool = True):
         super().__init__()
 
         self.monitor = monitor

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -69,7 +69,12 @@ class EarlyStopping(Callback):
         self.monitor_op = mode_dict[mode]
         self.min_delta *= 1 if self.monitor_op == np.greater else -1
 
-    def check_metrics(self, logs):
+    def _validate_condition_metric(self, logs):
+        """
+        Checks that the condition metric for early stopping is good
+        :param logs:
+        :return:
+        """
         monitor_val = logs.get(self.monitor)
         error_msg = (f'Early stopping conditioned on metric `{self.monitor}`'
                      f' which is not available. Available metrics are:'
@@ -94,7 +99,7 @@ class EarlyStopping(Callback):
     def on_epoch_end(self, trainer, pl_module):
         logs = trainer.callback_metrics
         stop_training = False
-        if not self.check_metrics(logs):
+        if not self._validate_condition_metric(logs):
             return stop_training
 
         current = logs.get(self.monitor)

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -14,6 +14,7 @@ import numpy as np
 from pytorch_lightning import _logger as log
 from pytorch_lightning.callbacks.base import Callback
 from pytorch_lightning.utilities import rank_zero_warn
+import torch
 
 
 class ModelCheckpoint(Callback):
@@ -106,11 +107,12 @@ class ModelCheckpoint(Callback):
         self.best = 0
         self.save_function = None
 
+        torch_inf = torch.tensor(np.Inf)
         mode_dict = {
-            'min': (np.less, np.Inf, 'min'),
-            'max': (np.greater, -np.Inf, 'max'),
-            'auto': (np.greater, -np.Inf, 'max') if 'acc' in self.monitor or self.monitor.startswith('fmeasure')
-            else (np.less, np.Inf, 'min'),
+            'min': (torch.lt, torch_inf, 'min'),
+            'max': (torch.gt, -torch_inf, 'max'),
+            'auto': (torch.gt, -torch_inf, 'max') if 'acc' in self.monitor or self.monitor.startswith('fmeasure')
+            else (torch.lt, torch_inf, 'min'),
         }
 
         if mode not in mode_dict:
@@ -136,11 +138,13 @@ class ModelCheckpoint(Callback):
         less_than_k_models = len(self.best_k_models) < self.save_top_k
         if less_than_k_models:
             return True
+
         try:
+            import pdb; pdb.set_trace()
             d = self.monitor_op(current, self.best_k_models[self.kth_best_model])
         except Exception as e:
-            import pdb; pdb.set_trace()
-            print('a')
+
+            print('s')
         return d
 
     def format_checkpoint_name(self, epoch, metrics, ver=None):

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -139,6 +139,7 @@ class ModelCheckpoint(Callback):
         try:
             d = self.monitor_op(current, self.best_k_models[self.kth_best_model])
         except Exception as e:
+            import pdb; pdb.set_trace()
             print('a')
         return d
 

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -139,13 +139,7 @@ class ModelCheckpoint(Callback):
         if less_than_k_models:
             return True
 
-        try:
-            import pdb; pdb.set_trace()
-            d = self.monitor_op(current, self.best_k_models[self.kth_best_model])
-        except Exception as e:
-
-            print('s')
-        return d
+        return self.monitor_op(current, self.best_k_models[self.kth_best_model])
 
     def format_checkpoint_name(self, epoch, metrics, ver=None):
         """Generate a filename according to the defined template.

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -136,7 +136,11 @@ class ModelCheckpoint(Callback):
         less_than_k_models = len(self.best_k_models) < self.save_top_k
         if less_than_k_models:
             return True
-        return self.monitor_op(current, self.best_k_models[self.kth_best_model])
+        try:
+            d = self.monitor_op(current, self.best_k_models[self.kth_best_model])
+        except Exception as e:
+            print('a')
+        return d
 
     def format_checkpoint_name(self, epoch, metrics, ver=None):
         """Generate a filename according to the defined template.

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -111,7 +111,8 @@ class ModelCheckpoint(Callback):
         mode_dict = {
             'min': (torch.lt, torch_inf, 'min'),
             'max': (torch.gt, -torch_inf, 'max'),
-            'auto': (torch.gt, -torch_inf, 'max') if 'acc' in self.monitor or self.monitor.startswith('fmeasure')
+            'auto': (torch.gt, -torch_inf, 'max') if 'acc' in self.monitor
+                                                     or self.monitor.startswith('fmeasure')
             else (torch.lt, torch_inf, 'min'),
         }
 

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -111,8 +111,7 @@ class ModelCheckpoint(Callback):
         mode_dict = {
             'min': (torch.lt, torch_inf, 'min'),
             'max': (torch.gt, -torch_inf, 'max'),
-            'auto': (torch.gt, -torch_inf, 'max') if 'acc' in self.monitor
-                                                     or self.monitor.startswith('fmeasure')
+            'auto': (torch.gt, -torch_inf, 'max') if 'acc' in self.monitor or self.monitor.startswith('fmeasure')
             else (torch.lt, torch_inf, 'min'),
         }
 
@@ -211,8 +210,9 @@ class ModelCheckpoint(Callback):
             current = metrics.get(self.monitor)
 
             if current is None:
-                rank_zero_warn(f'Can save best model only with {self.monitor} available, skipping.'
-                               ,RuntimeWarning)
+                rank_zero_warn(
+                    f'Can save best model only with {self.monitor} available, skipping.', RuntimeWarning
+                )
             elif self.check_monitor_top_k(current):
                 self._do_check_save(filepath, current, epoch)
             elif self.verbose > 0:

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -139,6 +139,9 @@ class ModelCheckpoint(Callback):
         if less_than_k_models:
             return True
 
+        if not isinstance(current, torch.Tensor):
+            current = torch.tensor(current)
+
         return self.monitor_op(current, self.best_k_models[self.kth_best_model])
 
     def format_checkpoint_name(self, epoch, metrics, ver=None):

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -117,7 +117,8 @@ class ModelCheckpoint(Callback):
         }
 
         if mode not in mode_dict:
-            rank_zero_warn(f'ModelCheckpoint mode {mode} is unknown, fallback to auto mode.', RuntimeWarning)
+            rank_zero_warn(f'ModelCheckpoint mode {mode} is unknown, '
+                           f'fallback to auto mode.', RuntimeWarning)
             mode = 'auto'
 
         self.monitor_op, self.kth_value, self.mode = mode_dict[mode]
@@ -210,7 +211,8 @@ class ModelCheckpoint(Callback):
             current = metrics.get(self.monitor)
 
             if current is None:
-                rank_zero_warn(f'Can save best model only with {self.monitor} available, skipping.', RuntimeWarning)
+                rank_zero_warn(f'Can save best model only with {self.monitor} available, skipping.'
+                               ,RuntimeWarning)
             elif self.check_monitor_top_k(current):
                 self._do_check_save(filepath, current, epoch)
             elif self.verbose > 0:

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -413,6 +413,8 @@ class TrainerEvaluationLoopMixin(ABC):
         # Validation/Test end callbacks
         if test_mode:
             self.on_test_end()
+        else:
+            self.on_validation_end()
 
     def evaluation_forward(self, model, batch, batch_idx, dataloader_idx, test_mode: bool = False):
         # make dataloader_idx arg in validation_step optional

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -891,8 +891,9 @@ class Trainer(
             self.main_progress_bar.close()
             self.val_progress_bar.close()
 
+            # verify that early stop has conditioned on a metric that exists
             if self.enable_early_stop:
-                self.early_stop_callback.check_metrics(callback_metrics)
+                self.early_stop_callback._validate_condition_metric(callback_metrics)
 
         # init progress bar
         pbar = tqdm(leave=True, position=2 * self.process_position,

--- a/pytorch_lightning/utilities/memory_utils.py
+++ b/pytorch_lightning/utilities/memory_utils.py
@@ -1,0 +1,24 @@
+def recursive_detach(in_dict):
+    """Detach all tensors in `in_dict`.
+
+    May operate recursively if some of the values in `in_dict` are dictionaries
+    which contain instances of `torch.Tensor`. Other types in `in_dict` are
+    not affected by this utility function.
+
+    Parameters
+    ----------
+    in_dict : dict
+
+    Returns
+    -------
+    out_dict : dict
+    """
+    out_dict = {}
+    for k, v in in_dict.items():
+        if isinstance(v, dict):
+            out_dict.update({k: recursive_detach(v)})
+        elif callable(getattr(v, 'detach', None)):
+            out_dict.update({k: v.detach()})
+        else:
+            out_dict.update({k: v})
+    return out_dict

--- a/tests/base/utils.py
+++ b/tests/base/utils.py
@@ -23,7 +23,7 @@ ROOT_PATH = os.path.abspath(os.path.dirname(__file__))
 def assert_speed_parity(pl_times, pt_times, num_epochs):
 
     # assert speeds
-    max_diff_per_epoch = 0.9
+    max_diff_per_epoch = 0.65
     pl_times = np.asarray(pl_times)
     pt_times = np.asarray(pt_times)
     diffs = pl_times - pt_times


### PR DESCRIPTION
Fixes #1510 
and a few other things along the way.

Now uses .detach to track metrics instead of .item() which keeps speed fast but decreases memory.

Also speeds things up:
Before this PR lightning slowed an epoch by 0.89 seconds, now only by 0.65 seconds (<1 sec per epoch). This baseline is compared with the same model trained using only PyTorch