### PR TITLE
Add example to README.md for fine-tuning BERT etc for QA datasets like Squad

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Check out this awesome list of research papers and implementations done with Lig
 - [Transformers transfer learning (Huggingface)](https://colab.research.google.com/drive/1F_RNcHzTfFuQf-LeKvSlud6x7jXYkG31#scrollTo=yr7eaxkF-djf)
 - [Transformers text classification](https://github.com/ricardorei/lightning-text-classification)
 - [VAE Library of over 18+ VAE flavors](https://github.com/AntixK/PyTorch-VAE)
+- [Finetune BERT, RoBERTa etc on QA Datasets like SQuAD](https://github.com/tshrjn/Finetune-QA/)
 
 ## Tutorials
 Check out our [introduction guide](https://pytorch-lightning.readthedocs.io/en/latest/introduction_guide.html) to get started.


### PR DESCRIPTION
Add a GitHub repo link as an example in the  README.md for fine-tuning BERT, RoBERTa etc for QA datasets like SQuAd.