### PR TITLE
Document use case of passing test dataloaders to Trainer.test()

### DIFF
--- a/docs/source/test_set.rst
+++ b/docs/source/test_set.rst
@@ -40,8 +40,8 @@ running the test set (ie: 16-bit, dp, ddp, etc...)
 
 Test additional data loaders
 ----------------------------
-You can still run inference on a test set even if the `test_dataloader` method hasn't been
-defined within your LightningModule instance. This would be the case when your test data
+You can still run inference on a test set even if the `test_dataloaders` method hasn't been
+defined within your :class:`~pytorch_lightning.core.LightningModule` instance. This would be the case when your test data
 is not available at the time your model was declared.
 
 .. code-block:: python

--- a/docs/source/test_set.rst
+++ b/docs/source/test_set.rst
@@ -46,6 +46,7 @@ the case in production systems where the model has already been trained and
 inference is being ran on novel test sets.
 
 .. code-block:: python
+
     # setup your data loader
     test = DataLoader(...)
 

--- a/docs/source/test_set.rst
+++ b/docs/source/test_set.rst
@@ -1,6 +1,6 @@
 Test set
 ========
-Lightning forces the user to run the test set separately to make sure it isn't evaluated by mistake
+Lightning forces the user to run the test set separately to make sure it isn't evaluated by mistake.
 
 
 Test after fit
@@ -14,6 +14,7 @@ To run the test set after training completes, use this method
 
     # run test set
     trainer.test()
+
 
 Test pre-trained model
 ----------------------
@@ -35,3 +36,22 @@ To run the test set on a pre-trained model, use this method.
 
 In this  case, the options you pass to trainer will be used when
 running the test set (ie: 16-bit, dp, ddp, etc...)
+
+
+Test additional data loaders
+----------------------------
+If no test sets were passed in to `trainer.fit()` or otherwise declared inside your
+LightningModule class, use this method to specify a test set to run. This is often
+the case in production systems where the model has already been trained and
+inference is being ran on novel test sets.
+
+.. code-block:: python
+    # setup your data loader
+    test = DataLoader(...)
+
+    # test (pass in the loader)
+    trainer.test(test_dataloaders=test)
+
+You can either pass in either a single dataloader or a list of them. This
+optional named parameter can be used in conjunction with any of the above use
+cases.

--- a/docs/source/test_set.rst
+++ b/docs/source/test_set.rst
@@ -38,9 +38,9 @@ In this  case, the options you pass to trainer will be used when
 running the test set (ie: 16-bit, dp, ddp, etc...)
 
 
-Test additional data loaders
-----------------------------
-You can still run inference on a test set even if the `test_dataloaders` method hasn't been
+Test with additional data loaders
+---------------------------------
+You can still run inference on a test set even if the `test_dataloader` method hasn't been
 defined within your :class:`~pytorch_lightning.core.LightningModule` instance. This would be the case when your test data
 is not available at the time your model was declared.
 

--- a/docs/source/test_set.rst
+++ b/docs/source/test_set.rst
@@ -40,9 +40,9 @@ running the test set (ie: 16-bit, dp, ddp, etc...)
 
 Test additional data loaders
 ----------------------------
-You can still run inference on a test set even if `test_dataloader` hasn't been declared
-in your LightningModule class. This would be the case when your testing data isn't available
-at the time your model is declared.
+You can still run inference on a test set even if the `test_dataloader` method hasn't been
+defined within your LightningModule instance. This would be the case when your test data
+is not available at the time your model was declared.
 
 .. code-block:: python
 

--- a/docs/source/test_set.rst
+++ b/docs/source/test_set.rst
@@ -40,10 +40,9 @@ running the test set (ie: 16-bit, dp, ddp, etc...)
 
 Test additional data loaders
 ----------------------------
-If no test sets were passed in to `trainer.fit()` or otherwise declared inside your
-LightningModule class, use this method to specify a test set to run. This is often
-the case in production systems where the model has already been trained and
-inference is being ran on novel test sets.
+You can still run inference on a test set even if `test_dataloader` hasn't been declared
+in your LightningModule class. This would be the case when your testing data isn't available
+at the time your model is declared.
 
 .. code-block:: python
 
@@ -53,6 +52,5 @@ inference is being ran on novel test sets.
     # test (pass in the loader)
     trainer.test(test_dataloaders=test)
 
-You can either pass in either a single dataloader or a list of them. This
-optional named parameter can be used in conjunction with any of the above use
-cases.
+You can either pass in a single dataloader or a list of them. This optional named
+parameter can be used in conjunction with any of the above use cases.


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? No, but it was discussed on the slack channel. I did make an issue for it as well #1990 
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

## What does this PR do?
Fixes #1990 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Always 🙃
