### PR TITLE
Fixing sampler logic for ddp with iterable dataset

### DIFF
--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -325,7 +325,7 @@ class TrainerTrainLoopMixin(ABC):
                 if self.reload_dataloaders_every_epoch:
                     self.reset_train_dataloader(model)
                 # set seed for distributed sampler (enables shuffling for each epoch)
-                if self.use_ddp or self.use_horovod \
+                if (self.use_ddp or self.use_horovod) \
                         and hasattr(self.train_dataloader.sampler, 'set_epoch'):
                     self.train_dataloader.sampler.set_epoch(epoch)
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Fixes training with iterable dataset with ddp. 
Currently if using iterable dataset, without setting sampler in ddp, self.train_dataloader.sampler will be `_InfiniteConstantSampler` by default in Pytorch. This sampler doesn't have attribute 'set_epoch'. This will create the error as following:
```
-- Process 0 terminated with the following error:
Traceback (most recent call last):
  File "/root/anaconda3/lib/python3.7/site-packages/torch/multiprocessing/spawn.py", line 20, in _wrap
    fn(i, *args)
  File "/root/anaconda3/lib/python3.7/site-packages/pytorch_lightning/trainer/distrib_data_parallel.py", line 372, in ddp_train
    self.run_pretrain_routine(model)
  File "/root/anaconda3/lib/python3.7/site-packages/pytorch_lightning/trainer/trainer.py", line 914, in run_pretrain_routine
    self.train()
  File "/root/anaconda3/lib/python3.7/site-packages/pytorch_lightning/trainer/training_loop.py", line 332, in train
    self.train_dataloader.sampler.set_epoch(epoch)
AttributeError: '_InfiniteConstantSampler' object has no attribute 'set_epoch'
```

The bug is caused by the logic sequence between `or` and `and` in the following code snippet: 
```
if self.use_ddp or self.use_horovod \
    and hasattr(self.train_dataloader.sampler, 'set_epoch'):
```
```
True or False and False = True
(True or False) and False = False
```
## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
