### PR TITLE
data transfer model hook (+ refactor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added using `store_true` for bool args ([#1822](https://github.com/PyTorchLightning/pytorch-lightning/pull/1822), [#1842](https://github.com/PyTorchLightning/pytorch-lightning/pull/1842))
 - Added dummy logger for internally disabling logging for some features ([#1836](https://github.com/PyTorchLightning/pytorch-lightning/pull/1836))
 
+- Added a model hook `transfer_batch_to_device` that enables moving custom data structures to the target device ([1756](https://github.com/PyTorchLightning/pytorch-lightning/pull/1756)).
+
 ### Changed
 
 - Enable `non-blocking` for device transfers to GPU ([#1843](https://github.com/PyTorchLightning/pytorch-lightning/pull/1843))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Speed up single-core TPU training by loading data using `ParallelLoader` ([#2033](https://github.com/PyTorchLightning/pytorch-lightning/pull/2033))
 
+- Added a model hook `transfer_batch_to_device` that enables moving custom data structures to the target device ([1756](https://github.com/PyTorchLightning/pytorch-lightning/pull/1756)).
+
 ### Changed
 
 - Allow user to select individual TPU core to train on ([#1729](https://github.com/PyTorchLightning/pytorch-lightning/pull/1729))
@@ -87,8 +89,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support multi-node distributed execution under `torchelastic` ([#1811](https://github.com/PyTorchLightning/pytorch-lightning/pull/1811), [#1818](https://github.com/PyTorchLightning/pytorch-lightning/pull/1818))
 - Added using `store_true` for bool args ([#1822](https://github.com/PyTorchLightning/pytorch-lightning/pull/1822), [#1842](https://github.com/PyTorchLightning/pytorch-lightning/pull/1842))
 - Added dummy logger for internally disabling logging for some features ([#1836](https://github.com/PyTorchLightning/pytorch-lightning/pull/1836))
-
-- Added a model hook `transfer_batch_to_device` that enables moving custom data structures to the target device ([1756](https://github.com/PyTorchLightning/pytorch-lightning/pull/1756)).
 
 ### Changed
 

--- a/pytorch_lightning/__init__.py
+++ b/pytorch_lightning/__init__.py
@@ -60,8 +60,8 @@ else:
         'Trainer',
         'LightningModule',
         'Callback',
-        'data_loader'
-        'seed_everything'
+        'data_loader',
+        'seed_everything',
     ]
 
     # necessary for regular bolts imports. Skip exception since bolts is not always installed

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -153,3 +153,41 @@ class ModelHooks(torch.nn.Module):
                     scaled_loss.backward()
         else:
             loss.backward()
+
+    def transfer_batch_to_device(self, batch: Any, device: torch.device) -> Any:
+        """
+        Override this hook if your :class:`~torch.utils.data.DataLoader` returns tensors
+        wrapped in a custom data structure.
+        Lightning only calls the hook if it does not recognize the data type of your batch as one of
+
+        - :class:`torch.Tensor`
+        - :class:`list`
+        - :class:`dict`
+        - :class:`tuple`
+        - ``torchtext.data.Batch`` (COMING SOON)
+
+        These data types (and any arbitrary nesting of them) are supported out of the box.
+        For anything else, you need to define how the data is moved to the target device (CPU, GPU, TPU, ...).
+
+        Example::
+
+            def transfer_batch_to_device(self, batch, device)
+                if isinstance(batch, CustomBatch):
+                    # move all tensors in your custom data structure to the device
+                    batch.samples = batch.samples.to(device)
+                    batch.targets = batch.targets.to(device)
+                return batch
+
+        Args:
+            batch: A batch of data that needs to be transferred to a new device.
+            device: The target device as defined in PyTorch.
+
+        Returns:
+            A reference to the data on the new device.
+
+        Note:
+            This hook should only transfer the data and not modify it, nor should it move the data to
+            any other device than the one passed in as argument.
+            The :class:`~pytorch_lightning.trainer.trainer.Trainer` already takes care of splitting the
+            batch and determines the target devices.
+        """

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -166,7 +166,8 @@ class ModelHooks(torch.nn.Module):
         - :class:`tuple`
         - ``torchtext.data.Batch`` (COMING SOON)
 
-        These data types (and any arbitrary nesting of them) are supported out of the box.
+        These data types (and any arbitrary nesting of them) are supported out of the box
+        (see :func:`~pytorch_lightning.utilities.apply_func.transfer_batch_to_device`).
         For anything else, you need to define how the data is moved to the target device (CPU, GPU, TPU, ...).
 
         Example::
@@ -190,4 +191,8 @@ class ModelHooks(torch.nn.Module):
             any other device than the one passed in as argument.
             The :class:`~pytorch_lightning.trainer.trainer.Trainer` already takes care of splitting the
             batch and determines the target devices.
+
+        See Also:
+            - :func:`~pytorch_lightning.utilities.apply_func.transfer_batch_to_device`
+            - :func:`~pytorch_lightning.utilities.apply_func.apply_to_collection`
         """

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -3,7 +3,7 @@ from typing import Any
 import torch
 from torch import Tensor
 from torch.optim.optimizer import Optimizer
-from pytorch_lightning.utilities import transfer_batch_to_device
+from pytorch_lightning.utilities import move_data_to_device
 
 
 try:
@@ -196,7 +196,7 @@ class ModelHooks(torch.nn.Module):
             batch and determines the target devices.
 
         See Also:
-            - :func:`~pytorch_lightning.utilities.apply_func.transfer_batch_to_device`
+            - :func:`~pytorch_lightning.utilities.apply_func.move_data_to_device`
             - :func:`~pytorch_lightning.utilities.apply_func.apply_to_collection`
         """
-        return transfer_batch_to_device(batch, device)
+        return move_data_to_device(batch, device)

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -120,7 +120,7 @@ class TrainerDPMixin(ABC):
                 ' Are you sure this machine has TPUs?'
             )
         device = xm.xla_device(tpu_id)
-        return self.__transfer_data_to_device(batch, device)
+        return transfer_batch_to_device(batch, device)
 
     def transfer_batch_to_gpu(self, batch: Any, gpu_id: Optional[int] = None):
         """

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -106,7 +106,7 @@ class TrainerDPMixin(ABC):
                 'Requested to transfer batch to TPU but XLA is not available.'
                 ' Are you sure this machine has TPUs?'
             )
-        device = xm.xla_device(tpu_id)
+        device = xm.xla_device(tpu_id)  # None will use all available devices
         return self.__transfer_data_to_device(batch, device)
 
     def transfer_batch_to_gpu(self, batch: Any, gpu_id: int):

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -100,7 +100,12 @@ class TrainerDPMixin(ABC):
             m.tpu_global_core_rank = self.tpu_global_core_rank
 
     def transfer_batch_to_tpu(self, batch: Any, tpu_id: int = None):
-        device = xm.xla_device(tpu_id) if XLA_AVAILABLE else torch.device('cpu')
+        if not XLA_AVAILABLE:
+            raise MisconfigurationException(
+                'Requested to transfer batch to TPU but XLA is not available.'
+                ' Are you sure this machine has TPUs?'
+            )
+        device = xm.xla_device(tpu_id)
         return self.__transfer_data_to_device(batch, device)
 
     def transfer_batch_to_gpu(self, batch: Any, gpu_id: int):

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -108,43 +108,6 @@ class TrainerDPMixin(ABC):
         return self.__transfer_data_to_device(batch, device)
 
     def __transfer_data_to_device(self, batch: Any, device: torch.device):
-        if callable(getattr(batch, 'to', None)):
-            return batch.to(device)
-
-        # when list
-        if isinstance(batch, list):
-            for i, x in enumerate(batch):
-                batch[i] = self.__transfer_data_to_device(x, device)
-            return batch
-
-        # when tuple
-        if isinstance(batch, tuple):
-            # when namedtuple
-            if hasattr(batch, '_fields'):
-                elem_type = type(batch)
-                return elem_type(*(self.__transfer_data_to_device(x, device) for x in batch))
-            else:
-                batch = list(batch)
-                for i, x in enumerate(batch):
-                    batch[i] = self.__transfer_data_to_device(x, device)
-                return tuple(batch)
-
-        # when dict
-        if isinstance(batch, dict):
-            for k, v in batch.items():
-                batch[k] = self.__transfer_data_to_device(v, device)
-
-            return batch
-
-        # check if the model hook can move the data
-        model = self.get_model()
-        if model is not None and self.is_overridden('transfer_batch_to_device', model):
-            batch = model.transfer_batch_to_device(batch, device)
-
-        # nothing matches, return the value as is without transform
-        return batch
-
-    def __transfer_data_to_device(self, batch: Any, device: torch.device):
 
         if self.is_overriden('transfer_batch_to_device'):
             return self.get_model().transfer_batch_to_device(batch, device)

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -109,7 +109,7 @@ class TrainerDPMixin(ABC):
 
     def __transfer_data_to_device(self, batch: Any, device: torch.device):
 
-        if self.is_overriden('transfer_batch_to_device'):
+        if self.is_overridden('transfer_batch_to_device'):
             return self.get_model().transfer_batch_to_device(batch, device)
 
         # base case: object can be directly moved using `to`

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -13,6 +13,7 @@ import torch
 from typing import Union, Callable, Any, List, Optional
 
 from pytorch_lightning import _logger as log
+from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.overrides.data_parallel import (
     LightningDistributedDataParallel,
@@ -140,7 +141,7 @@ class TrainerDPMixin(ABC):
         return self.__transfer_batch_to_device(batch, device)
 
     def __transfer_batch_to_device(self, batch: Any, device: torch.device):
-        if self.is_overridden('transfer_batch_to_device'):
+        if self.is_overridden(LightningModule.transfer_batch_to_device.__name__):
             # user-override for custom batch types
             return self.get_model().transfer_batch_to_device(batch, device)
         return transfer_batch_to_device(batch, device)

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -13,7 +13,6 @@ import torch
 from typing import Union, Callable, Any, List, Optional
 
 from pytorch_lightning import _logger as log
-from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.overrides.data_parallel import (
     LightningDistributedDataParallel,
@@ -141,9 +140,9 @@ class TrainerDPMixin(ABC):
         return self.__transfer_batch_to_device(batch, device)
 
     def __transfer_batch_to_device(self, batch: Any, device: torch.device):
-        if self.is_overridden(LightningModule.transfer_batch_to_device.__name__):
-            # user-override for custom batch types
-            return self.get_model().transfer_batch_to_device(batch, device)
+        model = self.get_model()
+        if model is not None:
+            return model.transfer_batch_to_device(batch, device)
         return transfer_batch_to_device(batch, device)
 
     def single_gpu_train(self, model):

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -100,16 +100,42 @@ class TrainerDPMixin(ABC):
             m.tpu_local_core_rank = self.tpu_local_core_rank
             m.tpu_global_core_rank = self.tpu_global_core_rank
 
-    def transfer_batch_to_tpu(self, batch: Any, tpu_id: int = None):
+    def transfer_batch_to_tpu(self, batch: Any, tpu_id: Optional[int] = None):
+        """
+        Transfers the data to the TPU.
+
+        Args:
+            batch: A tensor or collection of tensors.
+            tpu_id: The id of the TPU core. If omitted, the first available core is chosen.
+
+        Returns:
+            the tensor on the TPU device.
+
+        See Also:
+            - :func:`~pytorch_lightning.utilities.apply_func.transfer_batch_to_device`
+        """
         if not XLA_AVAILABLE:
             raise MisconfigurationException(
                 'Requested to transfer batch to TPU but XLA is not available.'
                 ' Are you sure this machine has TPUs?'
             )
-        device = xm.xla_device(tpu_id)  # None will use all available devices
+        device = xm.xla_device(tpu_id)
         return self.__transfer_data_to_device(batch, device)
 
-    def transfer_batch_to_gpu(self, batch: Any, gpu_id: int):
+    def transfer_batch_to_gpu(self, batch: Any, gpu_id: Optional[int] = None):
+        """
+        Transfers the data to the GPU.
+
+        Args:
+            batch: A tensor or collection of tensors.
+            gpu_id: The id of the GPU device. If omitted, the first available GPU is chosen.
+
+        Returns:
+            the tensor on the GPU device.
+
+        See Also:
+            - :func:`~pytorch_lightning.utilities.apply_func.transfer_batch_to_device`
+        """
         device = torch.device('cuda', gpu_id)
         return self.__transfer_batch_to_device(batch, device)
 

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -120,7 +120,7 @@ class TrainerDPMixin(ABC):
                 ' Are you sure this machine has TPUs?'
             )
         device = xm.xla_device(tpu_id)
-        return transfer_batch_to_device(batch, device)
+        return self.__transfer_batch_to_device(batch, device)
 
     def transfer_batch_to_gpu(self, batch: Any, gpu_id: Optional[int] = None):
         """

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -108,7 +108,7 @@ class TrainerDPMixin(ABC):
             batch: A tensor or collection of tensors.
             tpu_id: The id of the TPU core. If omitted, the first available core is chosen.
 
-        Returns:
+        Return:
             the tensor on the TPU device.
 
         See Also:
@@ -130,7 +130,7 @@ class TrainerDPMixin(ABC):
             batch: A tensor or collection of tensors.
             gpu_id: The id of the GPU device. If omitted, the first available GPU is chosen.
 
-        Returns:
+        Return:
             the tensor on the GPU device.
 
         See Also:

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -18,7 +18,7 @@ from pytorch_lightning.overrides.data_parallel import (
     LightningDistributedDataParallel,
     LightningDataParallel,
 )
-from pytorch_lightning.utilities import transfer_batch_to_device
+from pytorch_lightning.utilities import move_data_to_device
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.distributed import rank_zero_only
 
@@ -112,7 +112,7 @@ class TrainerDPMixin(ABC):
             the tensor on the TPU device.
 
         See Also:
-            - :func:`~pytorch_lightning.utilities.apply_func.transfer_batch_to_device`
+            - :func:`~pytorch_lightning.utilities.apply_func.move_data_to_device`
         """
         if not XLA_AVAILABLE:
             raise MisconfigurationException(
@@ -134,7 +134,7 @@ class TrainerDPMixin(ABC):
             the tensor on the GPU device.
 
         See Also:
-            - :func:`~pytorch_lightning.utilities.apply_func.transfer_batch_to_device`
+            - :func:`~pytorch_lightning.utilities.apply_func.move_data_to_device`
         """
         device = torch.device('cuda', gpu_id)
         return self.__transfer_batch_to_device(batch, device)
@@ -143,7 +143,7 @@ class TrainerDPMixin(ABC):
         model = self.get_model()
         if model is not None:
             return model.transfer_batch_to_device(batch, device)
-        return transfer_batch_to_device(batch, device)
+        return move_data_to_device(batch, device)
 
     def single_gpu_train(self, model):
         model.cuda(self.root_gpu)

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -99,8 +99,8 @@ class TrainerDPMixin(ABC):
             m.tpu_local_core_rank = self.tpu_local_core_rank
             m.tpu_global_core_rank = self.tpu_global_core_rank
 
-    def transfer_batch_to_tpu(self, batch: Any):
-        device = xm.xla_device() if XLA_AVAILABLE else torch.device('cpu')
+    def transfer_batch_to_tpu(self, batch: Any, tpu_id: int = None):
+        device = xm.xla_device(tpu_id) if XLA_AVAILABLE else torch.device('cpu')
         return self.__transfer_data_to_device(batch, device)
 
     def transfer_batch_to_gpu(self, batch: Any, gpu_id: int):

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -434,7 +434,7 @@ class TrainerEvaluationLoopMixin(ABC):
 
         # TPU data  transfer
         if self.use_tpu:
-            batch = self.transfer_batch_to_tpu(batch)
+            batch = self.transfer_batch_to_tpu(batch, self.tpu_id)
             args[0] = batch
 
         # CPU, TPU or gpu step

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -753,7 +753,7 @@ class TrainerTrainLoopMixin(ABC):
 
         # TPU support
         elif self.use_tpu:
-            batch = self.transfer_batch_to_tpu(batch)
+            batch = self.transfer_batch_to_tpu(batch, self.tpu_id)
             args[0] = batch
             output = self.model.training_step(*args)
 

--- a/pytorch_lightning/utilities/__init__.py
+++ b/pytorch_lightning/utilities/__init__.py
@@ -1,3 +1,4 @@
 """General utilities"""
 
 from pytorch_lightning.utilities.distributed import rank_zero_only, rank_zero_warn
+from pytorch_lightning.utilities.apply_func import transfer_batch_to_device

--- a/pytorch_lightning/utilities/__init__.py
+++ b/pytorch_lightning/utilities/__init__.py
@@ -1,4 +1,4 @@
 """General utilities"""
 
 from pytorch_lightning.utilities.distributed import rank_zero_only, rank_zero_warn
-from pytorch_lightning.utilities.apply_func import transfer_batch_to_device
+from pytorch_lightning.utilities.apply_func import move_data_to_device

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -39,6 +39,21 @@ def apply_to_collection(data: Any, dtype: Union[type, tuple], function: Callable
 
 
 def transfer_batch_to_device(batch: Any, device: torch.device):
+    """
+    Transfers a collection of tensors to the given device.
+
+    Args:
+        batch: A tensor or collection of tensors. See :func:`apply_to_collection`
+            for a list of supported collection types.
+        device: The device to which tensors should be moved
+
+    Returns:
+        the same collection but with all contained tensors residing on the new device.
+
+    See Also:
+        - :meth:`torch.Tensor.to`
+        - :class:`torch.device`
+    """
     def to(tensor):
         return tensor.to(device, non_blocking=True)
     return apply_to_collection(batch, dtype=torch.Tensor, function=to)

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -1,6 +1,8 @@
 from collections import Mapping, Sequence
 from typing import Any, Callable, Union
 
+import torch
+
 
 def apply_to_collection(data: Any, dtype: Union[type, tuple], function: Callable, *args, **kwargs) -> Any:
     """
@@ -34,3 +36,9 @@ def apply_to_collection(data: Any, dtype: Union[type, tuple], function: Callable
 
     # data is neither of dtype, nor a collection
     return data
+
+
+def transfer_batch_to_device(batch: Any, device: torch.device):
+    def to(tensor):
+        return tensor.to(device, non_blocking=True)
+    return apply_to_collection(batch, dtype=torch.Tensor, function=to)

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -47,7 +47,7 @@ def transfer_batch_to_device(batch: Any, device: torch.device):
             for a list of supported collection types.
         device: The device to which tensors should be moved
 
-    Returns:
+    Return:
         the same collection but with all contained tensors residing on the new device.
 
     See Also:

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -38,7 +38,7 @@ def apply_to_collection(data: Any, dtype: Union[type, tuple], function: Callable
     return data
 
 
-def transfer_batch_to_device(batch: Any, device: torch.device):
+def move_data_to_device(batch: Any, device: torch.device):
     """
     Transfers a collection of tensors to the given device.
 

--- a/tests/models/test_hooks.py
+++ b/tests/models/test_hooks.py
@@ -85,12 +85,14 @@ def test_transfer_batch_hook():
 
         hook_called = False
 
-        def transfer_batch_to_device(self, batch, device):
+        def transfer_batch_to_device(self, data, device):
             self.hook_called = True
-            if isinstance(batch, CustomBatch):
-                batch.samples = batch.samples.to(device)
-                batch.targets = batch.targets.to(device)
-            return batch
+            if isinstance(data, CustomBatch):
+                data.samples = data.samples.to(device)
+                data.targets = data.targets.to(device)
+            else:
+                data = super().transfer_batch_to_device(data, device)
+            return data
 
     model = CurrentTestModel()
     batch = CustomBatch((torch.zeros(5, 28), torch.ones(5, 1, dtype=torch.long)))

--- a/tests/models/test_hooks.py
+++ b/tests/models/test_hooks.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 import torch
 
@@ -68,3 +70,32 @@ def test_training_epoch_end_metrics_collection(tmpdir):
     # metrics are kept after each epoch
     for i in range(num_epochs):
         assert metrics[f'epoch_metric_{i}'] == i
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires GPU machine")
+def test_transfer_batch_hook():
+
+    class CustomBatch:
+
+        def __init__(self, data):
+            self.samples = data[0]
+            self.targets = data[1]
+
+    class CurrentTestModel(EvalModelTemplate):
+
+        def transfer_batch_to_device(self, batch, device):
+            if isinstance(batch, CustomBatch):
+                batch.samples = batch.samples.to(device)
+                batch.targets = batch.targets.to(device)
+            return batch
+
+    model = CurrentTestModel(tutils.get_default_hparams())
+    batch = CustomBatch((torch.zeros(5, 28), torch.ones(5, 1, dtype=torch.long)))
+
+    trainer = Trainer()
+    # running .fit() would require us to implement custom data loaders, we mock the model reference instead
+    trainer.get_model = MagicMock(return_value=model)
+
+    batch_gpu = trainer.transfer_batch_to_gpu(batch, 0)
+    device = torch.device('cuda', 0)
+    assert batch_gpu.samples.device == batch_gpu.targets.device == device

--- a/tests/models/test_hooks.py
+++ b/tests/models/test_hooks.py
@@ -89,7 +89,7 @@ def test_transfer_batch_hook():
                 batch.targets = batch.targets.to(device)
             return batch
 
-    model = CurrentTestModel(tutils.get_default_hparams())
+    model = CurrentTestModel()
     batch = CustomBatch((torch.zeros(5, 28), torch.ones(5, 1, dtype=torch.long)))
 
     trainer = Trainer()

--- a/tests/models/test_hooks.py
+++ b/tests/models/test_hooks.py
@@ -83,7 +83,10 @@ def test_transfer_batch_hook():
 
     class CurrentTestModel(EvalModelTemplate):
 
+        hook_called = False
+
         def transfer_batch_to_device(self, batch, device):
+            self.hook_called = True
             if isinstance(batch, CustomBatch):
                 batch.samples = batch.samples.to(device)
                 batch.targets = batch.targets.to(device)
@@ -95,7 +98,7 @@ def test_transfer_batch_hook():
     trainer = Trainer()
     # running .fit() would require us to implement custom data loaders, we mock the model reference instead
     trainer.get_model = MagicMock(return_value=model)
-
     batch_gpu = trainer.transfer_batch_to_gpu(batch, 0)
-    device = torch.device('cuda', 0)
-    assert batch_gpu.samples.device == batch_gpu.targets.device == device
+    expected = torch.device('cuda', 0)
+    assert model.hook_called
+    assert batch_gpu.samples.device == batch_gpu.targets.device == expected


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Part 1 of feature #1245 by introducing a hook. 

1. Refactored data transfer method such that all device information is contained in torch.device (necessary for model hook)
2. Removed .cuda() call since it is obsolete (can use .to() for every tensor)
3. Added a model hook which is called for all device transfers and by default implements the supported datatypes. The user can override this model hook to implement transfers of custom batch types.

**Open Questions:**
- What do we call the hook? transfer_data_to_device? transfer_batch_to_device? transfer_batch?

Other PRs that are blocked by this: #1729, #1526 

Link to test TPU works with this branch:
https://colab.research.google.com/drive/1wy6sbl8Bh6S3QaHzBsJNbhQ6UX1IC864?usp=sharing

## PR review
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
