### PR TITLE
Fixing a small issue in trainer logging 

### DIFF
--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -68,7 +68,7 @@ class TrainerLoggingMixin(ABC):
             step = scalar_metrics.pop("step")
         else:
             # added metrics by Lightning for convenience
-            metrics['epoch'] = self.current_epoch
+            scalar_metrics['epoch'] = self.current_epoch
             step = step if step is not None else self.global_step
         # log actual metrics
         if self.proc_rank == 0 and self.logger is not None:

--- a/tests/loggers/test_all.py
+++ b/tests/loggers/test_all.py
@@ -62,9 +62,9 @@ def test_loggers_fit_test(tmpdir, monkeypatch, logger_class):
     trainer.test()
 
     log_metric_names = [(s, sorted(m.keys())) for s, m in logger.history]
-    assert log_metric_names == [(0, ['val_acc', 'val_loss']),
-                                (0, ['train_some_val']),
-                                (1, ['test_acc', 'test_loss'])]
+    assert log_metric_names == [(0, ['epoch', 'val_acc', 'val_loss']),
+                                (0, ['epoch', 'train_some_val']),
+                                (1, ['epoch', 'test_acc', 'test_loss'])]
 
 
 @pytest.mark.parametrize("logger_class", [


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs? **No changes required**
- [x] Did you write any new necessary tests? **I don't think this requires any new tests, does it?** 
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)? **Should this be on the changelog?**

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Fixes half of #1520. This is the simpler half, where the epoch is logged into a dict that isn't passed to the loggers. 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
As much as can be in a one-line fix. 