### PR TITLE
added override for hparams in load_from_ckpt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added option to provide seed to random generators to ensure reproducibility ([#1572](https://github.com/PyTorchLightning/pytorch-lightning/pull/1572))
 
+- Added override for hparams in `load_from_ckpt` ([#1797](https://github.com/PyTorchLightning/pytorch-lightning/pull/1797))
+
 ### Changed
 
 - Reduction when `batch_size < num_gpus` ([#1609](https://github.com/PyTorchLightning/pytorch-lightning/pull/1609))

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -16,7 +16,7 @@ from pytorch_lightning import _logger as log
 from pytorch_lightning.core.grads import GradInformation
 from pytorch_lightning.core.hooks import ModelHooks
 from pytorch_lightning.core.memory import ModelSummary
-from pytorch_lightning.core.saving import ModelIO, load_hparams_from_tags_csv
+from pytorch_lightning.core.saving import ModelIO, load_hparams_from_tags_csv, update_hparams
 from pytorch_lightning.overrides.data_parallel import LightningDistributedDataParallel
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities import rank_zero_warn
@@ -1537,8 +1537,7 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
 
         # override the hparam keys that were passed in
         if hparam_overrides is not None:
-            for k, v in hparam_overrides.items():
-                checkpoint['hparams'][k] = v
+            update_hparams(hparams, hparam_overrides)
 
         model = cls._load_model_state(checkpoint, *args, **kwargs)
         return model

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1439,6 +1439,7 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
             checkpoint_path: str,
             map_location: Optional[Union[Dict[str, str], str, torch.device, int, Callable]] = None,
             tags_csv: Optional[str] = None,
+            hparam_overrides: Optional[Dict] = None,
             *args, **kwargs
     ) -> 'LightningModule':
         r"""
@@ -1480,6 +1481,7 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
                 use this method to pass in a .csv file with the hparams you'd like to use.
                 These will be converted into a :class:`~argparse.Namespace` and passed into your
                 :class:`LightningModule` for use.
+            hparam_overrides: A dictionary with keys to override in the hparams
 
         Return:
             :class:`LightningModule` with loaded weights and hyperparameters (if available).
@@ -1503,6 +1505,12 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
                     tags_csv='/path/to/hparams_file.csv'
                 )
 
+                # override some of the params with new values
+                MyLightningModule.load_from_checkpoint(
+                    PATH,
+                    hparam_overrides={'num_layers': 128, 'pretrained_ckpt_path': NEW_PATH}
+                )
+
                 # or load passing whatever args the model takes to load
                 MyLightningModule.load_from_checkpoint(
                     'path/to/checkpoint.ckpt',
@@ -1521,11 +1529,16 @@ class LightningModule(ABC, GradInformation, ModelIO, ModelHooks):
         else:
             checkpoint = torch.load(checkpoint_path, map_location=lambda storage, loc: storage)
 
+        # add the hparams from csv file to checkpoint
         if tags_csv is not None:
-            # add the hparams from csv file to checkpoint
             hparams = load_hparams_from_tags_csv(tags_csv)
             hparams.__setattr__('on_gpu', False)
             checkpoint['hparams'] = vars(hparams)
+
+        # override the hparam keys that were passed in
+        if hparam_overrides is not None:
+            for k, v in hparam_overrides.items():
+                checkpoint['hparams'][k] = v
 
         model = cls._load_model_state(checkpoint, *args, **kwargs)
         return model

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -48,6 +48,36 @@ class ModelIO(object):
         """
 
 
+def update_hparams(hparams, updates):
+    """
+    Overrides hparams with new values
+
+    >>> hparams = {'a', {'b': 2}, 'c': 1}
+    >>> updates = {'a': {'b': 4}, 'c': 1}
+    >>> update_hparams(hparams, updates)
+    >>> assert hparams['a']['b'] == 4, 'update hparams failed'
+
+    Args:
+        hparams:
+        updates:
+
+    Returns:
+
+    """
+    for k, v in updates.items():
+        # if missing, add the key
+        if k not in hparams:
+            hparams[k] = v
+            continue
+
+        # recurse if dictionary
+        if isinstance(v, dict):
+            update_hparams(hparams[k], updates[k])
+
+        # update the value
+        hparams[k] = v
+
+
 def load_hparams_from_tags_csv(tags_csv: str) -> Namespace:
     if not os.path.isfile(tags_csv):
         log.warning(f'Missing Tags: {tags_csv}.')

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -53,9 +53,10 @@ def update_hparams(hparams, updates):
     Overrides hparams with new values
 
     >>> hparams = {'a', {'b': 2}, 'c': 1}
-    >>> updates = {'a': {'b': 4}, 'c': 1}
+    >>> updates = {'a': {'b': 4}, 'c': 7}
     >>> update_hparams(hparams, updates)
     >>> assert hparams['a']['b'] == 4, 'update hparams failed'
+    >>> assert hparams['c'] == 7, 'update hparams failed'
 
     Args:
         hparams:

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -48,23 +48,21 @@ class ModelIO(object):
         """
 
 
-def update_hparams(hparams, updates):
+def update_hparams(hparams: dict, updates: dict) -> None:
     """
     Overrides hparams with new values
 
-    >>> hparams = {'a': {'b': 2}, 'c': 1}
-    >>> updates = {'a': {'b': 4}, 'c': 7}
-    >>> update_hparams(hparams, updates)
-    >>> hparams['a']['b']
-    4
-    >>> hparams['c']
-    7
+    >>> hparams = {'c': 4}
+    >>> update_hparams(hparams, {'a': {'b': 2}, 'c': 1})
+    >>> hparams['a']['b'], hparams['c']
+    (2, 1)
+    >>> update_hparams(hparams, {'a': {'b': 4}, 'c': 7})
+    >>> hparams['a']['b'], hparams['c']
+    (4, 7)
 
     Args:
-        hparams:
-        updates:
-
-    Returns:
+        hparams: the orifinal params and also resulting
+        updates: new params to be used as update
 
     """
     for k, v in updates.items():

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -52,11 +52,13 @@ def update_hparams(hparams, updates):
     """
     Overrides hparams with new values
 
-    >>> hparams = {'a', {'b': 2}, 'c': 1}
+    >>> hparams = {'a': {'b': 2}, 'c': 1}
     >>> updates = {'a': {'b': 4}, 'c': 7}
     >>> update_hparams(hparams, updates)
-    >>> assert hparams['a']['b'] == 4, 'update hparams failed'
-    >>> assert hparams['c'] == 7, 'update hparams failed'
+    >>> hparams['a']['b']
+    4
+    >>> hparams['c']
+    7
 
     Args:
         hparams:

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -61,7 +61,7 @@ def update_hparams(hparams: dict, updates: dict) -> None:
     (4, 7)
 
     Args:
-        hparams: the orifinal params and also resulting
+        hparams: the original params and also target object
         updates: new params to be used as update
 
     """
@@ -74,9 +74,9 @@ def update_hparams(hparams: dict, updates: dict) -> None:
         # recurse if dictionary
         if isinstance(v, dict):
             update_hparams(hparams[k], updates[k])
-
-        # update the value
-        hparams[k] = v
+        else:
+            # update the value
+            hparams.update({k: v})
 
 
 def load_hparams_from_tags_csv(tags_csv: str) -> Namespace:


### PR DESCRIPTION
Fixes #1474 

Enable the following... (ran into a bunch of issues with transfer learning when moving across clusters)... ugh.

I think @tullie has suggested something like this?

```python
# override some of the params with new values
MyLightningModule.load_from_checkpoint(
    PATH,
    hparam_overrides={'num_layers': 128, 'pretrained_ckpt_path': NEW_PATH}
)
```