### PR TITLE
reduce test warnings

### DIFF
--- a/tests/callbacks/test_callbacks.py
+++ b/tests/callbacks/test_callbacks.py
@@ -244,6 +244,7 @@ def test_pickling(tmpdir):
 
 
 @pytest.mark.parametrize('save_top_k', [-1, 0, 1, 2])
+@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
 def test_model_checkpoint_with_non_string_input(tmpdir, save_top_k):
     """ Test that None in checkpoint callback is valid and that chkp_path is set correctly """
     tutils.reset_seed()
@@ -266,6 +267,7 @@ def test_model_checkpoint_with_non_string_input(tmpdir, save_top_k):
     'logger_version,expected',
     [(None, 'version_0'), (1, 'version_1'), ('awesome', 'awesome')],
 )
+@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
 def test_model_checkpoint_path(tmpdir, logger_version, expected):
     """Test that "version_" prefix is only added when logger's version is an integer"""
     tutils.reset_seed()

--- a/tests/callbacks/test_callbacks.py
+++ b/tests/callbacks/test_callbacks.py
@@ -244,7 +244,7 @@ def test_pickling(tmpdir):
 
 
 @pytest.mark.parametrize('save_top_k', [-1, 0, 1, 2])
-@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
+@pytest.mark.filterwarnings("ignore:.*must be a Torch.Tensor instance, checkpoint not saved.*")
 def test_model_checkpoint_with_non_string_input(tmpdir, save_top_k):
     """ Test that None in checkpoint callback is valid and that chkp_path is set correctly """
     tutils.reset_seed()
@@ -267,7 +267,7 @@ def test_model_checkpoint_with_non_string_input(tmpdir, save_top_k):
     'logger_version,expected',
     [(None, 'version_0'), (1, 'version_1'), ('awesome', 'awesome')],
 )
-@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
+@pytest.mark.filterwarnings("ignore:.*must be a Torch.Tensor instance, checkpoint not saved.*")
 def test_model_checkpoint_path(tmpdir, logger_version, expected):
     """Test that "version_" prefix is only added when logger's version is an integer"""
     tutils.reset_seed()

--- a/tests/callbacks/test_lr.py
+++ b/tests/callbacks/test_lr.py
@@ -6,7 +6,7 @@ from pytorch_lightning.callbacks import LearningRateLogger
 from tests.base import EvalModelTemplate
 
 
-@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
+@pytest.mark.filterwarnings("ignore:.*must be a Torch.Tensor instance, checkpoint not saved.*")
 def test_lr_logger_single_lr(tmpdir):
     """ Test that learning rates are extracted and logged for single lr scheduler. """
     tutils.reset_seed()
@@ -51,7 +51,7 @@ def test_lr_logger_no_lr(tmpdir):
         assert result
 
 
-@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
+@pytest.mark.filterwarnings("ignore:.*must be a Torch.Tensor instance, checkpoint not saved.*")
 def test_lr_logger_multi_lrs(tmpdir):
     """ Test that learning rates are extracted and logged for multi lr schedulers. """
     tutils.reset_seed()
@@ -79,7 +79,7 @@ def test_lr_logger_multi_lrs(tmpdir):
         'Length of logged learning rates exceeds the number of epochs'
 
 
-@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
+@pytest.mark.filterwarnings("ignore:.*must be a Torch.Tensor instance, checkpoint not saved.*")
 def test_lr_logger_param_groups(tmpdir):
     """ Test that learning rates are extracted and logged for single lr scheduler. """
     tutils.reset_seed()

--- a/tests/callbacks/test_lr.py
+++ b/tests/callbacks/test_lr.py
@@ -6,6 +6,7 @@ from pytorch_lightning.callbacks import LearningRateLogger
 from tests.base import EvalModelTemplate
 
 
+@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
 def test_lr_logger_single_lr(tmpdir):
     """ Test that learning rates are extracted and logged for single lr scheduler. """
     tutils.reset_seed()
@@ -50,6 +51,7 @@ def test_lr_logger_no_lr(tmpdir):
         assert result
 
 
+@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
 def test_lr_logger_multi_lrs(tmpdir):
     """ Test that learning rates are extracted and logged for multi lr schedulers. """
     tutils.reset_seed()
@@ -77,6 +79,7 @@ def test_lr_logger_multi_lrs(tmpdir):
         'Length of logged learning rates exceeds the number of epochs'
 
 
+@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
 def test_lr_logger_param_groups(tmpdir):
     """ Test that learning rates are extracted and logged for single lr scheduler. """
     tutils.reset_seed()

--- a/tests/callbacks/test_progress_bar.py
+++ b/tests/callbacks/test_progress_bar.py
@@ -137,7 +137,7 @@ def test_progress_bar_fast_dev_run():
 
 
 @pytest.mark.parametrize('refresh_rate', [0, 1, 50])
-@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
+@pytest.mark.filterwarnings("ignore:.*must be a Torch.Tensor instance, checkpoint not saved.*")
 def test_progress_bar_progress_refresh(refresh_rate):
     """Test that the three progress bars get correctly updated when using different refresh rates."""
 

--- a/tests/callbacks/test_progress_bar.py
+++ b/tests/callbacks/test_progress_bar.py
@@ -137,6 +137,7 @@ def test_progress_bar_fast_dev_run():
 
 
 @pytest.mark.parametrize('refresh_rate', [0, 1, 50])
+@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
 def test_progress_bar_progress_refresh(refresh_rate):
     """Test that the three progress bars get correctly updated when using different refresh rates."""
 

--- a/tests/loggers/test_all.py
+++ b/tests/loggers/test_all.py
@@ -28,6 +28,7 @@ def _get_logger_args(logger_class, save_dir):
     # TrainsLogger,  # TODO: add this one
     # WandbLogger,  # TODO: add this one
 ])
+@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
 def test_loggers_fit_test(tmpdir, monkeypatch, logger_class):
     """Verify that basic functionality of all loggers."""
     # prevent comet logger from trying to print at exit, since
@@ -102,6 +103,7 @@ def test_loggers_pickle(tmpdir, monkeypatch, logger_class):
     pytest.param(dict(max_epochs=1, auto_scale_batch_size=True), id='Batch-size-Finder'),
     pytest.param(dict(max_epochs=10, auto_lr_find=True), id='LR-Finder'),
 ])
+@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
 def test_logger_reset_correctly(tmpdir, extra_params):
     """ Test that the tuners do not alter the logger reference """
     tutils.reset_seed()

--- a/tests/loggers/test_all.py
+++ b/tests/loggers/test_all.py
@@ -28,7 +28,7 @@ def _get_logger_args(logger_class, save_dir):
     # TrainsLogger,  # TODO: add this one
     # WandbLogger,  # TODO: add this one
 ])
-@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
+@pytest.mark.filterwarnings("ignore:.*must be a Torch.Tensor instance, checkpoint not saved.*")
 def test_loggers_fit_test(tmpdir, monkeypatch, logger_class):
     """Verify that basic functionality of all loggers."""
     # prevent comet logger from trying to print at exit, since
@@ -103,7 +103,7 @@ def test_loggers_pickle(tmpdir, monkeypatch, logger_class):
     pytest.param(dict(max_epochs=1, auto_scale_batch_size=True), id='Batch-size-Finder'),
     pytest.param(dict(max_epochs=10, auto_lr_find=True), id='LR-Finder'),
 ])
-@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
+@pytest.mark.filterwarnings("ignore:.*must be a Torch.Tensor instance, checkpoint not saved.*")
 def test_logger_reset_correctly(tmpdir, extra_params):
     """ Test that the tuners do not alter the logger reference """
     tutils.reset_seed()

--- a/tests/models/test_cpu.py
+++ b/tests/models/test_cpu.py
@@ -11,6 +11,7 @@ from pytorch_lightning.callbacks import EarlyStopping
 from tests.base import EvalModelTemplate
 
 
+@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
 def test_early_stopping_cpu_model(tmpdir):
     """Test each of the trainer options."""
     stopping = EarlyStopping(monitor='val_loss', min_delta=0.1)

--- a/tests/models/test_cpu.py
+++ b/tests/models/test_cpu.py
@@ -97,6 +97,7 @@ def test_default_logger_callbacks_cpu_model(tmpdir):
     model.unfreeze()
 
 
+@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
 def test_running_test_after_fitting(tmpdir):
     """Verify test() on fitted model."""
     model = EvalModelTemplate()

--- a/tests/models/test_cpu.py
+++ b/tests/models/test_cpu.py
@@ -11,7 +11,7 @@ from pytorch_lightning.callbacks import EarlyStopping
 from tests.base import EvalModelTemplate
 
 
-@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
+@pytest.mark.filterwarnings("ignore:.*must be a Torch.Tensor instance, checkpoint not saved.*")
 def test_early_stopping_cpu_model(tmpdir):
     """Test each of the trainer options."""
     stopping = EarlyStopping(monitor='val_loss', min_delta=0.1)
@@ -97,7 +97,7 @@ def test_default_logger_callbacks_cpu_model(tmpdir):
     model.unfreeze()
 
 
-@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
+@pytest.mark.filterwarnings("ignore:.*must be a Torch.Tensor instance, checkpoint not saved.*")
 def test_running_test_after_fitting(tmpdir):
     """Verify test() on fitted model."""
     model = EvalModelTemplate()

--- a/tests/models/test_hooks.py
+++ b/tests/models/test_hooks.py
@@ -29,6 +29,7 @@ def test_on_before_zero_grad_called(max_steps):
     assert 0 == model.on_before_zero_grad_called
 
 
+@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
 def test_training_epoch_end_metrics_collection(tmpdir):
     """ Test that progress bar metrics also get collected at the end of an epoch. """
     num_epochs = 3

--- a/tests/models/test_hooks.py
+++ b/tests/models/test_hooks.py
@@ -29,7 +29,7 @@ def test_on_before_zero_grad_called(max_steps):
     assert 0 == model.on_before_zero_grad_called
 
 
-@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
+@pytest.mark.filterwarnings("ignore:.*must be a Torch.Tensor instance, checkpoint not saved.*")
 def test_training_epoch_end_metrics_collection(tmpdir):
     """ Test that progress bar metrics also get collected at the end of an epoch. """
     num_epochs = 3

--- a/tests/models/test_hparams.py
+++ b/tests/models/test_hparams.py
@@ -31,6 +31,7 @@ class AggSubClassEvalModel(SubClassEvalModel):
                                  SubClassEvalModel,
                                  SubSubClassEvalModel,
                                  AggSubClassEvalModel])
+@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
 def test_collect_init_arguments(tmpdir, cls):
     """ Test that the model automatically saves the arguments passed into the constructor """
     extra_args = dict(my_loss=torch.nn.CosineEmbeddingLoss()) if cls is AggSubClassEvalModel else {}

--- a/tests/models/test_hparams.py
+++ b/tests/models/test_hparams.py
@@ -31,7 +31,7 @@ class AggSubClassEvalModel(SubClassEvalModel):
                                  SubClassEvalModel,
                                  SubSubClassEvalModel,
                                  AggSubClassEvalModel])
-@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
+@pytest.mark.filterwarnings("ignore:.*must be a Torch.Tensor instance, checkpoint not saved.*")
 def test_collect_init_arguments(tmpdir, cls):
     """ Test that the model automatically saves the arguments passed into the constructor """
     extra_args = dict(my_loss=torch.nn.CosineEmbeddingLoss()) if cls is AggSubClassEvalModel else {}

--- a/tests/trainer/test_lr_finder.py
+++ b/tests/trainer/test_lr_finder.py
@@ -74,6 +74,7 @@ def test_trainer_reset_correctly(tmpdir):
             f'Attribute {key} was not reset correctly after learning rate finder'
 
 
+@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
 def test_trainer_arg_bool(tmpdir):
     """ Test that setting trainer arg to bool works """
     hparams = EvalModelTemplate.get_default_hparams()
@@ -93,6 +94,7 @@ def test_trainer_arg_bool(tmpdir):
         'Learning rate was not altered after running learning rate finder'
 
 
+@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
 def test_trainer_arg_str(tmpdir):
     """ Test that setting trainer arg to string works """
     model = EvalModelTemplate()

--- a/tests/trainer/test_lr_finder.py
+++ b/tests/trainer/test_lr_finder.py
@@ -74,7 +74,7 @@ def test_trainer_reset_correctly(tmpdir):
             f'Attribute {key} was not reset correctly after learning rate finder'
 
 
-@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
+@pytest.mark.filterwarnings("ignore:.*must be a Torch.Tensor instance, checkpoint not saved.*")
 def test_trainer_arg_bool(tmpdir):
     """ Test that setting trainer arg to bool works """
     hparams = EvalModelTemplate.get_default_hparams()
@@ -94,7 +94,7 @@ def test_trainer_arg_bool(tmpdir):
         'Learning rate was not altered after running learning rate finder'
 
 
-@pytest.mark.filterwarnings("ignore:must be a Torch.Tensor instance, checkpoint not saved")
+@pytest.mark.filterwarnings("ignore:.*must be a Torch.Tensor instance, checkpoint not saved.*")
 def test_trainer_arg_str(tmpdir):
     """ Test that setting trainer arg to string works """
     model = EvalModelTemplate()


### PR DESCRIPTION
## What does this PR do?
Try to ignore all these warnings...
```
tests/models/test_cpu.py::test_early_stopping_cpu_model | 318s
-- | --
1700 | /drone/src/pytorch_lightning/utilities/distributed.py:23: RuntimeWarning: 2.5854711532592773 is supposed to be a torch.Tensor. Saving checkpoint may not work correctly. HINT: check the value of val_loss in your validation loop | 318s
1701 | warnings.warn(*args, **kwargs)
```
but it would be better to fix them instead

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
