### PR TITLE
add on fit_start on fit_end hooks

### DIFF
--- a/pytorch_lightning/callbacks/base.py
+++ b/pytorch_lightning/callbacks/base.py
@@ -22,6 +22,14 @@ class Callback(abc.ABC):
         """Called when the trainer initialization ends, model has not yet been set."""
         pass
 
+    def on_fit_start(self, trainer):
+        """Called when fit begins"""
+        pass
+
+    def on_fit_end(self, trainer):
+        """Called when fit ends"""
+        pass
+
     def on_sanity_check_start(self, trainer, pl_module):
         """Called when the validation sanity check starts."""
         pass

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -17,6 +17,12 @@ else:
 
 class ModelHooks(Module):
 
+    def on_fit_start(self):
+        """
+        Called at the very beginning of fit.
+        If on DDP it is called on every process
+        """
+
     # TODO: remove in v0.9.0
     def on_sanity_check_start(self):
         """

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -23,6 +23,12 @@ class ModelHooks(Module):
         If on DDP it is called on every process
         """
 
+    def on_fit_end(self):
+        """
+        Called at the very end of fit.
+        If on DDP it is called on every process
+        """
+
     # TODO: remove in v0.9.0
     def on_sanity_check_start(self):
         """

--- a/pytorch_lightning/trainer/callback_hook.py
+++ b/pytorch_lightning/trainer/callback_hook.py
@@ -21,6 +21,16 @@ class TrainerCallbackHookMixin(ABC):
         for callback in self.callbacks:
             callback.on_init_end(self)
 
+    def on_fit_start(self):
+        """Called when the trainer initialization begins, model has not yet been set."""
+        for callback in self.callbacks:
+            callback.on_fit_start(self)
+
+    def on_fit_end(self):
+        """Called when the trainer initialization begins, model has not yet been set."""
+        for callback in self.callbacks:
+            callback.on_fit_end(self)
+
     def on_sanity_check_start(self):
         """Called when the validation sanity check starts."""
         for callback in self.callbacks:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -787,8 +787,6 @@ class Trainer(
 
         # callbacks
         self.on_fit_start()
-
-        # model hooks
         if self.is_function_implemented('on_fit_start'):
             model.on_fit_start()
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -785,6 +785,13 @@ class Trainer(
         # check that model is configured correctly
         self.check_model_configuration(model)
 
+        # callbacks
+        self.on_fit_start()
+
+        # model hooks
+        if self.is_function_implemented('on_fit_start'):
+            model.on_fit_start()
+
         # on multi-gpu jobs we only want to manipulate (download, etc) on node_rank=0, local_rank=0
         # or in the case where each node needs to do its own manipulation in which case just local_rank=0
         if self.can_prepare_data():
@@ -879,6 +886,13 @@ class Trainer(
             self.optimizers, self.lr_schedulers, self.optimizer_frequencies = self.init_optimizers(model)
 
             self.run_pretrain_routine(model)
+
+        # callbacks
+        self.on_fit_end()
+
+        # model hooks
+        if self.is_function_implemented('on_fit_end'):
+            model.on_fit_end()
 
         # return 1 when finished
         # used for testing or when we need to know that training succeeded

--- a/tests/callbacks/test_callbacks.py
+++ b/tests/callbacks/test_callbacks.py
@@ -48,6 +48,8 @@ def test_trainer_callback_system(tmpdir):
             super().__init__()
             self.on_init_start_called = False
             self.on_init_end_called = False
+            self.on_fit_start_called = False
+            self.on_fit_end_called = False
             self.on_sanity_check_start_called = False
             self.on_sanity_check_end_called = False
             self.on_epoch_start_called = False
@@ -72,6 +74,14 @@ def test_trainer_callback_system(tmpdir):
         def on_init_end(self, trainer):
             assert isinstance(trainer, Trainer)
             self.on_init_end_called = True
+
+        def on_fit_start(self, trainer):
+            assert isinstance(trainer, Trainer)
+            self.on_fit_start_called = True
+
+        def on_fit_end(self, trainer):
+            assert isinstance(trainer, Trainer)
+            self.on_fit_end_called = True
 
         def on_sanity_check_start(self, trainer, pl_module):
             _check_args(trainer, pl_module)
@@ -149,6 +159,8 @@ def test_trainer_callback_system(tmpdir):
 
     assert not test_callback.on_init_start_called
     assert not test_callback.on_init_end_called
+    assert not test_callback.on_fit_start_called
+    assert not test_callback.on_fit_end_called
     assert not test_callback.on_sanity_check_start_called
     assert not test_callback.on_sanity_check_end_called
     assert not test_callback.on_epoch_start_called
@@ -172,6 +184,8 @@ def test_trainer_callback_system(tmpdir):
     assert trainer.callbacks[0] == test_callback
     assert test_callback.on_init_start_called
     assert test_callback.on_init_end_called
+    assert test_callback.on_fit_start_called
+    assert test_callback.on_fit_end_called
     assert not test_callback.on_sanity_check_start_called
     assert not test_callback.on_sanity_check_end_called
     assert not test_callback.on_epoch_start_called
@@ -193,6 +207,8 @@ def test_trainer_callback_system(tmpdir):
 
     assert test_callback.on_init_start_called
     assert test_callback.on_init_end_called
+    assert test_callback.on_fit_start_called
+    assert test_callback.on_fit_end_called
     assert test_callback.on_sanity_check_start_called
     assert test_callback.on_sanity_check_end_called
     assert test_callback.on_epoch_start_called

--- a/tests/callbacks/test_callbacks.py
+++ b/tests/callbacks/test_callbacks.py
@@ -184,8 +184,8 @@ def test_trainer_callback_system(tmpdir):
     assert trainer.callbacks[0] == test_callback
     assert test_callback.on_init_start_called
     assert test_callback.on_init_end_called
-    assert test_callback.on_fit_start_called
-    assert test_callback.on_fit_end_called
+    assert not test_callback.on_fit_start_called
+    assert not test_callback.on_fit_end_called
     assert not test_callback.on_sanity_check_start_called
     assert not test_callback.on_sanity_check_end_called
     assert not test_callback.on_epoch_start_called


### PR DESCRIPTION
@tullie @maximsch2 


```
    def on_fit_start(self):
        """
        Called at the very beginning of fit.
        If on DDP it is called on every process
        """

    def on_fit_end(self):
        """
        Called at the very end of fit.
        If on DDP it is called on every process
        """
```