### PR TITLE
add metrics to pl module

### DIFF
--- a/pytorch_lightning/__init__.py
+++ b/pytorch_lightning/__init__.py
@@ -54,6 +54,7 @@ else:
     from pytorch_lightning.callbacks import Callback
     from pytorch_lightning.trainer import Trainer
     from pytorch_lightning.utilities.seed import seed_everything
+    from pytorch_lightning import metrics
 
     __all__ = [
         'Trainer',
@@ -61,6 +62,7 @@ else:
         'Callback',
         'data_loader',
         'seed_everything',
+        'metrics'
     ]
 
     # necessary for regular bolts imports. Skip exception since bolts is not always installed


### PR DESCRIPTION
## What does this PR do?

metrics module can't import `pl.metrics` from `from pl import *` in 0.8.4 without `__all__`

Fixes # (issue) // Not discussed

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
