### PR TITLE
Mistake in parameters' grad norm tracking

### DIFF
--- a/pytorch_lightning/core/grads.py
+++ b/pytorch_lightning/core/grads.py
@@ -1,14 +1,36 @@
 """
 Module to describe gradients
 """
-from typing import Dict
+from typing import Dict, Union
 
 import torch
 
 
 class GradInformation(torch.nn.Module):
 
-    def grad_norm(self, norm_type: float) -> Dict[str, int]:
+    def grad_norm(self, norm_type: Union[float, int, str]) -> Dict[str, float]:
+        r"""Compute individual parameter's gradient norms and the overall norm.
+
+        Parameters
+        ----------
+        norm_type: float, int, str:
+            The type of the used p-norm, cast to float if necessary. Can be
+            ``'inf'`` for infinity norm.
+
+        Returns
+        -------
+        norms: dict
+            The dictionary of p-norms each individual gradient and the a
+            special entry for the total p-norm of the parameters' gradients
+            viewed as a single vector.
+
+        Details
+        -------
+        The overall norm is computed over all gradients together, as if they
+        were concatenated into a single vector.
+        """
+        norm_type = float(norm_type)
+
         norms, all_norms = {}, []
         for name, p in self.named_parameters():
             if p.grad is None:

--- a/pytorch_lightning/core/grads.py
+++ b/pytorch_lightning/core/grads.py
@@ -3,28 +3,23 @@ Module to describe gradients
 """
 from typing import Dict
 
-from torch import nn
+import torch
 
 
-class GradInformation(nn.Module):
+class GradInformation(torch.nn.Module):
 
     def grad_norm(self, norm_type: float) -> Dict[str, int]:
-        results = {}
-        total_norm = 0
+        norms, all_norms = {}, []
         for name, p in self.named_parameters():
-            if p.requires_grad:
-                try:
-                    param_norm = p.grad.data.norm(norm_type)
-                    total_norm += param_norm ** norm_type
-                    norm = param_norm ** (1 / norm_type)
+            if p.grad is None:
+                continue
 
-                    grad = round(norm.data.cpu().numpy().flatten()[0], 3)
-                    results['grad_{}_norm_{}'.format(norm_type, name)] = grad
-                except Exception:
-                    # this param had no grad
-                    pass
+            param_norm = float(p.grad.data.norm(norm_type))
+            norms[f'grad_{norm_type}_norm_{name}'] = round(param_norm, 3)
 
-        total_norm = total_norm ** (1. / norm_type)
-        grad = round(total_norm.data.cpu().numpy().flatten()[0], 3)
-        results['grad_{}_norm_total'.format(norm_type)] = grad
-        return results
+            all_norms.append(param_norm)
+
+        total_norm = float(torch.tensor(all_norms).norm(norm_type))
+        norms[f'grad_{norm_type}_norm_total'] = round(total_norm, 3)
+
+        return norms

--- a/pytorch_lightning/core/grads.py
+++ b/pytorch_lightning/core/grads.py
@@ -9,7 +9,7 @@ import torch
 class GradInformation(torch.nn.Module):
 
     def grad_norm(self, norm_type: Union[float, int, str]) -> Dict[str, float]:
-        r"""Compute individual parameter's gradient norms and the overall norm.
+        """Compute each parameter's gradient's norm and their overall norm.
 
         The overall norm is computed over all gradients together, as if they
         were concatenated into a single vector.
@@ -19,9 +19,9 @@ class GradInformation(torch.nn.Module):
                 Can be ``'inf'`` for infinity norm.
 
         Return:
-            norms: The dictionary of p-norms each individual gradient and the a
-                special entry for the total p-norm of the parameters' gradients
-                viewed as a single vector.
+            norms: The dictionary of p-norms of each parameter's gradient and
+                a special entry for the total p-norm of the gradients viewed
+                as a single vector.
         """
         norm_type = float(norm_type)
 

--- a/pytorch_lightning/core/grads.py
+++ b/pytorch_lightning/core/grads.py
@@ -11,23 +11,17 @@ class GradInformation(torch.nn.Module):
     def grad_norm(self, norm_type: Union[float, int, str]) -> Dict[str, float]:
         r"""Compute individual parameter's gradient norms and the overall norm.
 
-        Parameters
-        ----------
-        norm_type: float, int, str:
-            The type of the used p-norm, cast to float if necessary. Can be
-            ``'inf'`` for infinity norm.
-
-        Returns
-        -------
-        norms: dict
-            The dictionary of p-norms each individual gradient and the a
-            special entry for the total p-norm of the parameters' gradients
-            viewed as a single vector.
-
-        Details
-        -------
         The overall norm is computed over all gradients together, as if they
         were concatenated into a single vector.
+
+        Args:
+            norm_type: The type of the used p-norm, cast to float if necessary.
+                Can be ``'inf'`` for infinity norm.
+
+        Return:
+            norms: The dictionary of p-norms each individual gradient and the a
+                special entry for the total p-norm of the parameters' gradients
+                viewed as a single vector.
         """
         norm_type = float(norm_type)
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -101,7 +101,7 @@ class Trainer(
             log_gpu_memory: Optional[str] = None,
             progress_bar_refresh_rate: int = 1,
             overfit_pct: float = 0.0,
-            track_grad_norm: int = -1,
+            track_grad_norm: Union[int, float, str] = -1,
             check_val_every_n_epoch: int = 1,
             fast_dev_run: bool = False,
             accumulate_grad_batches: Union[int, Dict[int, int], List[list]] = 1,
@@ -205,7 +205,7 @@ class Trainer(
 
             overfit_pct: How much of training-, validation-, and test dataset to check.
 
-            track_grad_norm: -1 no tracking. Otherwise tracks that norm
+            track_grad_norm: -1 no tracking. Otherwise tracks that p-norm. May be set to 'inf' infinity-norm.
 
             check_val_every_n_epoch: Check val every n train epochs.
 
@@ -341,7 +341,13 @@ class Trainer(
             self.gradient_clip = gradient_clip
 
         self.check_val_every_n_epoch = check_val_every_n_epoch
-        self.track_grad_norm = track_grad_norm
+
+        if not isinstance(track_grad_norm, (int, float)) \
+           and track_grad_norm != 'inf':
+            raise MisconfigurationException("track_grad_norm can be an int, a "
+                                            "float or 'inf' (infinity norm).")
+        self.track_grad_norm = float(track_grad_norm)
+
         self.on_gpu = True if (gpus and torch.cuda.is_available()) else False
 
         # tpu config

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -342,10 +342,9 @@ class Trainer(
 
         self.check_val_every_n_epoch = check_val_every_n_epoch
 
-        if not isinstance(track_grad_norm, (int, float)) \
-           and track_grad_norm != 'inf':
-            raise MisconfigurationException("track_grad_norm can be an int, a "
-                                            "float or 'inf' (infinity norm).")
+        if not isinstance(track_grad_norm, (int, float)) and track_grad_norm != 'inf':
+            raise MisconfigurationException(
+                "track_grad_norm can be an int, a float or 'inf' (infinity norm).")
         self.track_grad_norm = float(track_grad_norm)
 
         self.on_gpu = True if (gpus and torch.cuda.is_available()) else False

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -625,7 +625,7 @@ class TrainerTrainLoopMixin(ABC):
 
                     # track gradient norms when requested
                     if batch_idx % self.row_log_interval == 0:
-                        if self.track_grad_norm > 0:
+                        if float(self.track_grad_norm) > 0:
                             model = self.get_model()
                             grad_norm_dic = model.grad_norm(
                                 self.track_grad_norm)

--- a/tests/models/test_grad_norm.py
+++ b/tests/models/test_grad_norm.py
@@ -43,7 +43,7 @@ class OnlyMetricsListLogger(LightningLoggerBase):
 class ModelWithManualGradTracker(EvalModelTemplate):
     def __init__(self, norm_type, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.stored_grad_norms, self.norm_type = [], norm_type
+        self.stored_grad_norms, self.norm_type = [], float(norm_type)
 
     # validation spoils logger's metrics with `val_loss` records
     validation_step = None
@@ -76,8 +76,8 @@ class ModelWithManualGradTracker(EvalModelTemplate):
 
 
 @pytest.mark.parametrize("seed", [479_158_593])  # a vetted random number
-@pytest.mark.parametrize("norm_type", [1., 1.25, 1.5, 2, 3, 5, 10, float('inf')])
-def test_custom_logger(tmpdir, norm_type, seed, rtol=5e-3):
+@pytest.mark.parametrize("norm_type", [1., 1.25, 1.5, 2, 3, 5, 10, 'inf'])
+def test_grad_tracking(tmpdir, norm_type, seed, rtol=5e-3):
     # rtol=5e-3 respects the 3 decmials rounding in `.grad_norms` and above
 
     seed_everything(seed)

--- a/tests/models/test_grad_norm.py
+++ b/tests/models/test_grad_norm.py
@@ -1,0 +1,102 @@
+import torch
+import pytest
+import numpy as np
+
+from pytorch_lightning import Trainer
+
+from pytorch_lightning.loggers import LightningLoggerBase
+from pytorch_lightning.utilities import rank_zero_only
+
+from tests.base import EvalModelTemplate
+
+
+class OnlyMetricsListLogger(LightningLoggerBase):
+    def __init__(self):
+        super().__init__()
+        self.metrics = []
+
+    @rank_zero_only
+    def log_metrics(self, metrics, step):
+        self.metrics.append(metrics)
+
+    @property
+    def experiment(self):
+        return 'test'
+
+    @rank_zero_only
+    def log_hyperparams(self, params):
+        pass
+
+    @rank_zero_only
+    def finalize(self, status):
+        pass
+
+    @property
+    def name(self):
+        return 'name'
+
+    @property
+    def version(self):
+        return '1'
+
+
+class ModelWithManualGradTracker(EvalModelTemplate):
+    def __init__(self, norm_type, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.stored_grad_norms, self.norm_type = [], norm_type
+
+    # validation spoils logger's metrics with `val_loss` records
+    validation_step = None
+    val_dataloader = None
+
+    def training_step(self, batch, batch_idx, optimizer_idx=None):
+        # just return a loss, no log or progress bar meta
+        x, y = batch
+        loss_val = self.loss(y, self(x.flatten(1, -1)))
+        return {'loss': loss_val}
+
+    def on_after_backward(self):
+        out, norms = {}, []
+        prefix = f'grad_{self.norm_type}_norm_'
+        for name, p in self.named_parameters():
+            if p.grad is None:
+                continue
+
+            # `np.linalg.norm` implementation likely uses fp64 intermediates
+            flat = p.grad.data.cpu().numpy().ravel()
+            norm = np.linalg.norm(flat, self.norm_type)
+            norms.append(norm)
+
+            out[prefix + name] = round(norm, 3)
+
+        # handle total norm
+        norm = np.linalg.norm(norms, self.norm_type)
+        out[prefix + 'total'] = round(norm, 3)
+        self.stored_grad_norms.append(out)
+
+
+# @pytest.mark.skip(reason="might fail for small `norm_type` due to round-off")
+@pytest.mark.parametrize("norm_type", [1., 1.25, 1.5, 2, 3, 5, 10, float('inf')])
+def test_custom_logger(tmpdir, norm_type):
+    # use a custom grad tracking module and a list logger
+    model = ModelWithManualGradTracker(norm_type)
+    logger = OnlyMetricsListLogger()
+
+    result = Trainer(
+        max_epochs=3,
+        logger=logger,
+        track_grad_norm=norm_type,
+        row_log_interval=1,  # request grad_norms every batch
+    ).fit(model)
+
+    assert result == 1, "Training failed"
+    assert logger.metrics
+
+    # compare the logged metrics gainst tracked by the model on `.backward`
+    for mod, log in zip(model.stored_grad_norms, logger.metrics):
+        common = mod.keys() & log.keys()
+
+        log, mod = [log[k] for k in common], [mod[k] for k in common]
+
+        # 1e-3 respects the round-off in grad_norms and above
+        assert np.allclose(log, mod, rtol=5e-3)


### PR DESCRIPTION
There is a mistake in [grad_norms](https://github.com/PyTorchLightning/pytorch-lightning/blob/fdbbe968256f6c68a5dbb840a2004b77a618ef61/pytorch_lightning/core/grads.py#L11) in `core.grads.GradInformation`. The mistake affects the reported gradient norm for every individual parameters, but not the total norm. This PR fixes the erroneous computation.

According to torch [docs](https://pytorch.org/docs/stable/torch.html#torch.norm) `torch.norm(tensor, p)` computes the vector norm: either 2-norm, or `sum(abs(x)**p)**(1./p)` if p != 2, and flattens the tensor if required. Now `p.grad.data.norm` in [grads.py#L17](https://github.com/PyTorchLightning/pytorch-lightning/blob/fdbbe968256f6c68a5dbb840a2004b77a618ef61/pytorch_lightning/core/grads.py#L17) is the same as `torch.norm(p.grad.data, ...)`, and thus computes the norm. However on [grads.py#L19](https://github.com/PyTorchLightning/pytorch-lightning/blob/fdbbe968256f6c68a5dbb840a2004b77a618ef61/pytorch_lightning/core/grads.py#L19) grad tracker takes the `p-th` root again, essentially making `params_norm` equal to `sum(abs(x)**p)**(1./(p**2)) = norm**(1./p)` which is not correct.

The following snippet, which borrows code from grads.py#L17-L19
```python
import torch
import numpy as np

x = torch.randn(3, 4, 32, 32) * 0.1
for norm_type in [1., 1.5, 2., 4.]:
    # numpy reference value
    np_val = np.linalg.norm(x.numpy().ravel(), norm_type)

    # according to docs (and definition of p-norm)
    tr_val_naive = (abs(x) ** norm_type).sum().pow(1./norm_type)

    # almost verbatim from grads.py#L17-L19
    param_norm = x.norm(norm_type)
    grad_norm = param_norm ** (1./norm_type)

    print(f'numpy.norm = {float(np_val):4g}, '
          f'torch.naive = {float(tr_val_naive):4g}, '
          f'grad_norm = {float(grad_norm):4g}')
```
produces 
```
numpy.norm = 972.305, torch.naive = 972.305, grad_norm = 972.306
numpy.norm = 47.8891, torch.naive = 47.8891, grad_norm = 13.1874
numpy.norm = 11.0455, torch.naive = 11.0455, grad_norm = 3.32348
numpy.norm = 1.38376, torch.naive = 1.38376, grad_norm = 1.08459
```
which is clearly incorrect.