### PR TITLE
Fixes EarlyStopping With Precision=16

### DIFF
--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -107,7 +107,7 @@ class EarlyStopping(Callback):
         # Allow instances to be re-used
         self.wait = 0
         self.stopped_epoch = 0
-        self.best = torch_inf if self.monitor_op == torch.lt else -torch_inf
+        self.best = -torch_inf if self.monitor_op(torch.Tensor(1), torch.Tensor(2))[0].item() else torch_inf
 
     def on_validation_end(self, trainer, pl_module):
         self._run_early_stopping_check(trainer, pl_module)

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -107,7 +107,7 @@ class EarlyStopping(Callback):
         # Allow instances to be re-used
         self.wait = 0
         self.stopped_epoch = 0
-        self.best = -torch_inf if self.monitor_op(torch.Tensor(1), torch.Tensor(2))[0].item() else torch_inf 
+        self.best = -torch_inf if self.monitor_op(torch.Tensor(1), torch.Tensor(2))[0].item() else torch_inf
 
     def on_validation_end(self, trainer, pl_module):
         self._run_early_stopping_check(trainer, pl_module)

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -107,7 +107,7 @@ class EarlyStopping(Callback):
         # Allow instances to be re-used
         self.wait = 0
         self.stopped_epoch = 0
-        self.best = -torch_inf if self.monitor_op(torch.Tensor(1), torch.Tensor(2))[0].item() else torch_inf
+        self.best = -torch_inf if self.monitor_op(torch.Tensor(1), torch.Tensor(2))[0].item() else torch_inf 
 
     def on_validation_end(self, trainer, pl_module):
         self._run_early_stopping_check(trainer, pl_module)


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you write any new necessary tests?  Sorta, see below

## What does this PR do?
Fixes #1815 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## The Problem
The problem and code to reproduce is available in the Issue #1815 

Here is some common sense / sanity code to validate the one-liner patch works according to specification:

```
import torch
import numpy as np
import apex.amp as amp
from pytorch_lightning.callbacks.early_stopping import EarlyStopping
torch_inf = torch.tensor(np.Inf)
es = EarlyStopping(mode='min')


torch_inf if es.monitor_op == torch.lt else -torch_inf 
Out[1]: tensor(inf)

-torch_inf if es.monitor_op(torch.Tensor(1), torch.Tensor(2))[0].item() else torch_inf
Out[2]: tensor(inf)

es = EarlyStopping(mode='max')
torch_inf if es.monitor_op == torch.lt else -torch_inf 
Out[3]: tensor(-inf)

-torch_inf if es.monitor_op(torch.Tensor(1), torch.Tensor(2))[0].item() else torch_inf
Out[4]: tensor(-inf)


es = EarlyStopping(mode='min')
model = torch.nn.Linear(5, 5).to('cuda')
optimizers = torch.optim.Adam(model.parameters(), lr=1e-3)
amp.initialize(model, optimizers)
torch_inf if es.monitor_op == torch.gt else -torch_inf
Out[5]: tensor(-inf)

# NOTE!! The above is incorrect, and is what this patch fixed

-torch_inf if es.monitor_op(torch.Tensor(1), torch.Tensor(2))[0].item() else torch_inf
Out[5]: tensor(inf)
```