### PR TITLE
Correct CWD for ddp subprocesses when using Hydra

### DIFF
--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -162,9 +162,8 @@ else:
 
 
 try:
-    from hydra.utils import to_absolute_path
+    from hydra.utils import to_absolute_path, get_original_cwd
     from hydra.core.hydra_config import HydraConfig
-    from hydra.utils import get_original_cwd
 except ImportError:
     HYDRA_AVAILABLE = False
 else:

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -163,6 +163,8 @@ else:
 
 try:
     from hydra.utils import to_absolute_path
+    from hydra.core.hydra_config import HydraConfig
+    from hydra.utils import get_original_cwd
 except ImportError:
     HYDRA_AVAILABLE = False
 else:
@@ -467,9 +469,7 @@ class TrainerDDPMixin(ABC):
             # if hydra is available and initialized, make sure to set the cwd correctly
             cwd: Optional[str] = None
             if HYDRA_AVAILABLE:
-                from hydra.core.hydra_config import HydraConfig
                 if HydraConfig.initialized():
-                    from hydra.utils import get_original_cwd
                     cwd = get_original_cwd()
             proc = subprocess.Popen(command, env=env_copy, cwd=cwd)
             self.interactive_ddp_procs.append(proc)

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -464,7 +464,14 @@ class TrainerDDPMixin(ABC):
             env_copy['LOCAL_RANK'] = f'{local_rank}'
 
             # start process
-            proc = subprocess.Popen(command, env=env_copy)
+            # if hydra is available and initialized, make sure to set the cwd correctly
+            cwd: Optional[str] = None
+            if HYDRA_AVAILABLE:
+                from hydra.core.hydra_config import HydraConfig
+                if HydraConfig.initialized():
+                    from hydra.utils import get_original_cwd
+                    cwd = get_original_cwd()
+            proc = subprocess.Popen(command, env=env_copy, cwd=cwd)
             self.interactive_ddp_procs.append(proc)
 
             # starting all processes at once can cause issues


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #2691. This PR sets the cwd of the ddp subprocesses to the original cwd returned by Hydra (when it's enabled). I looked for specific tests, but I think this will be caught by current integration tests? I did verify this manually with my own training script that I used to reproduce the bug.

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- N/A Did you make sure to update the documentation with your changes?
- N/A Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- N/A If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
