### PR TITLE
Fix callback default (horror bug!)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added a missing call to the `on_before_zero_grad` model hook ([#1493](https://github.com/PyTorchLightning/pytorch-lightning/pull/1493)). 
 
-- 
+- Fixed a bug that caused the `callbacks` Trainer argument to reference a global variable ([#1534](https://github.com/PyTorchLightning/pytorch-lightning/pull/1534)).
 
 
 ## [0.7.3] - 2020-04-09

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -546,7 +546,7 @@ class Trainer(
               (<class 'int'>, typing.Dict[int, int], typing.List[list]),
               1),
              ...
-             ('callbacks', (<class 'pytorch_lightning.callbacks.base.Callback'>,), []),
+             ('callbacks', (typing.List[pytorch_lightning.callbacks.base.Callback], <class 'NoneType'>), None),
              ('check_val_every_n_epoch', (<class 'int'>,), 1),
              ...
              ('max_epochs', (<class 'int'>,), 1000),

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -87,7 +87,7 @@ class Trainer(
             logger: Union[LightningLoggerBase, Iterable[LightningLoggerBase], bool] = True,
             checkpoint_callback: Union[ModelCheckpoint, bool] = True,
             early_stop_callback: Optional[Union[EarlyStopping, bool]] = False,
-            callbacks: List[Callback] = [],
+            callbacks: Optional[List[Callback]] = None,
             default_root_dir: Optional[str] = None,
             gradient_clip_val: float = 0,
             process_position: int = 0,
@@ -293,7 +293,7 @@ class Trainer(
         """
 
         # Init callbacks
-        self.callbacks = callbacks
+        self.callbacks = callbacks or []
         self.on_init_start()
 
         # benchmarking

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -546,7 +546,10 @@ class Trainer(
               (<class 'int'>, typing.Dict[int, int], typing.List[list]),
               1),
              ...
-             ('callbacks', (typing.List[pytorch_lightning.callbacks.base.Callback], <class 'NoneType'>), None),
+             ('callbacks',
+              (typing.List[pytorch_lightning.callbacks.base.Callback],
+               <class 'NoneType'>),
+               None),
              ('check_val_every_n_epoch', (<class 'int'>,), 1),
              ...
              ('max_epochs', (<class 'int'>,), 1000),


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
**Fixes a horror bug that took me sooo many hours to find when implementing #1450.**
An argument in a function or method should NEVER be initialized to an empty list! Here is an example of what happens when you do so:

```python
from pytorch_lightning import Trainer
from pytorch_lightning.callbacks import ModelCheckpoint


a = Trainer()
a.callbacks.append(ModelCheckpoint('./a'))

print(len(a.callbacks))

b = Trainer()
b.callbacks.append(ModelCheckpoint('./b'))

print(len(b.callbacks))


```
Output (on master):
```
1
2
```
Expected:
```
1
1
```

It is a big Python pitfall.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Not this time! 🙃
