### PR TITLE
Add Blue Score to seq2seq metrics

### DIFF
--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -229,7 +229,7 @@ RMSLE
     :noindex:
 
 Bleu
-^^^^^
+^^^^
 
 .. autoclass:: pytorch_lightning.metrics.seq2seq.Bleu
     :noindex:

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -403,6 +403,12 @@ stat_scores_multiple_classes (F)
 .. autofunction:: pytorch_lightning.metrics.functional.stat_scores_multiple_classes
     :noindex:
 
+bleu (F)
+^^^^^^^^
+
+.. autofunction:: pytorch_lightning.metrics.seq2seq.functional.bleu
+    :noindex:
+
 ----------------
 
 Metric pre-processing

--- a/docs/source/metrics.rst
+++ b/docs/source/metrics.rst
@@ -228,6 +228,12 @@ RMSLE
 .. autoclass:: pytorch_lightning.metrics.regression.RMSLE
     :noindex:
 
+Bleu
+^^^^^
+
+.. autoclass:: pytorch_lightning.metrics.seq2seq.Bleu
+    :noindex:
+
 ----------------
 
 Functional Metrics

--- a/pytorch_lightning/metrics/functional/seq2seq.py
+++ b/pytorch_lightning/metrics/functional/seq2seq.py
@@ -1,0 +1,23 @@
+import torch
+from torchtext.data.metrics import bleu_score
+from typing import List
+
+def bleu(
+    pred: List[str],
+    targ: List[str],
+    max_n : int = 4,
+    weights : list = [0.25, 0.25, 0.25, 0.25]
+) -> torch.Tensor:
+    """
+    Computes Bleu score.
+
+    Args:
+        pred: predicted texts
+        target: ground truth texts
+        max_n:  the maximum n-gram we want to use. E.g. if max_n=3, we will use unigrams, bigrams and trigrams
+        weights: a list of weights used for each n-gram category (uniform by default)
+    
+    Return:
+        Float Tensor with Bleu score.
+    """
+    return torch.tensor(bleu_score(pred,targ,max_n,weights))

--- a/pytorch_lightning/metrics/seq2seq.py
+++ b/pytorch_lightning/metrics/seq2seq.py
@@ -24,4 +24,4 @@ class Bleu(Metric):
         self.weights = weights
 
     def forward(self,x,y):
-        return torch.tensor(bleu(x,y,self.max_n,self.weights))
+        return bleu(x,y,self.max_n,self.weights)

--- a/pytorch_lightning/metrics/seq2seq.py
+++ b/pytorch_lightning/metrics/seq2seq.py
@@ -1,0 +1,26 @@
+import torch
+from torchtext.data.metrics import bleu_score
+
+
+from pytorch_lightning.metrics.metric import Metric
+
+class Bleu(Metric):
+    '''
+    Computes the Bleu score.
+
+    Example:
+    >>> candidate_corpus = [['My', 'full', 'pl', 'test'], ['Another', 'Sentence']]
+    >>> references_corpus = [[['My', 'full', 'pl', 'test'], ['Completely', 'Different']], [['No', 'Match']]]
+    >>> metric = Bleu()
+    >>> metric(candidate_corpus, references_corpus)
+    tensor(0.8409)
+    
+    '''
+
+    def __init__(self,max_n : int = 4,weights : list = [0.25, 0.25, 0.25, 0.25]):
+        super().__init__(name='bleu')
+        self.max_n=max_n 
+        self.weights = weights
+
+    def forward(self,x,y):
+        return torch.tensor(bleu_score(x,y,self.max_n,self.weights))

--- a/pytorch_lightning/metrics/seq2seq.py
+++ b/pytorch_lightning/metrics/seq2seq.py
@@ -1,6 +1,7 @@
 import torch
-from torchtext.data.metrics import bleu_score
-
+from pytorch_lightning.metrics.functional.seq2seq import (
+    bleu
+)
 
 from pytorch_lightning.metrics.metric import Metric
 
@@ -23,4 +24,4 @@ class Bleu(Metric):
         self.weights = weights
 
     def forward(self,x,y):
-        return torch.tensor(bleu_score(x,y,self.max_n,self.weights))
+        return torch.tensor(bleu(x,y,self.max_n,self.weights))

--- a/tests/metrics/functional/test_seq2seq.py
+++ b/tests/metrics/functional/test_seq2seq.py
@@ -1,0 +1,13 @@
+import pytest
+import torch
+
+from pytorch_lightning.metrics.functional.seq2seq import (
+    bleu
+)
+
+@pytest.mark.parametrize(['pred', 'target', 'expected'], [
+    pytest.param([['My', 'full', 'pl', 'test'], ['Another', 'Sentence']],[[['My', 'full', 'pl', 'test'], ['Completely', 'Different']], [['No', 'Match']]], 0.8409)
+])
+def test_mse(pred, target, expected):
+    score = bleu(torch.tensor(pred), torch.tensor(target))
+    assert pytest.approx(score.item(),0.1) == expected

--- a/tests/metrics/test_seq2seq.py
+++ b/tests/metrics/test_seq2seq.py
@@ -1,0 +1,9 @@
+import torch
+from pytorch_lightning.metrics.seq2seq import Bleu
+
+def test_bleu():
+    candidate_corpus = [['My', 'full', 'pl', 'test'], ['Another', 'Sentence']]
+    references_corpus = [[['My', 'full', 'pl', 'test'], ['Completely', 'Different']], [['No', 'Match']]]
+    metric = Bleu()
+    score = metric(candidate_corpus, references_corpus)
+    assert isinstance(score, torch.Tensor)


### PR DESCRIPTION
## What does this PR do?

This PR adds a new module inside Metrics: seq2seq
and adds a PL Metric wrapper for torchtext bleu_score
Fixes #1301

# Before submitting

- [Y] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [Y] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [Y] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [Y] Did you make sure to update the documentation with your changes?
- [Y] Did you write any new necessary tests? 
- [Y] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun? 
Absolutely!
