### PR TITLE
Fix local rank zero casting

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -382,7 +382,7 @@ class Trainer(
         # we need to call this here or NVIDIA flags and other messaging in init will show on all ranks
         # this way we only show it on rank 0
         if 'LOCAL_RANK' in os.environ:
-            rank_zero_only.rank = os.environ['LOCAL_RANK']
+            rank_zero_only.rank = int(os.environ['LOCAL_RANK'])
 
         # training bookeeping
         self.total_batch_idx = 0

--- a/pytorch_lightning/utilities/distributed.py
+++ b/pytorch_lightning/utilities/distributed.py
@@ -18,7 +18,7 @@ try:
     # add the attribute to the function but don't overwrite in case Trainer has already set it
     getattr(rank_zero_only, 'rank')
 except AttributeError:
-    rank_zero_only.rank = os.environ.get('LOCAL_RANK', 0)
+    rank_zero_only.rank = int(os.environ.get('LOCAL_RANK', 0))
 
 
 def _warn(*args, **kwargs):

--- a/pytorch_lightning/utilities/distributed.py
+++ b/pytorch_lightning/utilities/distributed.py
@@ -14,12 +14,8 @@ def rank_zero_only(fn):
     return wrapped_fn
 
 
-try:
-    # add the attribute to the function but don't overwrite in case Trainer has already set it
-    getattr(rank_zero_only, 'rank')
-except AttributeError:
-    rank_zero_only.rank = int(os.environ.get('LOCAL_RANK', 0))
-
+# add the attribute to the function but don't overwrite in case Trainer has already set it
+rank_zero_only.rank = getattr(rank_zero_only, 'rank', int(os.environ.get('LOCAL_RANK', 0)))
 
 def _warn(*args, **kwargs):
     warnings.warn(*args, **kwargs)


### PR DESCRIPTION
## What does this PR do?
The environment variable 'LOCAL_RANK' can be a string, causing the `if rank_zero_only.rank == 0` check to fail. This is similar to the casting added in https://github.com/PyTorchLightning/pytorch-lightning/pull/1811/

Fixes #2641

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
