### PR TITLE
Update type hints for multiple dataloaders in .fit() and .test()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added transfer learning example (for a binary classification task in computer vision) ([#1564](https://github.com/PyTorchLightning/pytorch-lightning/pull/1564))
 
+- Added type hints in `Trainer.fit()` and `Trainer.test()` to reflect that also a list of dataloaders can be passed in ([#1723](https://github.com/PyTorchLightning/pytorch-lightning/pull/1723)).
+
 ### Changed
  
 - Reduction when `batch_size < num_gpus` ([#1609](https://github.com/PyTorchLightning/pytorch-lightning/pull/1609))

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -672,7 +672,7 @@ class Trainer(
             self,
             model: LightningModule,
             train_dataloader: Optional[DataLoader] = None,
-            val_dataloaders: Optional[DataLoader] = None
+            val_dataloaders: Optional[Union[DataLoader, List[DataLoader]]] = None
     ):
         r"""
         Runs the full optimization routine.
@@ -913,7 +913,11 @@ class Trainer(
         # CORE TRAINING LOOP
         self.train()
 
-    def test(self, model: Optional[LightningModule] = None, test_dataloaders: Optional[DataLoader] = None):
+    def test(
+            self,
+            model: Optional[LightningModule] = None,
+            test_dataloaders: Optional[Union[DataLoader, List[DataLoader]]] = None
+    ):
         r"""
 
         Separates from fit to make sure you never run on your test set until you want to.

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -113,7 +113,7 @@ def test_multiple_test_dataloader(tmpdir):
     trainer.fit(model)
     trainer.test()
 
-    # verify there are 2 val loaders
+    # verify there are 2 test loaders
     assert len(trainer.test_dataloaders) == 2, \
         'Multiple test_dataloaders not initiated properly'
 
@@ -125,7 +125,7 @@ def test_multiple_test_dataloader(tmpdir):
     trainer.test()
 
 
-def test_train_dataloaders_passed_to_fit(tmpdir):
+def test_train_dataloader_passed_to_fit(tmpdir):
     """Verify that train dataloader can be passed to fit """
 
     class CurrentTestModel(LightTrainDataloader, TestModelBase):
@@ -175,7 +175,7 @@ def test_train_val_dataloaders_passed_to_fit(tmpdir):
 
 
 def test_all_dataloaders_passed_to_fit(tmpdir):
-    """Verify train, val & test dataloader can be passed to fit """
+    """Verify train, val & test dataloader(s) can be passed to fit and test method"""
 
     class CurrentTestModel(
         LightTrainDataloader,


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Multiple dataloaders can be pased to fit and test.
The type hints should reflect that

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
