### PR TITLE
added warning for None dataloader

### DIFF
--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -213,19 +213,19 @@ class TrainerDataLoadingMixin(ABC):
             dataloaders = [dataloaders]
 
         # shuffling in val and test set is bad practice
-        dataloadersClean = []
+        dataloaders_clean = []
         for loader in dataloaders:
             if loader is not None:
                 if mode in ('val', 'test') and hasattr(loader, 'sampler') and isinstance(loader.sampler, RandomSampler):
                     raise MisconfigurationException(
                         f'Your {mode}_dataloader has shuffle=True, it is best practice to turn'
                         ' this off for validation and test dataloaders.')
-                dataloadersClean.append(loader)
+                dataloaders_clean.append(loader)
             else:
                 log.warning("One of validation dataloaders is None.")
 
         # add samplers
-        dataloaders = [self.auto_add_sampler(dl, train=False) for dl in dataloadersClean]
+        dataloaders = [self.auto_add_sampler(dl, train=False) for dl in dataloaders_clean]
 
         num_batches = 0
 

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -213,19 +213,17 @@ class TrainerDataLoadingMixin(ABC):
             dataloaders = [dataloaders]
 
         # shuffling in val and test set is bad practice
-        dataloaders_clean = []
         for loader in dataloaders:
-            if loader is not None:
-                if mode in ('val', 'test') and hasattr(loader, 'sampler') and isinstance(loader.sampler, RandomSampler):
-                    raise MisconfigurationException(
-                        f'Your {mode}_dataloader has shuffle=True, it is best practice to turn'
-                        ' this off for validation and test dataloaders.')
-                dataloaders_clean.append(loader)
-            else:
-                log.warning("One of validation dataloaders is None.")
+            if mode in ('val', 'test') and hasattr(loader, 'sampler') and isinstance(loader.sampler, RandomSampler):
+                raise MisconfigurationException(
+                    f'Your {mode}_dataloader has shuffle=True, it is best practice to turn'
+                    ' this off for validation and test dataloaders.')
+
+        if any([dl is None for dl in dataloaders]):
+            rank_zero_warn("One of given dataloaders is None and it will be skipped.")
 
         # add samplers
-        dataloaders = [self.auto_add_sampler(dl, train=False) for dl in dataloaders_clean]
+        dataloaders = [self.auto_add_sampler(dl, train=False) for dl in dataloaders if dl is not None]
 
         num_batches = 0
 

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -9,7 +9,6 @@ from torch.utils.data.distributed import DistributedSampler
 from pytorch_lightning.core import LightningModule
 from pytorch_lightning.utilities import rank_zero_warn
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning import _logger as log
 
 try:
     from torch.utils.data import IterableDataset


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
This is follow up PR from PR #1560. Logs a warning if there are any validation dataloaders that are None. 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
