### PR TITLE
Fix example argument parser in docs

### DIFF
--- a/docs/source/hyperparameters.rst
+++ b/docs/source/hyperparameters.rst
@@ -213,7 +213,7 @@ Now we can allow each model to inject the arguments it needs in the main.py
         parser.add_argument('--model_name', type=str, default='gan', help='gan or mnist')
 
         # THIS LINE IS KEY TO PULL THE MODEL NAME
-        temp_args = parser.parse_known_args()
+        temp_args, _ = parser.parse_known_args()
 
         # let the model add what it wants
         if temp_args.model_name == 'gan':


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
[`parser.parse_known_args()`](https://docs.python.org/3.7/library/argparse.html#argparse.ArgumentParser.parse_known_args) actually returns a tuple of the Namespace of known args and a list of unknown args. We only want the former. Updated example in docs to reflect this.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Oh, it was a blast.