### PR TITLE
Fix argparse default value bug

### DIFF
--- a/tests/trainer/test_trainer_cli.py
+++ b/tests/trainer/test_trainer_cli.py
@@ -102,7 +102,21 @@ def test_add_argparse_args_redefined_error(cli_args, monkeypatch):
     pytest.param('--tpu_cores=8',
                  {'tpu_cores': 8}),
     pytest.param("--tpu_cores=1,",
-                 {'tpu_cores': '1,'})
+                 {'tpu_cores': '1,'}),
+    pytest.param(
+        "",
+        {
+            # These parameters are marked as Optional[...] in Trainer.__init__, with None as default.
+            # They should not be changed by the argparse interface.
+            "min_steps": None,
+            "max_steps": None,
+            "log_gpu_memory": None,
+            "distributed_backend": None,
+            "weights_save_path": None,
+            "truncated_bptt_steps": None,
+            "resume_from_checkpoint": None,
+            "profiler": None,
+        }),
 ])
 def test_argparse_args_parsing(cli_args, expected):
     """Test multi type argument with bool."""


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/1916.

Essentially this PR will make `parse_argparser` properly do the inverse of what `add_argparse_args` does.

The reason for the issue is that PL auto-generates an argparser that accepts flag style options, i.e. `--auto_lr_find` leads to `args.auto_lr_find is True`. The only way to provide a negative flag (for options that default to `True`) is to use `--auto_lr_find False`. Because some parameters (like `auto_lr_find`) can be both a boolean and a string, the generated parser for these arguments uses `nargs="?"`, which means that the default value becomes `None`, regardless of the default value in `__init__`. This means that for the flag-style options, `parse_argparser` needs to convert some of the `None` values to booleans.

Not sure if I should format with black or not, as that would create a large diff that is unrelated to the changes needed for the issue.

Also I think the argparse solution is not very robust. This PR simply fixes the immediate issue, but I think it is quite likely that something similar could happen again.


# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
