### PR TITLE
Bugfix: accumulation and suggestion for learning rate finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,8 +68,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed saving native AMP scaler state (introduced in [#1561](https://github.com/PyTorchLightning/pytorch-lightning/pull/1561))
 
-- Fixed missing profiler attribute in add_argparse_args() ArgumentParser ([#1794](https://github.com/PyTorchLightning/pytorch-lightning/pull/1794))
-
+- Fixed accumulation parameter and suggestion method for learning rate finder ([#1801](https://github.com/PyTorchLightning/pytorch-lightning/pull/1801))
 
 ## [0.7.5] - 2020-04-27
 

--- a/pytorch_lightning/trainer/lr_finder.py
+++ b/pytorch_lightning/trainer/lr_finder.py
@@ -315,10 +315,8 @@ class _LRFinder(object):
 
         Returns:
             lr: suggested initial learning rate to use
-            skip_begin: how many samples to skip in the beginning.
-                Prevent too naive estimates
-            skip_end: how many samples to skip in the end.
-                Prevent too optimistic estimates
+            skip_begin: how many samples to skip in the beginning. Prevent too naive estimates
+            skip_end: how many samples to skip in the end. Prevent too optimistic estimates
 
         """
         try:

--- a/pytorch_lightning/trainer/lr_finder.py
+++ b/pytorch_lightning/trainer/lr_finder.py
@@ -88,7 +88,7 @@ class TrainerLRFinderMixin(ABC):
                 then the search is stopped. To disable, set to None.
 
             num_accumulation_steps: deprepecated, number of batches to calculate loss over.
-                Set trainer argument `accumulate_grad_batches` instead.
+                Set trainer argument ``accumulate_grad_batches`` instead.
 
         Example::
 
@@ -315,10 +315,8 @@ class _LRFinder(object):
 
         Returns:
             lr: suggested initial learning rate to use
-
             skip_begin: how many samples to skip in the beginning.
                 Prevent too naive estimates
-
             skip_end: how many samples to skip in the end.
                 Prevent too optimistic estimates
 
@@ -329,8 +327,7 @@ class _LRFinder(object):
             self._optimal_idx = min_grad + skip_begin
             return self.results["lr"][self._optimal_idx]
         except Exception:
-            log.exception('Failed to compute suggesting for `lr`.'
-                          ' There might not be enough points.')
+            log.exception('Failed to compute suggesting for `lr`. There might not be enough points.')
             self._optimal_idx = None
 
 
@@ -342,13 +339,13 @@ class _LRCallback(Callback):
     Args:
         num_training: number of iterations done by the learning rate finder
         early_stop_threshold: threshold for stopping the search. If the
-            loss at any point is larger than `early_stop_threshold*best_loss`
-            then the search is stopped. To disable, set to `None`.
+            loss at any point is larger than ``early_stop_threshold*best_loss``
+            then the search is stopped. To disable, set to ``None``.
         progress_bar_refresh_rate: rate to refresh the progress bar for
             the learning rate finder
         beta: smoothing value, the loss being logged is a running average of
-            loss values logged until now. `beta` controls the forget rate i.e.
-            if `beta=0` all past information is ignored.
+            loss values logged until now. ``beta`` controls the forget rate i.e.
+            if ``beta=0`` all past information is ignored.
 
     """
     def __init__(self, num_training: int,

--- a/pytorch_lightning/trainer/lr_finder.py
+++ b/pytorch_lightning/trainer/lr_finder.py
@@ -342,8 +342,8 @@ class _LRCallback(Callback):
     Args:
         num_training: number of iterations done by the learning rate finder
         early_stop_threshold: threshold for stopping the search. If the
-                loss at any point is larger than `early_stop_threshold*best_loss`
-                then the search is stopped. To disable, set to `None`.
+            loss at any point is larger than `early_stop_threshold*best_loss`
+            then the search is stopped. To disable, set to `None`.
         progress_bar_refresh_rate: rate to refresh the progress bar for
             the learning rate finder
         beta: smoothing value, the loss being logged is a running average of

--- a/pytorch_lightning/trainer/lr_finder.py
+++ b/pytorch_lightning/trainer/lr_finder.py
@@ -127,7 +127,7 @@ class TrainerLRFinderMixin(ABC):
         lr_finder = _LRFinder(mode, min_lr, max_lr, num_training)
 
         # Use special lr logger callback
-        self.callbacks = [_LRCallback(num_training, 
+        self.callbacks = [_LRCallback(num_training,
                                       early_stop_threshold,
                                       progress_bar_refresh_rate=1)]
 
@@ -175,7 +175,7 @@ class TrainerLRFinderMixin(ABC):
         lr_finder.results.update({'lr': self.callbacks[0].lrs,
                                   'loss': self.callbacks[0].losses})
         lr_finder._total_batch_idx = self.total_batch_idx  # for debug purpose
-        
+
         # Reset model state
         self.restore(str(save_path), on_gpu=self.on_gpu)
         os.remove(save_path)
@@ -249,7 +249,7 @@ class _LRFinder(object):
         self.lr_min = lr_min
         self.lr_max = lr_max
         self.num_training = num_training
-        
+
         self.results = {}
         self._total_batch_idx = 0  # for debug purpose
 
@@ -337,9 +337,9 @@ class _LRCallback(Callback):
     """ Special callback used by the learning rate finder. This callbacks log
     the learning rate before each batch and log the corresponding loss after
     each batch. """
-    def __init__(self, num_training: int, 
+    def __init__(self, num_training: int,
                  early_stop_threshold: float = 4.0,
-                 progress_bar_refresh_rate: bool = False, 
+                 progress_bar_refresh_rate: bool = False,
                  beta: float = 0.98):
         self.num_training = num_training
         self.early_stop_threshold = early_stop_threshold

--- a/pytorch_lightning/trainer/lr_finder.py
+++ b/pytorch_lightning/trainer/lr_finder.py
@@ -113,7 +113,7 @@ class TrainerLRFinderMixin(ABC):
         """
         if num_accumulation_steps is not None:
             rank_zero_warn("Argument `num_accumulation_steps` has been deprepecated"
-                           " since v0.8.0 and will be removed in v1.0.0. Please"
+                           " since v0.7.6 and will be removed in 0.9. Please"
                            " set trainer argument `accumulate_grad_batches` instead.",
                            DeprecationWarning)
 
@@ -338,20 +338,17 @@ class _LRCallback(Callback):
     """ Special callback used by the learning rate finder. This callbacks log
     the learning rate before each batch and log the corresponding loss after
     each batch.
+
     Args:
-
         num_training: number of iterations done by the learning rate finder
-
         early_stop_threshold: threshold for stopping the search. If the
-                loss at any point is larger than early_stop_threshold*best_loss
-                then the search is stopped. To disable, set to None.
-
+                loss at any point is larger than `early_stop_threshold*best_loss`
+                then the search is stopped. To disable, set to `None`.
         progress_bar_refresh_rate: rate to refresh the progress bar for
             the learning rate finder
-
         beta: smoothing value, the loss being logged is a running average of
-            loss values logged until now. beta controls the forget rate i.e.
-            if beta=0 all past information is ignored.
+            loss values logged until now. `beta` controls the forget rate i.e.
+            if `beta=0` all past information is ignored.
 
     """
     def __init__(self, num_training: int,

--- a/pytorch_lightning/trainer/lr_finder.py
+++ b/pytorch_lightning/trainer/lr_finder.py
@@ -298,16 +298,23 @@ class _LRFinder(object):
 
         return fig
 
-    def suggestion(self):
+    def suggestion(self, skip_begin: int = 10, skip_end: int = 1):
         """ This will propose a suggestion for choice of initial learning rate
         as the point with the steepest negative gradient.
 
         Returns:
             lr: suggested initial learning rate to use
 
+            skip_begin: how many samples to skip in the beginning.
+                Prevent too naive estimates
+                
+            skip_end: how many samples to skip in the end.
+                Prevent too optimistic estimates
+
         """
         try:
-            min_grad = (np.gradient(np.array(self.results["loss"]))).argmin()
+            loss = self.results["loss"][skip_begin:-skip_end]
+            min_grad = (np.gradient(np.array(loss))).argmin()
             self._optimal_idx = min_grad
             return self.results["lr"][min_grad]
         except Exception:

--- a/tests/trainer/test_lr_finder.py
+++ b/tests/trainer/test_lr_finder.py
@@ -116,7 +116,7 @@ def test_trainer_arg_str(tmpdir):
 
 def test_call_to_trainer_method(tmpdir):
     """ Test that directly calling the trainer method works """
-    
+
     hparams = EvalModelTemplate.get_default_hparams()
     model = EvalModelTemplate(hparams)
 
@@ -139,7 +139,7 @@ def test_call_to_trainer_method(tmpdir):
 def test_accumulation_and_early_stopping(tmpdir):
     """ Test that early stopping of learning rate finder works, and that
         accumulation also works for this feature """
-    
+
     hparams = EvalModelTemplate.get_default_hparams()
     model = EvalModelTemplate(hparams)
 
@@ -157,13 +157,13 @@ def test_accumulation_and_early_stopping(tmpdir):
         'Learning rate was not altered after running learning rate finder'
     assert len(lrfinder.results['lr']) == 100, \
         'Early stopping for learning rate finder did not work'
-    assert lrfinder._total_batch_idx == 100*2, \
+    assert lrfinder._total_batch_idx == 100 * 2, \
         'Accumulation parameter did not work'
 
 
 def test_suggestion_parameters_work(tmpdir):
     """ Test that default skipping does not alter results in basic case """
-    
+
     hparams = EvalModelTemplate.get_default_hparams()
     model = EvalModelTemplate(hparams)
 
@@ -172,7 +172,7 @@ def test_suggestion_parameters_work(tmpdir):
         default_save_path=tmpdir,
         max_epochs=10,
     )
-    
+
     lrfinder = trainer.lr_find(model)
     lr1 = lrfinder.suggestion()
     lr2 = lrfinder.suggestion(skip_begin=0)
@@ -182,4 +182,3 @@ def test_suggestion_parameters_work(tmpdir):
         'Default skipping parameter should not influence suggested learning rate'
     assert lr1 != lr3, \
         'Skipping parameter did not influence learning rate'
-        

--- a/tests/trainer/test_lr_finder.py
+++ b/tests/trainer/test_lr_finder.py
@@ -84,7 +84,7 @@ def test_trainer_arg_bool(tmpdir):
     # logger file to get meta
     trainer = Trainer(
         default_save_path=tmpdir,
-        max_epochs=1,
+        max_epochs=5,
         auto_lr_find=True
     )
 
@@ -104,7 +104,7 @@ def test_trainer_arg_str(tmpdir):
     # logger file to get meta
     trainer = Trainer(
         default_save_path=tmpdir,
-        max_epochs=1,
+        max_epochs=5,
         auto_lr_find='my_fancy_lr'
     )
 
@@ -123,7 +123,7 @@ def test_call_to_trainer_method(tmpdir):
     # logger file to get meta
     trainer = Trainer(
         default_save_path=tmpdir,
-        max_epochs=1,
+        max_epochs=5,
     )
 
     lrfinder = trainer.lr_find(model, mode='linear')

--- a/tests/trainer/test_lr_finder.py
+++ b/tests/trainer/test_lr_finder.py
@@ -174,11 +174,8 @@ def test_suggestion_parameters_work(tmpdir):
     )
 
     lrfinder = trainer.lr_find(model)
-    lr1 = lrfinder.suggestion()
-    lr2 = lrfinder.suggestion(skip_begin=0)
-    lr3 = lrfinder.suggestion(skip_begin=80)  # way too high, should have an impact
+    lr1 = lrfinder.suggestion(skip_begin=10)  # default
+    lr2 = lrfinder.suggestion(skip_begin=80)  # way too high, should have an impact
 
-    assert lr1 == lr2, \
-        'Default skipping parameter should not influence suggested learning rate'
-    assert lr1 != lr3, \
+    assert lr1 != lr2, \
         'Skipping parameter did not influence learning rate'


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/1767, by implementing a `skip_begin` parameter (default 10) for the `lr_finder.suggestion` method

Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/1726, by only logging learning rate and loss when optimizer is called (as it should be). This also removes `num_accumulation_steps` since this is a duplicate of the `accumulate_grad_batches` trainer arg.

Added tests for both.
 


## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
