### PR TITLE
fix codecov command error in drone for master branch

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -44,7 +44,7 @@ steps:
     #- cd docs; make doctest; make coverage
     - coverage report
     # see: https://docs.codecov.io/docs/merging-reports
-    - codecov --token $CODECOV_TOKEN --flags=gpu,pytest --name="GPU-coverage" --env=linux --pr $DRONE_PULL_REQUEST --build $DRONE_BUILD_NUMBER --commit $DRONE_COMMIT
+    - codecov --token $CODECOV_TOKEN --flags=gpu,pytest --name="GPU-coverage" --env=linux --build $DRONE_BUILD_NUMBER --commit $DRONE_COMMIT
     # --build $DRONE_BUILD_NUMBER --branch $DRONE_BRANCH --commit $DRONE_COMMIT --tag $DRONE_TAG --pr $DRONE_PULL_REQUEST
     # - codecov --token $CODECOV_TOKEN --flags=gpu,pytest --build $DRONE_BUILD_NUMBER
     - python tests/collect_env_details.py


### PR DESCRIPTION
## What does this PR do?

on master we see this error when codecov tries to upload
http://35.192.60.23/PyTorchLightning/pytorch-lightning/6028/1/2
Since master is not a pull requrest, the --pr argument does not work there.
This is why the badge on the README page is always red and I think this is also why each PR is always claiming +2% coverage since the results are not getting uploaded. 

```
+ codecov --token $CODECOV_TOKEN --flags=gpu,pytest --name="GPU-coverage" --env=linux --pr $DRONE_PULL_REQUEST --build $DRONE_BUILD_NUMBER --commit $DRONE_COMMIT
--
1336 | usage: codecov [-h] [--version] [--token TOKEN] [--file [FILE [FILE ...]]]
1337 | [--flags [FLAGS [FLAGS ...]]] [--env [ENV [ENV ...]]]
1338 | [--required] [--name NAME] [--gcov-root GCOV_ROOT]
1339 | [--gcov-glob [GCOV_GLOB [GCOV_GLOB ...]]]
1340 | [--gcov-exec GCOV_EXEC] [--gcov-args GCOV_ARGS]
1341 | [-X [DISABLE [DISABLE ...]]] [--root ROOT] [--commit COMMIT]
1342 | [--prefix PREFIX] [--branch BRANCH] [--build BUILD] [--pr PR]
1343 | [--tag TAG] [--slug SLUG] [--url URL] [--cacert CACERT]
1344 | [--dump] [-v] [--no-color]
1345 | codecov: error: argument --pr: expected one argument

```
From codecov manpage:
```
  --pr PR               Specify a custom pr number, provided automatically for
                        supported CI companies
```
So I think we don't need it. Let's try to remove it.