### PR TITLE
Fix default value in documentation

### DIFF
--- a/pytorch_lightning/trainer/__init__.py
+++ b/pytorch_lightning/trainer/__init__.py
@@ -162,7 +162,7 @@ Check `NVIDIA apex docs <https://nvidia.github.io/apex/amp.html#opt-levels>`_ fo
 Example::
 
     # default used by the Trainer
-    trainer = Trainer(amp_level='O1')
+    trainer = Trainer(amp_level='O2')
 
 auto_scale_batch_size
 ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Updated the default `amp_level` in the documentation since it changed in #2362 