### PR TITLE
Only call load_spawn_weights if COLAB_GPU or KAGGLE_URL_BASE

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -750,8 +750,9 @@ class Trainer(
                 # train
                 mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model,))
                 # load weights if not interrupted
-                self.load_spawn_weights(model)
-                self.model = model
+                if os.getenv('COLAB_GPU') or os.getenv('KAGGLE_URL_BASE'):
+                    self.load_spawn_weights(model)
+                    self.model = model
 
         # 1 gpu or dp option triggers training using DP module
         # easier to avoid NCCL issues


### PR DESCRIPTION
environment variables are set

# Before submitting

- [Y] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [Y] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [NA] Did you make sure to update the docs?   
- [NA] Did you write any new necessary tests?  
- [NA] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Fixes #1637.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Of course.  Coding is fun.
