### PR TITLE
Revert namespace package search to normal package search

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -227,8 +227,7 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     (master_doc, project, project + ' Documentation', author, project,
-     'The lightweight PyTorch wrapper for ML researchers. Scale your models. Write less boilerplate.',
-     'Miscellaneous'),
+     'One line description of project.', 'Miscellaneous'),
 ]
 
 # -- Options for Epub output -------------------------------------------------

--- a/pytorch_lightning/__init__.py
+++ b/pytorch_lightning/__init__.py
@@ -1,6 +1,6 @@
 """Root package info."""
 
-__version__ = '0.7.4rc1'
+__version__ = '0.7.4rc2'
 __author__ = 'William Falcon et al.'
 __author_email__ = 'waf2107@columbia.edu'
 __license__ = 'Apache-2.0'

--- a/pytorch_lightning/utilities/memory_utils.py
+++ b/pytorch_lightning/utilities/memory_utils.py
@@ -1,17 +1,15 @@
-def recursive_detach(in_dict):
+def recursive_detach(in_dict: dict) -> dict:
     """Detach all tensors in `in_dict`.
 
     May operate recursively if some of the values in `in_dict` are dictionaries
     which contain instances of `torch.Tensor`. Other types in `in_dict` are
     not affected by this utility function.
 
-    Parameters
-    ----------
-    in_dict : dict
+    Args:
+        in_dict:
 
-    Returns
-    -------
-    out_dict : dict
+    Return:
+        out_dict:
     """
     out_dict = {}
     for k, v in in_dict.items():

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os
 from io import open
 # Always prefer setuptools over distutils
-from setuptools import setup, find_namespace_packages
+from setuptools import setup, find_packages
 
 try:
     import builtins
@@ -57,7 +57,7 @@ setup(
     url=pytorch_lightning.__homepage__,
     download_url='https://github.com/PyTorchLightning/pytorch-lightning',
     license=pytorch_lightning.__license__,
-    packages=find_namespace_packages(exclude=['tests', 'tests/*', 'benchmarks']),
+    packages=find_packages(exclude=['tests', 'tests/*', 'benchmarks']),
 
     long_description=load_long_describtion(),
     long_description_content_type='text/markdown',


### PR DESCRIPTION
# Before submitting

Sorry I was mixing different types of namespace packages. This time it should work.

for installing lightning we need to search for normal packages. But afterwards we need to declare it a namespace package in __init__
