### PR TITLE
Finish Ananthsub patch 1 (enable prepare_data from correct processes). clarify local vs global rank

### DIFF
--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -228,7 +228,7 @@ class ModelCheckpoint(Callback):
     @rank_zero_only
     def on_validation_end(self, trainer, pl_module):
         # only run on main process
-        if trainer.proc_rank != 0:
+        if trainer.global_rank != 0:
             return
 
         metrics = trainer.callback_metrics

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -990,9 +990,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
 
                     return model, optimizers
         """
-        model, optimizers = amp.initialize(
-            model, optimizers, opt_level=amp_level,
-        )
+        model, optimizers = amp.initialize(model, optimizers, opt_level=amp_level)
 
         return model, optimizers
 

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -933,7 +933,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
         for SLURM managed cluster.
 
         Args:
-            global_rank: The current process rank within the node (local_rank).
+            global_rank: The global process idx.
             world_size: Number of GPUs being use across all nodes. (num_nodes * num_gpus).
             is_slurm_managing_tasks: is cluster managed by SLURM.
 

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -99,7 +99,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
                     self.print(x, 'in forward')
 
         """
-        if self.trainer.proc_rank == 0:
+        if self.trainer.global_rank == 0:
             print(*args, **kwargs)
 
     @abstractmethod
@@ -933,7 +933,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
         for SLURM managed cluster.
 
         Args:
-            proc_rank: The current process rank within the node.
+            proc_rank: The current process rank within the node (local_rank).
             world_size: Number of GPUs being use across all nodes. (num_nodes * num_gpus).
             is_slurm_managing_tasks: is cluster managed by SLURM.
 
@@ -990,7 +990,9 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
 
                     return model, optimizers
         """
-        model, optimizers = amp.initialize(model, optimizers, opt_level=amp_level)
+        model, optimizers = amp.initialize(
+            model, optimizers, opt_level=amp_level,
+        )
 
         return model, optimizers
 

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -99,7 +99,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
                     self.print(x, 'in forward')
 
         """
-        if self.trainer.global_rank == 0:
+        if self.trainer.is_global_zero:
             print(*args, **kwargs)
 
     @abstractmethod

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -922,7 +922,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
 
     def init_ddp_connection(
             self,
-            proc_rank: int,
+            global_rank: int,
             world_size: int,
             is_slurm_managing_tasks: bool = True
     ) -> None:
@@ -933,7 +933,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
         for SLURM managed cluster.
 
         Args:
-            proc_rank: The current process rank within the node (local_rank).
+            global_rank: The current process rank within the node (local_rank).
             world_size: Number of GPUs being use across all nodes. (num_nodes * num_gpus).
             is_slurm_managing_tasks: is cluster managed by SLURM.
 
@@ -956,8 +956,8 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
                         f"is not equal to the computed world size ({world_size}). Ignored.")
 
         torch_backend = "nccl" if self.trainer.on_gpu else "gloo"
-        log.info(f"initializing ddp: LOCAL_RANK: {proc_rank}/{world_size - 1} WORLD_SIZE:{world_size}")
-        torch_distrib.init_process_group(torch_backend, rank=proc_rank, world_size=world_size)
+        log.info(f"initializing ddp: GLOBAL_RANK: {global_rank}, MEMBER: {global_rank+1}/{world_size}")
+        torch_distrib.init_process_group(torch_backend, rank=global_rank, world_size=world_size)
 
     def configure_apex(
             self,

--- a/pytorch_lightning/trainer/__init__.py
+++ b/pytorch_lightning/trainer/__init__.py
@@ -585,6 +585,11 @@ Example::
     --env=XLA_USE_BF16=1
     -- python your_trainer_file.py
 
+prepare_data_per_node
+^^^^^^^^^^^^^^^^^^^^^
+If True will call `prepare_data()` on LOCAL_RANK=0 for every node.
+If False will only call from NODE_RANK=0, LOCAL_RANK=0
+
 tpu_cores
 ^^^^^^^^^
 - How many TPU cores to train on (1 or 8).

--- a/pytorch_lightning/trainer/__init__.py
+++ b/pytorch_lightning/trainer/__init__.py
@@ -590,6 +590,14 @@ prepare_data_per_node
 If True will call `prepare_data()` on LOCAL_RANK=0 for every node.
 If False will only call from NODE_RANK=0, LOCAL_RANK=0
 
+Example::
+
+    # default
+    Trainer(prepare_data_per_node=True)
+
+    # use only NODE_RANK=0, LOCAL_RANK=0
+    Trainer(prepare_data_per_node=False)
+
 tpu_cores
 ^^^^^^^^^
 - How many TPU cores to train on (1 or 8).

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -57,7 +57,7 @@ class TrainerDataLoadingMixin(ABC):
 
     # this is just a summary on variables used in this abstract class,
     #  the proper values/initialisation should be done in child class
-    proc_rank: int
+    global_rank: int
     use_ddp: bool
     use_ddp2: bool
     use_horovod: bool
@@ -147,7 +147,7 @@ class TrainerDataLoadingMixin(ABC):
                 'ddp_cpu': self.num_processes * self.num_nodes
             }
             assert self.distributed_backend is not None
-            kwargs = dict(num_replicas=world_size[self.distributed_backend], rank=self.proc_rank)
+            kwargs = dict(num_replicas=world_size[self.distributed_backend], rank=self.global_rank)
         sampler = DistributedSampler(dataloader.dataset, **kwargs)
         return sampler
 

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -304,7 +304,7 @@ class TrainerDDPMixin(ABC):
         if self.is_slurm_managing_tasks:
             log.info('Multi-processing is handled by Slurm.')
 
-    def determin_local_rank(self):
+    def determine_local_rank(self):
         if self.is_slurm_managing_tasks:
             return int(os.environ['SLURM_LOCALID'])
 

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -455,6 +455,7 @@ class TrainerDDPMixin(ABC):
         # on world_size=0 let everyone know training is starting
         if self.is_global_zero:
             log.info('-' * 100)
+            log.info(f'distributed_backend={self.distributed_backend}')
             log.info(f'All DDP processes registered. Starting ddp with {self.world_size} processes')
             log.info('-' * 100)
 

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -166,6 +166,10 @@ class TrainerDDPMixin(ABC):
     node_rank: int
 
     @property
+    def is_global_zero(self) -> int:
+        """Warning: this is just empty shell for code implemented in other class."""
+
+    @property
     @abstractmethod
     def num_gpus(self) -> int:
         """Warning: this is just empty shell for code implemented in other class."""

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -300,6 +300,13 @@ class TrainerDDPMixin(ABC):
         if self.is_slurm_managing_tasks:
             log.info('Multi-processing is handled by Slurm.')
 
+    def determin_local_rank(self):
+        if self.is_slurm_managing_tasks:
+            return int(os.environ['SLURM_LOCALID'])
+
+        else:
+            return int(os.environ.get('LOCAL_RANK', 0))
+
     def determine_ddp_node_rank(self):
         if self.is_slurm_managing_tasks:
             return int(os.environ['SLURM_NODEID'])

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -450,9 +450,9 @@ class TrainerDDPMixin(ABC):
 
         # on world_size=0 let everyone know training is starting
         if self.is_global_zero:
-            log.info('-'*100)
+            log.info('-' * 100)
             log.info(f'All DDP processes registered. Starting ddp with {self.world_size} processes')
-            log.info('-'*100)
+            log.info('-' * 100)
 
         # CHOOSE OPTIMIZER
         # allow for lr schedulers as well

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -449,7 +449,7 @@ class TrainerDDPMixin(ABC):
         model.init_ddp_connection(self.global_rank, self.world_size, self.is_slurm_managing_tasks)
 
         # on world_size=0 let everyone know training is starting
-        if self.global_rank == 0:
+        if self.is_global_zero:
             log.info('-'*100)
             log.info(f'All DDP processes registered. Starting ddp with {self.world_size} processes')
             log.info('-'*100)
@@ -502,7 +502,7 @@ class TrainerDDPMixin(ABC):
         :param model:
         :return:
         """
-        if self.global_rank == 0:
+        if self.is_global_zero:
             path = os.path.join(self.default_root_dir, '__temp_weight_ddp_end.ckpt')
             self.save_checkpoint(path)
 
@@ -516,7 +516,7 @@ class TrainerDDPMixin(ABC):
 
         loaded_model = original_model
 
-        if self.global_rank == 0:
+        if self.is_global_zero:
             # load weights saved in ddp
             path = os.path.join(self.default_root_dir, '__temp_weight_ddp_end.ckpt')
             loaded_model = original_model.__class__.load_from_checkpoint(path)

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -57,7 +57,7 @@ class TrainerDPMixin(ABC):
     root_gpu: ...
     amp_level: str
     precision: ...
-    proc_rank: int
+    global_rank: int
     tpu_local_core_rank: int
     tpu_global_core_rank: int
     use_tpu: bool
@@ -183,8 +183,8 @@ class TrainerDPMixin(ABC):
         if self.tpu_global_core_rank != 0 and self.progress_bar_callback is not None:
             self.progress_bar_callback.disable()
 
-        self.proc_rank = self.tpu_local_core_rank
-        rank_zero_only.rank = self.proc_rank
+        self.global_rank = self.tpu_local_core_rank
+        rank_zero_only.rank = self.global_rank
 
         # CHOOSE OPTIMIZER
         # allow for lr schedulers as well
@@ -289,8 +289,8 @@ class TrainerDPMixin(ABC):
 
         # Update logger rank info from Horovod to avoid race conditions from  different ranks
         # creating directories / writing files in the same locations.
-        self.proc_rank = hvd.rank()
-        rank_zero_only.rank = self.proc_rank
+        self.global_rank = hvd.rank()
+        rank_zero_only.rank = self.global_rank
 
         with ExitStack() as stack:
             for optimizer in self.optimizers:

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -375,7 +375,7 @@ class TrainerEvaluationLoopMixin(ABC):
         self.add_progress_bar_metrics(prog_bar_metrics)
 
         # log results of test
-        if test_mode and self.global_rank == 0:
+        if test_mode and self.is_global_zero:
             print('-' * 80)
             print('TEST RESULTS')
             pprint(callback_metrics)

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -191,7 +191,7 @@ class TrainerEvaluationLoopMixin(ABC):
         """Warning: this is just empty shell for code implemented in other class."""
 
     @abstractmethod
-    def get_model(self):
+    def get_model(self) -> LightningModule:
         """Warning: this is just empty shell for code implemented in other class."""
 
     @abstractmethod

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -124,13 +124,12 @@ In this second case, the options you pass to trainer will be used when running
 
 from abc import ABC, abstractmethod
 from pprint import pprint
-from typing import Callable, Optional
+from typing import Callable
 
 import torch
 from torch.utils.data import DataLoader
 
 from pytorch_lightning.core.lightning import LightningModule
-from pytorch_lightning.profiler.profilers import BaseProfiler
 from pytorch_lightning.overrides.data_parallel import LightningDistributedDataParallel, LightningDataParallel
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities import rank_zero_warn
@@ -160,8 +159,6 @@ class TrainerEvaluationLoopMixin(ABC):
     use_dp: bool
     use_ddp2: bool
     use_horovod: bool
-    use_amp: bool
-    use_native_amp: bool
     single_gpu: bool
     data_parallel_device_ids: ...
     model: LightningModule
@@ -170,15 +167,14 @@ class TrainerEvaluationLoopMixin(ABC):
     fast_dev_run: ...
     process_output: ...
     progress_bar_dict: ...
-    proc_rank: int
+    global_rank: int
     current_epoch: int
     callback_metrics: ...
     test_dataloaders: DataLoader
     val_dataloaders: DataLoader
     use_tpu: bool
     reload_dataloaders_every_epoch: ...
-    tpu_id: Optional[int]
-    profiler: BaseProfiler
+    tpu_id: int
 
     # Callback system
     on_validation_batch_start: Callable
@@ -195,7 +191,7 @@ class TrainerEvaluationLoopMixin(ABC):
         """Warning: this is just empty shell for code implemented in other class."""
 
     @abstractmethod
-    def get_model(self) -> LightningModule:
+    def get_model(self):
         """Warning: this is just empty shell for code implemented in other class."""
 
     @abstractmethod
@@ -379,7 +375,7 @@ class TrainerEvaluationLoopMixin(ABC):
         self.add_progress_bar_metrics(prog_bar_metrics)
 
         # log results of test
-        if test_mode and self.proc_rank == 0:
+        if test_mode and self.global_rank == 0:
             print('-' * 80)
             print('TEST RESULTS')
             pprint(callback_metrics)

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -124,7 +124,7 @@ In this second case, the options you pass to trainer will be used when running
 
 from abc import ABC, abstractmethod
 from pprint import pprint
-from typing import Callable
+from typing import Callable, Optional
 
 import torch
 from torch.utils.data import DataLoader

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import Iterable, Optional
+from typing import Union, Iterable
 
 import torch
 
@@ -15,10 +15,10 @@ class TrainerLoggingMixin(ABC):
     current_epoch: int
     on_gpu: bool
     log_gpu_memory: ...
-    logger: Optional[LightningLoggerBase]
+    logger: Union[LightningLoggerBase, bool]
     progress_bar_metrics: ...
     global_step: int
-    proc_rank: int
+    global_rank: int
     use_dp: bool
     use_ddp2: bool
     default_root_dir: str
@@ -69,7 +69,7 @@ class TrainerLoggingMixin(ABC):
             scalar_metrics['epoch'] = self.current_epoch
             step = step if step is not None else self.global_step
         # log actual metrics
-        if self.proc_rank == 0 and self.logger is not None:
+        if self.global_rank == 0 and self.logger is not None:
             self.logger.agg_and_log_metrics(scalar_metrics, step=step)
             self.logger.save()
 

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -69,7 +69,7 @@ class TrainerLoggingMixin(ABC):
             scalar_metrics['epoch'] = self.current_epoch
             step = step if step is not None else self.global_step
         # log actual metrics
-        if self.global_rank == 0 and self.logger is not None:
+        if self.is_global_zero and self.logger is not None:
             self.logger.agg_and_log_metrics(scalar_metrics, step=step)
             self.logger.save()
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -528,7 +528,7 @@ class Trainer(
         Examples:
             >>> args = Trainer.get_init_arguments_and_types()
             >>> import pprint
-            >>> pprint.pprint(sorted(args))
+            >>> pprint.pprint(sorted(args))  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
             [('accumulate_grad_batches',
               (<class 'int'>, typing.Dict[int, int], typing.List[list]),
               1),

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -488,6 +488,10 @@ class Trainer(
         self.on_init_end()
 
     @property
+    def is_global_zero(self):
+        return self.is_global_zero
+
+    @property
     def slurm_job_id(self) -> Optional[int]:
         try:
             job_id = os.environ['SLURM_JOB_ID']
@@ -942,7 +946,7 @@ class Trainer(
 
         # print model summary
         # TODO: remove self.testing condition because model.summarize() is wiping out the weights
-        if self.global_rank == 0 and self.weights_summary is not None and not self.testing:
+        if self.is_global_zero and self.weights_summary is not None and not self.testing:
             if self.weights_summary in ['full', 'top']:
                 ref_model.summarize(mode=self.weights_summary)
             else:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -489,7 +489,7 @@ class Trainer(
 
     @property
     def is_global_zero(self):
-        return self.is_global_zero
+        return self.global_rank == 0
 
     @property
     def slurm_job_id(self) -> Optional[int]:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -444,7 +444,6 @@ class Trainer(
             self.init_tpu()
 
         # init flags for SLURM+ddp to work
-        self.global_rank = 0
         self.world_size = 1
         self.interactive_ddp_procs = []
         self.configure_slurm_ddp(self.num_nodes)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -788,7 +788,7 @@ class Trainer(
         if self.can_prepare_data():
             model.prepare_data()
             self._is_data_prepared = True
-            
+
         # Run auto batch size scaling
         if self.auto_scale_batch_size:
             if isinstance(self.auto_scale_batch_size, bool):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -448,7 +448,7 @@ class Trainer(
         self.interactive_ddp_procs = []
         self.configure_slurm_ddp(self.num_nodes)
         self.node_rank = self.determine_ddp_node_rank()
-        self.local_rank = self.determin_local_rank()
+        self.local_rank = self.determine_local_rank()
         self.global_rank = 0
 
         # nvidia setup

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -123,7 +123,7 @@ class Trainer(
         replace_sampler_ddp: bool = True,
         terminate_on_nan: bool = False,
         auto_scale_batch_size: Union[str, bool] = False,
-        prepare_data_per_node: bool = False,
+        prepare_data_per_node: bool = True,
         amp_level: str = 'O1',  # backward compatible, todo: remove in v1.0.0
         num_tpu_cores: Optional[int] = None,  # backward compatible, todo: remove in v0.9.0
         use_amp=None,  # backward compatible, todo: remove in v0.9.0

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -542,6 +542,7 @@ class Trainer(
              ('max_epochs', (<class 'int'>,), 1000),
              ...
              ('precision', (<class 'int'>,), 32),
+             ('prepare_data_per_node', (<class 'bool'>,), True),
              ('print_nan_grads', (<class 'bool'>,), False),
              ('process_position', (<class 'int'>,), 0),
              ('profiler',

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -528,7 +528,7 @@ class Trainer(
         Examples:
             >>> args = Trainer.get_init_arguments_and_types()
             >>> import pprint
-            >>> pprint.pprint(sorted(args))  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+            >>> pprint.pprint(sorted(args))
             [('accumulate_grad_batches',
               (<class 'int'>, typing.Dict[int, int], typing.List[list]),
               1),

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -888,8 +888,7 @@ class Trainer(
             return self.local_rank == 0
 
         else:
-            if self.node_rank == 0 and self.local_rank == 0:
-                return
+            return self.node_rank == 0 and self.local_rank == 0
 
     def __attach_dataloaders(self, model, train_dataloader=None, val_dataloaders=None, test_dataloaders=None):
         # when dataloader is passed via fit, patch the train_dataloader

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -448,7 +448,7 @@ class Trainer(
         self.interactive_ddp_procs = []
         self.configure_slurm_ddp(self.num_nodes)
         self.node_rank = self.determine_ddp_node_rank()
-        self.local_rank = int(os.environ.get('LOCAL_RANK', 0))
+        self.local_rank = self.determin_local_rank()
         self.global_rank = 0
 
         # nvidia setup

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -132,7 +132,7 @@ class TrainerIOMixin(ABC):
     use_ddp2: bool
     use_horovod: bool
     checkpoint_callback: ...
-    proc_rank: int
+    global_rank: int
     weights_save_path: str
     logger: LightningLoggerBase
     early_stop_callback: ...
@@ -213,7 +213,7 @@ class TrainerIOMixin(ABC):
             signal.signal(signal.SIGTERM, self.term_handler)
 
     def sig_handler(self, signum, frame):  # pragma: no-cover
-        if self.proc_rank == 0:
+        if self.global_rank == 0:
             # save weights
             log.info('handling SIGUSR1')
             self.hpc_save(self.weights_save_path, self.logger)
@@ -262,7 +262,7 @@ class TrainerIOMixin(ABC):
     def save_checkpoint(self, filepath, weights_only: bool = False):
         checkpoint = self.dump_checkpoint(weights_only)
 
-        if self.proc_rank == 0:
+        if self.global_rank == 0:
             # do the actual save
             try:
                 self._atomic_save(checkpoint, filepath)

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -213,7 +213,7 @@ class TrainerIOMixin(ABC):
             signal.signal(signal.SIGTERM, self.term_handler)
 
     def sig_handler(self, signum, frame):  # pragma: no-cover
-        if self.global_rank == 0:
+        if self.is_global_zero:
             # save weights
             log.info('handling SIGUSR1')
             self.hpc_save(self.weights_save_path, self.logger)
@@ -262,7 +262,7 @@ class TrainerIOMixin(ABC):
     def save_checkpoint(self, filepath, weights_only: bool = False):
         checkpoint = self.dump_checkpoint(weights_only)
 
-        if self.global_rank == 0:
+        if self.is_global_zero:
             # do the actual save
             try:
                 self._atomic_save(checkpoint, filepath)

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -480,7 +480,7 @@ class TrainerTrainLoopMixin(ABC):
             # when logs should be saved
             should_save_log = (batch_idx + 1) % self.log_save_interval == 0 or early_stop_epoch
             if should_save_log or self.fast_dev_run:
-                if self.global_rank == 0 and self.logger is not None:
+                if self.is_global_zero and self.logger is not None:
                     self.logger.save()
 
             # when metrics should be logged

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -249,7 +249,7 @@ class TrainerTrainLoopMixin(ABC):
     on_validation_end: Callable
 
     @abstractmethod
-    def get_model(self):
+    def get_model(self) -> LightningModule:
         """Warning: this is just empty shell for code implemented in other class."""
 
     @abstractmethod

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -145,7 +145,7 @@ import atexit
 import signal
 from abc import ABC, abstractmethod
 from typing import Callable
-from typing import Union, List, Optional
+from typing import Union, List
 
 import numpy as np
 import torch
@@ -214,7 +214,7 @@ class TrainerTrainLoopMixin(ABC):
     global_step: int
     testing: bool
     log_save_interval: float
-    proc_rank: int
+    global_rank: int
     row_log_interval: float
     truncated_bptt_steps: ...
     optimizers: ...
@@ -236,8 +236,7 @@ class TrainerTrainLoopMixin(ABC):
     total_batch_idx: int
     checkpoint_callback: ...
     terminate_on_nan: bool
-    tpu_id: Optional[int]
-    interactive_ddp_procs: List
+    tpu_id: int
 
     # Callback system
     callbacks: List[Callback]
@@ -250,7 +249,7 @@ class TrainerTrainLoopMixin(ABC):
     on_validation_end: Callable
 
     @abstractmethod
-    def get_model(self) -> LightningModule:
+    def get_model(self):
         """Warning: this is just empty shell for code implemented in other class."""
 
     @abstractmethod
@@ -481,7 +480,7 @@ class TrainerTrainLoopMixin(ABC):
             # when logs should be saved
             should_save_log = (batch_idx + 1) % self.log_save_interval == 0 or early_stop_epoch
             if should_save_log or self.fast_dev_run:
-                if self.proc_rank == 0 and self.logger is not None:
+                if self.global_rank == 0 and self.logger is not None:
                     self.logger.save()
 
             # when metrics should be logged


### PR DESCRIPTION
- Enables prepare_data only from global rank 0 if requested or from each node's rank 0
- Clarifies local_rank vs global_rank
- adds self.is_global_zero for ease of ops only for node=0, local=0

Fixes #1878 
Fixes #2163 