### PR TITLE
Add a GKE cleanup workflow to run once per hour.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ references:
        sudo pip install pycobertura
        pycobertura show coverage.xml
 
-  delete_jobs: &delete_jobs
+  delete_gke_jobs: &delete_gke_jobs
    run:
      name: Delete GKE Jobs
      command: |
@@ -136,14 +136,12 @@ jobs:
   cleanup-gke-jobs:
     docker:
       - image: circleci/python:3.7
-    environment:
-      - MAX_CHECKS: 60
     steps:
       - gcp-gke/install
       - gcp-gke/update-kubeconfig-with-credentials:
           cluster: $GKE_CLUSTER
           perform-login: true
-      - *delete_jobs
+      - *delete_gke_jobs
 
 
 workflows:
@@ -153,12 +151,5 @@ workflows:
       - build-Docs
       - TPU-tests
   cleanup:
-    triggers:
-      - schedule:
-          cron: "0 * * * *"
-          filters:
-            branches:
-              only:
-                - master
     jobs:
       - cleanup-gke-jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,5 +151,15 @@ workflows:
       - build-Docs
       - TPU-tests
   cleanup:
+    triggers:
+      - schedule:
+          # The cron format is:
+          # min (0-59) hour (0-23) monthday (1-31) month (1-12) weekday (0-6, 0=Sun)
+          # Set to run at the first minute of every hour.
+          cron: "0 * * * *"
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - cleanup-gke-jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,16 @@ references:
        sudo pip install pycobertura
        pycobertura show coverage.xml
 
+  delete_jobs: &delete_jobs
+   run:
+     name: Delete GKE Jobs
+     command: |
+       # Match jobs whose age matches patterns like '1h' or '1d', i.e. any job
+       # that has been around longer than 1hr. First print all columns for
+       # matches, then execute the delete.
+       kubectl get job | awk 'match($4,/[0-9]+[dh]/) {print $0}'
+       kubectl delete job $(kubectl get job | awk 'match($4,/[0-9]+[dh]/) {print $1}')
+
 jobs:
 
   TPU-tests:
@@ -123,9 +133,32 @@ jobs:
           path: docs/build/html/
           destination: html
 
+  cleanup-gke-jobs:
+    docker:
+      - image: circleci/python:3.7
+    environment:
+      - MAX_CHECKS: 60
+    steps:
+      - gcp-gke/install
+      - gcp-gke/update-kubeconfig-with-credentials:
+          cluster: $GKE_CLUSTER
+          perform-login: true
+      - *delete_jobs
+
+
 workflows:
   version: 2
   tpu-tests:
     jobs:
       - build-Docs
       - TPU-tests
+  cleanup:
+    triggers:
+      - schedule:
+          cron: "0 * * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - cleanup-gke-jobs


### PR DESCRIPTION
## What does this PR do?

Once per hour, kill and delete all GKE jobs that have an age >1hr. This prevents buildup of stale jobs and prevents and erroneous long-running jobs in case the job accidentally has a long timeout.

Fixes # (issue)

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
