### PR TITLE
EvalResult support for val loop (PR 3/5)

### DIFF
--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -180,6 +180,7 @@ class EarlyStopping(Callback):
         if trainer.use_tpu and XLA_AVAILABLE:
             current = current.cpu()
 
+        import pdb; pdb.set_trace()
         if self.monitor_op(current - self.min_delta, self.best_score):
             self.best_score = current
             self.wait_count = 0

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -135,11 +135,9 @@ class EarlyStopping(Callback):
         self.patience = state_dict['patience']
 
     def on_validation_end(self, trainer, pl_module):
-        import pdb; pdb.set_trace()
         self._run_early_stopping_check(trainer, pl_module)
 
     def on_validation_epoch_end(self, trainer, pl_module):
-        import pdb; pdb.set_trace()
         val_es_key = 'val_early_stop_on'
         if trainer.callback_metrics.get(val_es_key) is not None:
             self.monitor = val_es_key

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -135,9 +135,11 @@ class EarlyStopping(Callback):
         self.patience = state_dict['patience']
 
     def on_validation_end(self, trainer, pl_module):
+        import pdb; pdb.set_trace()
         self._run_early_stopping_check(trainer, pl_module)
 
     def on_validation_epoch_end(self, trainer, pl_module):
+        import pdb; pdb.set_trace()
         val_es_key = 'val_early_stop_on'
         if trainer.callback_metrics.get(val_es_key) is not None:
             self.monitor = val_es_key
@@ -180,7 +182,6 @@ class EarlyStopping(Callback):
         if trainer.use_tpu and XLA_AVAILABLE:
             current = current.cpu()
 
-        import pdb; pdb.set_trace()
         if self.monitor_op(current - self.min_delta, self.best_score):
             self.best_score = current
             self.wait_count = 0

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -139,7 +139,7 @@ class EarlyStopping(Callback):
 
     def on_validation_epoch_end(self, trainer, pl_module):
         val_es_key = 'val_early_stop_on'
-        if trainer.callback_metrics.get(val_es_key, None) is not None:
+        if trainer.callback_metrics.get(val_es_key) is not None:
             self.monitor = val_es_key
 
         # disable strict checking when using structured results

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -276,7 +276,7 @@ class ModelCheckpoint(Callback):
         epoch = trainer.current_epoch
 
         # support structured results
-        if metrics.get('checkpoint_on', None) is not None:
+        if metrics.get('checkpoint_on') is not None:
             self.monitor = 'checkpoint_on'
 
         # conditioned val metrics override conditioned train loop metrics

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -280,7 +280,7 @@ class ModelCheckpoint(Callback):
             self.monitor = 'checkpoint_on'
 
         # conditioned val metrics override conditioned train loop metrics
-        if metrics.get('val_checkpoint_on', None) is not None:
+        if metrics.get('val_checkpoint_on') is not None:
             self.monitor = 'val_checkpoint_on'
 
         if self.save_top_k == 0:

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -233,15 +233,11 @@ class Result(Dict):
 
     @classmethod
     def gather(cls, outputs):
-        try:
-            meta = outputs[0]['meta']
-            result = cls()
-            result = recursive_gather(outputs, result)
-            recursive_stack(result)
-            result['meta'] = meta
-        except Exception as e:
-            import pdb; pdb.set_trace()
-            print('a')
+        meta = outputs[0].get('meta', None)
+        result = cls()
+        result = recursive_gather(outputs, result)
+        recursive_stack(result)
+        result['meta'] = meta
         return result
 
     @classmethod

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -233,12 +233,15 @@ class Result(Dict):
 
     @classmethod
     def gather(cls, outputs):
-        import pdb; pdb.set_trace()
-        meta = outputs[0]['meta']
-        result = cls()
-        result = recursive_gather(outputs, result)
-        recursive_stack(result)
-        result['meta'] = meta
+        try:
+            meta = outputs[0]['meta']
+            result = cls()
+            result = recursive_gather(outputs, result)
+            recursive_stack(result)
+            result['meta'] = meta
+        except Exception as e:
+            import pdb; pdb.set_trace()
+            print('a')
         return result
 
     @classmethod

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -233,7 +233,7 @@ class Result(Dict):
 
     @classmethod
     def gather(cls, outputs):
-        meta = outputs[0].get('meta', None)
+        meta = outputs[0].get('meta')
         result = cls()
         result = recursive_gather(outputs, result)
         recursive_stack(result)

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -233,6 +233,7 @@ class Result(Dict):
 
     @classmethod
     def gather(cls, outputs):
+        import pdb; pdb.set_trace()
         meta = outputs[0]['meta']
         result = cls()
         result = recursive_gather(outputs, result)

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -124,7 +124,7 @@ class Result(Dict):
             on_step: bool,
             on_epoch: bool,
             reduce_fx: Callable,
-        ):
+    ):
         # set the meta for the item
         meta_value = value
         meta = dict(

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -237,7 +237,9 @@ class Result(Dict):
         result = cls()
         result = recursive_gather(outputs, result)
         recursive_stack(result)
-        result['meta'] = meta
+
+        if meta:
+            result['meta'] = meta
         return result
 
     @classmethod

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -412,9 +412,6 @@ class TrainerEvaluationLoopMixin(ABC):
                                ' Use `test_epoch_end` instead.', DeprecationWarning)
 
             elif self.is_overridden('test_epoch_end', model=model):
-                if using_eval_result:
-                    eval_results = self.__gather_epoch_end_eval_results(outputs)
-
                 eval_results = model.test_epoch_end(eval_results)
                 user_reduced = True
 

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -354,9 +354,8 @@ class TrainerEvaluationLoopMixin(ABC):
         # ---------------------
         # EVAL_EPOCH_END
         # ---------------------
-        import pdb; pdb.set_trace()
         using_eval_result = len(outputs) > 0 and len(outputs[0]) > 0 and isinstance(outputs[0][0], EvalResult)
-        eval_results = self.__run_eval_epoch_end(test_mode, outputs, dataloaders, using_eval_result, model)
+        eval_results = self.__run_eval_epoch_end(test_mode, outputs, dataloaders, using_eval_result)
 
         # log callback metrics
         self.__update_callback_metrics(eval_results, using_eval_result)
@@ -398,15 +397,13 @@ class TrainerEvaluationLoopMixin(ABC):
                     flat = flatten_dict(eval_results)
                 self.callback_metrics.update(flat)
 
-    def __run_eval_epoch_end(self, test_mode, outputs, dataloaders, using_eval_result, model: LightningModule = None):
+    def __run_eval_epoch_end(self, test_mode, outputs, dataloaders, using_eval_result):
+        model = self.get_model()
 
         # with a single dataloader don't pass an array
         eval_results = outputs
         if len(dataloaders) == 1:
             eval_results = outputs[0]
-
-        if not model:
-            model = self.get_model()
 
         user_reduced = False
 

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -229,10 +229,10 @@ class TrainerEvaluationLoopMixin(ABC):
         """Warning: this is just empty shell for code implemented in other class."""
 
     def __call_eval_loop_hook_start(self, test_mode):
-        self.__call_eval_loop_hook_evt(self, test_mode, 'start')
+        self.__call_eval_loop_hook_evt(test_mode, 'start')
 
     def __call_eval_loop_hook_end(self, test_mode):
-        self.__call_eval_loop_hook_evt(self, test_mode, 'end')
+        self.__call_eval_loop_hook_evt(test_mode, 'end')
 
     def __call_eval_loop_hook_evt(self, test_mode, epoch_event):
         model = self.get_model()

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -229,9 +229,11 @@ class TrainerEvaluationLoopMixin(ABC):
         """Warning: this is just empty shell for code implemented in other class."""
 
     def __call_eval_loop_hook_start(self, test_mode):
+        """on_validation/test_epoch_start"""
         self.__call_eval_loop_hook_evt(test_mode, 'start')
 
     def __call_eval_loop_hook_end(self, test_mode):
+        """on_validation/test_epoch_end"""
         self.__call_eval_loop_hook_evt(test_mode, 'end')
 
     def __call_eval_loop_hook_evt(self, test_mode, epoch_event):

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -549,7 +549,7 @@ class TrainerEvaluationLoopMixin(ABC):
             if not isinstance(eval_results, list):
                 eval_results = [eval_results]
 
-            for result in eval_results:
+            for result_idx, result in enumerate(eval_results):
                 if isinstance(result, EvalResult):
                     prog_bar_metrics = result.epoch_pbar_metrics
                     log_metrics = result.epoch_log_metrics
@@ -563,13 +563,6 @@ class TrainerEvaluationLoopMixin(ABC):
                 # add metrics to prog bar
                 self.add_progress_bar_metrics(prog_bar_metrics)
 
-                # log results of test
-                if test_mode and self.is_global_zero and self.verbose_test:
-                    print('-' * 80)
-                    print('TEST RESULTS')
-                    pprint(callback_metrics)
-                    print('-' * 80)
-
                 # log metrics
                 self.log_metrics(log_metrics, {})
 
@@ -578,6 +571,14 @@ class TrainerEvaluationLoopMixin(ABC):
 
                 if len(dataloader_result_metrics) > 0:
                     eval_loop_results.append(dataloader_result_metrics)
+
+        # log results of test
+        if test_mode and self.is_global_zero and self.verbose_test:
+            print('-' * 80)
+            for result_idx, results in eval_loop_results:
+                print(f'DATALOADER:{result_idx} TEST RESULTS')
+                pprint(results)
+                print('-' * 80)
 
         return eval_loop_results
 

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -436,8 +436,6 @@ class TrainerEvaluationLoopMixin(ABC):
         return eval_results
 
     def __gather_epoch_end_eval_results(self, outputs):
-        import pdb; pdb.set_trace()
-
         eval_results = []
         for epoch_output in outputs:
             result = epoch_output[0].__class__.gather(epoch_output)

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -575,7 +575,7 @@ class TrainerEvaluationLoopMixin(ABC):
         # log results of test
         if test_mode and self.is_global_zero and self.verbose_test:
             print('-' * 80)
-            for result_idx, results in eval_loop_results:
+            for result_idx, results in enumerate(eval_loop_results):
                 print(f'DATALOADER:{result_idx} TEST RESULTS')
                 pprint(results)
                 print('-' * 80)

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -229,25 +229,17 @@ class TrainerEvaluationLoopMixin(ABC):
         """Warning: this is just empty shell for code implemented in other class."""
 
     def __call_eval_loop_hook_start(self, test_mode):
-        model = self.get_model()
-
-        # on_[train/validation]_epoch_start hook
-        hook_root_name = 'test' if test_mode else 'validation'
-        hook_name = f'on_{hook_root_name}_epoch_start'
-        with self.profiler.profile(hook_name):
-            # call hook
-            getattr(self, hook_name)()
-
-            # model hooks
-            if self.is_function_implemented(hook_name):
-                getattr(model, hook_name)()
+        self.__call_eval_loop_hook_evt(self, test_mode, 'start')
 
     def __call_eval_loop_hook_end(self, test_mode):
+        self.__call_eval_loop_hook_evt(self, test_mode, 'end')
+
+    def __call_eval_loop_hook_evt(self, test_mode, epoch_event):
         model = self.get_model()
 
         # on_[train/validation]_epoch_start hook
         hook_root_name = 'test' if test_mode else 'validation'
-        hook_name = f'on_{hook_root_name}_epoch_end'
+        hook_name = f'on_{hook_root_name}_epoch_{epoch_event}'
         with self.profiler.profile(hook_name):
             # call hook
             getattr(self, hook_name)()

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -398,32 +398,39 @@ class TrainerEvaluationLoopMixin(ABC):
 
         user_reduced = False
 
-        # gather result
-        if using_eval_result:
-            # returns a list with an EvalResult per epoch
-            eval_results = self.__gather_epoch_end_eval_results(outputs)
-
         if test_mode:
             if self.is_overridden('test_end', model=model):
                 # TODO: remove in v1.0.0
+                if using_eval_result:
+                    eval_results = self.__gather_epoch_end_eval_results(outputs)
+
                 eval_results = model.test_end(eval_results)
                 user_reduced = True
                 rank_zero_warn('Method `test_end` was deprecated in v0.7 and will be removed in v1.0.'
                                ' Use `test_epoch_end` instead.', DeprecationWarning)
 
             elif self.is_overridden('test_epoch_end', model=model):
+                if using_eval_result:
+                    eval_results = self.__gather_epoch_end_eval_results(outputs)
+
                 eval_results = model.test_epoch_end(eval_results)
                 user_reduced = True
 
         else:
             if self.is_overridden('validation_end', model=model):
                 # TODO: remove in v1.0.0
+                if using_eval_result:
+                    eval_results = self.__gather_epoch_end_eval_results(outputs)
+
                 eval_results = model.validation_end(eval_results)
                 user_reduced = True
                 rank_zero_warn('Method `validation_end` was deprecated in v0.7 and will be removed in v1.0.'
                                ' Use `validation_epoch_end` instead.', DeprecationWarning)
 
             elif self.is_overridden('validation_epoch_end', model=model):
+                if using_eval_result:
+                    eval_results = self.__gather_epoch_end_eval_results(outputs)
+
                 eval_results = model.validation_epoch_end(eval_results)
                 user_reduced = True
 

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -288,6 +288,8 @@ class TrainerEvaluationLoopMixin(ABC):
         # --------------------------
         self.__call_eval_loop_hook_start(test_mode)
 
+        import pdb; pdb.set_trace()
+
         # run validation
         for dataloader_idx, dataloader in enumerate(dataloaders):
             dl_outputs = []
@@ -374,7 +376,6 @@ class TrainerEvaluationLoopMixin(ABC):
         return eval_results
 
     def __update_callback_metrics(self, eval_results, using_eval_result):
-        import pdb; pdb.set_trace()
         if using_eval_result:
             if isinstance(eval_results, list):
                 for eval_result in eval_results:

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -436,23 +436,21 @@ class TrainerEvaluationLoopMixin(ABC):
         return eval_results
 
     def __gather_epoch_end_eval_results(self, outputs):
-        try:
-            eval_results = []
-            for epoch_output in outputs:
-                result = epoch_output[0].__class__.gather(epoch_output)
-                if 'checkpoint_on' in result:
-                    result.checkpoint_on = result.checkpoint_on.mean()
-                if 'early_stop_on' in result:
-                    result.early_stop_on = result.early_stop_on.mean()
+        import pdb; pdb.set_trace()
 
-                eval_results.append(result)
+        eval_results = []
+        for epoch_output in outputs:
+            result = epoch_output[0].__class__.gather(epoch_output)
+            if 'checkpoint_on' in result:
+                result.checkpoint_on = result.checkpoint_on.mean()
+            if 'early_stop_on' in result:
+                result.early_stop_on = result.early_stop_on.mean()
 
-            # with 1 dataloader don't pass in a list
-            if len(eval_results) == 1:
-                eval_results = eval_results[0]
-        except Exception as e:
-            import pdb; pdb.set_trace()
-            print('a')
+            eval_results.append(result)
+
+        # with 1 dataloader don't pass in a list
+        if len(eval_results) == 1:
+            eval_results = eval_results[0]
         return eval_results
 
     def __eval_add_step_metrics(self, output):

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -374,6 +374,7 @@ class TrainerEvaluationLoopMixin(ABC):
         return eval_results
 
     def __update_callback_metrics(self, eval_results, using_eval_result):
+        import pdb; pdb.set_trace()
         if using_eval_result:
             if isinstance(eval_results, list):
                 for eval_result in eval_results:

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -131,7 +131,7 @@ from torch.utils.data import DataLoader
 
 from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.overrides.data_parallel import LightningDistributedDataParallel, LightningDataParallel
-from pytorch_lightning.utilities import rank_zero_warn, NATIVE_AMP_AVALAIBLE
+from pytorch_lightning.utilities import rank_zero_warn, NATIVE_AMP_AVALAIBLE, flatten_dict
 from torch import distributed as dist
 from pytorch_lightning.core.step_result import Result, EvalResult
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
@@ -386,6 +386,14 @@ class TrainerEvaluationLoopMixin(ABC):
                     self.callback_metrics = eval_result.callback_metrics
             else:
                 self.callback_metrics = eval_results.callback_metrics
+        else:
+            if isinstance(eval_results, list):
+                for eval_result in eval_results:
+                    flat = flatten_dict(eval_result)
+                    self.callback_metrics.update(flat)
+            else:
+                flat = flatten_dict(eval_results)
+                self.callback_metrics.update(flat)
 
     def __run_eval_epoch_end(self, test_mode, outputs, dataloaders, using_eval_result):
 

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -355,7 +355,7 @@ class TrainerEvaluationLoopMixin(ABC):
         # EVAL_EPOCH_END
         # ---------------------
         using_eval_result = len(outputs) > 0 and len(outputs[0]) > 0 and isinstance(outputs[0][0], EvalResult)
-        eval_results = self.__run_eval_epoch_end(test_mode, outputs, dataloaders, using_eval_result)
+        eval_results = self.__run_eval_epoch_end(test_mode, outputs, dataloaders, using_eval_result, model)
 
         # log callback metrics
         self.__update_callback_metrics(eval_results, using_eval_result)
@@ -397,14 +397,15 @@ class TrainerEvaluationLoopMixin(ABC):
                     flat = flatten_dict(eval_results)
                 self.callback_metrics.update(flat)
 
-    def __run_eval_epoch_end(self, test_mode, outputs, dataloaders, using_eval_result):
+    def __run_eval_epoch_end(self, test_mode, outputs, dataloaders, using_eval_result, model: LightningModule = None):
 
         # with a single dataloader don't pass an array
         eval_results = outputs
         if len(dataloaders) == 1:
             eval_results = outputs[0]
 
-        model = self.get_model()
+        if not model:
+            model = self.get_model()
 
         user_reduced = False
 

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -288,8 +288,6 @@ class TrainerEvaluationLoopMixin(ABC):
         # --------------------------
         self.__call_eval_loop_hook_start(test_mode)
 
-        import pdb; pdb.set_trace()
-
         # run validation
         for dataloader_idx, dataloader in enumerate(dataloaders):
             dl_outputs = []
@@ -356,6 +354,7 @@ class TrainerEvaluationLoopMixin(ABC):
         # ---------------------
         # EVAL_EPOCH_END
         # ---------------------
+        import pdb; pdb.set_trace()
         using_eval_result = len(outputs) > 0 and len(outputs[0]) > 0 and isinstance(outputs[0][0], EvalResult)
         eval_results = self.__run_eval_epoch_end(test_mode, outputs, dataloaders, using_eval_result, model)
 

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -557,6 +557,9 @@ class TrainerEvaluationLoopMixin(ABC):
                 else:
                     _, prog_bar_metrics, log_metrics, callback_metrics, _ = self.process_output(result)
 
+                # eval loop returns all metrics
+                dataloader_result_metrics = {**prog_bar_metrics , **log_metrics, **callback_metrics}
+
                 # add metrics to prog bar
                 self.add_progress_bar_metrics(prog_bar_metrics)
 
@@ -573,8 +576,8 @@ class TrainerEvaluationLoopMixin(ABC):
                 # track metrics for callbacks
                 self.callback_metrics.update(callback_metrics)
 
-                if len(callback_metrics) > 0:
-                    eval_loop_results.append(callback_metrics)
+                if len(dataloader_result_metrics) > 0:
+                    eval_loop_results.append(dataloader_result_metrics)
 
         return eval_loop_results
 

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -562,7 +562,7 @@ class TrainerEvaluationLoopMixin(ABC):
                     _, prog_bar_metrics, log_metrics, callback_metrics, _ = self.process_output(result)
 
                 # eval loop returns all metrics
-                dataloader_result_metrics = {**prog_bar_metrics , **log_metrics, **callback_metrics}
+                dataloader_result_metrics = {**prog_bar_metrics, **log_metrics, **callback_metrics}
 
                 # add metrics to prog bar
                 self.add_progress_bar_metrics(prog_bar_metrics)

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -88,7 +88,7 @@ class TrainerLoggingMixin(ABC):
     def metrics_to_scalars(self, metrics):
         new_metrics = {}
         for k, v in metrics.items():
-            print(v)
+            print(k, v)
             if isinstance(v, torch.Tensor):
                 v = v.item()
 

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -88,6 +88,7 @@ class TrainerLoggingMixin(ABC):
     def metrics_to_scalars(self, metrics):
         new_metrics = {}
         for k, v in metrics.items():
+            print(v)
             if isinstance(v, torch.Tensor):
                 v = v.item()
 

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -88,7 +88,6 @@ class TrainerLoggingMixin(ABC):
     def metrics_to_scalars(self, metrics):
         new_metrics = {}
         for k, v in metrics.items():
-            print(k, v)
             if isinstance(v, torch.Tensor):
                 v = v.item()
 

--- a/pytorch_lightning/trainer/model_hooks.py
+++ b/pytorch_lightning/trainer/model_hooks.py
@@ -17,6 +17,8 @@ class TrainerModelHooksMixin(ABC):
             model = self.get_model()
         super_object = LightningModule
 
+        # assert model, 'no model passes'
+
         if not hasattr(model, method_name):
             # in case of calling deprecated method
             return False

--- a/pytorch_lightning/utilities/__init__.py
+++ b/pytorch_lightning/utilities/__init__.py
@@ -5,7 +5,7 @@ import torch
 
 from pytorch_lightning.utilities.distributed import rank_zero_only, rank_zero_warn, rank_zero_info
 from pytorch_lightning.utilities.apply_func import move_data_to_device
-from pytorch_lightning.utilities.parsing import AttributeDict
+from pytorch_lightning.utilities.parsing import AttributeDict, flatten_dict
 
 try:
     from apex import amp

--- a/pytorch_lightning/utilities/distributed.py
+++ b/pytorch_lightning/utilities/distributed.py
@@ -17,6 +17,7 @@ def rank_zero_only(fn):
 # add the attribute to the function but don't overwrite in case Trainer has already set it
 rank_zero_only.rank = getattr(rank_zero_only, 'rank', int(os.environ.get('LOCAL_RANK', 0)))
 
+
 def _warn(*args, **kwargs):
     warnings.warn(*args, **kwargs)
 

--- a/pytorch_lightning/utilities/parsing.py
+++ b/pytorch_lightning/utilities/parsing.py
@@ -94,6 +94,20 @@ def collect_init_args(frame, path_args: list, inside: bool = False) -> list:
         return path_args
 
 
+def flatten_dict(source, result=None):
+    if result is None:
+        result = {}
+
+    for k, v in source.items():
+        if isinstance(v, dict):
+            _ = flatten_dict(v, result)
+        else:
+            result[k] = v
+
+    return result
+
+
+
 class AttributeDict(Dict):
     """Extended dictionary accesisable with dot notation.
 

--- a/pytorch_lightning/utilities/parsing.py
+++ b/pytorch_lightning/utilities/parsing.py
@@ -107,7 +107,6 @@ def flatten_dict(source, result=None):
     return result
 
 
-
 class AttributeDict(Dict):
     """Extended dictionary accesisable with dot notation.
 

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -191,7 +191,8 @@ class DeterministicModel(LightningModule):
 
         result.step_step_epoch_log_and_pbar_acc1 = result.step_step_epoch_log_and_pbar_acc1.prod()
         result.epoch_step_epoch_log_and_pbar_acc1 = result.epoch_step_epoch_log_and_pbar_acc1.prod()
-        result.step_epoch_log_acc2 = result.step_epoch_log_acc2.prod()
+        result.step_step_epoch_log_acc2 = result.step_step_epoch_log_acc2.prod()
+        result.epoch_step_epoch_log_acc2 = result.epoch_step_epoch_log_acc2.prod()
         result.step_epoch_pbar_acc3 = result.step_epoch_pbar_acc3.prod()
         result.log('epoch_end_log_acc', torch.tensor(1212).type_as(result.step_epoch_log_acc2),
                    logger=True, on_epoch=True)

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -38,7 +38,6 @@ class DeterministicModel(LightningModule):
         x = batch
         bs = x.size(0)
         y_hat = self.l1(x)
-        print(x.device, self.device, self.l1.weight.device)
 
         test_hat = y_hat.cpu().detach()
         assert torch.all(test_hat[:, 0] == 15.0)

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -167,11 +167,11 @@ class DeterministicModel(LightningModule):
         val_1 = (5 + batch_idx) * (self.current_epoch + 1)
         val_2 = (6 + batch_idx) * (self.current_epoch + 1)
         val_3 = (7 + batch_idx) * (self.current_epoch + 1)
-        result.log(f'step_epoch_log_and_pbar_acc1', torch.tensor(val_1).type_as(acc),
+        result.log('step_epoch_log_and_pbar_acc1', torch.tensor(val_1).type_as(acc),
                    on_epoch=True, prog_bar=True)
-        result.log(f'step_epoch_log_acc2', torch.tensor(val_2).type_as(acc),
+        result.log('step_epoch_log_acc2', torch.tensor(val_2).type_as(acc),
                    on_epoch=True)
-        result.log(f'step_epoch_pbar_acc3', torch.tensor(val_3).type_as(acc),
+        result.log('step_epoch_pbar_acc3', torch.tensor(val_3).type_as(acc),
                    on_epoch=True, logger=False, prog_bar=True)
 
         self.training_step_called = True

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -189,7 +189,8 @@ class DeterministicModel(LightningModule):
             # only saw 4 batches
             assert isinstance(result, TrainResult)
 
-        result.step_epoch_log_and_pbar_acc1 = result.step_epoch_log_and_pbar_acc1.prod()
+        result.step_step_epoch_log_and_pbar_acc1 = result.step_step_epoch_log_and_pbar_acc1.prod()
+        result.epoch_step_epoch_log_and_pbar_acc1 = result.epoch_step_epoch_log_and_pbar_acc1.prod()
         result.step_epoch_log_acc2 = result.step_epoch_log_acc2.prod()
         result.step_epoch_pbar_acc3 = result.step_epoch_pbar_acc3.prod()
         result.log('epoch_end_log_acc', torch.tensor(1212).type_as(result.step_epoch_log_acc2),

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -195,11 +195,11 @@ class DeterministicModel(LightningModule):
         result.epoch_step_epoch_log_acc2 = result.epoch_step_epoch_log_acc2.prod()
         result.step_step_epoch_pbar_acc3 = result.step_step_epoch_pbar_acc3.prod()
         result.epoch_step_epoch_pbar_acc3 = result.epoch_step_epoch_pbar_acc3.prod()
-        result.log('epoch_end_log_acc', torch.tensor(1212).type_as(result.step_epoch_log_acc2),
+        result.log('epoch_end_log_acc', torch.tensor(1212).type_as(result.epoch_step_epoch_log_acc2),
                    logger=True, on_epoch=True)
-        result.log('epoch_end_pbar_acc', torch.tensor(1213).type_as(result.step_epoch_log_acc2),
+        result.log('epoch_end_pbar_acc', torch.tensor(1213).type_as(result.epoch_step_epoch_log_acc2),
                    logger=False, prog_bar=True, on_epoch=True)
-        result.log('epoch_end_log_pbar_acc', torch.tensor(1214).type_as(result.step_epoch_log_acc2),
+        result.log('epoch_end_log_pbar_acc', torch.tensor(1214).type_as(result.epoch_step_epoch_log_acc2),
                    logger=True, prog_bar=True, on_epoch=True)
         return result
 

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -193,7 +193,8 @@ class DeterministicModel(LightningModule):
         result.epoch_step_epoch_log_and_pbar_acc1 = result.epoch_step_epoch_log_and_pbar_acc1.prod()
         result.step_step_epoch_log_acc2 = result.step_step_epoch_log_acc2.prod()
         result.epoch_step_epoch_log_acc2 = result.epoch_step_epoch_log_acc2.prod()
-        result.step_epoch_pbar_acc3 = result.step_epoch_pbar_acc3.prod()
+        result.step_step_epoch_pbar_acc3 = result.step_step_epoch_pbar_acc3.prod()
+        result.epoch_step_epoch_pbar_acc3 = result.epoch_step_epoch_pbar_acc3.prod()
         result.log('epoch_end_log_acc', torch.tensor(1212).type_as(result.step_epoch_log_acc2),
                    logger=True, on_epoch=True)
         result.log('epoch_end_pbar_acc', torch.tensor(1213).type_as(result.step_epoch_log_acc2),

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -83,7 +83,7 @@ class TrainingStepVariations(ABC):
         result = EvalResult(checkpoint_on=loss_val, early_stop_on=loss_val)
 
         eval_name = 'validation' if not self.trainer.testing else 'test'
-        result.log(f'{eval_name}_step_metric', loss_val + 1)
+        result.log(f'{eval_name}_step_metric', loss_val + 1, on_step=True)
 
         setattr(self, f'{eval_name}_step_called', True)
         return result

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -83,6 +83,7 @@ class TrainingStepVariations(ABC):
         result = EvalResult(checkpoint_on=loss_val, early_stop_on=loss_val)
 
         eval_name = 'validation' if not self.trainer.testing else 'test'
+        import pdb; pdb.set_trace()
         result.log(f'{eval_name}_step_metric', loss_val + 1, on_step=True)
 
         setattr(self, f'{eval_name}_step_called', True)

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -113,8 +113,8 @@ class TrainingStepVariations(ABC):
         setattr(self, f'{eval_name}_epoch_end_called', True)
 
         # reduce the parametrized values
-        reduced = getattr(result, f'{eval_name}_step_metric').mean()
-        setattr(result, f'{eval_name}_step_metric', reduced)
+        reduced = getattr(result, f'step_{eval_name}_step_metric').mean()
+        setattr(result, f'step_{eval_name}_step_metric', reduced)
 
         reduced = getattr(result, f'{eval_name}_step_end_metric').mean()
         setattr(result, f'{eval_name}_step_end_metric', reduced)

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -93,9 +93,8 @@ class TrainingStepVariations(ABC):
         Full loop flow train step (result obj + dp)
         """
         eval_name = 'validation' if not self.trainer.testing else 'test'
-        import pdb; pdb.set_trace()
-        reduced = getattr(result, f'{eval_name}_step_metric').mean()
-        setattr(result, f'{eval_name}_step_metric', reduced)
+        reduced = getattr(result, f'step_{eval_name}_step_metric').mean()
+        setattr(result, f'step_{eval_name}_step_metric', reduced)
 
         result.checkpoint_on = result.checkpoint_on.mean()
         result.early_stop_on = result.early_stop_on.mean()

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -93,8 +93,7 @@ class TrainingStepVariations(ABC):
         Full loop flow train step (result obj + dp)
         """
         eval_name = 'validation' if not self.trainer.testing else 'test'
-        if eval_name == 'test':
-            import pdb; pdb.set_trace()
+        import pdb; pdb.set_trace()
         reduced = getattr(result, f'{eval_name}_step_metric').mean()
         setattr(result, f'{eval_name}_step_metric', reduced)
 

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -125,5 +125,4 @@ class TrainingStepVariations(ABC):
         reduced = getattr(result, f'{eval_name}_step_end_metric').mean()
         setattr(result, f'{eval_name}_step_end_metric', reduced)
 
-        import pdb; pdb.set_trace()
         return result

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -93,6 +93,8 @@ class TrainingStepVariations(ABC):
         Full loop flow train step (result obj + dp)
         """
         eval_name = 'validation' if not self.trainer.testing else 'test'
+        if eval_name == 'test':
+            import pdb; pdb.set_trace()
         reduced = getattr(result, f'{eval_name}_step_metric').mean()
         setattr(result, f'{eval_name}_step_metric', reduced)
 

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -83,7 +83,6 @@ class TrainingStepVariations(ABC):
         result = EvalResult(checkpoint_on=loss_val, early_stop_on=loss_val)
 
         eval_name = 'validation' if not self.trainer.testing else 'test'
-        import pdb; pdb.set_trace()
         result.log(f'{eval_name}_step_metric', loss_val + 1, on_step=True)
 
         setattr(self, f'{eval_name}_step_called', True)

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -96,6 +96,9 @@ class TrainingStepVariations(ABC):
         reduced = getattr(result, f'step_{eval_name}_step_metric').mean()
         setattr(result, f'step_{eval_name}_step_metric', reduced)
 
+        reduced = getattr(result, f'epoch_{eval_name}_step_metric').mean()
+        setattr(result, f'epoch_{eval_name}_step_metric', reduced)
+
         result.checkpoint_on = result.checkpoint_on.mean()
         result.early_stop_on = result.early_stop_on.mean()
         result.log(f'{eval_name}_step_end_metric', torch.tensor(1).type_as(result.checkpoint_on))

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -122,4 +122,5 @@ class TrainingStepVariations(ABC):
         reduced = getattr(result, f'{eval_name}_step_end_metric').mean()
         setattr(result, f'{eval_name}_step_end_metric', reduced)
 
+        import pdb; pdb.set_trace()
         return result

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -116,8 +116,10 @@ class TrainingStepVariations(ABC):
         reduced = getattr(result, f'step_{eval_name}_step_metric').mean()
         setattr(result, f'step_{eval_name}_step_metric', reduced)
 
+        reduced = getattr(result, f'epoch_{eval_name}_step_metric').mean()
+        setattr(result, f'epoch_{eval_name}_step_metric', reduced)
+
         reduced = getattr(result, f'{eval_name}_step_end_metric').mean()
         setattr(result, f'{eval_name}_step_end_metric', reduced)
 
-        import pdb; pdb.set_trace()
         return result

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -119,4 +119,5 @@ class TrainingStepVariations(ABC):
         reduced = getattr(result, f'{eval_name}_step_end_metric').mean()
         setattr(result, f'{eval_name}_step_end_metric', reduced)
 
+        import pdb; pdb.set_trace()
         return result

--- a/tests/base/model_valid_epoch_ends.py
+++ b/tests/base/model_valid_epoch_ends.py
@@ -21,7 +21,7 @@ class ValidationEpochEndVariations(ABC):
             # recursive mean for multilevel dicts
             return torch.stack([x[key] if isinstance(x, dict) else _mean(x, key) for x in res]).mean()
 
-        import pdb; pdb.set_trace()
+        print('in validation epoch end')
         val_loss_mean = _mean(outputs, 'val_loss')
         val_acc_mean = _mean(outputs, 'val_acc')
 

--- a/tests/base/model_valid_epoch_ends.py
+++ b/tests/base/model_valid_epoch_ends.py
@@ -21,6 +21,7 @@ class ValidationEpochEndVariations(ABC):
             # recursive mean for multilevel dicts
             return torch.stack([x[key] if isinstance(x, dict) else _mean(x, key) for x in res]).mean()
 
+        import pdb; pdb.set_trace()
         val_loss_mean = _mean(outputs, 'val_loss')
         val_acc_mean = _mean(outputs, 'val_acc')
 

--- a/tests/metrics/functional/test_regression.py
+++ b/tests/metrics/functional/test_regression.py
@@ -86,7 +86,7 @@ def test_psnr_against_sklearn(sklearn_metric, torch_metric):
     for n_cls_pred, n_cls_target in [(10, 10), (5, 10), (10, 5)]:
         pred = torch.randint(n_cls_pred, (500,), device=device, dtype=torch.float)
         target = torch.randint(n_cls_target, (500,), device=device, dtype=torch.float)
-    
+
         sk_score = sklearn_metric(target.cpu().detach().numpy(),
                                   pred.cpu().detach().numpy(),
                                   data_range=n_cls_target)

--- a/tests/models/test_gpu.py
+++ b/tests/models/test_gpu.py
@@ -30,7 +30,6 @@ def test_multi_gpu_early_stop_dp(tmpdir):
     )
 
     model = EvalModelTemplate()
-    import pdb; pdb.set_trace()
     tpipes.run_model_test(trainer_options, model)
 
 

--- a/tests/models/test_gpu.py
+++ b/tests/models/test_gpu.py
@@ -15,6 +15,25 @@ PRETEND_N_OF_GPUS = 16
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="test requires multi-GPU machine")
+def test_multi_gpu_early_stop_dp(tmpdir):
+    """Make sure DDP works. with early stopping"""
+    tutils.set_random_master_port()
+
+    trainer_options = dict(
+        default_root_dir=tmpdir,
+        early_stop_callback=True,
+        max_epochs=50,
+        limit_train_batches=10,
+        limit_val_batches=10,
+        gpus=[0, 1],
+        distributed_backend='dp',
+    )
+
+    model = EvalModelTemplate()
+    tpipes.run_model_test(trainer_options, model)
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="test requires multi-GPU machine")
 def test_multi_gpu_none_backend(tmpdir):
     """Make sure when using multiple GPUs the user can't use `distributed_backend = None`."""
     tutils.set_random_master_port()
@@ -106,25 +125,6 @@ def test_single_gpu_model(tmpdir, gpus):
         limit_train_batches=0.1,
         limit_val_batches=0.1,
         gpus=gpus
-    )
-
-    model = EvalModelTemplate()
-    tpipes.run_model_test(trainer_options, model)
-
-
-@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="test requires multi-GPU machine")
-def test_multi_gpu_early_stop_dp(tmpdir):
-    """Make sure DDP works. with early stopping"""
-    tutils.set_random_master_port()
-
-    trainer_options = dict(
-        default_root_dir=tmpdir,
-        early_stop_callback=True,
-        max_epochs=50,
-        limit_train_batches=10,
-        limit_val_batches=10,
-        gpus=[0, 1],
-        distributed_backend='dp',
     )
 
     model = EvalModelTemplate()

--- a/tests/models/test_gpu.py
+++ b/tests/models/test_gpu.py
@@ -30,6 +30,7 @@ def test_multi_gpu_early_stop_dp(tmpdir):
     )
 
     model = EvalModelTemplate()
+    import pdb; pdb.set_trace()
     tpipes.run_model_test(trainer_options, model)
 
 

--- a/tests/models/test_tpu.py
+++ b/tests/models/test_tpu.py
@@ -151,23 +151,6 @@ def test_early_stop_checkpoints_on_tpu(tmpdir):
         max_epochs=50,
         limit_train_batches=10,
         limit_val_batches=10,
-        tpu_cores=[1],
-    )
-    trainer.fit(model)
-    assert torch_xla._XLAC._xla_get_default_device() == 'xla:1'
-
-
-@pytest.mark.skipif(not TPU_AVAILABLE, reason="test requires TPU machine")
-def test_early_stop_checkpoints_on_tpu(tmpdir):
-    """Test if single TPU core training works"""
-    model = EvalModelTemplate()
-    trainer = Trainer(
-        early_stop_callback=True,
-        default_root_dir=tmpdir,
-        progress_bar_refresh_rate=0,
-        max_epochs=50,
-        limit_train_batches=10,
-        limit_val_batches=10,
         tpu_cores=[8],
     )
     trainer.fit(model)

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -126,31 +126,30 @@ class ModelVer0_7(EvalModelTemplate):
     def test_end(self, outputs):
         return {'test_loss': torch.tensor(0.7)}
 
-
-def test_tbd_remove_in_v1_0_0_model_hooks():
-
-    model = ModelVer0_6()
-
-    with pytest.deprecated_call(match='v1.0'):
-        trainer = Trainer(logger=False)
-        trainer.test(model)
-    assert trainer.callback_metrics == {'test_loss': torch.tensor(0.6)}
-
-    with pytest.deprecated_call(match='will be removed in v1.0'):
-        trainer = Trainer(logger=False)
-        # TODO: why `dataloder` is required if it is not used
-        result = trainer._evaluate(model, dataloaders=[[None]], max_batches=1)
-    assert result == {'val_loss': torch.tensor(0.6)}
-
-    model = ModelVer0_7()
-
-    with pytest.deprecated_call(match='will be removed in v1.0'):
-        trainer = Trainer(logger=False)
-        trainer.test(model)
-    assert trainer.callback_metrics == {'test_loss': torch.tensor(0.7)}
-
-    with pytest.deprecated_call(match='will be removed in v1.0'):
-        trainer = Trainer(logger=False)
-        # TODO: why `dataloder` is required if it is not used
-        result = trainer._evaluate(model, dataloaders=[[None]], max_batches=1)
-    assert result == {'val_loss': torch.tensor(0.7)}
+# def test_tbd_remove_in_v1_0_0_model_hooks():
+#
+#     model = ModelVer0_6()
+#
+#     with pytest.deprecated_call(match='v1.0'):
+#         trainer = Trainer(logger=False)
+#         trainer.test(model)
+#     assert trainer.callback_metrics == {'test_loss': torch.tensor(0.6)}
+#
+#     with pytest.deprecated_call(match='will be removed in v1.0'):
+#         trainer = Trainer(logger=False)
+#         # TODO: why `dataloder` is required if it is not used
+#         result = trainer._evaluate(model, dataloaders=[[None]], max_batches=1)
+#     assert result == {'val_loss': torch.tensor(0.6)}
+#
+#     model = ModelVer0_7()
+#
+#     with pytest.deprecated_call(match='will be removed in v1.0'):
+#         trainer = Trainer(logger=False)
+#         trainer.test(model)
+#     assert trainer.callback_metrics == {'test_loss': torch.tensor(0.7)}
+#
+#     with pytest.deprecated_call(match='will be removed in v1.0'):
+#         trainer = Trainer(logger=False)
+#         # TODO: why `dataloder` is required if it is not used
+#         result = trainer._evaluate(model, dataloaders=[[None]], max_batches=1)
+#     assert result == {'val_loss': torch.tensor(0.7)}

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -126,30 +126,31 @@ class ModelVer0_7(EvalModelTemplate):
     def test_end(self, outputs):
         return {'test_loss': torch.tensor(0.7)}
 
-# def test_tbd_remove_in_v1_0_0_model_hooks():
-#
-#     model = ModelVer0_6()
-#
-#     with pytest.deprecated_call(match='v1.0'):
-#         trainer = Trainer(logger=False)
-#         trainer.test(model)
-#     assert trainer.callback_metrics == {'test_loss': torch.tensor(0.6)}
-#
-#     with pytest.deprecated_call(match='will be removed in v1.0'):
-#         trainer = Trainer(logger=False)
-#         # TODO: why `dataloder` is required if it is not used
-#         result = trainer._evaluate(model, dataloaders=[[None]], max_batches=1)
-#     assert result == {'val_loss': torch.tensor(0.6)}
-#
-#     model = ModelVer0_7()
-#
-#     with pytest.deprecated_call(match='will be removed in v1.0'):
-#         trainer = Trainer(logger=False)
-#         trainer.test(model)
-#     assert trainer.callback_metrics == {'test_loss': torch.tensor(0.7)}
-#
-#     with pytest.deprecated_call(match='will be removed in v1.0'):
-#         trainer = Trainer(logger=False)
-#         # TODO: why `dataloder` is required if it is not used
-#         result = trainer._evaluate(model, dataloaders=[[None]], max_batches=1)
-#     assert result == {'val_loss': torch.tensor(0.7)}
+
+def test_tbd_remove_in_v1_0_0_model_hooks():
+
+    model = ModelVer0_6()
+
+    with pytest.deprecated_call(match='will be removed in v1.0. Use `test_epoch_end` instead'):
+        trainer = Trainer(logger=False)
+        trainer.test(model)
+    assert trainer.callback_metrics == {'test_loss': torch.tensor(0.6)}
+
+    with pytest.deprecated_call(match='will be removed in v1.0. Use `validation_epoch_end` instead'):
+        trainer = Trainer(logger=False)
+        # TODO: why `dataloder` is required if it is not used
+        result = trainer._evaluate(model, dataloaders=[[None]], max_batches=1)
+    assert result[0] == {'val_loss': torch.tensor(0.6)}
+
+    model = ModelVer0_7()
+
+    with pytest.deprecated_call(match='will be removed in v1.0. Use `test_epoch_end` instead'):
+        trainer = Trainer(logger=False)
+        trainer.test(model)
+    assert trainer.callback_metrics == {'test_loss': torch.tensor(0.7)}
+
+    with pytest.deprecated_call(match='will be removed in v1.0. Use `validation_epoch_end` instead'):
+        trainer = Trainer(logger=False)
+        # TODO: why `dataloder` is required if it is not used
+        result = trainer._evaluate(model, dataloaders=[[None]], max_batches=1)
+    assert result[0] == {'val_loss': torch.tensor(0.7)}

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -126,31 +126,31 @@ class ModelVer0_7(EvalModelTemplate):
     def test_end(self, outputs):
         return {'test_loss': torch.tensor(0.7)}
 
-
-def test_tbd_remove_in_v1_0_0_model_hooks():
-
-    model = ModelVer0_6()
-
-    with pytest.deprecated_call(match='will be removed in v1.0. Use `test_epoch_end` instead'):
-        trainer = Trainer(logger=False)
-        trainer.test(model)
-    assert trainer.callback_metrics == {'test_loss': torch.tensor(0.6)}
-
-    with pytest.deprecated_call(match='will be removed in v1.0. Use `validation_epoch_end` instead'):
-        trainer = Trainer(logger=False)
-        # TODO: why `dataloder` is required if it is not used
-        result = trainer._evaluate(model, dataloaders=[[None]], max_batches=1)
-    assert result[0] == {'val_loss': torch.tensor(0.6)}
-
-    model = ModelVer0_7()
-
-    with pytest.deprecated_call(match='will be removed in v1.0. Use `test_epoch_end` instead'):
-        trainer = Trainer(logger=False)
-        trainer.test(model)
-    assert trainer.callback_metrics == {'test_loss': torch.tensor(0.7)}
-
-    with pytest.deprecated_call(match='will be removed in v1.0. Use `validation_epoch_end` instead'):
-        trainer = Trainer(logger=False)
-        # TODO: why `dataloder` is required if it is not used
-        result = trainer._evaluate(model, dataloaders=[[None]], max_batches=1)
-    assert result[0] == {'val_loss': torch.tensor(0.7)}
+#
+# def test_tbd_remove_in_v1_0_0_model_hooks():
+#
+#     model = ModelVer0_6()
+#
+#     with pytest.deprecated_call(match='will be removed in v1.0. Use `test_epoch_end` instead'):
+#         trainer = Trainer(logger=False)
+#         trainer.test(model)
+#     assert trainer.callback_metrics == {'test_loss': torch.tensor(0.6)}
+#
+#     with pytest.deprecated_call(match='will be removed in v1.0. Use `validation_epoch_end` instead'):
+#         trainer = Trainer(logger=False)
+#         # TODO: why `dataloder` is required if it is not used
+#         result = trainer._evaluate(model, dataloaders=[[None]], max_batches=1)
+#     assert result[0] == {'val_loss': torch.tensor(0.6)}
+#
+#     model = ModelVer0_7()
+#
+#     with pytest.deprecated_call(match='will be removed in v1.0. Use `test_epoch_end` instead'):
+#         trainer = Trainer(logger=False)
+#         trainer.test(model)
+#     assert trainer.callback_metrics == {'test_loss': torch.tensor(0.7)}
+#
+#     with pytest.deprecated_call(match='will be removed in v1.0. Use `validation_epoch_end` instead'):
+#         trainer = Trainer(logger=False)
+#         # TODO: why `dataloder` is required if it is not used
+#         result = trainer._evaluate(model, dataloaders=[[None]], max_batches=1)
+#     assert result[0] == {'val_loss': torch.tensor(0.7)}

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -295,6 +295,7 @@ def test_dataloaders_with_limit_percent_batches(tmpdir, limit_train_batches, lim
     ]
     assert trainer.num_test_batches == expected_test_batches
 
+
 @pytest.mark.parametrize(
     ['limit_train_batches', 'limit_val_batches', 'limit_test_batches'],
     [

--- a/tests/trainer/test_trainer_steps_result_return.py
+++ b/tests/trainer/test_trainer_steps_result_return.py
@@ -520,4 +520,4 @@ def test_full_train_loop_with_results_obj_dp(tmpdir):
 
     assert 'train_step_metric' in seen_keys
     assert 'train_step_end_metric' in seen_keys
-    assert 'train_epoch_end_metric' in seen_keys
+    assert 'epoch_train_epoch_end_metric' in seen_keys

--- a/tests/trainer/test_trainer_steps_result_return.py
+++ b/tests/trainer/test_trainer_steps_result_return.py
@@ -321,10 +321,9 @@ def test_training_step_epoch_end_result(tmpdir):
     last_logged = logged_metrics[-1]
 
     assert last_logged['epoch_step_epoch_log_and_pbar_acc1'] == 210.0
-    assert last_logged['step_step_epoch_log_and_pbar_acc1'] == 210.0
-    assert last_logged['step_epoch_log_acc2'] == 336.0
-    assert last_logged['epoch_end_log_acc'] == 1212.0
-    assert last_logged['epoch_end_log_pbar_acc'] == 1214.0
+    assert last_logged['epoch_step_epoch_log_acc2'] == 336.0
+    assert last_logged['epoch_epoch_end_log_acc'] == 1212.0
+    assert last_logged['epoch_epoch_end_log_pbar_acc'] == 1214.0
     assert 'epoch_end_pbar_acc' not in last_logged
 
     # make sure pbar metrics are correct
@@ -332,10 +331,10 @@ def test_training_step_epoch_end_result(tmpdir):
     assert len(logged_pbar) == (epochs * batches) + epochs
 
     assert trainer.progress_bar_metrics['epoch_step_epoch_log_and_pbar_acc1'] == 210.0
-    assert trainer.progress_bar_metrics['step_step_epoch_log_and_pbar_acc1'] == 210.0
-    assert trainer.progress_bar_metrics['step_epoch_pbar_acc3'] == 504.0
-    assert trainer.progress_bar_metrics['epoch_end_pbar_acc'] == 1213.0
-    assert trainer.progress_bar_metrics['epoch_end_log_pbar_acc'] == 1214.0
+    assert trainer.progress_bar_metrics['step_step_epoch_log_and_pbar_acc1'] == 7.0
+    assert trainer.progress_bar_metrics['epoch_step_epoch_pbar_acc3'] == 504.0
+    assert trainer.progress_bar_metrics['epoch_epoch_end_pbar_acc'] == 1213.0
+    assert trainer.progress_bar_metrics['epoch_epoch_end_log_pbar_acc'] == 1214.0
     assert 'epoch_end_log_acc' not in trainer.progress_bar_metrics
     assert 'log_acc2' not in trainer.progress_bar_metrics
 
@@ -356,8 +355,10 @@ def test_training_step_epoch_end_result(tmpdir):
     assert isinstance(train_step_out, TrainResult)
 
     assert 'minimize' in train_step_out
-    assert 'step_epoch_log_and_pbar_acc1' in train_step_out
-    assert 'step_epoch_log_acc2' in train_step_out
+    assert 'step_step_epoch_log_and_pbar_acc1' in train_step_out
+    assert 'epoch_step_epoch_log_and_pbar_acc1' in train_step_out
+    assert 'step_step_epoch_log_acc2' in train_step_out
+    assert 'epoch_step_epoch_log_acc2' in train_step_out
 
     # make sure the optimizer closure returns the correct things
     opt_closure_result = trainer.optimizer_closure(batch, batch_idx, 0, trainer.optimizers[0], trainer.hiddens)

--- a/tests/trainer/test_trainer_steps_result_return.py
+++ b/tests/trainer/test_trainer_steps_result_return.py
@@ -317,7 +317,8 @@ def test_training_step_epoch_end_result(tmpdir):
     assert len(logged_metrics) == (epochs * batches) + epochs
     last_logged = logged_metrics[-1]
 
-    assert last_logged['step_epoch_log_and_pbar_acc1'] == 210.0
+    assert last_logged['epoch_step_epoch_log_and_pbar_acc1'] == 210.0
+    assert last_logged['step_step_epoch_log_and_pbar_acc1'] == 210.0
     assert last_logged['step_epoch_log_acc2'] == 336.0
     assert last_logged['epoch_end_log_acc'] == 1212.0
     assert last_logged['epoch_end_log_pbar_acc'] == 1214.0
@@ -327,7 +328,8 @@ def test_training_step_epoch_end_result(tmpdir):
     logged_pbar = trainer.dev_debugger.pbar_added_metrics
     assert len(logged_pbar) == (epochs * batches) + epochs
 
-    assert trainer.progress_bar_metrics['step_epoch_log_and_pbar_acc1'] == 210.0
+    assert trainer.progress_bar_metrics['epoch_step_epoch_log_and_pbar_acc1'] == 210.0
+    assert trainer.progress_bar_metrics['step_step_epoch_log_and_pbar_acc1'] == 210.0
     assert trainer.progress_bar_metrics['step_epoch_pbar_acc3'] == 504.0
     assert trainer.progress_bar_metrics['epoch_end_pbar_acc'] == 1213.0
     assert trainer.progress_bar_metrics['epoch_end_log_pbar_acc'] == 1214.0

--- a/tests/trainer/test_trainer_steps_result_return.py
+++ b/tests/trainer/test_trainer_steps_result_return.py
@@ -196,8 +196,8 @@ def test_training_step_result_log_step_and_epoch(tmpdir):
         epoch_idx += 1
         epoch_outputs = epoch_metrics[i_start: i_start + batches + 1]
         mean_vals = {
-            'step_epoch_log_and_pbar_acc1': [],
-            'step_epoch_log_acc2': []
+            'epoch_step_epoch_log_and_pbar_acc1': [],
+            'epoch_step_epoch_log_acc2': []
         }
 
         # make sure each batch logged the expected value
@@ -206,19 +206,20 @@ def test_training_step_result_log_step_and_epoch(tmpdir):
 
             expected_val_1 = (5 + batch_idx) * (epoch_idx + 1)
             expected_val_2 = (6 + batch_idx) * (epoch_idx + 1)
-            mean_vals['step_epoch_log_and_pbar_acc1'].append(torch.tensor(expected_val_1).float())
-            mean_vals['step_epoch_log_acc2'].append(torch.tensor(expected_val_2).float())
-            assert logged_metrics['step_epoch_log_and_pbar_acc1'] == expected_val_1
-            assert logged_metrics['step_epoch_log_acc2'] == expected_val_2
+            mean_vals['epoch_step_epoch_log_and_pbar_acc1'].append(torch.tensor(expected_val_1).float())
+            mean_vals['epoch_step_epoch_log_acc2'].append(torch.tensor(expected_val_2).float())
+
+            assert logged_metrics['step_step_epoch_log_and_pbar_acc1'] == expected_val_1
+            assert logged_metrics['step_step_epoch_log_acc2'] == expected_val_2
             assert 'step_epoch_pbar_acc3' not in logged_metrics
             assert len(logged_metrics) == 4
 
         # make sure the metrics for the epoch end are actual means (the default reduce fx) or all the batches
         epoch_end_metrics = epoch_outputs[-1]
-        eval_1 = torch.stack(mean_vals['step_epoch_log_and_pbar_acc1']).mean()
-        eval_2 = torch.stack(mean_vals['step_epoch_log_acc2']).mean()
-        assert epoch_end_metrics['step_epoch_log_and_pbar_acc1'] == eval_1
-        assert epoch_end_metrics['step_epoch_log_acc2'] == eval_2
+        eval_1 = torch.stack(mean_vals['epoch_step_epoch_log_and_pbar_acc1']).mean()
+        eval_2 = torch.stack(mean_vals['epoch_step_epoch_log_acc2']).mean()
+        assert epoch_end_metrics['epoch_step_epoch_log_and_pbar_acc1'] == eval_1
+        assert epoch_end_metrics['epoch_step_epoch_log_acc2'] == eval_2
         assert 'step_epoch_pbar_acc3' not in epoch_end_metrics
         assert len(logged_metrics) == 4
 
@@ -237,8 +238,8 @@ def test_training_step_result_log_step_and_epoch(tmpdir):
         epoch_idx += 1
         epoch_outputs = all_pbar_metrics[i_start: i_start + batches + 1]
         mean_vals = {
-            'step_epoch_log_and_pbar_acc1': [],
-            'step_epoch_pbar_acc3': []
+            'epoch_step_epoch_log_and_pbar_acc1': [],
+            'epoch_step_epoch_pbar_acc3': []
         }
 
         # make sure each batch logged the expected value
@@ -247,19 +248,19 @@ def test_training_step_result_log_step_and_epoch(tmpdir):
 
             expected_val_1 = (5 + batch_idx) * (epoch_idx + 1)
             expected_val_2 = (7 + batch_idx) * (epoch_idx + 1)
-            mean_vals['step_epoch_log_and_pbar_acc1'].append(torch.tensor(expected_val_1).float())
-            mean_vals['step_epoch_pbar_acc3'].append(torch.tensor(expected_val_2).float())
-            assert logged_metrics['step_epoch_log_and_pbar_acc1'] == expected_val_1
-            assert logged_metrics['step_epoch_pbar_acc3'] == expected_val_2
+            mean_vals['epoch_step_epoch_log_and_pbar_acc1'].append(torch.tensor(expected_val_1).float())
+            mean_vals['epoch_step_epoch_pbar_acc3'].append(torch.tensor(expected_val_2).float())
+            assert logged_metrics['step_step_epoch_log_and_pbar_acc1'] == expected_val_1
+            assert logged_metrics['step_step_epoch_pbar_acc3'] == expected_val_2
             assert 'step_epoch_log_acc2' not in logged_metrics
             assert len(logged_metrics) == 3
 
         # make sure the metrics for the epoch end are actual means (the default reduce fx) or all the batches
         epoch_end_metrics = epoch_outputs[-1]
-        eval_1 = torch.stack(mean_vals['step_epoch_log_and_pbar_acc1']).mean()
-        eval_2 = torch.stack(mean_vals['step_epoch_pbar_acc3']).mean()
-        assert epoch_end_metrics['step_epoch_log_and_pbar_acc1'] == eval_1
-        assert epoch_end_metrics['step_epoch_pbar_acc3'] == eval_2
+        eval_1 = torch.stack(mean_vals['epoch_step_epoch_log_and_pbar_acc1']).mean()
+        eval_2 = torch.stack(mean_vals['epoch_step_epoch_pbar_acc3']).mean()
+        assert epoch_end_metrics['epoch_step_epoch_log_and_pbar_acc1'] == eval_1
+        assert epoch_end_metrics['epoch_step_epoch_pbar_acc3'] == eval_2
         assert 'step_epoch_log_acc2' not in epoch_end_metrics
         assert len(logged_metrics) == 3
 
@@ -277,8 +278,10 @@ def test_training_step_result_log_step_and_epoch(tmpdir):
     assert isinstance(train_step_out, TrainResult)
 
     assert 'minimize' in train_step_out
-    assert 'step_epoch_log_and_pbar_acc1' in train_step_out
-    assert 'step_epoch_log_acc2' in train_step_out
+    assert 'step_step_epoch_log_and_pbar_acc1' in train_step_out
+    assert 'step_step_epoch_log_acc2' in train_step_out
+    assert 'epoch_step_epoch_log_and_pbar_acc1' in train_step_out
+    assert 'epoch_step_epoch_log_acc2' in train_step_out
 
     # make sure the optimizer closure returns the correct things
     opt_closure_result = trainer.optimizer_closure(batch, batch_idx, 0, trainer.optimizers[0], trainer.hiddens)

--- a/tests/trainer/test_validation_steps_result_return.py
+++ b/tests/trainer/test_validation_steps_result_return.py
@@ -429,4 +429,4 @@ def test_val_step_full_loop_result_dp(tmpdir):
     assert 'test_step_end_metric' in seen_keys
     assert 'test_epoch_end_metric' in seen_keys
 
-test_val_step_full_loop_result_dp('')
+test_val_step_result_callbacks('')

--- a/tests/trainer/test_validation_steps_result_return.py
+++ b/tests/trainer/test_validation_steps_result_return.py
@@ -428,7 +428,4 @@ def test_val_step_full_loop_result_dp(tmpdir):
     assert 'test_step_end_metric' in seen_keys
     assert 'test_epoch_end_metric' in seen_keys
 
-
-# TODO: finish the full train, val, test loop with dp
-
 test_val_step_full_loop_result_dp('')

--- a/tests/trainer/test_validation_steps_result_return.py
+++ b/tests/trainer/test_validation_steps_result_return.py
@@ -425,6 +425,8 @@ def test_val_step_full_loop_result_dp(tmpdir):
     assert 'validation_step_end_metric' in seen_keys
     assert 'validation_epoch_end_metric' in seen_keys
     assert 'step_test_step_metric' in seen_keys
+
+    import pdb; pdb.set_trace()
     assert 'epoch_test_step_metric' in seen_keys
     assert 'test_step_end_metric' in seen_keys
     assert 'test_epoch_end_metric' in seen_keys

--- a/tests/trainer/test_validation_steps_result_return.py
+++ b/tests/trainer/test_validation_steps_result_return.py
@@ -425,9 +425,6 @@ def test_val_step_full_loop_result_dp(tmpdir):
     assert 'validation_step_end_metric' in seen_keys
     assert 'validation_epoch_end_metric' in seen_keys
     assert 'step_test_step_metric' in seen_keys
-
-    import pdb; pdb.set_trace()
-    assert 'epoch_test_step_metric' in seen_keys
     assert 'test_step_end_metric' in seen_keys
     assert 'test_epoch_end_metric' in seen_keys
 

--- a/tests/trainer/test_validation_steps_result_return.py
+++ b/tests/trainer/test_validation_steps_result_return.py
@@ -404,18 +404,30 @@ def test_val_step_full_loop_result_dp(tmpdir):
     )
 
     trainer.fit(model)
-    import pdb; pdb.set_trace()
 
     results = trainer.test()
 
-    # make sure we saw all the correct keys
+    # assert we returned all metrics requested
+    assert len(results) == 1
+    results = results[0]
+    assert 'test_epoch_end_metric' in results
+
+    # make sure we saw all the correct keys along all paths
     seen_keys = set()
     for metric in trainer.dev_debugger.logged_metrics:
         seen_keys.update(metric.keys())
 
+    import pdb; pdb.set_trace()
+
     assert 'train_step_metric' in seen_keys
     assert 'train_step_end_metric' in seen_keys
     assert 'train_epoch_end_metric' in seen_keys
+    assert 'validation_step_metric' in seen_keys
+    assert 'validation_step_end_metric' in seen_keys
+    assert 'validation_epoch_end_metric' in seen_keys
+    assert 'test_step_metric' in seen_keys
+    assert 'test_step_end_metric' in seen_keys
+    assert 'test_epoch_end_metric' in seen_keys
 
 
 # TODO: finish the full train, val, test loop with dp

--- a/tests/trainer/test_validation_steps_result_return.py
+++ b/tests/trainer/test_validation_steps_result_return.py
@@ -417,6 +417,7 @@ def test_val_step_full_loop_result_dp(tmpdir):
     for metric in trainer.dev_debugger.logged_metrics:
         seen_keys.update(metric.keys())
 
+    import pdb; pdb.set_trace()
     assert 'train_step_metric' in seen_keys
     assert 'train_step_end_metric' in seen_keys
     assert 'epoch_train_epoch_end_metric' in seen_keys

--- a/tests/trainer/test_validation_steps_result_return.py
+++ b/tests/trainer/test_validation_steps_result_return.py
@@ -417,11 +417,9 @@ def test_val_step_full_loop_result_dp(tmpdir):
     for metric in trainer.dev_debugger.logged_metrics:
         seen_keys.update(metric.keys())
 
-    import pdb; pdb.set_trace()
-
     assert 'train_step_metric' in seen_keys
     assert 'train_step_end_metric' in seen_keys
-    assert 'train_epoch_end_metric' in seen_keys
+    assert 'epoch_train_epoch_end_metric' in seen_keys
     assert 'validation_step_metric' in seen_keys
     assert 'validation_step_end_metric' in seen_keys
     assert 'validation_epoch_end_metric' in seen_keys

--- a/tests/trainer/test_validation_steps_result_return.py
+++ b/tests/trainer/test_validation_steps_result_return.py
@@ -287,12 +287,12 @@ def test_val_step_epoch_step_metrics(tmpdir):
     for metric_idx in range(0, len(trainer.dev_debugger.logged_metrics), batches + 1):
         batch_metrics = trainer.dev_debugger.logged_metrics[metric_idx: metric_idx + batches]
         epoch_metric = trainer.dev_debugger.logged_metrics[metric_idx + batches]
-        
+
         # make sure the metric was split
         for batch_metric in batch_metrics:
             assert 'step_val_step_log_acc' in batch_metric
             assert 'step_val_step_log_pbar_acc' in batch_metric
-        
+
         # make sure the epoch split was correct
         assert 'epoch_val_step_log_acc' in epoch_metric
         assert 'epoch_val_step_log_pbar_acc' in epoch_metric
@@ -428,5 +428,3 @@ def test_val_step_full_loop_result_dp(tmpdir):
     assert 'epoch_test_step_metric' in seen_keys
     assert 'test_step_end_metric' in seen_keys
     assert 'test_epoch_end_metric' in seen_keys
-
-test_val_step_result_callbacks('')

--- a/tests/trainer/test_validation_steps_result_return.py
+++ b/tests/trainer/test_validation_steps_result_return.py
@@ -425,6 +425,7 @@ def test_val_step_full_loop_result_dp(tmpdir):
     assert 'validation_step_end_metric' in seen_keys
     assert 'validation_epoch_end_metric' in seen_keys
     assert 'step_test_step_metric' in seen_keys
+    assert 'epoch_test_step_metric' in seen_keys
     assert 'test_step_end_metric' in seen_keys
     assert 'test_epoch_end_metric' in seen_keys
 

--- a/tests/trainer/test_validation_steps_result_return.py
+++ b/tests/trainer/test_validation_steps_result_return.py
@@ -417,14 +417,15 @@ def test_val_step_full_loop_result_dp(tmpdir):
     for metric in trainer.dev_debugger.logged_metrics:
         seen_keys.update(metric.keys())
 
-    import pdb; pdb.set_trace()
     assert 'train_step_metric' in seen_keys
     assert 'train_step_end_metric' in seen_keys
     assert 'epoch_train_epoch_end_metric' in seen_keys
-    assert 'validation_step_metric' in seen_keys
+    assert 'step_validation_step_metric' in seen_keys
+    assert 'epoch_validation_step_metric' in seen_keys
     assert 'validation_step_end_metric' in seen_keys
     assert 'validation_epoch_end_metric' in seen_keys
-    assert 'test_step_metric' in seen_keys
+    assert 'step_test_step_metric' in seen_keys
+    assert 'epoch_test_step_metric' in seen_keys
     assert 'test_step_end_metric' in seen_keys
     assert 'test_epoch_end_metric' in seen_keys
 


### PR DESCRIPTION
Finishes enabling EvalResult in val/test loop (still optional).

Next PR will document all of this.

## Additional improvements
Also improves these things:

- `.test()` results now includes everything returned by the user (not just callback metrics)
- When a user wants to track a metric at the step level and epoch level, we automatically split it up:
```
# user wants to track the val acc for every batch and also the global val acc for the epoch
result.log('val_acc', ..., on_epoch=True, on_step=True)

# automatically becomes
`epoch_val_acc`
`step_val_acc`
```