### PR TITLE
fix _reset_eval_dataloader() for IterableDataset

### DIFF
--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -219,7 +219,7 @@ class TrainerDataLoadingMixin(ABC):
                     ' this off for validation and test dataloaders.')
 
         # add samplers
-        dataloaders = [self.auto_add_sampler(dl, train=False) for dl in dataloaders if dl]
+        dataloaders = [self.auto_add_sampler(dl, train=False) for dl in dataloaders]
 
         num_batches = 0
 

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -219,7 +219,7 @@ class TrainerDataLoadingMixin(ABC):
                     ' this off for validation and test dataloaders.')
 
         # add samplers
-        dataloaders = [self.auto_add_sampler(dl, train=False) for dl in dataloaders]
+        dataloaders = [self.auto_add_sampler(dl, train=False) for dl in dataloaders if dl != None]
 
         num_batches = 0
 

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -219,7 +219,7 @@ class TrainerDataLoadingMixin(ABC):
                     ' this off for validation and test dataloaders.')
 
         # add samplers
-        dataloaders = [self.auto_add_sampler(dl, train=False) for dl in dataloaders if dl != None]
+        dataloaders = [self.auto_add_sampler(dl, train=False) for dl in dataloaders if dl is not None]
 
         num_batches = 0
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
I encountered the following error `TypeError: object of type 'MyIterableDataset' has no len()` from [line 190](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pytorch_lightning/trainer/data_loading.py#L190) in _reset_eval_dataloader() in data_loading.py file when using an `IterableDataset` for the validation dataset. 

The `if dl` caused the issue. `if dl` is equivalent to bool(dl) = `dataloader.__bool__`, but there is no `dataloader.__bool__` so bool() uses `dataloader.__len__` > 0. But... [`dataloader.__len__`](https://github.com/pytorch/pytorch/blob/master/torch/utils/data/dataloader.py#L313) uses `IterableDataset.__len__` for `IterableDataset`s for which `__len__` is undefined.

Resolving the issue by comparing to None, `if dl is not None`, in _reset_eval_dataloader().

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
👍 
