### PR TITLE
Fix ROC metric for CUDA tensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed an issue with forward hooks not being removed after model summary ([#2298](https://github.com/PyTorchLightning/pytorch-lightning/pull/2298))
 
+- Fixed ROC metric for CUDA tensors ([#2304](https://github.com/PyTorchLightning/pytorch-lightning/pull/2304))
 
 ## [0.8.1] - 2020-06-19
 

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -3,6 +3,7 @@ from functools import wraps
 from typing import Optional, Tuple, Callable
 
 import torch
+from torch.nn import functional as F
 
 from pytorch_lightning.metrics.functional.reduction import reduce
 from pytorch_lightning.utilities import rank_zero_warn
@@ -500,8 +501,7 @@ def _binary_clf_curve(
     # the indices associated with the distinct values. We also
     # concatenate a value for the end of the curve.
     distinct_value_indices = torch.where(pred[1:] - pred[:-1])[0]
-    threshold_idxs = torch.cat([distinct_value_indices,
-                                torch.tensor([target.size(0) - 1])])
+    threshold_idxs = F.pad(distinct_value_indices, (0, 1), value=target.size(0) - 1)
 
     target = (target == pos_label).to(torch.long)
     tps = torch.cumsum(target * weight, dim=0)[threshold_idxs]

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -47,23 +47,37 @@ def test_against_sklearn(sklearn_metric, torch_metric):
     """Compare PL metrics to sklearn version."""
     pred = torch.randint(10, (500,))
     target = torch.randint(10, (500,))
+    
+    if torch.cuda.is_available():
+        device = 'cuda'
+    else:
+        device = 'cpu'
+        
+    pred = pred.to(device)
+    target = target.to(device)
 
     assert torch.allclose(
-        torch.tensor(sklearn_metric(target, pred), dtype=torch.float),
+        torch.tensor(sklearn_metric(target, pred), dtype=torch.float, device=device),
         torch_metric(pred, target))
 
     pred = torch.randint(10, (200,))
     target = torch.randint(5, (200,))
+    
+    pred = pred.to(device)
+    target = target.to(device)
 
     assert torch.allclose(
-        torch.tensor(sklearn_metric(target, pred), dtype=torch.float),
+        torch.tensor(sklearn_metric(target, pred), dtype=torch.float, device=device),
         torch_metric(pred, target))
 
     pred = torch.randint(5, (200,))
     target = torch.randint(10, (200,))
+    
+    pred = pred.to(device)
+    target = target.to(device)
 
     assert torch.allclose(
-        torch.tensor(sklearn_metric(target, pred), dtype=torch.float),
+        torch.tensor(sklearn_metric(target, pred), dtype=torch.float, device=device),
         torch_metric(pred, target))
 
 

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -48,10 +48,7 @@ def test_against_sklearn(sklearn_metric, torch_metric):
     pred = torch.randint(10, (500,))
     target = torch.randint(10, (500,))
 
-    if torch.cuda.is_available():
-        device = 'cuda'
-    else:
-        device = 'cpu'
+    device = 'cuda' if torch.cuda.is_available() else 'cpu'
 
     pred = pred.to(device)
     target = target.to(device)

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -47,37 +47,37 @@ def test_against_sklearn(sklearn_metric, torch_metric):
     """Compare PL metrics to sklearn version."""
     pred = torch.randint(10, (500,))
     target = torch.randint(10, (500,))
-    
+
     if torch.cuda.is_available():
         device = 'cuda'
     else:
         device = 'cpu'
-        
+
     pred = pred.to(device)
     target = target.to(device)
 
     assert torch.allclose(
-        torch.tensor(sklearn_metric(target, pred), dtype=torch.float, device=device),
+        torch.tensor(sklearn_metric(target.cpu().detach().numpy(), pred.cpu().detach().numpy()), dtype=torch.float, device=device),
         torch_metric(pred, target))
 
     pred = torch.randint(10, (200,))
     target = torch.randint(5, (200,))
-    
+
     pred = pred.to(device)
     target = target.to(device)
 
     assert torch.allclose(
-        torch.tensor(sklearn_metric(target, pred), dtype=torch.float, device=device),
+        torch.tensor(sklearn_metric(target.cpu().detach().numpy(), pred.cpu().detach().numpy()), dtype=torch.float, device=device),
         torch_metric(pred, target))
 
     pred = torch.randint(5, (200,))
     target = torch.randint(10, (200,))
-    
+
     pred = pred.to(device)
     target = target.to(device)
 
     assert torch.allclose(
-        torch.tensor(sklearn_metric(target, pred), dtype=torch.float, device=device),
+        torch.tensor(sklearn_metric(target.cpu().detach().numpy(), pred.cpu().detach().numpy()), dtype=torch.float, device=device),
         torch_metric(pred, target))
 
 

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -57,7 +57,7 @@ def test_against_sklearn(sklearn_metric, torch_metric):
     target = target.to(device)
 
     assert torch.allclose(
-        torch.tensor(sklearn_metric(target.cpu().detach().numpy(), 
+        torch.tensor(sklearn_metric(target.cpu().detach().numpy(),
                                     pred.cpu().detach().numpy()), dtype=torch.float, device=device),
         torch_metric(pred, target))
 
@@ -68,7 +68,7 @@ def test_against_sklearn(sklearn_metric, torch_metric):
     target = target.to(device)
 
     assert torch.allclose(
-        torch.tensor(sklearn_metric(target.cpu().detach().numpy(), 
+        torch.tensor(sklearn_metric(target.cpu().detach().numpy(),
                                     pred.cpu().detach().numpy()), dtype=torch.float, device=device),
         torch_metric(pred, target))
 
@@ -79,7 +79,7 @@ def test_against_sklearn(sklearn_metric, torch_metric):
     target = target.to(device)
 
     assert torch.allclose(
-        torch.tensor(sklearn_metric(target.cpu().detach().numpy(), 
+        torch.tensor(sklearn_metric(target.cpu().detach().numpy(),
                                     pred.cpu().detach().numpy()), dtype=torch.float, device=device),
         torch_metric(pred, target))
 

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -45,35 +45,26 @@ from pytorch_lightning.metrics.functional.classification import (
 ])
 def test_against_sklearn(sklearn_metric, torch_metric):
     """Compare PL metrics to sklearn version."""
-    pred = torch.randint(10, (500,))
-    target = torch.randint(10, (500,))
-
     device = 'cuda' if torch.cuda.is_available() else 'cpu'
 
-    pred = pred.to(device)
-    target = target.to(device)
+    pred = torch.randint(10, (500,), device=device)
+    target = torch.randint(10, (500,), device=device)
 
     assert torch.allclose(
         torch.tensor(sklearn_metric(target.cpu().detach().numpy(),
                                     pred.cpu().detach().numpy()), dtype=torch.float, device=device),
         torch_metric(pred, target))
 
-    pred = torch.randint(10, (200,))
-    target = torch.randint(5, (200,))
-
-    pred = pred.to(device)
-    target = target.to(device)
+    pred = torch.randint(10, (200,), device=device)
+    target = torch.randint(5, (200,), device=device)
 
     assert torch.allclose(
         torch.tensor(sklearn_metric(target.cpu().detach().numpy(),
                                     pred.cpu().detach().numpy()), dtype=torch.float, device=device),
         torch_metric(pred, target))
 
-    pred = torch.randint(5, (200,))
-    target = torch.randint(10, (200,))
-
-    pred = pred.to(device)
-    target = target.to(device)
+    pred = torch.randint(5, (200,), device=device)
+    target = torch.randint(10, (200,), device=device)
 
     assert torch.allclose(
         torch.tensor(sklearn_metric(target.cpu().detach().numpy(),

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -57,7 +57,8 @@ def test_against_sklearn(sklearn_metric, torch_metric):
     target = target.to(device)
 
     assert torch.allclose(
-        torch.tensor(sklearn_metric(target.cpu().detach().numpy(), pred.cpu().detach().numpy()), dtype=torch.float, device=device),
+        torch.tensor(sklearn_metric(target.cpu().detach().numpy(), 
+                                    pred.cpu().detach().numpy()), dtype=torch.float, device=device),
         torch_metric(pred, target))
 
     pred = torch.randint(10, (200,))
@@ -67,7 +68,8 @@ def test_against_sklearn(sklearn_metric, torch_metric):
     target = target.to(device)
 
     assert torch.allclose(
-        torch.tensor(sklearn_metric(target.cpu().detach().numpy(), pred.cpu().detach().numpy()), dtype=torch.float, device=device),
+        torch.tensor(sklearn_metric(target.cpu().detach().numpy(), 
+                                    pred.cpu().detach().numpy()), dtype=torch.float, device=device),
         torch_metric(pred, target))
 
     pred = torch.randint(5, (200,))
@@ -77,7 +79,8 @@ def test_against_sklearn(sklearn_metric, torch_metric):
     target = target.to(device)
 
     assert torch.allclose(
-        torch.tensor(sklearn_metric(target.cpu().detach().numpy(), pred.cpu().detach().numpy()), dtype=torch.float, device=device),
+        torch.tensor(sklearn_metric(target.cpu().detach().numpy(), 
+                                    pred.cpu().detach().numpy()), dtype=torch.float, device=device),
         torch_metric(pred, target))
 
 


### PR DESCRIPTION
## What does this PR do?

Previously roc metric (and auroc) errors when passed in CUDA tensors,
due to torch.tensor construction without specifying device.
This fixes the error by using F.pad instead.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
