### PR TITLE
fixes logger crash on ddp

### DIFF
--- a/pl_examples/models/lightning_template.py
+++ b/pl_examples/models/lightning_template.py
@@ -150,15 +150,12 @@ class LightningTemplateModel(LightningModule):
         self.mnist_test = MNIST(self.data_root, train=False, download=False, transform=transform)
 
     def train_dataloader(self):
-        log.info('Training data loader called.')
         return DataLoader(self.mnist_train, batch_size=self.batch_size, num_workers=4)
 
     def val_dataloader(self):
-        log.info('Validation data loader called.')
         return DataLoader(self.mnist_test, batch_size=self.batch_size, num_workers=4)
 
     def test_dataloader(self):
-        log.info('Test data loader called.')
         return DataLoader(self.mnist_test, batch_size=self.batch_size, num_workers=4)
 
     @staticmethod

--- a/pytorch_lightning/trainer/callback_config.py
+++ b/pytorch_lightning/trainer/callback_config.py
@@ -51,6 +51,7 @@ class TrainerCallbackConfigMixin(ABC):
                 if self.weights_save_path is not None:
                     save_dir = self.weights_save_path
 
+                import pdb; pdb.set_trace()
                 version = self.logger.version if isinstance(
                     self.logger.version, str) else f'version_{self.logger.version}'
                 ckpt_path = os.path.join(

--- a/pytorch_lightning/trainer/callback_config.py
+++ b/pytorch_lightning/trainer/callback_config.py
@@ -32,7 +32,6 @@ class TrainerCallbackConfigMixin(ABC):
     def is_overridden(self, *args):
         """Warning: this is just empty shell for code implemented in other class."""
 
-    @
     def configure_checkpoint_callback(self):
         """
         Weight path set in this priority:

--- a/pytorch_lightning/trainer/callback_config.py
+++ b/pytorch_lightning/trainer/callback_config.py
@@ -6,7 +6,6 @@ from typing import List, Callable, Optional
 from pytorch_lightning.callbacks import Callback, ModelCheckpoint, EarlyStopping, ProgressBarBase, ProgressBar
 from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities import rank_zero_only
 
 
 class TrainerCallbackConfigMixin(ABC):
@@ -33,7 +32,7 @@ class TrainerCallbackConfigMixin(ABC):
     def is_overridden(self, *args):
         """Warning: this is just empty shell for code implemented in other class."""
 
-    @rank_zero_only
+    @
     def configure_checkpoint_callback(self):
         """
         Weight path set in this priority:
@@ -55,6 +54,7 @@ class TrainerCallbackConfigMixin(ABC):
 
                 version = self.logger.version if isinstance(
                     self.logger.version, str) else f'version_{self.logger.version}'
+                print(self.local_rank, self.logger.version, self.logger.name, version)
                 ckpt_path = os.path.join(save_dir, self.logger.name, version, "checkpoints")
             else:
                 ckpt_path = os.path.join(self.default_root_dir, "checkpoints")

--- a/pytorch_lightning/trainer/callback_config.py
+++ b/pytorch_lightning/trainer/callback_config.py
@@ -51,17 +51,10 @@ class TrainerCallbackConfigMixin(ABC):
                 if self.weights_save_path is not None:
                     save_dir = self.weights_save_path
 
-                if self.local_rank == 0:
-                    print(self.logger.version)
-                    import pdb; pdb.set_trace()
                 version = self.logger.version if isinstance(
                     self.logger.version, str) else f'version_{self.logger.version}'
-                ckpt_path = os.path.join(
-                    save_dir,
-                    self.logger.name,
-                    version,
-                    "checkpoints"
-                )
+                print(save_dir, self.logger.name, version)
+                ckpt_path = os.path.join(save_dir, self.logger.name, version, "checkpoints")
             else:
                 ckpt_path = os.path.join(self.default_root_dir, "checkpoints")
 

--- a/pytorch_lightning/trainer/callback_config.py
+++ b/pytorch_lightning/trainer/callback_config.py
@@ -42,7 +42,7 @@ class TrainerCallbackConfigMixin(ABC):
         ckpt_path = self.default_root_dir
         if self.checkpoint_callback:
             # init a default one
-            if self.logger.experiment is not None:
+            if self.logger is not None and self.global_rank != 0:
                 save_dir = (getattr(self.logger, 'save_dir', None) or
                             getattr(self.logger, '_save_dir', None) or
                             self.default_root_dir)

--- a/pytorch_lightning/trainer/callback_config.py
+++ b/pytorch_lightning/trainer/callback_config.py
@@ -51,7 +51,9 @@ class TrainerCallbackConfigMixin(ABC):
                 if self.weights_save_path is not None:
                     save_dir = self.weights_save_path
 
-                import pdb; pdb.set_trace()
+                if self.local_rank == 0:
+                    print(self.logger.version)
+                    import pdb; pdb.set_trace()
                 version = self.logger.version if isinstance(
                     self.logger.version, str) else f'version_{self.logger.version}'
                 ckpt_path = os.path.join(

--- a/pytorch_lightning/trainer/callback_config.py
+++ b/pytorch_lightning/trainer/callback_config.py
@@ -42,7 +42,7 @@ class TrainerCallbackConfigMixin(ABC):
         ckpt_path = self.default_root_dir
         if self.checkpoint_callback:
             # init a default one
-            if self.logger is not None:
+            if self.logger.experiment is not None:
                 save_dir = (getattr(self.logger, 'save_dir', None) or
                             getattr(self.logger, '_save_dir', None) or
                             self.default_root_dir)
@@ -53,7 +53,6 @@ class TrainerCallbackConfigMixin(ABC):
 
                 version = self.logger.version if isinstance(
                     self.logger.version, str) else f'version_{self.logger.version}'
-                print(self.local_rank, self.logger.version, self.logger.name, version)
                 ckpt_path = os.path.join(save_dir, self.logger.name, version, "checkpoints")
             else:
                 ckpt_path = os.path.join(self.default_root_dir, "checkpoints")

--- a/pytorch_lightning/trainer/callback_config.py
+++ b/pytorch_lightning/trainer/callback_config.py
@@ -42,7 +42,7 @@ class TrainerCallbackConfigMixin(ABC):
         ckpt_path = self.default_root_dir
         if self.checkpoint_callback:
             # init a default one
-            if self.logger is not None and self.global_rank != 0:
+            if self.logger is not None and self.logger.checkpoint is not None:
                 save_dir = (getattr(self.logger, 'save_dir', None) or
                             getattr(self.logger, '_save_dir', None) or
                             self.default_root_dir)

--- a/pytorch_lightning/trainer/callback_config.py
+++ b/pytorch_lightning/trainer/callback_config.py
@@ -42,7 +42,7 @@ class TrainerCallbackConfigMixin(ABC):
         ckpt_path = self.default_root_dir
         if self.checkpoint_callback:
             # init a default one
-            if self.logger is not None and self.logger.checkpoint is not None:
+            if self.logger is not None and self.logger.experiment is not None:
                 save_dir = (getattr(self.logger, 'save_dir', None) or
                             getattr(self.logger, '_save_dir', None) or
                             self.default_root_dir)

--- a/pytorch_lightning/trainer/callback_config.py
+++ b/pytorch_lightning/trainer/callback_config.py
@@ -6,6 +6,7 @@ from typing import List, Callable, Optional
 from pytorch_lightning.callbacks import Callback, ModelCheckpoint, EarlyStopping, ProgressBarBase, ProgressBar
 from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
+from pytorch_lightning.utilities import rank_zero_only
 
 
 class TrainerCallbackConfigMixin(ABC):
@@ -32,6 +33,7 @@ class TrainerCallbackConfigMixin(ABC):
     def is_overridden(self, *args):
         """Warning: this is just empty shell for code implemented in other class."""
 
+    @rank_zero_only
     def configure_checkpoint_callback(self):
         """
         Weight path set in this priority:
@@ -53,7 +55,6 @@ class TrainerCallbackConfigMixin(ABC):
 
                 version = self.logger.version if isinstance(
                     self.logger.version, str) else f'version_{self.logger.version}'
-                print(save_dir, self.logger.name, version)
                 ckpt_path = os.path.join(save_dir, self.logger.name, version, "checkpoints")
             else:
                 ckpt_path = os.path.join(self.default_root_dir, "checkpoints")


### PR DESCRIPTION
Fixes #2299 

Something was accessing a property of the logger (which exists in every process) instead of the .experiment object which only exists on global_rank = 0.

This went beyond wb, probably affected all loggers?

Anyhow, ddp away with loggers! 