### PR TITLE
Warn user when IterableDataset has __len__ defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added reduce ddp results on eval ([#2434](https://github.com/PyTorchLightning/pytorch-lightning/pull/2434))
 
+- Added a warning when an `IterableDataset` has `__len__` defined ([#2437](https://github.com/PyTorchLightning/pytorch-lightning/pull/2437))
+
 ### Changed
 
 

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -1,9 +1,11 @@
+import multiprocessing
 import platform
 from abc import ABC, abstractmethod
 from typing import Union, List, Tuple, Callable, Optional
-import multiprocessing
 
+import torch
 import torch.distributed as torch_distrib
+from packaging.version import parse
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torch.utils.data.distributed import DistributedSampler
 
@@ -61,7 +63,7 @@ def _has_len(dataloader: DataLoader) -> bool:
     except NotImplementedError:  # e.g. raised by torchtext if a batch_size_fn is used
         has_len = False
 
-    if has_len and _has_iterable_dataset(dataloader):
+    if has_len and _has_iterable_dataset(dataloader) and parse(torch.__version__) >= parse("1.4.0"):
         rank_zero_warn(
             'Your `IterableDataset` has `__len__` defined.'
             ' In combination with multi-processing data loading (e.g. batch size > 1),'

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -1,11 +1,11 @@
 import multiprocessing
 import platform
 from abc import ABC, abstractmethod
+from distutils.version import LooseVersion
 from typing import Union, List, Tuple, Callable, Optional
 
 import torch
 import torch.distributed as torch_distrib
-from packaging.version import parse
 from torch.utils.data import DataLoader, RandomSampler, SequentialSampler
 from torch.utils.data.distributed import DistributedSampler
 
@@ -63,7 +63,7 @@ def _has_len(dataloader: DataLoader) -> bool:
     except NotImplementedError:  # e.g. raised by torchtext if a batch_size_fn is used
         has_len = False
 
-    if has_len and _has_iterable_dataset(dataloader) and version.parse(torch.__version__) >= version.parse("1.4.0"):
+    if has_len and _has_iterable_dataset(dataloader) and LooseVersion(torch.__version__) >= LooseVersion("1.4.0"):
         rank_zero_warn(
             'Your `IterableDataset` has `__len__` defined.'
             ' In combination with multi-processing data loading (e.g. batch size > 1),'

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -63,7 +63,7 @@ def _has_len(dataloader: DataLoader) -> bool:
     except NotImplementedError:  # e.g. raised by torchtext if a batch_size_fn is used
         has_len = False
 
-    if has_len and _has_iterable_dataset(dataloader) and parse(torch.__version__) >= parse("1.4.0"):
+    if has_len and _has_iterable_dataset(dataloader) and version.parse(torch.__version__) >= version.parse("1.4.0"):
         rank_zero_warn(
             'Your `IterableDataset` has `__len__` defined.'
             ' In combination with multi-processing data loading (e.g. batch size > 1),'

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -297,11 +297,7 @@ class TrainerDataLoadingMixin(ABC):
         # datasets could be none, 1 or 2+
         if len(dataloaders) != 0:
             for i, dataloader in enumerate(dataloaders):
-                try:
-                    num_batches = len(dataloader)
-                except (TypeError, NotImplementedError):
-                    num_batches = float('inf')
-
+                num_batches = len(dataloader) if _has_len(dataloader) else float('inf')
                 self._worker_check(dataloader, f'{mode} dataloader {i}')
 
                 # percent or num_steps

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -144,9 +144,8 @@ class TrainerDataLoadingMixin(ABC):
     def auto_add_sampler(self, dataloader: DataLoader, train: bool) -> DataLoader:
 
         # don't do anything if it's not a dataloader
-        # don't manipulate iterable datasets
         is_dataloader = isinstance(dataloader, DataLoader)
-
+        # don't manipulate iterable datasets
         is_iterable_ds = _has_iterable_dataset(dataloader)
 
         if not is_dataloader or is_iterable_ds:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,4 +7,3 @@ future>=0.17.1  # required for builtins in setup.py
 # pyyaml>=3.13
 PyYAML>=5.1  # OmegaConf requirement
 tqdm>=4.41.0
-packaging

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,3 +7,4 @@ future>=0.17.1  # required for builtins in setup.py
 # pyyaml>=3.13
 PyYAML>=5.1  # OmegaConf requirement
 tqdm>=4.41.0
+packaging

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -492,7 +492,6 @@ def test_warning_with_few_workers(tmpdir, ckpt_path):
 @pytest.mark.xfail(
     parse(torch.__version__) < parse("1.4.0"),
     reason="IterableDataset with __len__ before 1.4 raises",
-    raises=TypeError
 )
 def test_warning_with_iterable_dataset_and_len(tmpdir):
     """ Tests that a warning messages is shown when an IterableDataset defines `__len__`. """

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -492,6 +492,7 @@ def test_warning_with_iterable_dataset_and_len(tmpdir):
     """ Tests that a warning messages is shown when an IterableDataset defines `__len__`. """
     model = EvalModelTemplate()
     original_dataset = model.train_dataloader().dataset
+
     class IterableWithLen(IterableDataset):
 
         def __iter__(self):

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -3,10 +3,11 @@ import platform
 import pytest
 import torch
 from torch.utils.data.dataloader import DataLoader
-from torch.utils.data.dataset import Subset
+from torch.utils.data.dataset import Subset, IterableDataset
 
 import tests.base.develop_pipelines as tpipes
 from pytorch_lightning import Trainer
+from pytorch_lightning.trainer.data_loading import _has_len, _has_iterable_dataset
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.base import EvalModelTemplate
 
@@ -485,6 +486,31 @@ def test_warning_with_few_workers(tmpdir, ckpt_path):
     test_options = dict(test_dataloaders=train_dl, ckpt_path=ckpt_path)
     with pytest.warns(UserWarning, match='test'):
         trainer.test(**test_options)
+
+
+def test_warning_with_iterable_dataset_and_len(tmpdir):
+    """ Tests that a warning messages is shown when an IterableDataset defines `__len__`. """
+    model = EvalModelTemplate()
+    original_dataset = model.train_dataloader().dataset
+    class IterableWithLen(IterableDataset):
+
+        def __iter__(self):
+            return iter(original_dataset)
+
+        def __len__(self):
+            return len(original_dataset)
+
+    dataloader = DataLoader(IterableWithLen(), batch_size=16)
+    assert _has_len(dataloader)
+    assert _has_iterable_dataset(dataloader)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=3,
+    )
+    with pytest.warns(UserWarning, match='Your `IterableDataset` has `__len__` defined.'):
+        trainer.fit(model, train_dataloader=dataloader, val_dataloaders=[dataloader])
+    with pytest.warns(UserWarning, match='Your `IterableDataset` has `__len__` defined.'):
+        trainer.test(model, test_dataloaders=[dataloader])
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason='Test requires multiple GPUs')

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -2,6 +2,7 @@ import platform
 
 import pytest
 import torch
+from packaging.version import parse
 from torch.utils.data.dataloader import DataLoader
 from torch.utils.data.dataset import Subset, IterableDataset
 
@@ -488,6 +489,11 @@ def test_warning_with_few_workers(tmpdir, ckpt_path):
         trainer.test(**test_options)
 
 
+@pytest.mark.xfail(
+    parse(torch.__version__) < parse("1.4.0"),
+    reason="IterableDataset with __len__ before 1.4 raises",
+    raises=TypeError
+)
 def test_warning_with_iterable_dataset_and_len(tmpdir):
     """ Tests that a warning messages is shown when an IterableDataset defines `__len__`. """
     model = EvalModelTemplate()


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #2429

torch < 1.4: An `IterableDataset` with `__len__` defined raises a TypeError
torch >= 1.4: It does not raise an error, but we still want to display a warning because it is most likely unintentional and could lead to side effects. 


# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
