### PR TITLE
Horovod: adjust base LR used by schedulers to scale with the number of workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed Horovod backend to scale LR schedlers with the optimizer ([#2626](https://github.com/PyTorchLightning/pytorch-lightning/pull/2626))
+
 
 
 ## [0.8.5] - 2020-07-09

--- a/tests/models/test_horovod.py
+++ b/tests/models/test_horovod.py
@@ -205,9 +205,6 @@ def test_horovod_multi_optimizer_with_scheduling_stepping(tmpdir):
     adjusted_lr1 = [pg['lr'] for pg in trainer.optimizers[0].param_groups][0]
     adjusted_lr2 = [pg['lr'] for pg in trainer.optimizers[1].param_groups][0]
 
-    print(adjusted_lr1)
-    print(adjusted_lr2)
-
     # Called ones after end of epoch
     assert pytest.approx(init_lr * 0.1) == adjusted_lr1
 

--- a/tests/models/test_horovod.py
+++ b/tests/models/test_horovod.py
@@ -205,8 +205,8 @@ def test_horovod_multi_optimizer_with_scheduling_stepping(tmpdir):
     adjusted_lr1 = [pg['lr'] for pg in trainer.optimizers[0].param_groups][0]
     adjusted_lr2 = [pg['lr'] for pg in trainer.optimizers[1].param_groups][0]
 
-    # Called ones after end of epoch
+    # Called ones after end of epoch with gamma=0.1
     assert pytest.approx(init_lr * 0.1) == adjusted_lr1
 
-    # Called every 3 steps, meaning for 1 epoch of 11 batches, it is called 3 times
+    # Called every 3 steps, meaning for 1 epoch of 11 batches, it is called 3 times with gamma=0.1
     assert pytest.approx(init_lr * 0.1) == adjusted_lr2

--- a/tests/models/test_horovod.py
+++ b/tests/models/test_horovod.py
@@ -5,6 +5,9 @@ import shlex
 import subprocess
 import sys
 
+from unittest.mock import patch
+
+import numpy as np
 import pytest
 import torch
 
@@ -113,7 +116,6 @@ def test_horovod_multi_gpu(tmpdir):
 @pytest.mark.skipif(not _nccl_available(), reason="test requires Horovod with NCCL support")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires GPU machine")
 def test_horovod_transfer_batch_to_gpu(tmpdir):
-
     class TestTrainingStepModel(EvalModelTemplate):
         def training_step(self, batch, *args, **kwargs):
             x, y = batch
@@ -175,3 +177,39 @@ def test_horovod_multi_optimizer(tmpdir):
     assert get_model_params(model.generator) != get_model_params(model.discriminator)
     assert get_model_params(model.generator) == get_optimizer_params(trainer.optimizers[0])
     assert get_model_params(model.discriminator) == get_optimizer_params(trainer.optimizers[1])
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Horovod is not supported on Windows")
+def test_horovod_multi_optimizer_with_scheduling_stepping(tmpdir):
+    hparams = EvalModelTemplate.get_default_hparams()
+    model = EvalModelTemplate(**hparams)
+    model.configure_optimizers = model.configure_optimizers__multiple_schedulers
+
+    num_workers = 8
+    init_lr = hparams.get('learning_rate') * num_workers
+
+    with patch('pytorch_lightning.trainer.distrib_parts.hvd.size') as mock_hvd_size:
+        mock_hvd_size.return_value = 8
+
+        # fit model
+        trainer = Trainer(
+            default_root_dir=tmpdir,
+            max_epochs=1,
+            limit_val_batches=0.5,
+            limit_train_batches=0.2,
+            distributed_backend='horovod'
+        )
+        results = trainer.fit(model)
+        assert results == 1
+
+    adjusted_lr1 = [pg['lr'] for pg in trainer.optimizers[0].param_groups][0]
+    adjusted_lr2 = [pg['lr'] for pg in trainer.optimizers[1].param_groups][0]
+
+    print(adjusted_lr1)
+    print(adjusted_lr2)
+
+    # Called ones after end of epoch
+    assert pytest.approx(init_lr * 0.1) == adjusted_lr1
+
+    # Called every 3 steps, meaning for 1 epoch of 11 batches, it is called 3 times
+    assert pytest.approx(init_lr * 0.1) == adjusted_lr2


### PR DESCRIPTION
In #2574 it was observed that the learning rate used to initialize learning rate schedulers is in conflict with the way we scale the learning rate with the number of Horovod workers.  Because the learning rate schedulers are initialized before the scaling, the scaling would be overridden.  This PR fixes this so that optimizers and LR schedulers scale up correctly.

Follow-ups to consider would be:

- Make scaling work for other backends like DDP.
- Add an option to configure the LR scaling in the Trainer.