### PR TITLE
Support OmegaConf in Lightning

### DIFF
--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -361,8 +361,8 @@ class TrainerIOMixin(ABC):
                 checkpoint['hparams_type'] = 'Namespace'
                 checkpoint['hparams'] = vars(model.hparams)
             elif OMEGACONF_AVAILABLE and isinstance(model.hparams, omegaconf.DictConfig):
-                    checkpoint['hparams_type'] = 'DictConfig'
-                    checkpoint['hparams'] = model.hparams
+                checkpoint['hparams_type'] = 'DictConfig'
+                checkpoint['hparams'] = model.hparams
             else:
                 raise ValueError(
                     'The acceptable hparams type is dict, argparse.Namespace,',

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -119,6 +119,15 @@ except ImportError:
 else:
     HOROVOD_AVAILABLE = True
 
+try:
+    import omegaconf
+except ImportError:
+    OMEGACONF_AVAILABLE = False
+else:
+    OMEGACONF_AVAILABLE = True
+
+
+
 
 class TrainerIOMixin(ABC):
 
@@ -351,10 +360,13 @@ class TrainerIOMixin(ABC):
             elif isinstance(model.hparams, Namespace):
                 checkpoint['hparams_type'] = 'Namespace'
                 checkpoint['hparams'] = vars(model.hparams)
+            elif OMEGACONF_AVAILABLE and isinstance(model.hparams, omegaconf.DictConfig):
+                    checkpoint['hparams_type'] = 'DictConfig'
+                    checkpoint['hparams'] = model.hparams
             else:
                 raise ValueError(
-                    'The acceptable hparams type is dict or argparse.Namespace,',
-                    f' not {checkpoint["hparams_type"]}'
+                    'The acceptable hparams type is dict, argparse.Namespace,',
+                    f' or omegaconf.DictConfig, not {checkpoint["hparams_type"]}'
                 )
         else:
             rank_zero_warn(

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -127,8 +127,6 @@ else:
     OMEGACONF_AVAILABLE = True
 
 
-
-
 class TrainerIOMixin(ABC):
 
     # this is just a summary on variables used in this abstract class,


### PR DESCRIPTION
Lightning hparams were recently changed to support only dicts and ArgParse namespaces. This diff (re)introduces compatibility with OmegaConf DictConfig, which is the type of config that Hydra uses.

## What does this PR do?
Fixes #1880.
