### PR TITLE
Fixing horovod with GPU training code 

### DIFF
--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -259,7 +259,7 @@ class TrainerDDPMixin(ABC):
             self.data_parallel_device_ids = None
             self.on_gpu = False
         elif distributed_backend == 'horovod':
-            if gpus
+            self.on_gpu = True if self.num_gpus >= 1 else False
             self._set_horovod_backend()
 
         # throw error to force user ddp or ddp2 choice

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -259,6 +259,7 @@ class TrainerDDPMixin(ABC):
             self.data_parallel_device_ids = None
             self.on_gpu = False
         elif distributed_backend == 'horovod':
+            if gpus
             self._set_horovod_backend()
 
         # throw error to force user ddp or ddp2 choice
@@ -564,11 +565,11 @@ class TrainerDDPMixin(ABC):
                 'Install with \n $HOROVOD_WITH_PYTORCH=1 pip install horovod[pytorch]'
             )
 
-        if self.num_gpus > 1 or self.num_nodes > 1:
-            raise MisconfigurationException(
-                'Horovod does not support setting num_nodes / num_gpus explicitly. Use '
-                'horovodrun / mpirun to configure the number of processes.'
-            )
+#         if self.num_gpus > 1 or self.num_nodes > 1:
+#             raise MisconfigurationException(
+#                 'Horovod does not support setting num_nodes / num_gpus explicitly. Use '
+#                 'horovodrun / mpirun to configure the number of processes.'
+#             )
 
     @staticmethod
     def has_horovodrun():


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## What does this PR do?
Fixes # (issue).

https://pytorch-lightning.readthedocs.io/en/stable/multi_gpu.html guides to set 'gpus' to use GPU with Horovod, but it returns error saying;

> Horovod does not support setting num_nodes / num_gpus explicitly. Use 
>horovodrun / mpirun to configure the number of processes.

This PR is to set self.on_gpu if gpus >= 1, and to remove the error message.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
