### PR TITLE
Enable NeptuneLogger to work with distributed_backend=ddp

### DIFF
--- a/tests/loggers/test_neptune.py
+++ b/tests/loggers/test_neptune.py
@@ -10,53 +10,68 @@ from tests.base import EvalModelTemplate
 
 @patch('pytorch_lightning.loggers.neptune.neptune')
 def test_neptune_online(neptune):
-    logger = NeptuneLogger(api_key='test', offline_mode=False, project_name='project')
-    neptune.init.assert_called_once_with(api_token='test', project_qualified_name='project')
+    logger = NeptuneLogger(api_key='test', project_name='project')
 
-    assert logger.name == neptune.create_experiment().name
-    assert logger.version == neptune.create_experiment().id
+    created_experiment = neptune.Session.with_default_backend().get_project().create_experiment()
+
+    # It's important to check if the internal variable _experiment was initialized in __init__.
+    # Calling logger.experiment would cause a side-effect of initializing _experiment,
+    # if it wasn't already initialized.
+    assert logger._experiment == created_experiment
+    assert logger.name == created_experiment.name
+    assert logger.version == created_experiment.id
+
+
+@patch('pytorch_lightning.loggers.neptune.neptune')
+def test_neptune_offline(neptune):
+    logger = NeptuneLogger(offline_mode=True)
+
+    neptune.Session.assert_called_once_with(backend=neptune.OfflineBackend())
+    assert logger.experiment == neptune.Session().get_project().create_experiment()
 
 
 @patch('pytorch_lightning.loggers.neptune.neptune')
 def test_neptune_additional_methods(neptune):
-    logger = NeptuneLogger(offline_mode=True)
+    logger = NeptuneLogger(api_key='test', project_name='project')
+
+    created_experiment = neptune.Session.with_default_backend().get_project().create_experiment()
 
     logger.log_metric('test', torch.ones(1))
-    neptune.create_experiment().log_metric.assert_called_once_with('test', torch.ones(1))
-    neptune.create_experiment().log_metric.reset_mock()
+    created_experiment.log_metric.assert_called_once_with('test', torch.ones(1))
+    created_experiment.log_metric.reset_mock()
 
     logger.log_metric('test', 1.0)
-    neptune.create_experiment().log_metric.assert_called_once_with('test', 1.0)
-    neptune.create_experiment().log_metric.reset_mock()
+    created_experiment.log_metric.assert_called_once_with('test', 1.0)
+    created_experiment.log_metric.reset_mock()
 
     logger.log_metric('test', 1.0, step=2)
-    neptune.create_experiment().log_metric.assert_called_once_with('test', x=2, y=1.0)
-    neptune.create_experiment().log_metric.reset_mock()
+    created_experiment.log_metric.assert_called_once_with('test', x=2, y=1.0)
+    created_experiment.log_metric.reset_mock()
 
     logger.log_text('test', 'text')
-    neptune.create_experiment().log_metric.assert_called_once_with('test', 'text')
-    neptune.create_experiment().log_metric.reset_mock()
+    created_experiment.log_metric.assert_called_once_with('test', 'text')
+    created_experiment.log_metric.reset_mock()
 
     logger.log_image('test', 'image file')
-    neptune.create_experiment().log_image.assert_called_once_with('test', 'image file')
-    neptune.create_experiment().log_image.reset_mock()
+    created_experiment.log_image.assert_called_once_with('test', 'image file')
+    created_experiment.log_image.reset_mock()
 
     logger.log_image('test', 'image file', step=2)
-    neptune.create_experiment().log_image.assert_called_once_with('test', x=2, y='image file')
-    neptune.create_experiment().log_image.reset_mock()
+    created_experiment.log_image.assert_called_once_with('test', x=2, y='image file')
+    created_experiment.log_image.reset_mock()
 
     logger.log_artifact('file')
-    neptune.create_experiment().log_artifact.assert_called_once_with('file', None)
+    created_experiment.log_artifact.assert_called_once_with('file', None)
 
     logger.set_property('property', 10)
-    neptune.create_experiment().set_property.assert_called_once_with('property', 10)
+    created_experiment.set_property.assert_called_once_with('property', 10)
 
     logger.append_tags('one tag')
-    neptune.create_experiment().append_tags.assert_called_once_with('one tag')
-    neptune.create_experiment().append_tags.reset_mock()
+    created_experiment.append_tags.assert_called_once_with('one tag')
+    created_experiment.append_tags.reset_mock()
 
     logger.append_tags(['two', 'tags'])
-    neptune.create_experiment().append_tags.assert_called_once_with('two', 'tags')
+    created_experiment.append_tags.assert_called_once_with('two', 'tags')
 
 
 def test_neptune_leave_open_experiment_after_fit(tmpdir):


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Fixes #1683 (issue).

The main change in this PR is that Neptune experiment is created eagerly on NeptuneLogger instantiation. After it's created it can be retrieved in spawned Trainer process. This enables the logger to work in distrubuted trainings.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
