### PR TITLE
docs: add hint about register_buffer

### DIFF
--- a/docs/source/multi_gpu.rst
+++ b/docs/source/multi_gpu.rst
@@ -50,18 +50,19 @@ This will make your code scale to any arbitrary number of GPUs or TPUs with Ligh
         z = torch.Tensor(2, 3)
         z = z.type_as(x, device=self.device)
 
-The LightningModule knows what device it is on. You can access the reference via `self.device`.
+The :class:`~pytorch_lightning.core.lightning.LightningModule` knows what device it is on. You can access the reference via `self.device`.
 Sometimes it is necessary to store tensors as module attributes. However, if they are not parameters they will
 remain on the CPU even if the module gets moved to a new device. To prevent that and remain device agnostic,
-register the tensor as a buffer with :meth:`~torch.nn.Module.register_buffer`.
+register the tensor as a buffer in your modules's `__init__` method with :meth:`~torch.nn.Module.register_buffer`.
 
 .. testcode::
 
-    # in your Lightning- or nn.Module
-    def __init__(self):
-        ...
-        self.register_buffer("sigma", torch.eye(3))
-        # you can now access self.sigma anywhere in your module
+    class LitModel(LightningModule):
+
+        def __init__(self):
+            ...
+            self.register_buffer("sigma", torch.eye(3))
+            # you can now access self.sigma anywhere in your module
 
 
 Remove samplers

--- a/docs/source/multi_gpu.rst
+++ b/docs/source/multi_gpu.rst
@@ -33,8 +33,8 @@ Delete any calls to .cuda() or .to(device).
     def forward(self, x):
         x_hat = layer_1(x)
 
-Init tensors using type_as
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Init tensors using type_as and register_buffer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 When you need to create a new tensor, use `type_as`.
 This will make your code scale to any arbitrary number of GPUs or TPUs with Lightning.
 
@@ -51,6 +51,18 @@ This will make your code scale to any arbitrary number of GPUs or TPUs with Ligh
         z = z.type_as(x, device=self.device)
 
 The LightningModule knows what device it is on. You can access the reference via `self.device`.
+Sometimes it is necessary to store tensors as module attributes. However, if they are not parameters they will
+remain on the CPU even if the module gets moved to a new device. To prevent that and remain device agnostic,
+register the tensor as a buffer with :meth:´~torch.nn.Module.register_buffer´.
+
+.. testcode::
+
+    # in your Lightning- or nn.Module
+    def __init__(self):
+        ...
+        self.register_buffer("sigma", torch.eye(3))
+        # you can now access self.sigma anywhere in your module
+
 
 Remove samplers
 ^^^^^^^^^^^^^^^

--- a/docs/source/multi_gpu.rst
+++ b/docs/source/multi_gpu.rst
@@ -53,7 +53,7 @@ This will make your code scale to any arbitrary number of GPUs or TPUs with Ligh
 The LightningModule knows what device it is on. You can access the reference via `self.device`.
 Sometimes it is necessary to store tensors as module attributes. However, if they are not parameters they will
 remain on the CPU even if the module gets moved to a new device. To prevent that and remain device agnostic,
-register the tensor as a buffer with :meth:´~torch.nn.Module.register_buffer´.
+register the tensor as a buffer with :meth:`~torch.nn.Module.register_buffer`.
 
 .. testcode::
 

--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -60,11 +60,12 @@ LightningModules know what device they are on! Construct tensors on the device d
     # bad
     t = torch.rand(2, 2).cuda()
 
-    # good (self is lightningModule)
+    # good (self is LightningModule)
     t = torch.rand(2, 2, device=self.device)
 
 
-For tensors that need to be model attributes, it is best practice to register them as buffers:
+For tensors that need to be model attributes, it is best practice to register them as buffers in the modules's
+`__init__` method:
 
 .. code-block:: python
 

--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -51,17 +51,28 @@ Don't call this unnecessarily! Every time you call this ALL your GPUs have to wa
 
 ----------
 
-construct tensors directly on device
-------------------------------------
-LightningModules know what device they are on! construct tensors on the device directly to avoid CPU->Device transfer.
+Construct tensors directly on the device
+----------------------------------------
+LightningModules know what device they are on! Construct tensors on the device directly to avoid CPU->Device transfer.
 
-.. code-block:: python
+.. testcode::
 
     # bad
-    t = tensor.rand(2, 2).cuda()
+    t = torch.rand(2, 2).cuda()
 
     # good (self is lightningModule)
-    t = tensor.rand(2,2, device=self.device)
+    t = torch.rand(2, 2, device=self.device)
+
+
+For tensors that need to be model attributes, it is best practice to register them as buffers:
+
+.. testcode::
+
+    # bad
+    self.t = torch.rand(2, 2, device=self.device)
+
+    # good
+    self.register_buffer("t", torch.rand(2, 2))
 
 ----------
 

--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -55,7 +55,7 @@ Construct tensors directly on the device
 ----------------------------------------
 LightningModules know what device they are on! Construct tensors on the device directly to avoid CPU->Device transfer.
 
-.. testcode::
+.. code-block:: python
 
     # bad
     t = torch.rand(2, 2).cuda()

--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -66,7 +66,7 @@ LightningModules know what device they are on! Construct tensors on the device d
 
 For tensors that need to be model attributes, it is best practice to register them as buffers:
 
-.. testcode::
+.. code-block:: python
 
     # bad
     self.t = torch.rand(2, 2, device=self.device)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Tensors that are attributes to the modules should be registered as buffers to be device agnostic. This adds a hint to the docs how to do it. It is a frequently asked question. 

This was discussed on slack
https://app.slack.com/client/TR9DVT48M/threads/thread/CQXV8BRH9-1594276998.342300

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
