### PR TITLE
Remove explicit flush from tensorboard logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Remove explicit flush from tensorboard logger ([#2126] https://github.com/PyTorchLightning/pytorch-lightning/pull/2126)
+
 - Add Metric Base Classes ([#1326](https://github.com/PyTorchLightning/pytorch-lightning/pull/1326), [#1877](https://github.com/PyTorchLightning/pytorch-lightning/pull/1877))
 
 - Added type hints in `Trainer.fit()` and `Trainer.test()` to reflect that also a list of dataloaders can be passed in ([#1723](https://github.com/PyTorchLightning/pytorch-lightning/pull/1723))

--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -144,12 +144,6 @@ class TensorBoardLogger(LightningLoggerBase):
     @rank_zero_only
     def save(self) -> None:
         super().save()
-        try:
-            self.experiment.flush()
-        except AttributeError:
-            # you are using PT version (<v1.2) which does not have implemented flush
-            self.experiment._get_file_writer().flush()
-
         dir_path = self.log_dir
         if not os.path.isdir(dir_path):
             dir_path = self.save_dir


### PR DESCRIPTION
The explicit flushing has caused downstream bugs and is unnecessary because it's asynchronously flushed by the file writer anyway. See: https://github.com/tensorflow/tensorboard/blob/74214c309f72c4ecab000a983efb224679dfff73/tensorboard/summary/writer/event_file_writer.py#L160