### PR TITLE
Fixed crashing in ModelCheckpoint() with filepath=None and save_top_k > 0 (default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+  - Fixed crashing at ModelCheckpoint() with filepath=None and save_top_k > 0 ([#1673](https://github.com/PyTorchLightning/pytorch-lightning/pull/1673))
 
 ## [0.7.5] - 2020-04-27
 

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -86,7 +86,7 @@ class ModelCheckpoint(Callback):
                  save_top_k: int = 1, save_weights_only: bool = False,
                  mode: str = 'auto', period: int = 1, prefix: str = ''):
         super().__init__()
-        if save_top_k > 0 and filepath != None and os.path.isdir(filepath) and len(os.listdir(filepath)) > 0:
+        if save_top_k != 0 and filepath is not None and os.path.isdir(filepath) and len(os.listdir(filepath)) > 0:
             rank_zero_warn(
                 f"Checkpoint directory {filepath} exists and is not empty with save_top_k != 0."
                 "All files in this directory will be deleted when a checkpoint is saved!"

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -86,7 +86,7 @@ class ModelCheckpoint(Callback):
                  save_top_k: int = 1, save_weights_only: bool = False,
                  mode: str = 'auto', period: int = 1, prefix: str = ''):
         super().__init__()
-        if save_top_k > 0 and os.path.isdir(filepath) and len(os.listdir(filepath)) > 0:
+        if save_top_k > 0 and filepath != None and os.path.isdir(filepath) and len(os.listdir(filepath)) > 0:
             rank_zero_warn(
                 f"Checkpoint directory {filepath} exists and is not empty with save_top_k != 0."
                 "All files in this directory will be deleted when a checkpoint is saved!"


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? #1660 
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs? No need to update, because 'None' is default
- [ ] Did you write any new necessary tests? See notes below.
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CHANGELOG.md)?

I wanted to add a test, but there was already one:

[Test](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/tests/callbacks/test_callbacks.py#L254-L275)

The important part here is: It didn't crash because save_top_k is checked for > 0 in init(). Where ModelCheckpoint(None) would crash. So I changed also save_top_k > 0 to save_top_k != 0 which should be logical correct.

Don't know if another test is needed there. Can make one which checks for not crash of ModelCheckpoint() with default values.

## What does this PR do?
Fixes #1660.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
