### PR TITLE
Callback Metric Dict getting overwritten by Log and Progress Bar Dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed shell injection vulnerability in subprocess call ([#2786](https://github.com/PyTorchLightning/pytorch-lightning/pull/2786))
 
+- Fixed callback metric getting overwritten by progress bar or log metric ([#1800](https://github.com/PyTorchLightning/pytorch-lightning/pull/1800))
+
 ## [0.8.5] - 2020-07-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed data transfer to device when using `torchtext.data.Field` and `include_lengths is True` ([#2689](https://github.com/PyTorchLightning/pytorch-lightning/pull/2689)) 
 
+- Fixed callback metric getting overwritten by progress bar or log metric ([#1800](https://github.com/PyTorchLightning/pytorch-lightning/pull/1800))
+
 - Fixed shuffle argument for distributed sampler ([#2789](https://github.com/PyTorchLightning/pytorch-lightning/pull/2789))
 
 - Fixed logging interval ([#2694](https://github.com/PyTorchLightning/pytorch-lightning/pull/2694))

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -185,13 +185,13 @@ class TrainerLoggingMixin(ABC):
         hiddens = output.get('hiddens')
 
         # iterate over log_metric and progress_bar metric values
-        # and add it to the callback metric dict because every 
-        # metric value of logging or progressbar could be a candidate 
+        # and add it to the callback metric dict because every
+        # metric value of logging or progressbar could be a candidate
         # for early stopping or similar
-        # 
+        #
         # NOTE: through the dict looping sequence a priority is defined
         # so first log metrics values will be added if not existing and
-        # then progress bar values if not existing in callback and log metric 
+        # then progress bar values if not existing in callback and log metric
         for metric_dict in [log_metrics, progress_bar_metrics]:
             for key in metric_dict.keys():
                 if key not in callback_metrics.keys():

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -184,6 +184,19 @@ class TrainerLoggingMixin(ABC):
         # ---------------
         hiddens = output.get('hiddens')
 
+        # iterate over log_metric and progress_bar metric values
+        # and add it to the callback metric dict because every 
+        # metric value of logging or progressbar could be a candidate 
+        # for early stopping or similar
+        # 
+        # NOTE: through the dict looping sequence a priority is defined
+        # so first log metrics values will be added if not existing and
+        # then progress bar values if not existing in callback and log metric 
+        for metric_dict in [log_metrics, progress_bar_metrics]:
+            for key in metric_dict.keys():
+                if key not in callback_metrics.keys():
+                    callback_metrics[key] = metric_dict[key]
+
         # detach all metrics for callbacks to prevent memory leaks
         # no .item() because it will slow things down
         callback_metrics = recursive_detach(callback_metrics)

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -184,10 +184,6 @@ class TrainerLoggingMixin(ABC):
         # ---------------
         hiddens = output.get('hiddens')
 
-        # use every metric passed in as a candidate for callback
-        callback_metrics.update(progress_bar_metrics)
-        callback_metrics.update(log_metrics)
-
         # detach all metrics for callbacks to prevent memory leaks
         # no .item() because it will slow things down
         callback_metrics = recursive_detach(callback_metrics)


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)

- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?

- [x] Did you make sure to update the docs?
   
- [x] Did you write any new necessary tests?
  
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Fixes #1727.

Dict values passed to progress bar or log overwriting callback values. See example in issue.

There are several options to solve it. This simply removes adding progress bar and log values to callback dict. Tests passed on my machine.

**But this will affect users code e.g. when log metric as early stopping metric was used**

## PR review    
**Opinions, other solutions, recommendations, ... welcome!** Also help in updating docs.

## Did you have fun?
🙃
