### PR TITLE
Fix CI crash on coverage upload timeout

### DIFF
--- a/.github/workflows/ci-test-base.yml
+++ b/.github/workflows/ci-test-base.yml
@@ -98,6 +98,5 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: coverage.xml
         flags: cpu,pytest
-        env_vars: ${{ runner.os }},python${{ matrix.python-version }}
         name: Base-coverage
-        fail_ci_if_error: true
+        fail_ci_if_error: false

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -140,6 +140,5 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: coverage.xml
         flags: cpu,pytest
-        env_vars: ${{ runner.os }},python${{ matrix.python-version }}
         name: CPU-coverage
-        fail_ci_if_error: true
+        fail_ci_if_error: false

--- a/.github/workflows/tpu-testing.yml
+++ b/.github/workflows/tpu-testing.yml
@@ -127,6 +127,5 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: coverage
         flags: tpu,pytest
-        env_vars: ${{ runner.os }},python
         name: TPU-coverage
-        fail_ci_if_error: true
+        fail_ci_if_error: false

--- a/.github/workflows/tpu-testing.yml
+++ b/.github/workflows/tpu-testing.yml
@@ -128,4 +128,4 @@ jobs:
         file: coverage
         flags: tpu,pytest
         name: TPU-coverage
-        fail_ci_if_error: false
+        fail_ci_if_error: true


### PR DESCRIPTION
## What does this PR do?

We experience random HTTP timeouts on coverage upload, leading to CI jobs getting marked as failed, even though the tests passed. See for example [here](https://github.com/PyTorchLightning/pytorch-lightning/pull/2546/checks?check_run_id=847719299).
We can set the flag to not fail if the upload is incomplete.


```
##[warning]Unexpected input 'env_vars', valid inputs are ['name', 'token', 'file', 'flags', 'fail_ci_if_error']
Run codecov/codecov-action@v1
  with:
    file: coverage.xml
    flags: cpu,pytest
    env_vars: Windows,python3.6
    name: CPU-coverage
    fail_ci_if_error: true
  env:
    pythonLocation: C:\hostedtoolcache\windows\Python\3.6.8\x64
D:\a\_actions\codecov\codecov-action\v1\dist\index.js:20817
      throw error;
      ^

Error: connect ETIMEDOUT 35.199.43.247:443
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1129:14) {
  errno: 'ETIMEDOUT',
  code: 'ETIMEDOUT',
  syscall: 'connect',
  address: '35.199.43.247',
  port: 443
}
```

