### PR TITLE
Fix root node resolution for SLURM cluster with dash in host name

### DIFF
--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -426,8 +426,8 @@ class TrainerDDPMixin(ABC):
 
     def resolve_root_node_address(self, root_node):
         if '[' in root_node:
-            name = root_node.split('[')[0]
-            number = root_node.split(',')[0]
+            name, numbers = root_node.split('[', maxsplit=1)
+            number = numbers.split(',', maxsplit=1)[0]
             if '-' in number:
                 number = number.split('-')[0]
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
  - No need for a bugfix, right?
- [ ] Did you write any new necessary tests?
  - Not sure if this need any new tests as the general behaviour of the function is already tested  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Fixes #1943 

For now this is about the minimal change to fix the issue, but it might be better to completely rewrite the function as

```python
def resolve_root_node_address(root_node):
    """Extract a root node from a SLURM node list."""
    m = re.match(r"(?P<name>.*?)\[(?P<number>\d+)(-\d+)?(,.*)?\]", root_node)
    if not m:
        return root_node
    if m.group("number") is None:
        return m.group("name")
    return m.group("name") + m.group("number")
```

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
