### PR TITLE
Error if callbacks are passed wrongly

### DIFF
--- a/pytorch_lightning/trainer/callback_config.py
+++ b/pytorch_lightning/trainer/callback_config.py
@@ -4,6 +4,7 @@ from typing import Union
 
 from pytorch_lightning.callbacks import ModelCheckpoint, EarlyStopping
 from pytorch_lightning.loggers import LightningLoggerBase
+from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 
 class TrainerCallbackConfigMixin(ABC):
@@ -95,3 +96,15 @@ class TrainerCallbackConfigMixin(ABC):
         else:
             self.early_stop_callback = early_stop_callback
             self.enable_early_stop = True
+
+    def check_callback_config(self):
+        for callback in self.callbacks:
+            if isinstance(callback, ModelCheckpoint):
+                raise MisconfigurationException(
+                    'You passed a `ModelCheckpoint` callback to trainer argument `callback`, '
+                    ' but it should instead be passed to argument `checkpoint_callback`')
+
+            if isinstance(callback, EarlyStopping):
+                raise MisconfigurationException(
+                    'You passed a `EarlyStopping` callback to trainer argument `callback`, '
+                    ' but it should instead be passed to argument `early_stop_callback`')

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -294,6 +294,7 @@ class Trainer(
 
         # Init callbacks
         self.callbacks = callbacks or []
+        self.check_callback_config()
         self.on_init_start()
 
         # benchmarking


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/1524.
If the user pass a `ModelCheckpoint` to trainer argument `callback` instead of `checkpoint_callback`, it will give a non-informative error. This PR implement a simple check that callbacks passed to trainer argument `callback` are not instances of `ModelCheckpoint` or `EarlyStopping` since these need to be passed to other trainer args. 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
