### PR TITLE
lr_finder: Fix typo in docstring

### DIFF
--- a/pytorch_lightning/trainer/lr_finder.py
+++ b/pytorch_lightning/trainer/lr_finder.py
@@ -94,7 +94,7 @@ class TrainerLRFinderMixin(ABC):
 
             # Inspect results
             fig = lr_finder.plot(); fig.show()
-            suggested_lr = lr_finder.suggest()
+            suggested_lr = lr_finder.suggestion()
 
             # Overwrite lr and create new model
             hparams.lr = suggested_lr


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
I've noticed that example in docstring for `lr_find` uses `.suggest()` instead of `.suggestion()`. 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
