### PR TITLE
quick-fix for --gpus flag bug

### DIFF
--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -310,6 +310,9 @@ class TrainerDDPMixin(ABC):
         num_cores = self.tpu_cores if self.tpu_cores is not None else 0
         rank_zero_info(f'TPU available: {XLA_AVAILABLE}, using: {num_cores} TPU cores')
 
+        if torch.cuda.is_available() and not self.on_gpu:
+            rank_zero_warn('GPU available but not used. Set the --gpus flag in the script.')
+
     def configure_slurm_ddp(self, num_gpu_nodes):
         self.is_slurm_managing_tasks = False
 

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -311,7 +311,7 @@ class TrainerDDPMixin(ABC):
         rank_zero_info(f'TPU available: {XLA_AVAILABLE}, using: {num_cores} TPU cores')
 
         if torch.cuda.is_available() and not self.on_gpu:
-            rank_zero_warn('GPU available but not used. Set the --gpus flag in the script.')
+            rank_zero_warn('GPU available but not used. Set the --gpus flag when calling the script.')
 
     def configure_slurm_ddp(self, num_gpu_nodes):
         self.is_slurm_managing_tasks = False

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -465,10 +465,6 @@ class Trainer(
 
         self.on_gpu = True if (gpus and torch.cuda.is_available()) else False
 
-        # quick-fix for --gpus flag bug
-        if callable(gpus) and gpus.__name__ == self._arg_default.__name__:
-            self.on_gpu = False
-
         # tpu config
         if num_tpu_cores is not None:
             rank_zero_warn("Argument `num_tpu_cores` is now set by `tpu_cores` since v0.7.6"
@@ -535,6 +531,10 @@ class Trainer(
         self.data_parallel_device_ids = _parse_gpu_ids(self.gpus)
         self.root_gpu = determine_root_gpu_device(self.data_parallel_device_ids)
         self.root_device = torch.device("cpu")
+
+        # self.data_parallel_device_ids is None if gpus is callable
+        if self.data_parallel_device_ids is None:
+            self.on_gpu = False
 
         # tpu state flags
         self.use_tpu = False

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -463,8 +463,6 @@ class Trainer(
                 "track_grad_norm can be an int, a float or 'inf' (infinity norm).")
         self.track_grad_norm = float(track_grad_norm)
 
-        self.on_gpu = True if (gpus and torch.cuda.is_available()) else False
-
         # tpu config
         if num_tpu_cores is not None:
             rank_zero_warn("Argument `num_tpu_cores` is now set by `tpu_cores` since v0.7.6"
@@ -532,9 +530,7 @@ class Trainer(
         self.root_gpu = determine_root_gpu_device(self.data_parallel_device_ids)
         self.root_device = torch.device("cpu")
 
-        # self.data_parallel_device_ids is None if gpus is callable
-        if self.data_parallel_device_ids is None:
-            self.on_gpu = False
+        self.on_gpu = True if (self.data_parallel_device_ids and torch.cuda.is_available()) else False
 
         # tpu state flags
         self.use_tpu = False

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -465,6 +465,10 @@ class Trainer(
 
         self.on_gpu = True if (gpus and torch.cuda.is_available()) else False
 
+        # quick-fix for --gpus flag bug
+        if callable(gpus) and gpus.__name__ == self._arg_default.__name__:
+            self.on_gpu = False
+
         # tpu config
         if num_tpu_cores is not None:
             rank_zero_warn("Argument `num_tpu_cores` is now set by `tpu_cores` since v0.7.6"


### PR DESCRIPTION
## What does this PR do?

Prevents setting self.on_gpu as True when --gpus flag is not passed by the user in the case where the following way is used to create the trainer
```
parser = Trainer.add_argparse_args(parser)
args = parser.parse_args()

trainer = Trainer.from_argparse_args(args)
```

Fixes #2669 

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->
