### PR TITLE
Fix local variables being collected into module_arguments dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed an issue where local variables were being collected into module_arguments ([#2048](https://github.com/PyTorchLightning/pytorch-lightning/pull/2048))
 
-- Fixed an issue with `auto_collect_arguments` not working for signatures that have the instance not named `self` ([#2048](https://github.com/PyTorchLightning/pytorch-lightning/pull/2048))
+- Fixed an issue with `auto_collect_arguments` collecting local variables that are not constructor arguments and not working for signatures that have the instance not named `self` ([#2048](https://github.com/PyTorchLightning/pytorch-lightning/pull/2048))
 
 ## [0.7.6] - 2020-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Allow use of same `WandbLogger` instance for multiple training loops ([#2055](https://github.com/PyTorchLightning/pytorch-lightning/pull/2055))
 
+- Fixed an issue where local variables were being collected into module_arguments ([#2048](https://github.com/PyTorchLightning/pytorch-lightning/pull/2048))
+
+- Fixed an issue with `auto_collect_arguments` not working for signatures that have the instance not named `self` ([#2048](https://github.com/PyTorchLightning/pytorch-lightning/pull/2048))
+
 ## [0.7.6] - 2020-05-16
 
 ### Added

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1701,8 +1701,8 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
     def auto_collect_arguments(self) -> None:
         """
         Collect all module arguments in the current constructor and all child constructors.
-        The child constructors are all the ``__init__`` methods that reach the current class with
-        by calling ``super().__init__()``.
+        The child constructors are all the ``__init__`` methods that reach the current class through
+        (chained) ``super().__init__()`` calls.
         """
         frame = inspect.currentframe()
 

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1707,13 +1707,15 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
         frame = inspect.currentframe()
 
         frame_args = _collect_init_args(frame.f_back, [])
-        child = _get_latest_child(frame)
+        self_arguments = frame_args[-1]
 
         # set module_arguments in child
-        child._module_self_arguments = frame_args[-1]
-        child._module_parents_arguments = {}
+        self._module_self_arguments = self_arguments
+        self._module_parents_arguments = {}
+
+        # add all arguments from parents
         for args in frame_args[:-1]:
-            child._module_parents_arguments.update(args)
+            self._module_parents_arguments.update(args)
 
     @property
     def module_arguments(self) -> dict:
@@ -1763,11 +1765,3 @@ def _collect_init_args(frame, path_args: list) -> list:
         return _collect_init_args(frame.f_back, path_args)
     else:
         return path_args
-
-
-def _get_latest_child(frame, child: object = None) -> object:
-    """Recursive search for lowest child."""
-    if 'self' in frame.f_locals:
-        return _get_latest_child(frame.f_back, frame.f_locals['self'])
-    else:
-        return child

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1762,7 +1762,6 @@ def _collect_init_args(frame, path_args: list) -> list:
 
         # only collect variables that appear in the signature
         local_args = {k: local_vars[k] for k in init_parameters.keys()}
-        local_args.update(local_args.get(varargs_identifier, {}))
         local_args.update(local_args.get(kwargs_identifier, {}))
         local_args = {k: v for k, v in local_args.items() if k not in exclude_argnames}
 

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1762,6 +1762,7 @@ def _collect_init_args(frame, path_args: list) -> list:
 
         # only collect variables that appear in the signature
         local_args = {k: local_vars[k] for k in init_parameters.keys()}
+        local_args.update(local_args.get(varargs_identifier, {}))
         local_args.update(local_args.get(kwargs_identifier, {}))
         local_args = {k: v for k, v in local_args.items() if k not in exclude_argnames}
 

--- a/tests/models/test_hparams.py
+++ b/tests/models/test_hparams.py
@@ -139,8 +139,8 @@ class LocalVariableModel1(EvalModelTemplate):
     """ This model has the super().__init__() call at the end. """
 
     def __init__(self, arg1, arg2, *args, **kwargs):
-        self.argument1 = arg1
-        arg1 = None  # arg2 intentionally not set
+        self.argument1 = arg1  # arg2 intentionally not set
+        arg1 = 'overwritten'
         local_var = 1234
         super().__init__(*args, **kwargs)  # this is intentionally here at the end
 
@@ -151,7 +151,7 @@ class LocalVariableModel2(EvalModelTemplate):
     def __init__(self, arg1, arg2, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.argument1 = arg1  # arg2 intentionally not set
-        arg1 = None
+        arg1 = 'overwritten'
         local_var = 1234
         self.auto_collect_arguments()  # this is intentionally here at the end
 
@@ -164,5 +164,5 @@ def test_collect_init_arguments_with_local_vars(cls):
     """ Tests that only the arguments are collected and not local variables. """
     model = cls(arg1=1, arg2=2)
     assert 'local_var' not in model.module_arguments
-    assert model.module_arguments['arg1'] is None
+    assert model.module_arguments['arg1'] == 'overwritten'
     assert model.module_arguments['arg2'] == 2

--- a/tests/models/test_hparams.py
+++ b/tests/models/test_hparams.py
@@ -73,6 +73,15 @@ class SubClassEvalModel(EvalModelTemplate):
         self.auto_collect_arguments()
 
 
+class SelfRenamedEvalModel(EvalModelTemplate):
+
+    def __init__(obj, *args, other_arg=300, **kwargs):  # intentionally named obj
+        super().__init__(*args, **kwargs)
+        obj.other_arg = other_arg
+        other_arg = 321
+        obj.auto_collect_arguments()
+
+
 class SubSubClassEvalModel(SubClassEvalModel):
     pass
 
@@ -85,10 +94,13 @@ class AggSubClassEvalModel(SubClassEvalModel):
         self.auto_collect_arguments()
 
 
-@pytest.mark.parametrize("cls", [EvalModelTemplate,
-                                 SubClassEvalModel,
-                                 SubSubClassEvalModel,
-                                 AggSubClassEvalModel])
+@pytest.mark.parametrize("cls", [
+    EvalModelTemplate,
+    SubClassEvalModel,
+    SubSubClassEvalModel,
+    AggSubClassEvalModel,
+    SelfRenamedEvalModel
+])
 def test_collect_init_arguments(tmpdir, cls):
     """ Test that the model automatically saves the arguments passed into the constructor """
     extra_args = dict(my_loss=torch.nn.CosineEmbeddingLoss()) if cls is AggSubClassEvalModel else {}

--- a/tests/models/test_hparams.py
+++ b/tests/models/test_hparams.py
@@ -44,14 +44,8 @@ def test_class_nesting(tmpdir):
     A().test()
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason='OmegaConf only for Python >= 3.8')
 def test_omegaconf(tmpdir):
-
-    # ogc only for 3.8
-    major = sys.version_info[0]
-    minor = sys.version_info[1]
-    if major < 3 and minor < 8:
-        return
-
     conf = OmegaConf.create({"k": "v", "list": [15.4, {"a": "1", "b": "2"}]})
     model = OmegaConfModel(conf)
 

--- a/tests/models/test_hparams.py
+++ b/tests/models/test_hparams.py
@@ -67,10 +67,12 @@ class SubClassEvalModel(EvalModelTemplate):
         self.auto_collect_arguments()
 
 
-class SelfRenamedEvalModel(EvalModelTemplate):
+class UnconventionalArgsEvalModel(EvalModelTemplate):
+    """ A model that has unconventional names for "self", "*args" and "**kwargs". """
 
-    def __init__(obj, *args, other_arg=300, **kwargs):  # intentionally named obj
-        super().__init__(*args, **kwargs)
+    def __init__(obj, *more_args, other_arg=300, **more_kwargs):
+        # intentionally named obj
+        super().__init__(*more_args, **more_kwargs)
         obj.other_arg = other_arg
         other_arg = 321
         obj.auto_collect_arguments()
@@ -93,7 +95,7 @@ class AggSubClassEvalModel(SubClassEvalModel):
     SubClassEvalModel,
     SubSubClassEvalModel,
     AggSubClassEvalModel,
-    SelfRenamedEvalModel
+    UnconventionalArgsEvalModel,
 ])
 def test_collect_init_arguments(tmpdir, cls):
     """ Test that the model automatically saves the arguments passed into the constructor """


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
     - not these changes specifically but it was discussed that we should fix any issues
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by blank line to reduce collisions -->

## What does this PR do?
Fixes issues 6 and 7 in #1937 

- local variables that are not also init args will not be collected
- "self", "*args" or "**kwargs" can now be renamed to something else  and collection still works
- removed the redundant recursive child search because the "self" instance is ALWAYS the most specific type anyway.

The new tests that I added fail on master, proofing that the this PR actually fixes the issue.
I will follow up with another PR that will add even more tests for things like multiple inheritance etc.
