### PR TITLE
docs: dont mock imports when running sphinx doctest

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -45,6 +45,8 @@ jobs:
         shell: bash
 
       - name: Test Documentation
+        env:
+          SPHINX_MOCK_REQUIREMENTS: 0
         run: |
           # First run the same pipeline as Read-The-Docs
           apt-get update && sudo apt-get install -y cmake

--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           # python -m pip install --upgrade --user pip
           pip install -r requirements/base.txt -U -f https://download.pytorch.org/whl/torch_stable.html -q
+          pip install -r requirements/extra.txt
           pip install -r requirements/docs.txt
           python --version ; pip --version ; pip list
         shell: bash

--- a/docs/source/apex.rst
+++ b/docs/source/apex.rst
@@ -21,6 +21,7 @@ Native torch
 When using PyTorch 1.6+ Lightning uses the native amp implementation to support 16-bit.
 
 .. testcode::
+    :skipif: not APEX_AVAILABLE and not NATIVE_AMP_AVALAIBLE
 
     # turn on 16-bit
     trainer = Trainer(precision=16)
@@ -62,6 +63,7 @@ Enable 16-bit
 ^^^^^^^^^^^^^
 
 .. testcode::
+    :skipif: not APEX_AVAILABLE and not NATIVE_AMP_AVALAIBLE
 
     # turn on 16-bit
     trainer = Trainer(amp_level='O2', precision=16)
@@ -76,6 +78,7 @@ TPU 16-bit
 16-bit on TPus is much simpler. To use 16-bit with TPUs set precision to 16 when using the tpu flag
 
 .. testcode::
+    :skipif: not XLA_AVAILABLE
 
     # DEFAULT
     trainer = Trainer(tpu_cores=8, precision=32)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -416,7 +416,11 @@ import importlib
 import os
 import torch
 
-TORCHVISION_AVAILABLE = importlib.util.find_spec('torchvision')
+from pytorch_lightning.utilities import NATIVE_AMP_AVALAIBLE
+APEX_AVAILABLE = importlib.util.find_spec("apex") is not None
+XLA_AVAILABLE = importlib.util.find_spec("torch_xla") is not None
+TORCHVISION_AVAILABLE = importlib.util.find_spec("torchvision") is not None
+
 
 """
 coverage_skip_undoc_in_source = True

--- a/pytorch_lightning/trainer/__init__.py
+++ b/pytorch_lightning/trainer/__init__.py
@@ -721,6 +721,7 @@ If used on TPU will use torch.bfloat16 but tensor printing
 will still show torch.float32.
 
 .. testcode::
+    :skipif: not APEX_AVAILABLE and not NATIVE_AMP_AVALAIBLE
 
     # default used by the Trainer
     trainer = Trainer(precision=32)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Needed in #2391. 
Currently we mock all packages in base.txt and extra.txt when running sphinx doctest, because the env variable is not set. 
Setting the env variable in the github action will now run the tests properly here on github, but will still mock as before on RTD. 

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
