### PR TITLE
Fixes automatic parser bug

### DIFF
--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -290,7 +290,7 @@ class TrainerDDPMixin(ABC):
                 gpu_str = ','.join([str(x) for x in data_parallel_device_ids])
                 os.environ["CUDA_VISIBLE_DEVICES"] = gpu_str
 
-        log.info(f'using CUDA_VISIBLE_DEVICES: {os.environ["CUDA_VISIBLE_DEVICES"]}')
+        log.info(f'CUDA_VISIBLE_DEVICES: [{os.environ["CUDA_VISIBLE_DEVICES"]}]')
 
     def ddp_train(self, process_idx, model):
         """

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -290,7 +290,7 @@ class TrainerDDPMixin(ABC):
                 gpu_str = ','.join([str(x) for x in data_parallel_device_ids])
                 os.environ["CUDA_VISIBLE_DEVICES"] = gpu_str
 
-        log.info(f'VISIBLE GPU IDs: {os.environ["CUDA_VISIBLE_DEVICES"]}')
+        log.info(f'using CUDA_VISIBLE_DEVICES: {os.environ["CUDA_VISIBLE_DEVICES"]}')
 
     def ddp_train(self, process_idx, model):
         """

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -290,7 +290,7 @@ class TrainerDDPMixin(ABC):
                 gpu_str = ','.join([str(x) for x in data_parallel_device_ids])
                 os.environ["CUDA_VISIBLE_DEVICES"] = gpu_str
 
-        log.info(f'VISIBLE GPUS: {os.environ["CUDA_VISIBLE_DEVICES"]}')
+        log.info(f'VISIBLE GPU IDs: {os.environ["CUDA_VISIBLE_DEVICES"]}')
 
     def ddp_train(self, process_idx, model):
         """

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -646,6 +646,7 @@ def check_gpus_data_type(gpus):
     :return: return unmodified gpus variable
     """
 
+    import pdb; pdb.set_trace()
     if gpus is not None and (not isinstance(gpus, (int, str, list)) or isinstance(gpus, bool)):
         raise MisconfigurationException("GPUs must be int, string or list of ints or None.")
 

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -622,6 +622,7 @@ class TrainerDPMixin(ABC):
 
 
 def normalize_parse_gpu_string_input(s):
+    import pdb; pdb.set_trace()
     if isinstance(s, str):
         if s == '-1':
             return -1
@@ -696,7 +697,6 @@ def parse_gpu_ids(gpus):
     """
 
     # Check that gpus param is None, Int, String or List
-    import pdb; pdb.set_trace()
     check_gpus_data_type(gpus)
 
     # Handle the case when no gpus are requested

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -626,6 +626,7 @@ def normalize_parse_gpu_string_input(s):
         if s == '-1':
             return -1
         else:
+            import pdb; pdb.set_trace()
             return [int(x.strip()) for x in s.split(',')]
     else:
         return s

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -645,7 +645,10 @@ def check_gpus_data_type(gpus):
         Throws otherwise
     :return: return unmodified gpus variable
     """
-    import pdb; pdb.set_trace()
+
+    # nothin was passed into the GPUs argument
+    if callable(gpus):
+        return
 
     if gpus is not None and (not isinstance(gpus, (int, str, list)) or isinstance(gpus, bool)):
         raise MisconfigurationException("GPUs must be int, string or list of ints or None.")

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -626,7 +626,6 @@ def normalize_parse_gpu_string_input(s):
         if s == '-1':
             return -1
         else:
-            import pdb; pdb.set_trace()
             return [int(x.strip()) for x in s.split(',')]
     else:
         return s
@@ -697,6 +696,7 @@ def parse_gpu_ids(gpus):
     """
 
     # Check that gpus param is None, Int, String or List
+    import pdb; pdb.set_trace()
     check_gpus_data_type(gpus)
 
     # Handle the case when no gpus are requested

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -646,10 +646,6 @@ def check_gpus_data_type(gpus):
     :return: return unmodified gpus variable
     """
 
-    # nothin was passed into the GPUs argument
-    if callable(gpus):
-        return
-
     if gpus is not None and (not isinstance(gpus, (int, str, list)) or isinstance(gpus, bool)):
         raise MisconfigurationException("GPUs must be int, string or list of ints or None.")
 
@@ -698,6 +694,10 @@ def parse_gpu_ids(gpus):
         If no GPUs are available but the value of gpus variable indicates request for GPUs
         then a misconfiguration exception is raised.
     """
+
+    # nothing was passed into the GPUs argument
+    if callable(gpus):
+        return None
 
     # Check that gpus param is None, Int, String or List
     check_gpus_data_type(gpus)

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -646,7 +646,6 @@ def check_gpus_data_type(gpus):
     :return: return unmodified gpus variable
     """
 
-    import pdb; pdb.set_trace()
     if gpus is not None and (not isinstance(gpus, (int, str, list)) or isinstance(gpus, bool)):
         raise MisconfigurationException("GPUs must be int, string or list of ints or None.")
 

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -645,6 +645,7 @@ def check_gpus_data_type(gpus):
         Throws otherwise
     :return: return unmodified gpus variable
     """
+    import pdb; pdb.set_trace()
 
     if gpus is not None and (not isinstance(gpus, (int, str, list)) or isinstance(gpus, bool)):
         raise MisconfigurationException("GPUs must be int, string or list of ints or None.")

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -622,12 +622,11 @@ class TrainerDPMixin(ABC):
 
 
 def normalize_parse_gpu_string_input(s):
-    import pdb; pdb.set_trace()
     if isinstance(s, str):
         if s == '-1':
             return -1
         else:
-            return [int(x.strip()) for x in s.split(',')]
+            return [int(x.strip()) for x in s.split(',') if len(x) > 0]
     else:
         return s
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -600,11 +600,25 @@ class Trainer(
         for arg, arg_types, arg_default in (at for at in cls.get_init_arguments_and_types()
                                             if at[0] not in depr_arg_names):
 
-            import pdb; pdb.set_trace()
+            # import pdb; pdb.set_trace()
             for allowed_type in (at for at in allowed_types if at in arg_types):
                 if allowed_type is bool:
                     def allowed_type(x):
                         return bool(distutils.util.strtobool(x))
+
+                if arg == 'gpus':
+                    def allowed_type(x):
+                        if ',' in x:
+                            return str
+                        else:
+                            return int
+
+                    def arg_default(x):
+                        if ',' in x:
+                            return str
+                        else:
+                            return int
+
                 parser.add_argument(
                     f'--{arg}',
                     default=arg_default,

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -607,16 +607,12 @@ class Trainer(
 
                 if arg == 'gpus':
                     def allowed_type(x):
-                        if x is None:
-                            return None
                         if ',' in x:
                             return str(x)
                         else:
                             return int(x)
 
                     def arg_default(x):
-                        if x is None:
-                            return None
                         if ',' in x:
                             return str(x)
                         else:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -600,7 +600,6 @@ class Trainer(
         for arg, arg_types, arg_default in (at for at in cls.get_init_arguments_and_types()
                                             if at[0] not in depr_arg_names):
 
-            # import pdb; pdb.set_trace()
             for allowed_type in (at for at in allowed_types if at in arg_types):
                 if allowed_type is bool:
                     def allowed_type(x):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -600,8 +600,7 @@ class Trainer(
         for arg, arg_types, arg_default in (at for at in cls.get_init_arguments_and_types()
                                             if at[0] not in depr_arg_names):
 
-            if arg == 'gpus':
-                import pdb; pdb.set_trace()
+            import pdb; pdb.set_trace()
             for allowed_type in (at for at in allowed_types if at in arg_types):
                 if allowed_type is bool:
                     def allowed_type(x):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -609,15 +609,15 @@ class Trainer(
                 if arg == 'gpus':
                     def allowed_type(x):
                         if ',' in x:
-                            return str
+                            return str(x)
                         else:
-                            return int
+                            return int(x)
 
                     def arg_default(x):
                         if ',' in x:
-                            return str
+                            return str(x)
                         else:
-                            return int
+                            return int(x)
 
                 parser.add_argument(
                     f'--{arg}',

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -599,6 +599,9 @@ class Trainer(
         # TODO: get "help" from docstring :)
         for arg, arg_types, arg_default in (at for at in cls.get_init_arguments_and_types()
                                             if at[0] not in depr_arg_names):
+
+            if arg == 'gpus':
+                import pdb; pdb.set_trace()
             for allowed_type in (at for at in allowed_types if at in arg_types):
                 if allowed_type is bool:
                     def allowed_type(x):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -607,12 +607,16 @@ class Trainer(
 
                 if arg == 'gpus':
                     def allowed_type(x):
+                        if x is None:
+                            return None
                         if ',' in x:
                             return str(x)
                         else:
                             return int(x)
 
                     def arg_default(x):
+                        if x is None:
+                            return None
                         if ',' in x:
                             return str(x)
                         else:

--- a/tests/models/test_gpu.py
+++ b/tests/models/test_gpu.py
@@ -283,13 +283,6 @@ def test_parse_gpu_fail_on_unsupported_inputs(mocked_device_count, gpus):
 
 
 @pytest.mark.gpus_param_tests
-def test_parse_gpu_fail_on_empty_string(mocked_device_count):
-    # This currently results in a ValueError instead of MisconfigurationException
-    with pytest.raises(ValueError):
-        parse_gpu_ids('')
-
-
-@pytest.mark.gpus_param_tests
 @pytest.mark.parametrize("gpus", [[1, 2, 19], -1, '-1'])
 def test_parse_gpu_fail_on_non_existant_id(mocked_device_count_0, gpus):
     with pytest.raises(MisconfigurationException):

--- a/tests/models/test_gpu.py
+++ b/tests/models/test_gpu.py
@@ -259,6 +259,7 @@ def test_determine_root_gpu_device(gpus, expected_root_gpu):
     pytest.param('0', [0]),
     pytest.param('3', [3]),
     pytest.param('1, 3', [1, 3]),
+    pytest.param('2,', [2]),
     pytest.param('-1', list(range(PRETEND_N_OF_GPUS)), id="'-1' - use all gpus"),
 ])
 def test_parse_gpu_ids(mocked_device_count, gpus, expected_gpu_ids):


### PR DESCRIPTION
```--gpus "1"``` sets 1 GPU (any index)
```--gpus "1,"``` sets the "1" GPU (gpu at index 0)
```--gpus 2``` sets 2 GPUs (any index)
```--gpus "1,"``` sets the "2" GPU (gpu at index 1)
```--gpus "3,4"``` sets the "3,4" GPUs (gpu at index 3,4)