### PR TITLE
Skip workers warning test on windows

### DIFF
--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -1,3 +1,5 @@
+import platform
+
 import pytest
 import torch
 
@@ -488,6 +490,7 @@ def test_error_on_zero_len_dataloader(tmpdir):
         trainer.fit(model)
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Does not apply to Windows platform.')
 def test_warning_with_few_workers(tmpdir):
     """ Test that error is raised if dataloader with only a few workers is used """
     tutils.reset_seed()


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Extends #1430.
On Windows, the test `test_warning_with_few_workers` fails because it expects a warning, but the warning is omitted [here](https://github.com/PyTorchLightning/pytorch-lightning/blob/b0bf51f99f0ffa3e2a015a366d5bd751ed3dfa36/pytorch_lightning/trainer/data_loading.py#L80) when on Windows, so the test should be skipped in that case.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
