### PR TITLE
Fix lost compatibility with custom datatypes implementing `.to`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `average_precision` metric ([#2319](https://github.com/PyTorchLightning/pytorch-lightning/pull/2319))
 
+- Fixed lost compatibility with custom datatypes implementing `.to` ([#2335](https://github.com/PyTorchLightning/pytorch-lightning/pull/2335))
+
 ## [0.8.1] - 2020-06-19
 
 ### Fixed

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -204,7 +204,7 @@ class ModelHooks(Module):
 
         The data types listed below (and any arbitrary nesting of them) are supported out of the box:
 
-        - :class:`torch.Tensor`
+        - :class:`torch.Tensor` or anything that implements `.to(...)`
         - :class:`list`
         - :class:`dict`
         - :class:`tuple`

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from collections import Mapping, Sequence
 from typing import Any, Callable, Union
 
@@ -38,14 +39,41 @@ def apply_to_collection(data: Any, dtype: Union[type, tuple], function: Callable
     return data
 
 
+class TransferrableDataType(ABC):
+    """
+    A custom type for data that can be moved to a torch device via `.to(...)`.
+
+    Example:
+        >>> isinstance(torch.rand(2, 3), TransferrableDataType)
+        True
+        >>> isinstance(dict, TransferrableDataType)
+        False
+        >>> class CustomObject:
+        ...     def __init__(self):
+        ...         self.x = torch.rand(2, 2)
+        ...     def to(self, device):
+        ...         self.x.to(device)
+        >>> isinstance(CustomObject(), TransferrableDataType)
+        True
+    """
+
+    @classmethod
+    def __subclasshook__(cls, subclass):
+        if cls is TransferrableDataType:
+            to = getattr(subclass, "to", None)
+            return callable(to)
+        return NotImplemented
+
+
 def move_data_to_device(batch: Any, device: torch.device):
     """
-    Transfers a collection of tensors to the given device.
+    Transfers a collection of data to the given device. Any object that defines a method
+    ``to(device)`` will be moved and all other objects in the collection will be left untouched.
 
     Args:
-        batch: A tensor or collection of tensors. See :func:`apply_to_collection`
-            for a list of supported collection types.
-        device: The device to which tensors should be moved
+        batch: A tensor or collection of tensors or anything that has a method `.to(...)`.
+            See :func:`apply_to_collection` for a list of supported collection types.
+        device: The device to which the data should be moved
 
     Return:
         the same collection but with all contained tensors residing on the new device.
@@ -54,6 +82,6 @@ def move_data_to_device(batch: Any, device: torch.device):
         - :meth:`torch.Tensor.to`
         - :class:`torch.device`
     """
-    def to(tensor):
-        return tensor.to(device, non_blocking=True)
-    return apply_to_collection(batch, dtype=torch.Tensor, function=to)
+    def to(data):
+        return data.to(device, non_blocking=True)
+    return apply_to_collection(batch, dtype=TransferrableDataType, function=to)

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -39,15 +39,15 @@ def apply_to_collection(data: Any, dtype: Union[type, tuple], function: Callable
     return data
 
 
-class TransferrableDataType(ABC):
+class TransferableDataType(ABC):
     """
     A custom type for data that can be moved to a torch device via `.to(...)`.
 
     Example:
 
-        >>> isinstance(dict, TransferrableDataType)
+        >>> isinstance(dict, TransferableDataType)
         False
-        >>> isinstance(torch.rand(2, 3), TransferrableDataType)
+        >>> isinstance(torch.rand(2, 3), TransferableDataType)
         True
         >>> class CustomObject:
         ...     def __init__(self):
@@ -55,13 +55,13 @@ class TransferrableDataType(ABC):
         ...     def to(self, device):
         ...         self.x = self.x.to(device)
         ...         return self
-        >>> isinstance(CustomObject(), TransferrableDataType)
+        >>> isinstance(CustomObject(), TransferableDataType)
         True
     """
 
     @classmethod
     def __subclasshook__(cls, subclass):
-        if cls is TransferrableDataType:
+        if cls is TransferableDataType:
             to = getattr(subclass, "to", None)
             return callable(to)
         return NotImplemented
@@ -86,4 +86,4 @@ def move_data_to_device(batch: Any, device: torch.device):
     """
     def to(data):
         return data.to(device, non_blocking=True)
-    return apply_to_collection(batch, dtype=TransferrableDataType, function=to)
+    return apply_to_collection(batch, dtype=TransferableDataType, function=to)

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -44,15 +44,17 @@ class TransferrableDataType(ABC):
     A custom type for data that can be moved to a torch device via `.to(...)`.
 
     Example:
-        >>> isinstance(torch.rand(2, 3), TransferrableDataType)
-        True
+
         >>> isinstance(dict, TransferrableDataType)
         False
+        >>> isinstance(torch.rand(2, 3), TransferrableDataType)
+        True
         >>> class CustomObject:
         ...     def __init__(self):
         ...         self.x = torch.rand(2, 2)
         ...     def to(self, device):
-        ...         self.x.to(device)
+        ...         self.x = self.x.to(device)
+        ...         return self
         >>> isinstance(CustomObject(), TransferrableDataType)
         True
     """

--- a/tests/models/test_gpu.py
+++ b/tests/models/test_gpu.py
@@ -286,3 +286,15 @@ def test_single_gpu_batch_parse():
     batch = trainer.transfer_batch_to_gpu(batch, 0)
     assert batch[0].a.device.index == 0
     assert batch[0].a.type() == 'torch.cuda.FloatTensor'
+
+    # non-Tensor that has `.to()` defined
+    class CustomBatchType:
+        def __init__(self):
+            self.a = torch.rand(2, 2)
+
+        def to(self, *args, **kwargs):
+            self.a = self.a.to(*args, **kwargs)
+            return self
+
+    batch = trainer.transfer_batch_to_gpu(CustomBatchType())
+    assert batch.a.type() == 'torch.cuda.FloatTensor'


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #2314

When I refactored the data transfer and added a model hook in #1756, I accidentally removed the ability to move non-tensor datastructures that implement `.to()`. This PR re-enables that via a duck typing check. For this type of data, the user is not required to override the hook, since PL can handle this out of the box now.

The test alone  fails on master, confirming that the changes here fix the bug.

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
