### PR TITLE
Add Transformers Question Answering to community examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ Check out this awesome list of research papers and implementations done with Lig
 - [Transformers transfer learning (Huggingface)](https://colab.research.google.com/drive/1F_RNcHzTfFuQf-LeKvSlud6x7jXYkG31#scrollTo=yr7eaxkF-djf)
 - [Transformers text classification](https://github.com/ricardorei/lightning-text-classification)
 - [VAE Library of over 18+ VAE flavors](https://github.com/AntixK/PyTorch-VAE)
-- [Finetune BERT, RoBERTa etc on QA Datasets like SQuAD](https://github.com/tshrjn/Finetune-QA/)
+- [Transformers Question Answering (SQuAD)](https://github.com/tshrjn/Finetune-QA/)
 - [Pytorch-Lightning + Microsoft NNI with Docker](https://github.com/davinnovation/pytorch-boilerplate)
 
 ## Tutorials

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -53,6 +53,7 @@ PyTorch Lightning Documentation
    Transformers transfer learning (Huggingface) <https://colab.research.google.com/drive/1F_RNcHzTfFuQf-LeKvSlud6x7jXYkG31#scrollTo=yr7eaxkF-djf>
    Transformers text classification <https://github.com/ricardorei/lightning-text-classification>
    VAE Library of over 18+ VAE flavors <https://github.com/AntixK/PyTorch-VAE>
+   Transformers Question Answering (SQuAD) <https://github.com/tshrjn/Finetune-QA/>
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
## What does this PR do?

Adds links to Transformers Question Answering repo (where one can fine-tune BERT, Roberta etc over QA datasets like squad) to community examples.


# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?
