### PR TITLE
Adding DictConfig check in `isinstance`

### DIFF
--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -9,7 +9,7 @@ import numpy as np
 import torch
 
 from pytorch_lightning.utilities import rank_zero_only
-
+from omegaconf import DictConfig
 
 class LightningLoggerBase(ABC):
     """
@@ -174,9 +174,9 @@ class LightningLoggerBase(ABC):
 
         def _dict_generator(input_dict, prefixes=None):
             prefixes = prefixes[:] if prefixes else []
-            if isinstance(input_dict, dict):
+            if isinstance(input_dict, (dict,DictConfig)):
                 for key, value in input_dict.items():
-                    if isinstance(value, (dict, Namespace)):
+                    if isinstance(value, (dict, Namespace,DictConfig)):
                         value = vars(value) if isinstance(value, Namespace) else value
                         for d in _dict_generator(value, prefixes + [key]):
                             yield d


### PR DESCRIPTION
Instead of checking only `dict`, adding the check for `DictConfig` so it can work with Hydra.

# Before submitting

- [ x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## What does this PR do?
Fixes #2058 .

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
