### PR TITLE
correct trainer.fit production example

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -817,7 +817,7 @@ class Trainer(
             train, val = DataLoader(...), DataLoader(...)
             trainer = Trainer()
             model = LightningModule()
-            trainer.fit(model, train_dataloader=train, val_dataloader=val)
+            trainer.fit(model, train_dataloader=train, val_dataloaders=val)
 
             # Option 1 & 2 can be mixed, for example the training set can be
             # defined as part of the model, and validation can then be feed to .fit()


### PR DESCRIPTION
trainer.fit uses the parameter `val_dataloaders` but in the documentation it is `val_dataloader`, which is invalid.

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [x] Did you write any new necessary tests?  
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## What does this PR do?
Fixes documentation for `trainer.fit` production use case that shows a wrong parameter

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
