### PR TITLE
Added small eps to dice and iou to avoid NaN

### DIFF
--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -891,7 +891,7 @@ def dice_score(
 
         tp, fp, tn, fn, sup = stat_scores(pred=pred, target=target, class_index=i)
 
-        denom = (2 * tp + fp + fn).to(torch.float)
+        denom = (2 * tp + fp + fn + 1e-15).to(torch.float)
 
         if torch.isclose(denom, torch.zeros_like(denom)).any():
             # nan result
@@ -945,5 +945,5 @@ def iou(pred: torch.Tensor, target: torch.Tensor,
         tps = tps[1:]
         fps = fps[1:]
         fns = fns[1:]
-    iou = tps / (fps + fns + tps)
+    iou = tps / (fps + fns + tps + 1e-15)
     return reduce(iou, reduction=reduction)


### PR DESCRIPTION
The code fixes a bug calculating both the IoU and the Dice metrics, which resulted in a nan in the calculation. This was due to not including a small eps in the division on both these metrics. I have added a eps (equal to `1e-15`), which successfully prevents this `NaN` calculation. 

## Example

### Previous Code (with bug)

```py
import torch
from pytorch_lightning.metrics.functional import iou

y = torch.tensor([0, 1, 2, 3, 3])
y_true = torch.tensor([0, 1, 2, 2, 2])

# reduction = 'none' so we can see the iou for each class
out = iou(y, y_true, num_classes=5, reduction='none')

print(out)
>>> tensor([1.0000, 1.0000, 0.3333, 0.0000,    nan])
```

The fifth class has a IoU of `nan`, not `0`.

### Fixed code


```py
import torch
from pytorch_lightning.metrics.functional import iou

y = torch.tensor([0, 1, 2, 3, 3])
y_true = torch.tensor([0, 1, 2, 2, 2])

# reduction = 'none' so we can see the iou for each class
out = iou(y, y_true, num_classes=5, reduction='none')

print(out)
>>> tensor([1.0000, 1.0000, 0.3333, 0.0000, 0.0000])
```