### PR TITLE
Don't convert namedtuple to tuple

### DIFF
--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -461,10 +461,15 @@ class TrainerDPMixin(ABC):
 
         # when tuple
         if isinstance(batch, tuple):
-            batch = list(batch)
-            for i, x in enumerate(batch):
-                batch[i] = self.__transfer_data_to_device(x, device, gpu_id)
-            return tuple(batch)
+            # when namedtuple
+            if hasattr(batch, '_fields'):
+                elem_type = type(batch)
+                return elem_type(*(self.__transfer_data_to_device(x, device, gpu_id) for x in batch))
+            else:
+                batch = list(batch)
+                for i, x in enumerate(batch):
+                    batch[i] = self.__transfer_data_to_device(x, device, gpu_id)
+                return tuple(batch)
 
         # when dict
         if isinstance(batch, dict):

--- a/tests/models/test_cpu.py
+++ b/tests/models/test_cpu.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 import platform
 
 import pytest
@@ -220,6 +221,13 @@ def test_single_gpu_batch_parse():
 
     assert batch[1][0]['b'].device.index == 0
     assert batch[1][0]['b'].type() == 'torch.cuda.FloatTensor'
+
+    # namedtuple of tensor
+    BatchType = namedtuple('BatchType', ['a', 'b'])
+    batch = [BatchType(a=torch.rand(2, 3), b=torch.rand(2, 3)) for _ in range(2)]
+    batch = trainer.transfer_batch_to_gpu(batch, 0)
+    assert batch[0].a.device.index == 0
+    assert batch[0].a.type() == 'torch.cuda.FloatTensor'
 
 
 def test_simple_cpu(tmpdir):


### PR DESCRIPTION
# Before submitting
This is just a proposed solution for sending namedtuples to the GPU without converting them to regular tuples.  I am open to suggestions.

Sending data to devices seems to fit the pattern of recursively doing a thing to the elements of contaners.  Good examples of this are `default_collate` and `default_convert` in pytorch. 
https://github.com/pytorch/pytorch/blob/master/torch/utils/data/_utils/collate.py#L15

We could take this PR further by following the pattern in pytorch so that lightning works with all the same types.  On the other hand, I'm not sure if this pattern satisfies the 'Simple code' requirement.

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Fixes #1588 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
