### PR TITLE
Adds back the slow spawn ddp implementation that people want

### DIFF
--- a/docs/source/multi_gpu.rst
+++ b/docs/source/multi_gpu.rst
@@ -200,7 +200,8 @@ Distributed modes
 Lightning allows multiple ways of training
 
 - Data Parallel (`distributed_backend='dp'`) (multiple-gpus, 1 machine)
-- DistributedDataParallel (`distributed_backend='ddp'`) (multiple-gpus across many machines).
+- DistributedDataParallel (`distributed_backend='ddp'`) (multiple-gpus across many machines (python script based)).
+- DistributedDataParallel (`distributed_backend='ddp_spawn'`) (multiple-gpus across many machines (spawn based)).
 - DistributedDataParallel 2 (`distributed_backend='ddp2'`) (dp in a machine, ddp across machines).
 - Horovod (`distributed_backend='horovod'`) (multi-machine, multi-gpu, configured at runtime)
 - TPUs (`tpu_cores=8|x`) (tpu or TPU pod)
@@ -253,6 +254,25 @@ Distributed Data Parallel
     # train on 32 GPUs (4 nodes)
     trainer = Trainer(gpus=8, distributed_backend='ddp', num_nodes=4)
 
+This Lightning implementation of ddp calls your script under the hood multiple times with the correct environment
+variables. If your code does not support this (ie: jupyter notebook, colab, or a nested script without a root package),
+use `dp` or `ddp_spawn`
+
+.. code-block:: bash
+
+    # example for 3 GPUs ddp
+    MASTER_ADDR=localhost MASTER_PORT=random() WORLD_SIZE=3 NODE_RANK=0 LOCAL_RANK=0 python my_file.py --gpus 3 --etc
+    MASTER_ADDR=localhost MASTER_PORT=random() WORLD_SIZE=3 NODE_RANK=1 LOCAL_RANK=0 python my_file.py --gpus 3 --etc
+    MASTER_ADDR=localhost MASTER_PORT=random() WORLD_SIZE=3 NODE_RANK=2 LOCAL_RANK=0 python my_file.py --gpus 3 --etc
+
+The reason we use ddp this way is because `ddp_spawn` has a few limitations (because of Python and PyTorch):
+
+1. Since `.spawn()` trains the model in subprocesses, the model on the main process does not get updated.
+2. Dataloader(num_workers=N) where N is large bottlenecks training with ddp...
+  ie: it will be VERY slow or not work at all. This is a PyTorch limitation.
+
+However, if you don't mind these limitations, please use `ddp_spawn`.
+
 Distributed Data Parallel 2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In certain cases, it's advantageous to use all batches on the same machine instead of a subset.
@@ -274,6 +294,75 @@ In  this case, we can use ddp2 which behaves like dp in a machine and ddp across
 
     # train on 32 GPUs (4 nodes)
     trainer = Trainer(gpus=8, distributed_backend='ddp2', num_nodes=4)
+
+Distributed Data Parallel Spawn
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`ddp_spawn` is exactly like `ddp` except that it uses .spawn to start the training processes.
+
+.. warning:: It is STRONGLY recommended to use `ddp` for speed and performance.
+
+.. code-block:: python
+
+    mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model, ))
+
+Here's how to call this.
+
+.. code-block:: python
+
+    # train on 8 GPUs (same machine (ie: node))
+    trainer = Trainer(gpus=8, distributed_backend='ddp')
+
+Use this method if your script does not support being called from the command line (ie: it is nested without a root
+project module). However, we STRONGLY discourage this use because it has limitations (because of Python and PyTorch):
+
+1. The model you pass in will not update. Please save a checkpoint and restore from there.
+2. Set Dataloader(num_workers=0) or it will bottleneck training.
+
+`ddp` is MUCH faster than `ddp_spawn`. We recommend you install a top-level module for your project using setup.py
+
+.. code-block:: python
+
+    # setup.py
+    #!/usr/bin/env python
+
+    from setuptools import setup, find_packages
+
+    setup(name='src',
+          version='0.0.1',
+          description='Describe Your Cool Project',
+          author='',
+          author_email='',
+          url='https://github.com/YourSeed',  # REPLACE WITH YOUR OWN GITHUB PROJECT LINK
+          install_requires=[
+                'pytorch-lightning'
+          ],
+          packages=find_packages()
+          )
+
+Then setup your project like so:
+
+.. code-block:: bash
+
+    /project
+        /src
+            some_file.py
+            /or_a_folder
+        setup.py
+
+Then install as a root-level package
+
+.. code-block:: bash
+
+    cd /project
+    pip install -e .
+
+Now you can call your scripts anywhere
+
+.. code-block:: bash
+
+    cd /project/src
+    python some_file.py --distributed_backend 'ddp' --gpus 8
+
 
 Horovod
 ^^^^^^^
@@ -516,3 +605,8 @@ And then launch the elastic job with:
 
 See the official `PytorchElastic documentation <https://pytorch.org/elastic>`_ for details
 on installation and more use cases.
+
+Jupyter Notebooks
+-----------------
+Unfortunately any `ddp_` is not supported in jupyter notebooks. Please use `dp` for multiple GPUs. This is a known
+Jupyter issue. If you feel like taking a stab at adding this support, feel free to submit a PR!

--- a/docs/source/multi_gpu.rst
+++ b/docs/source/multi_gpu.rst
@@ -270,6 +270,7 @@ The reason we use ddp this way is because `ddp_spawn` has a few limitations (bec
 1. Since `.spawn()` trains the model in subprocesses, the model on the main process does not get updated.
 2. Dataloader(num_workers=N) where N is large bottlenecks training with ddp...
   ie: it will be VERY slow or not work at all. This is a PyTorch limitation.
+3. Forces everything to be picklable.
 
 However, if you don't mind these limitations, please use `ddp_spawn`.
 
@@ -610,3 +611,18 @@ Jupyter Notebooks
 -----------------
 Unfortunately any `ddp_` is not supported in jupyter notebooks. Please use `dp` for multiple GPUs. This is a known
 Jupyter issue. If you feel like taking a stab at adding this support, feel free to submit a PR!
+
+Pickle Errors
+--------------
+Multi-GPU training sometimes requires your model to be pickled. If you run into an issue with pickling
+try the following to figure out the issue
+
+.. code-block:: python
+
+    import pickle
+
+    model = YourModel()
+    pickle.dumps(model)
+
+However, if you use `ddp` the pickling requirement is not there and you should be fine. If you use `ddp_spawn` the
+pickling requirement remains. This is a limitation of Python.

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -139,6 +139,7 @@ class TrainerDataLoadingMixin(ABC):
         else:
             world_size = {
                 'ddp': self.num_nodes * self.num_processes,
+                'ddp_spawn': self.num_nodes * self.num_processes,
                 'ddp2': self.num_nodes,
                 'ddp_cpu': self.num_processes * self.num_nodes
             }

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -378,6 +378,7 @@ class TrainerDDPMixin(ABC):
 
         self.interactive_ddp_procs = []
         for local_rank in range(1, self.num_processes):
+            print('launching local_rank', local_rank)
             env_copy = os.environ.copy()
             env_copy['LOCAL_RANK'] = f'{local_rank}'
 

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -470,10 +470,6 @@ class TrainerDDPMixin(ABC):
         # continue training routine
         self.run_pretrain_routine(model)
 
-        # spawn removed the memory from the model
-        if self.distributed_backend == 'ddp_spawn':
-            self.save_spawn_weights(model)
-
     def save_spawn_weights(self, model):
         """
         Dump a temporary checkpoint after ddp ends to get weights out of the process

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -471,6 +471,7 @@ class TrainerDDPMixin(ABC):
         model = model.configure_ddp(model, device_ids)
 
         # continue training routine
+        print('-'*100)
         print('training')
         self.run_pretrain_routine(model)
 

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -457,7 +457,7 @@ class TrainerDDPMixin(ABC):
             self.reinit_scheduler_properties(self.optimizers, self.lr_schedulers)
 
         # DDP2 uses all GPUs on the machine
-        if self.distributed_backend == 'ddp':
+        if self.distributed_backend == 'ddp' or self.distributed_backend == 'ddp_spawn':
             device_ids = [self.root_gpu]
         elif self.use_ddp2:
             device_ids = self.data_parallel_device_ids

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -427,7 +427,13 @@ class TrainerDDPMixin(ABC):
         # try to init for 20 times at max in case ports are taken
         # where to store ip_table
         model.trainer = self
+        print('-'*100)
+        print('starting ddp')
+        print('-'*100)
         model.init_ddp_connection(self.proc_rank, self.world_size, self.is_slurm_managing_tasks)
+        print('-'*100)
+        print('ddp started')
+        print('-'*100)
 
         # CHOOSE OPTIMIZER
         # allow for lr schedulers as well

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -465,7 +465,7 @@ class TrainerDDPMixin(ABC):
             device_ids = None
 
         # allow user to configure ddp
-        print('configuring ddp')
+        print('configuring ddp', device_ids, self.root_gpu)
         model = model.configure_ddp(model, device_ids)
 
         # continue training routine

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -467,7 +467,9 @@ class TrainerDDPMixin(ABC):
             device_ids = None
 
         # allow user to configure ddp
+        print('-'*100)
         print('configuring ddp', device_ids, self.root_gpu)
+        print('-'*100)
         model = model.configure_ddp(model, device_ids)
 
         # continue training routine

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -402,6 +402,7 @@ class TrainerDDPMixin(ABC):
         :param cluster_obj:
         :return:
         """
+        print('ddp_train', process_idx)
         # offset the process id if requested
         process_idx = process_idx + proc_offset
 

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -392,6 +392,7 @@ class TrainerDDPMixin(ABC):
             sleep(delay)
 
         local_rank = 0
+        import pdb; pdb.set_trace()
         self.ddp_train(local_rank, model, is_master=True)
 
     def ddp_train(self, process_idx, model, is_master=False, proc_offset=0):

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -221,7 +221,7 @@ class TrainerDDPMixin(ABC):
             elif self.num_gpus > 1:
                 self.use_dp = True
 
-        elif distributed_backend == "ddp":
+        elif distributed_backend in ['ddp', 'ddp_spawn']:
             if self.num_gpus == 0:
                 if self.num_nodes > 1 or self.num_processes > 1:
                     self.use_ddp = True  # ddp_cpu

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -392,7 +392,6 @@ class TrainerDDPMixin(ABC):
             sleep(delay)
 
         local_rank = 0
-        import pdb; pdb.set_trace()
         self.ddp_train(local_rank, model, is_master=True)
 
     def ddp_train(self, process_idx, model, is_master=False, proc_offset=0):
@@ -466,9 +465,11 @@ class TrainerDDPMixin(ABC):
             device_ids = None
 
         # allow user to configure ddp
+        print('configuring ddp')
         model = model.configure_ddp(model, device_ids)
 
         # continue training routine
+        print('training')
         self.run_pretrain_routine(model)
 
     def save_spawn_weights(self, model):

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -403,7 +403,6 @@ class TrainerDDPMixin(ABC):
         :param cluster_obj:
         :return:
         """
-        print('ddp_train', process_idx)
         # offset the process id if requested
         process_idx = process_idx + proc_offset
 
@@ -427,13 +426,7 @@ class TrainerDDPMixin(ABC):
         # try to init for 20 times at max in case ports are taken
         # where to store ip_table
         model.trainer = self
-        print('-'*100)
-        print('starting ddp')
-        print('-'*100)
         model.init_ddp_connection(self.proc_rank, self.world_size, self.is_slurm_managing_tasks)
-        print('-'*100)
-        print('ddp started')
-        print('-'*100)
 
         # CHOOSE OPTIMIZER
         # allow for lr schedulers as well
@@ -473,14 +466,9 @@ class TrainerDDPMixin(ABC):
             device_ids = None
 
         # allow user to configure ddp
-        print('-'*100)
-        print('configuring ddp', device_ids, self.root_gpu)
-        print('-'*100)
         model = model.configure_ddp(model, device_ids)
 
         # continue training routine
-        print('-'*100)
-        print('training')
         self.run_pretrain_routine(model)
 
     def save_spawn_weights(self, model):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -882,10 +882,10 @@ class Trainer(
 
             elif self.distributed_backend == 'ddp_spawn':
                 # spin up peers
-                mp.spawn(self.ddp_train, nprocs=self.num_processes - 1, args=(model, False), join=False)
+                mp.spawn(self.ddp_train, nprocs=self.num_processes - 1, args=(model, False, 1), join=False)
 
                 # stay in context for main proc
-                self.ddp_train(process_idx=self.num_processes, is_master=True)
+                self.ddp_train(process_idx=0, model=model, is_master=True)
 
             elif self.distributed_backend == 'ddp':
                 print('starting spawn children')

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -246,7 +246,7 @@ class Trainer(
 
                     Use `row_log_interval` instead. Will remove 0.9.0.
 
-            distributed_backend: The distributed backend to use.
+            distributed_backend: The distributed backend to use (dp, ddp, ddp2, ddp_spawn)
 
             use_amp:
                 .. warning:: .. deprecated:: 0.7.0

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -882,7 +882,7 @@ class Trainer(
 
             elif self.distributed_backend == 'ddp_spawn':
                 # spin up peers
-                mp.spawn(self.ddp_train, nprocs=self.num_processes - 1, args=(model, False, 1), join=False)
+                mp.spawn(self.ddp_train, nprocs=self.num_processes - 1, args=(model, False, 1, ), join=False)
 
                 # stay in context for main proc
                 self.ddp_train(process_idx=self.num_processes, is_master=True)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -882,7 +882,7 @@ class Trainer(
 
             elif self.distributed_backend == 'ddp_spawn':
                 # spin up peers
-                mp.spawn(self.ddp_train, nprocs=self.num_processes - 1, args=(model, False, 1), join=False)
+                mp.spawn(self.ddp_train, nprocs=self.num_processes - 1, args=(model, False, 1))
 
                 # stay in context for main proc
                 self.ddp_train(process_idx=0, model=model, is_master=True)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -882,7 +882,7 @@ class Trainer(
 
             elif self.distributed_backend == 'ddp_spawn':
                 # spin up peers
-                mp.spawn(self.ddp_train, nprocs=self.num_processes-1, args=(model, False, 1), join=False)
+                mp.spawn(self.ddp_train, nprocs=self.num_processes - 1, args=(model, False, 1), join=False)
 
                 # stay in context for main proc
                 self.ddp_train(process_idx=self.num_processes, is_master=True)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -885,6 +885,8 @@ class Trainer(
                 mp.spawn(self.ddp_train, nprocs=self.num_processes - 1, args=(model, False, 1))
 
                 # stay in context for main proc
+                print('*'*100)
+                print('main proc start')
                 self.ddp_train(process_idx=0, model=model, is_master=True)
 
             elif self.distributed_backend == 'ddp':

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -882,7 +882,7 @@ class Trainer(
 
             elif self.distributed_backend == 'ddp_spawn':
                 # spin up peers
-                mp.spawn(self.ddp_train, nprocs=self.num_processes - 1, args=(model, False, 1, ), join=False)
+                mp.spawn(self.ddp_train, nprocs=self.num_processes - 1, args=(model, False), join=False)
 
                 # stay in context for main proc
                 self.ddp_train(process_idx=self.num_processes, is_master=True)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -881,7 +881,7 @@ class Trainer(
                 mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model,))
 
             elif self.distributed_backend == 'ddp_spawn':
-                model.share_memory()
+                # model.share_memory()
 
                 # spin up peers
                 mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model, ))

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -881,13 +881,10 @@ class Trainer(
                 mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model,))
 
             elif self.distributed_backend == 'ddp_spawn':
-                # spin up peers
-                mp.spawn(self.ddp_train, nprocs=self.num_processes - 1, args=(model, False, 1))
+                model.share_memory()
 
-                # stay in context for main proc
-                print('*'*100)
-                print('main proc start')
-                self.ddp_train(process_idx=0, model=model, is_master=True)
+                # spin up peers
+                mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model, ))
 
             elif self.distributed_backend == 'ddp':
                 print('starting spawn children')

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -888,6 +888,7 @@ class Trainer(
                 self.ddp_train(process_idx=self.num_processes, is_master=True)
 
             elif self.distributed_backend == 'ddp':
+                print('starting spawn children')
                 self.spawn_ddp_children(model)
 
         # 1 gpu or dp option triggers training using DP module

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -880,11 +880,11 @@ class Trainer(
                 self.model = model
                 mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model,))
 
-            elif self.distributed_backend == 'ddp_spawn':
+            elif self.distributed_backend == 'ddp_fork':
                 model.share_memory()
 
                 # spin up peers
-                mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model, ))
+                mp.start_processes(self.ddp_train, nprocs=self.num_processes, args=(model, ), start_method='fork')
 
             elif self.distributed_backend == 'ddp':
                 self.spawn_ddp_children(model)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -884,7 +884,7 @@ class Trainer(
                 model.share_memory()
 
                 # spin up peers
-                mp.start_processes(self.ddp_train, nprocs=self.num_processes, args=(model, ), start_method='fork')
+                mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model, ))
 
             elif self.distributed_backend == 'ddp':
                 self.spawn_ddp_children(model)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -887,7 +887,6 @@ class Trainer(
                 mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model, ))
 
             elif self.distributed_backend == 'ddp':
-                print('starting spawn children')
                 self.spawn_ddp_children(model)
 
         # 1 gpu or dp option triggers training using DP module

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -880,7 +880,7 @@ class Trainer(
                 self.model = model
                 mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model,))
 
-            elif self.distributed_backend == 'ddp_fork':
+            elif self.distributed_backend == 'ddp_spawn':
                 model.share_memory()
 
                 # spin up peers

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -881,7 +881,7 @@ class Trainer(
                 mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model,))
 
             elif self.distributed_backend == 'ddp_spawn':
-                # model.share_memory()
+                model.share_memory()
 
                 # spin up peers
                 mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model, ))


### PR DESCRIPTION
the implementation with .spawn has many issues

- original model does not retain weights.
- dataloader num_workers doesn't scale well.

This PR adds back this implementation under 'ddp_spawn' but keeps the much faster, script-based version 'ddp' as default.

FIxes #2116 
Fixes #2104 (use ddp_spawn in the meantime)
Fixes #2092 
Fixes #2086 
Fixes #2085 