### PR TITLE
Fix average_precision metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed an issue with forward hooks not being removed after model summary ([#2298](https://github.com/PyTorchLightning/pytorch-lightning/pull/2298))
 
-- Fixed average_precision metric : added missing parantheses ([#2319](https://github.com/PyTorchLightning/pytorch-lightning/pull/2319))
+- Fixed `average_precision` metric ([#2319](https://github.com/PyTorchLightning/pytorch-lightning/pull/2319))
 
 
 ## [0.8.1] - 2020-06-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed an issue with forward hooks not being removed after model summary ([#2298](https://github.com/PyTorchLightning/pytorch-lightning/pull/2298))
 
+- Fixed average_precision metric : added missing parantheses ([#2319](https://github.com/PyTorchLightning/pytorch-lightning/pull/2319))
+
 
 ## [0.8.1] - 2020-06-19
 

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -844,7 +844,7 @@ def average_precision(
     # Return the step function integral
     # The following works because the last entry of precision is
     # guaranteed to be 1, as returned by precision_recall_curve
-    return -torch.sum(recall[1:] - recall[:-1] * precision[:-1])
+    return -torch.sum((recall[1:] - recall[:-1]) * precision[:-1])
 
 
 def dice_score(

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -342,18 +342,19 @@ def test_auc(x, y, expected):
     assert auc(torch.tensor(x), torch.tensor(y)) == expected
 
 
-def test_average_precision_constant_values():
+@pytest.mark.parametrize(['scores', 'target', 'expected_score'], [
     # Check the average_precision_score of a constant predictor is
     # the TPR
-
     # Generate a dataset with 25% of positives
-    target = torch.zeros(100, dtype=torch.float)
-    target[::4] = 1
     # And a constant score
-    pred = torch.ones(100)
     # The precision is then the fraction of positive whatever the recall
     # is, as there is only one threshold:
-    assert average_precision(pred, target).item() == .25
+    pytest.param(torch.tensor([1, 1, 1, 1]), torch.tensor([0, 0, 0, 1]), .25),
+    # With treshold .8 : 1 TP and 2 TN and one FN
+    pytest.param(torch.tensor([.6, .7, .8, 9]), torch.tensor([1, 0, 0, 1]), .75),
+])
+def test_average_precision(scores, target, expected_score):
+    assert average_precision(scores, target) == expected_score
 
 
 @pytest.mark.parametrize(['pred', 'target', 'expected'], [


### PR DESCRIPTION
## What does this PR do?

This PR fixes `pytorch_lightning.metrics.functional.average_precision`. It also adds a test that would have failed with the old implementation

Parentheses were missing in the definition of the function.

Bug described in #2315.

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
