### PR TITLE
Support **DictConfig hparam serialization

### DIFF
--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -330,7 +330,8 @@ def save_hparams_to_yaml(config_yaml, hparams: Union[dict, Namespace]) -> None:
     if not gfile.isdir(os.path.dirname(config_yaml)):
         raise RuntimeError(f"Missing folder: {os.path.dirname(config_yaml)}.")
 
-    if OMEGACONF_AVAILABLE and isinstance(hparams, Container):
+    if Container is not None and (OmegaConf.is_config(hparams) or
+                                  OmegaConf.is_config(v) for v in hparams.values() ):
         from omegaconf import OmegaConf
 
         OmegaConf.save(hparams, config_yaml, resolve=True)

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -328,7 +328,7 @@ def save_hparams_to_yaml(config_yaml, hparams: Union[dict, Namespace]) -> None:
     if not gfile.isdir(os.path.dirname(config_yaml)):
         raise RuntimeError(f"Missing folder: {os.path.dirname(config_yaml)}.")
 
-    if OmegaConf is not None:
+    if OmegaConf is not None and not isinstance(hparams, Namespace):
         if OmegaConf.is_config(hparams):
             OmegaConf.save(hparams, config_yaml, resolve=True)
         elif (OmegaConf.is_config(v) for v in hparams.values()):

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -328,23 +328,26 @@ def save_hparams_to_yaml(config_yaml, hparams: Union[dict, Namespace]) -> None:
     if not gfile.isdir(os.path.dirname(config_yaml)):
         raise RuntimeError(f"Missing folder: {os.path.dirname(config_yaml)}.")
 
-    if OmegaConf is not None and not isinstance(hparams, Namespace):
-        if OmegaConf.is_config(hparams):
-            OmegaConf.save(hparams, config_yaml, resolve=True)
-        elif (OmegaConf.is_config(v) for v in hparams.values()):
-            OmegaConf.save(OmegaConf.create(hparams), config_yaml, resolve=True)
-        return
-
-    # saving the standard way
+    # convert Namespace or AD to dict
     if isinstance(hparams, Namespace):
         hparams = vars(hparams)
     elif isinstance(hparams, AttributeDict):
         hparams = dict(hparams)
+
+    # saving with OmegaConf objects
+    if OmegaConf is not None:
+        if OmegaConf.is_config(hparams):
+            OmegaConf.save(hparams, config_yaml, resolve=True)
+            return
+        for v in hparams.values():
+            if OmegaConf.is_config(v):
+                OmegaConf.save(OmegaConf.create(hparams), config_yaml, resolve=True)
+                return
+
+    # saving the standard way
     assert isinstance(hparams, dict)
-
-    with cloud_open(config_yaml, "w", newline="") as fp:
+    with open(config_yaml, 'w', newline='') as fp:
         yaml.dump(hparams, fp)
-
 
 def convert(val: str) -> Union[int, float, bool, str]:
     try:


### PR DESCRIPTION
## What does this PR do?

**Context:** Passing an unpacked `DictConfig` to `__init__()` and then calling `save_hyperparameters()`

**Bug:** `save_hyperparameters()` deals with the unpacked `DictConfig` as a `dict` which might still contain values of type `DictConfig`. Upon serialization during saving, this errors out because it is handled with `yaml.dump()`.

**Fix:** Enables OmegaConf to serialize the object as originally intended by casting back to a `DictConfig`.

Fixes: #2844 

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Always.
