### PR TITLE
Missing profiler attribute in add_argparse_args() ArgumentParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed saving native AMP scaler state (introduced in [#1561](https://github.com/PyTorchLightning/pytorch-lightning/pull/1561))
 
+- Fixed missing profiler attribute in add_argparse_args() ArgumentParser ([#1794](https://github.com/PyTorchLightning/pytorch-lightning/pull/1794))
+
 
 ## [0.7.5] - 2020-04-27
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -574,6 +574,7 @@ class Trainer(
              ('process_position', (<class 'int'>,), 0),
              ('profiler',
               (<class 'pytorch_lightning.profiler.profilers.BaseProfiler'>,
+               <class 'bool'>,
                <class 'NoneType'>),
               None),
              ...

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -124,7 +124,7 @@ class Trainer(
             num_sanity_val_steps: int = 5,
             truncated_bptt_steps: Optional[int] = None,
             resume_from_checkpoint: Optional[str] = None,
-            profiler: Optional[BaseProfiler] = None,
+            profiler: Optional[Union[BaseProfiler, bool]] = None,
             benchmark: bool = False,
             reload_dataloaders_every_epoch: bool = False,
             auto_lr_find: Union[bool, str] = False,

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -613,6 +613,32 @@ class Trainer(
 
         Only arguments of the allowed types (str, float, int, bool) will
         extend the `parent_parser`.
+
+        Examples:
+            >>> import argparse
+            >>> import pprint
+            >>> parser = argparse.ArgumentParser()
+            >>> parser = Trainer.add_argparse_args(parser)
+            >>> args = parser.parse_args([])
+            >>> pprint.pprint(vars(args))  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            {...
+             'check_val_every_n_epoch': 1,
+             'checkpoint_callback': True,
+             'default_root_dir': None,
+             'distributed_backend': None,
+             'early_stop_callback': False,
+             ...
+             'logger': True,
+             'max_epochs': 1000,
+             'max_steps': None,
+             'min_epochs': 1,
+             'min_steps': None,
+             ...
+             'profiler': None,
+             'progress_bar_callback': True,
+             'progress_bar_refresh_rate': 1,
+             ...}
+
         """
         parser = ArgumentParser(parents=[parent_parser], add_help=False, )
 


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?  No need.
- [x] Did you write any new necessary tests? Edit: Added doctest example which also be evaluated as test
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Fixes #1665 (issue).

A user added an ArgumentParser to add_argparse_args() and the default value for the profiler (args.profiler) is not passed. This is because in add_argparse_args() it is checked if the argument is of type str, float, bool or int which was not set to profiler (although it is correct to pass Trainer(..., profiler=True)).

See [add_argparse_args()](https://github.com/PyTorchLightning/PyTorch-Lightning/blob/master/pytorch_lightning/trainer/trainer.py#L615-L655) and [Trainer Docs](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html).

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
