### PR TITLE
Typo fix in metrics docs

### DIFF
--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -216,13 +216,13 @@ IoU
 RMSE
 ^^^^
 
-.. autoclass:: pytorch_lightning.metrics.regression.RMSLE
+.. autoclass:: pytorch_lightning.metrics.regression.RMSE
     :noindex:
 
 RMSLE
 ^^^^^
 
-.. autoclass:: pytorch_lightning.metrics.regression.RMSE
+.. autoclass:: pytorch_lightning.metrics.regression.RMSLE
     :noindex:
 
 ---


### PR DESCRIPTION
There was a typo in metrics description: RMSE titled metric was actually RMSLE and vice-versa. So I've fixed it, changing two characters.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?   
- [ ] Did you write any new necessary tests?  
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## What does this PR do?
Fixes typo in metrics docs

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
