### PR TITLE
[tiny] Fix training_dataloader usage to be train_dataloader instead.

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1274,17 +1274,17 @@ class Trainer(
             if not self.is_overridden('training_step', model):
                 raise MisconfigurationException(
                     'No `training_step()` method defined. Lightning `Trainer` expects as minimum a'
-                    ' `training_step()`, `training_dataloader()` and `configure_optimizers()` to be defined.')
+                    ' `training_step()`, `train_dataloader()` and `configure_optimizers()` to be defined.')
 
             if not self.is_overridden('train_dataloader', model):
                 raise MisconfigurationException(
                     'No `train_dataloader()` method defined. Lightning `Trainer` expects as minimum a'
-                    ' `training_step()`, `training_dataloader()` and `configure_optimizers()` to be defined.')
+                    ' `training_step()`, `train_dataloader()` and `configure_optimizers()` to be defined.')
 
             if not self.is_overridden('configure_optimizers', model):
                 raise MisconfigurationException(
                     'No `configure_optimizers()` method defined. Lightning `Trainer` expects as minimum a'
-                    ' `training_step()`, `training_dataloader()` and `configure_optimizers()` to be defined.')
+                    ' `training_step()`, `train_dataloader()` and `configure_optimizers()` to be defined.')
 
             # Check val_dataloader, validation_step and validation_epoch_end
             if self.is_overridden('val_dataloader', model):

--- a/tests/trainer/test_checks.py
+++ b/tests/trainer/test_checks.py
@@ -11,7 +11,7 @@ from tests.base import EvalModelTemplate
 
 def test_wrong_train_setting(tmpdir):
     """
-    * Test that an error is thrown when no `training_dataloader()` is defined
+    * Test that an error is thrown when no `train_dataloader()` is defined
     * Test that an error is thrown when no `training_step()` is defined
     """
     tutils.reset_seed()


### PR DESCRIPTION
There are usages of `training_dataloader`, which is a method that no longer seems to exist in LightingModule. Instead, these usages should be updated to `train_dataloader`.


