### PR TITLE
[WIP]: ddp pickle fix for learning rate finder

### DIFF
--- a/pytorch_lightning/trainer/lr_finder.py
+++ b/pytorch_lightning/trainer/lr_finder.py
@@ -168,8 +168,7 @@ class TrainerLRFinderMixin(ABC):
                  train_dataloader=train_dataloader,
                  val_dataloaders=val_dataloaders)
         lr_finder._total_batch_idx = self.total_batch_idx  # for debug purpose
-        import pdb
-        pdb.set_trace()
+
         # Prompt if we stopped early
         if self.global_step != num_training:
             log.info('LR finder stopped early due to diverging loss.')


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/1831
This fixes the pickle error on ddp for the learning rate finder as described in the issue. I can get the learning rate finder to finish its search, however since the internal state is destroyed after ddp training so are the logged results. How can I get around this?
