### PR TITLE
remove type annotation in LightningTemplateModel init

### DIFF
--- a/pl_examples/models/lightning_template.py
+++ b/pl_examples/models/lightning_template.py
@@ -46,7 +46,7 @@ class LightningTemplateModel(LightningModule):
                  out_features: int = 10,
                  hidden_dim: int = 1000,
                  **kwargs
-                 ) -> 'LightningTemplateModel':
+                 ):
         # init superclass
         super().__init__()
         self.drop_prob = drop_prob


### PR DESCRIPTION
## What does this PR do?

Removed type annotation because `__init__()` does not return anything.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
