### PR TITLE
Support returning python scalars in DP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added remaining `sklearn` metrics: `AveragePrecision`, `BalancedAccuracy`, `CohenKappaScore`, `DCG`, `Hamming`, `Hinge`, `Jaccard`, `MeanAbsoluteError`, `MeanSquaredError`, `MeanSquaredLogError`, `MedianAbsoluteError`, `R2Score`, `MeanPoissonDeviance`, `MeanGammaDeviance`, `MeanTweedieDeviance`, `ExplainedVariance` ([#2562](https://github.com/PyTorchLightning/pytorch-lightning/pull/2562))
 
+- Added support returning python scalars in DP ([#1935](https://github.com/PyTorchLightning/pytorch-lightning/pull/1935))
+
 ### Changed
 
 - Truncated long version numbers in progress bar ([#2594](https://github.com/PyTorchLightning/pytorch-lightning/pull/2594))

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -168,7 +168,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
 
         """
 
-    def training_step(self, *args, **kwargs) -> Union[int, Dict[str, Union[Tensor, Dict[str, Tensor]]]]:
+    def training_step(self, *args, **kwargs) -> Union[int, Dict[str, Union[Tensor, Dict[str, Union[float, Tensor]]]]]:
         r"""
         Here you compute and return the training loss and some additional metrics for e.g.
         the progress bar or logger.
@@ -186,8 +186,8 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
             When implementing :meth:`training_step`, return whatever you need in that step:
 
             - loss -> tensor scalar **REQUIRED**
-            - progress_bar -> Dict for progress bar display. Must have either tensors or scalars
-            - log -> Dict of metrics to add to logger. Must have either tensors or scalars (no images, etc)
+            - progress_bar -> Dict for progress bar display. Must have either scalar tensors or Python scalars
+            - log -> Dict of metrics to add to logger. Must have either scalar tensors or Python scalars (no images, etc)
 
         In this step you'd normally do the forward pass and calculate the loss for a batch.
         You can also do fancier things like multiple forward passes or something model specific.
@@ -358,8 +358,8 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
             Dict with loss key and optional log or progress bar keys.
 
             - loss -> tensor scalar **REQUIRED**
-            - progress_bar -> Dict for progress bar display. Must have only tensors
-            - log -> Dict of metrics to add to logger. Must have only tensors (no images, etc)
+            - progress_bar -> Dict for progress bar display. Must have either scalar tensors or Python scalars
+            - log -> Dict of metrics to add to logger. Must have either scalar tensors or Python scalars (no images, etc)
 
         Examples:
             .. code-block:: python
@@ -575,8 +575,8 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
             Dict or OrderedDict.
             May have the following optional keys:
 
-            - progress_bar (dict for progress bar display; either tensors or scalars)
-            - log (dict of metrics to add to logger; either tensors or scalars).
+            - progress_bar (dict for progress bar display; either scalar tensors or Python scalars)
+            - log (dict of metrics to add to logger; either scalar tensors or Python scalars).
 
         Note:
             If you didn't define a :meth:`validation_step`, this won't be called.
@@ -800,8 +800,8 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
         Return:
             Dict or OrderedDict: Dict has the following optional keys:
 
-            - progress_bar -> Dict for progress bar display. Must have only tensors.
-            - log -> Dict of metrics to add to logger. Must have only tensors (no images, etc).
+            - progress_bar -> Dict for progress bar display. Must have either scalar tensors or Python scalars.
+            - log -> Dict of metrics to add to logger. Must have either scalar tensors or Python scalars (no images, etc).
 
         Note:
             If you didn't define a :meth:`test_step`, this won't be called.

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -186,8 +186,8 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
             When implementing :meth:`training_step`, return whatever you need in that step:
 
             - loss -> tensor scalar **REQUIRED**
-            - progress_bar -> Dict for progress bar display. Must have only tensors
-            - log -> Dict of metrics to add to logger. Must have only tensors (no images, etc)
+            - progress_bar -> Dict for progress bar display. Must have either tensors or scalars
+            - log -> Dict of metrics to add to logger. Must have either tensors or scalars (no images, etc)
 
         In this step you'd normally do the forward pass and calculate the loss for a batch.
         You can also do fancier things like multiple forward passes or something model specific.
@@ -202,14 +202,14 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
                     out = self(x)
                     loss = self.loss(out, x)
 
-                    logger_logs = {'training_loss': loss} # optional (MUST ALL BE TENSORS)
+                    logger_logs = {'training_loss': loss} # optional
 
                     # if using TestTubeLogger or TensorBoardLogger you can nest scalars
-                    logger_logs = {'losses': logger_logs} # optional (MUST ALL BE TENSORS)
+                    logger_logs = {'losses': logger_logs} # optional
 
                     output = {
                         'loss': loss, # required
-                        'progress_bar': {'training_loss': loss}, # optional (MUST ALL BE TENSORS)
+                        'progress_bar': {'training_loss': loss}, # optional
                         'log': logger_logs
                     }
 
@@ -259,8 +259,8 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
         """
 
     def training_epoch_end(
-        self, outputs: Union[List[Dict[str, Tensor]], List[List[Dict[str, Tensor]]]]
-    ) -> Dict[str, Dict[str, Tensor]]:
+        self, outputs: Union[List[Dict[str, Tensor]], List[List[Dict[str, Union[float, Tensor]]]]]
+    ) -> Dict[str, Dict[str, Union[float, Tensor]]]:
         """Called at the end of the training epoch with the outputs of all training steps.
 
         .. code-block:: python
@@ -334,7 +334,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
                     return results
         """
 
-    def training_step_end(self, *args, **kwargs) -> Dict[str, Union[Tensor, Dict[str, Tensor]]]:
+    def training_step_end(self, *args, **kwargs) -> Dict[str, Union[Tensor, Dict[str, Union[float, Tensor]]]]:
         """
         Use this when training with dp or ddp2 because :meth:`training_step`
         will operate on only part of the batch. However, this is still optional
@@ -396,7 +396,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
             See the :ref:`multi-gpu-training` guide for more details.
         """
 
-    def validation_step(self, *args, **kwargs) -> Dict[str, Tensor]:
+    def validation_step(self, *args, **kwargs) -> Dict[str, Union[float, Tensor]]:
         r"""
         Operates on a single batch of data from the validation set.
         In this step you'd might generate examples or calculate anything of interest like accuracy.
@@ -486,7 +486,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
             the model goes back to training mode and gradients are enabled.
         """
 
-    def validation_step_end(self, *args, **kwargs) -> Dict[str, Tensor]:
+    def validation_step_end(self, *args, **kwargs) -> Dict[str, Union[float, Tensor]]:
         """
         Use this when validating with dp or ddp2 because :meth:`validation_step`
         will operate on only part of the batch. However, this is still optional
@@ -553,8 +553,8 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
         """
 
     def validation_epoch_end(
-        self, outputs: Union[List[Dict[str, Tensor]], List[List[Dict[str, Tensor]]]]
-    ) -> Dict[str, Dict[str, Tensor]]:
+        self, outputs: Union[List[Dict[str, Union[float, Tensor]]], List[List[Dict[str, Union[float, Tensor]]]]]
+    ) -> Dict[str, Dict[str, Union[float, Tensor]]]:
         """
         Called at the end of the validation epoch with the outputs of all validation steps.
 
@@ -575,8 +575,8 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
             Dict or OrderedDict.
             May have the following optional keys:
 
-            - progress_bar (dict for progress bar display; only tensors)
-            - log (dict of metrics to add to logger; only tensors).
+            - progress_bar (dict for progress bar display; either tensors or scalars)
+            - log (dict of metrics to add to logger; either tensors or scalars).
 
         Note:
             If you didn't define a :meth:`validation_step`, this won't be called.
@@ -630,7 +630,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
                     return results
         """
 
-    def test_step(self, *args, **kwargs) -> Dict[str, Tensor]:
+    def test_step(self, *args, **kwargs) -> Dict[str, Union[float, Tensor]]:
         r"""
         Operates on a single batch of data from the test set.
         In this step you'd normally generate examples or calculate anything of interest
@@ -713,7 +713,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
             to training mode and gradients are enabled.
         """
 
-    def test_step_end(self, *args, **kwargs) -> Dict[str, Tensor]:
+    def test_step_end(self, *args, **kwargs) -> Dict[str, Union[float, Tensor]]:
         """
         Use this when testing with dp or ddp2 because :meth:`test_step` will operate
         on only part of the batch. However, this is still optional
@@ -779,8 +779,8 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
         """
 
     def test_epoch_end(
-        self, outputs: Union[List[Dict[str, Tensor]], List[List[Dict[str, Tensor]]]]
-    ) -> Dict[str, Dict[str, Tensor]]:
+        self, outputs: Union[List[Dict[str, Union[float, Tensor]]], List[List[Dict[str, Union[float, Tensor]]]]]
+    ) -> Dict[str, Dict[str, Union[float, Tensor]]]:
         """
         Called at the end of a test epoch with the output of all test steps.
 

--- a/pytorch_lightning/overrides/data_parallel.py
+++ b/pytorch_lightning/overrides/data_parallel.py
@@ -102,8 +102,6 @@ class LightningDataParallel(DataParallel):
         """
 
         def gather_method(outputs):
-            if all(t.dim() == 0 for t in outputs) and self.dim == 0:
-                outputs = tuple(t.view(1) for t in outputs)
             return Gather.apply(self.output_device, self.dim, *outputs)
 
         return apply_to_collection(outputs, torch.Tensor, gather_method)

--- a/pytorch_lightning/trainer/ignored_warnings.py
+++ b/pytorch_lightning/trainer/ignored_warnings.py
@@ -3,12 +3,9 @@ import warnings
 
 def ignore_scalar_return_in_dp():
     # Users get confused by this warning so we silence it
-    m_1 = (
-        'Was asked to gather along dimension 0, but all '
-        'input tensors were scalars; will instead unsqueeze '
-        'and return a vector.'
-    )
-    warnings.filterwarnings('ignore', message=m_1)
+    warnings.filterwarnings('ignore', message='Was asked to gather along dimension 0, but all '
+                                              'input tensors were scalars; will instead unsqueeze '
+                                              'and return a vector.')
 
 
 ignore_scalar_return_in_dp()

--- a/pytorch_lightning/trainer/ignored_warnings.py
+++ b/pytorch_lightning/trainer/ignored_warnings.py
@@ -3,9 +3,9 @@ import warnings
 
 def ignore_scalar_return_in_dp():
     # Users get confused by this warning so we silence it
-    warnings.filterwarnings('ignore', message='Was asked to gather along dimension 0, but all '
-                                              'input tensors were scalars; will instead unsqueeze '
-                                              'and return a vector.')
+    warnings.filterwarnings('ignore', message='Was asked to gather along dimension 0, but all'
+                                              ' input tensors were scalars; will instead unsqueeze'
+                                              ' and return a vector.')
 
 
 ignore_scalar_return_in_dp()

--- a/pytorch_lightning/trainer/ignored_warnings.py
+++ b/pytorch_lightning/trainer/ignored_warnings.py
@@ -3,11 +3,11 @@ import warnings
 
 def ignore_scalar_return_in_dp():
     # Users get confused by this warning so we silence it
-    m_1 = """
-    Was asked to gather along dimension 0, but all
-    input tensors were scalars; will instead unsqueeze
-    and return a vector.
-    """
+    m_1 = (
+        'Was asked to gather along dimension 0, but all '
+        'input tensors were scalars; will instead unsqueeze '
+        'and return a vector.'
+    )
     warnings.filterwarnings('ignore', message=m_1)
 
 

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -208,6 +208,10 @@ class TrainerLoggingMixin(ABC):
             if isinstance(output[k], dict):
                 output[k] = self.reduce_distributed_output(output[k], num_gpus)
 
+            # compute the average of scalars
+            if isinstance(output[k], list):
+                output[k] = sum(output[k]) / len(output[k])
+
             # do nothing when there's a scalar
             elif isinstance(output[k], torch.Tensor) and output[k].dim() == 0:
                 pass

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -209,7 +209,7 @@ class TrainerLoggingMixin(ABC):
                 output[k] = self.reduce_distributed_output(output[k], num_gpus)
 
             # compute the average of scalars
-            if isinstance(output[k], list):
+            elif isinstance(output[k], list):
                 output[k] = sum(output[k]) / len(output[k])
 
             # do nothing when there's a scalar

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -22,12 +22,21 @@ class TrainingStepVariations(ABC):
 
         # calculate loss
         loss_val = self.loss(y, y_hat)
+        loss_scalar = loss_val.item()
 
         # alternate possible outputs to test
+        if batch_idx % 2 == 0:
+            output = OrderedDict({
+                'loss': loss_val,
+                'progress_bar': {'some_val': loss_val * loss_val},
+                'log': {'train_some_val': loss_val * loss_val},
+            })
+
+        # return scalars for "log" and "progress_bar"
         output = OrderedDict({
             'loss': loss_val,
-            'progress_bar': {'some_val': loss_val * loss_val},
-            'log': {'train_some_val': loss_val * loss_val},
+            'progress_bar': {'some_val': loss_scalar * loss_scalar},
+            'log': {'train_some_val': loss_scalar * loss_scalar},
         })
         return output
 

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -10,6 +10,7 @@ class TrainingStepVariations(ABC):
     """
     Houses all variations of training steps
     """
+
     test_step_inf_loss = float('inf')
 
     def training_step(self, batch, batch_idx, optimizer_idx=None):
@@ -17,27 +18,23 @@ class TrainingStepVariations(ABC):
         # forward pass
         x, y = batch
         x = x.view(x.size(0), -1)
-
         y_hat = self(x)
 
         # calculate loss
         loss_val = self.loss(y, y_hat)
-        loss_scalar = loss_val.item()
+        log_val = loss_val
 
-        # alternate possible outputs to test
+        # alternate between tensors and scalars for "log" and "progress_bar"
         if batch_idx % 2 == 0:
-            output = OrderedDict({
-                'loss': loss_val,
-                'progress_bar': {'some_val': loss_val * loss_val},
-                'log': {'train_some_val': loss_val * loss_val},
-            })
+            log_val = log_val.item()
 
-        # return scalars for "log" and "progress_bar"
-        output = OrderedDict({
-            'loss': loss_val,
-            'progress_bar': {'some_val': loss_scalar * loss_scalar},
-            'log': {'train_some_val': loss_scalar * loss_scalar},
-        })
+        output = OrderedDict(
+            {
+                'loss': loss_val,
+                'progress_bar': {'some_val': log_val * log_val},
+                'log': {'train_some_val': log_val * log_val},
+            }
+        )
         return output
 
     def training_step__inf_loss(self, batch, batch_idx, optimizer_idx=None):

--- a/tests/base/model_valid_epoch_ends.py
+++ b/tests/base/model_valid_epoch_ends.py
@@ -26,7 +26,7 @@ class ValidationEpochEndVariations(ABC):
         val_acc_mean = _mean(outputs, 'val_acc')
 
         # alternate between tensor and scalar
-        if self.current_epoch % 2:
+        if self.current_epoch % 2 == 0:
             metrics_dict = {'val_loss': val_loss_mean.item(), 'val_acc': val_acc_mean.item()}
         else:
             metrics_dict = {'val_loss': val_loss_mean, 'val_acc': val_acc_mean}

--- a/tests/base/model_valid_epoch_ends.py
+++ b/tests/base/model_valid_epoch_ends.py
@@ -25,7 +25,11 @@ class ValidationEpochEndVariations(ABC):
         val_loss_mean = _mean(outputs, 'val_loss')
         val_acc_mean = _mean(outputs, 'val_acc')
 
-        metrics_dict = {'val_loss': val_loss_mean, 'val_acc': val_acc_mean}
+        # alternate between tensor and scalar
+        if self.current_epoch % 2:
+            metrics_dict = {'val_loss': val_loss_mean.item(), 'val_acc': val_acc_mean.item()}
+        else:
+            metrics_dict = {'val_loss': val_loss_mean, 'val_acc': val_acc_mean}
         results = {'progress_bar': metrics_dict, 'log': metrics_dict}
         return results
 

--- a/tests/base/model_valid_epoch_ends.py
+++ b/tests/base/model_valid_epoch_ends.py
@@ -27,9 +27,10 @@ class ValidationEpochEndVariations(ABC):
 
         # alternate between tensor and scalar
         if self.current_epoch % 2 == 0:
-            metrics_dict = {'val_loss': val_loss_mean.item(), 'val_acc': val_acc_mean.item()}
-        else:
-            metrics_dict = {'val_loss': val_loss_mean, 'val_acc': val_acc_mean}
+            val_loss_mean = val_loss_mean.item()
+            val_acc_mean = val_acc_mean.item()
+
+        metrics_dict = {'val_loss': val_loss_mean, 'val_acc': val_acc_mean}
         results = {'progress_bar': metrics_dict, 'log': metrics_dict}
         return results
 
@@ -58,6 +59,6 @@ class ValidationEpochEndVariations(ABC):
         results = {
             'val_loss': torch.stack([v for k, v in pbar.items() if k.startswith('val_loss')]).mean(),
             'progress_bar': pbar,
-            'log': logs
+            'log': logs,
         }
         return results


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Fixes #1861 and #1904.
I'm not sure if this fix is the right approach. In the docs it's mentioned that `training_step` must return `Tensor` (even for the `progress_bar` dict). But with this PR it'll also work with scalars. Were there other reasons (besides the issues above) to force users to stick with tensors?

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
