### PR TITLE
Fix scale_batch_size() when using a LRScheduler

### DIFF
--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -347,12 +347,12 @@ class TrainerTrainLoopMixin(ABC):
                 # -----------------
                 self.run_training_epoch()
 
-                # update LR schedulers
-                self.update_learning_rates(interval='epoch')
-
                 if self.max_steps and self.max_steps == self.global_step:
                     self.run_training_teardown()
                     return
+
+                # update LR schedulers
+                self.update_learning_rates(interval='epoch')
 
                 # early stopping
                 met_min_epochs = epoch >= self.min_epochs - 1


### PR DESCRIPTION
The order of the learning rate updates when `run_training_teardown()` was pending was restricting the use of a learning rate scheduler monitoring a metric that only exists at the end of a validation loop.

Due to @SkafteNicki's suggestion I changed the order of the `self.update_learning_rates()` and `self.run_training_teardown()` in the `training_loop.py`.

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Fixes #1889 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
