### PR TITLE
fix bilinear upsampling in unet example

### DIFF
--- a/pl_examples/models/unet.py
+++ b/pl_examples/models/unet.py
@@ -99,7 +99,10 @@ class Up(nn.Module):
         super().__init__()
         self.upsample = None
         if bilinear:
-            self.upsample = nn.Upsample(scale_factor=2, mode='bilinear', align_corners=True)
+            self.upsample = nn.Sequential(
+                nn.Upsample(scale_factor=2, mode="bilinear", align_corners=True),
+                nn.Conv2d(in_ch, in_ch // 2, kernel_size=1),
+            )
         else:
             self.upsample = nn.ConvTranspose2d(in_ch, in_ch // 2, kernel_size=2, stride=2)
 


### PR DESCRIPTION
## What does this PR do?
This PR fixes a bug in the unet example related to the bilinear upsampling. In order mimic the transposed convolution, we need to add a 1x1 conv after the upsampling to half the number of output channels.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
