### PR TITLE
Pid port + duplicate rank_zero logging

### DIFF
--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -378,11 +378,12 @@ class TrainerDDPMixin(ABC):
         try:
             default_port = os.environ['MASTER_PORT']
         except Exception:
-            import os
+            # use the process id as a seed to a generator for port only
             pid = os.getpid()
             rng1 = np.random.RandomState(pid)
             default_port = rng1.randint(10000, 19999, 1)[0]
-            os.environ['MASTER_PORT'] = str(default_port)
+
+        os.environ['MASTER_PORT'] = str(default_port)
 
     def spawn_ddp_children(self, model):
         self.__set_random_port()

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -129,7 +129,6 @@ from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.distributed import rank_zero_only, rank_zero_warn, rank_zero_info
-import numpy as np
 
 try:
     from apex import amp

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -372,7 +372,6 @@ class TrainerDDPMixin(ABC):
     def __set_random_port(self):
         """
         When running DDP NOT managed by SLURM, the ports might collide
-        :return:
         """
         try:
             default_port = os.environ['MASTER_PORT']

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -129,6 +129,7 @@ from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.distributed import rank_zero_only, rank_zero_warn, rank_zero_info
+import numpy as np
 
 try:
     from apex import amp
@@ -377,8 +378,10 @@ class TrainerDDPMixin(ABC):
         try:
             default_port = os.environ['MASTER_PORT']
         except Exception:
-            import random
-            default_port = random.randint(10000, 19000)
+            import os
+            pid = os.getpid()
+            rng1 = np.random.RandomState(pid)
+            default_port = rng1.randint(10000, 19999, 1)[0]
             os.environ['MASTER_PORT'] = str(default_port)
 
     def spawn_ddp_children(self, model):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -32,7 +32,7 @@ from pytorch_lightning.trainer.training_loop import TrainerTrainLoopMixin
 from pytorch_lightning.trainer.training_tricks import TrainerTrainingTricksMixin
 from pytorch_lightning.trainer.lr_finder import TrainerLRFinderMixin
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities import rank_zero_warn, parsing, rank_zero_info
+from pytorch_lightning.utilities import rank_zero_warn, parsing, rank_zero_info, rank_zero_only
 
 try:
     from apex import amp
@@ -321,6 +321,12 @@ class Trainer(
             # fixing non-deterministic part of horovod
             # https://github.com/PyTorchLightning/pytorch-lightning/pull/1572/files#r420279383
             os.environ["HOROVOD_FUSION_THRESHOLD"] = str(0)
+
+        # init the default rank if exists
+        if 'LOCAL_RANK' in os.environ:
+            rank_zero_only.rank = os.environ['LOCAL_RANK']
+        if 'SLURM_JOB_ID' in os.environ:
+            rank_zero_only.rank = os.environ['SLURM_JOB_ID']
 
         # Init callbacks
         self.prepare_data_per_node = prepare_data_per_node

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -892,6 +892,7 @@ class Trainer(
                 mp.spawn(self.ddp_train, nprocs=self.num_processes, args=(model,))
 
             elif self.distributed_backend == 'ddp_spawn':
+                self.__set_random_port()
                 model.share_memory()
 
                 # spin up peers

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -323,6 +323,8 @@ class Trainer(
             os.environ["HOROVOD_FUSION_THRESHOLD"] = str(0)
 
         # init the default rank if exists
+        # we need to call this here or NVIDIA flags and other messaging in init will show on all ranks
+        # this way we only show it on rank 0
         if 'LOCAL_RANK' in os.environ:
             rank_zero_only.rank = os.environ['LOCAL_RANK']
         if 'SLURM_JOB_ID' in os.environ:


### PR DESCRIPTION
Implements #2140 in a way that works.

For local ddp, we now use the process id as a numpy sub-seed to generate a random port. This way since the user sets the full seed we can use the parent process id as a  seed before spawning off children.

Also solves an issue where on init when ranks are know, we shouldn't see duplicate messages