### PR TITLE
Fixed the default value of auto_lr_find in docs

### DIFF
--- a/docs/source/lr_finder.rst
+++ b/docs/source/lr_finder.rst
@@ -23,7 +23,7 @@ Warnings:
 - LR support for DDP is not implemented yet, it is comming soon.
 
 Using Lightning's built-in LR finder
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In the most basic use case, this feature can be enabled during trainer construction
 with ``Trainer(auto_lr_find=True)``. When ``.fit(model)`` is called, the LR finder

--- a/docs/source/lr_finder.rst
+++ b/docs/source/lr_finder.rst
@@ -22,19 +22,19 @@ Warnings:
 - For the moment, this feature only works with models having a single optimizer.
 - LR support for DDP is not implemented yet, it is comming soon.
 
-Using Lightnings build-in LR finder
+Using Lightning's built-in LR finder
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 In the most basic use case, this feature can be enabled during trainer construction
-with ``Trainer(auto_lr_find=True)``. When ``.fit(model)`` is called, the lr finder
+with ``Trainer(auto_lr_find=True)``. When ``.fit(model)`` is called, the LR finder
 will automatically be run before any training is done. The ``lr`` that is found
 and used will be written to the console and logged together with all other
 hyperparameters of the model.
     
 .. testcode::
         
-    # default, no automatic learning rate finder
-    trainer = Trainer(auto_lr_find=True)
+    # default: no automatic learning rate finder
+    trainer = Trainer(auto_lr_find=False)
 
 When the ``lr`` or ``learning_rate`` key in hparams exists, this flag sets your learning_rate.
 In both cases, if the respective fields are not found, an error will be thrown.


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
The default value of `auto_lr_find` to the `Trainer` was specified wrong in the docs, so I fixed it, along with some minor typos.
