### PR TITLE
fix worker warning

### DIFF
--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -124,24 +124,24 @@ class TrainerDataLoadingMixin(ABC):
         # ddp_spawn + num_workers > 0 don't mix! tell the user
         is_dataloader = isinstance(dataloader, DataLoader)
         using_spawn = self.distributed_backend == 'ddp_spawn'
-        if on_windows:
-            pass
-        elif is_dataloader and dataloader.num_workers > 0 and using_spawn:
-            rank_zero_warn('Dataloader(num_workers>0) and ddp_spawn do not mix well! '
-                           'Your performance might suffer dramatically. '
-                           'Please consider setting distributed_backend=ddp to use num_workers > 0 '
-                           '(this is a bottleneck of Python .spawn() and PyTorch')
+        if is_dataloader and not on_windows:
+            if dataloader.num_workers > 0 and using_spawn:
+                rank_zero_warn('Dataloader(num_workers>0) and ddp_spawn do not mix well!'
+                               ' Your performance might suffer dramatically.'
+                               ' Please consider setting distributed_backend=ddp to use num_workers > 0'
+                               ' (this is a bottleneck of Python .spawn() and PyTorch')
 
-        elif is_dataloader and dataloader.num_workers == 0 and using_spawn:
-            rank_zero_warn('You are using `distributed_backend=ddp_spawn` with num_workers=0. '
-                           'For much faster performance, switch to `distributed_backend=ddp` and set `num_workers>0`')
+            elif dataloader.num_workers == 0 and using_spawn:
+                rank_zero_warn('You are using `distributed_backend=ddp_spawn` with num_workers=0.'
+                               ' For much faster performance, switch to `distributed_backend=ddp`'
+                               ' and set `num_workers>0`')
 
-        elif is_dataloader and dataloader.num_workers <= 2 and multiprocessing.cpu_count() > 2 and not using_spawn:
-            num_cpus = multiprocessing.cpu_count()
-            rank_zero_warn(f'The dataloader, {name}, does not have many workers which may be a bottleneck.'
-                           ' Consider increasing the value of the `num_workers` argument` '
-                           f'(try {num_cpus} which is the number of cpus on this machine)'
-                           ' in the `DataLoader` init to improve performance.')
+            elif dataloader.num_workers <= 2 and multiprocessing.cpu_count() > 2 and not using_spawn:
+                num_cpus = multiprocessing.cpu_count()
+                rank_zero_warn(f'The dataloader, {name}, does not have many workers which may be a bottleneck.'
+                               ' Consider increasing the value of the `num_workers` argument`'
+                               f' (try {num_cpus} which is the number of cpus on this machine)'
+                               ' in the `DataLoader` init to improve performance.')
 
     def auto_add_sampler(self, dataloader: DataLoader, train: bool) -> DataLoader:
 


### PR DESCRIPTION
## What does this PR do?

Kaggle environments have 2 CPUs, which triggers an unnecessary warning for num_workers = 2.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
