### PR TITLE
Fix ModelCheckpoint example

### DIFF
--- a/docs/source/weights_loading.rst
+++ b/docs/source/weights_loading.rst
@@ -42,7 +42,7 @@ To modify the behavior of checkpointing pass in your own callback.
     # DEFAULTS used by the Trainer
     checkpoint_callback = ModelCheckpoint(
         filepath=os.getcwd(),
-        save_top_k=True,
+        save_top_k=1,
         verbose=True,
         monitor='val_loss',
         mode='min',


### PR DESCRIPTION
## What does this PR do?

According to ModelCheckpoint [documentation](https://pytorch-lightning.readthedocs.io/en/stable/callbacks.html#model-checkpointing), `save_top_k` should be an `int` and has default value '1', however, example snippet on the [Saving and Loading weights](https://pytorch-lightning.readthedocs.io/en/stable/weights_loading.html#automatic-saving) page has mentioned `save_top_k=True` as the default value. I've changed it to '1' as per the class [definition](https://github.com/PyTorchLightning/pytorch-lightning/blob/63bd0582e35ad865c1f07f61975456f65de0f41f/pytorch_lightning/callbacks/model_checkpoint.py#L97).

# Before submitting

- [X] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you create a separate PR for every change.
- [X] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
