### PR TITLE
make the error message readable

### DIFF
--- a/pytorch_lightning/trainer/auto_mix_precision.py
+++ b/pytorch_lightning/trainer/auto_mix_precision.py
@@ -24,9 +24,10 @@ class TrainerAMPMixin(ABC):
         # TODO: replace `use_amp` by `precision` all below for v0.9.0
         if self.use_amp and not APEX_AVAILABLE:  # pragma: no-cover
             raise ModuleNotFoundError(
-                "You set `use_amp=True` but do not have apex installed."
-                "Install apex first using this guide and rerun with use_amp=True:"
-                "https://github.com/NVIDIA/apex#linux his run will NOT use 16 bit precision"
+                "You set `use_amp=True` but do not have apex installed. "
+                "Install apex first using this guide: https://github.com/NVIDIA/apex#linux "
+                "and rerun with use_amp=True. "
+                "This run will NOT use 16 bit precision"    
             )
 
         if self.use_amp:

--- a/pytorch_lightning/trainer/auto_mix_precision.py
+++ b/pytorch_lightning/trainer/auto_mix_precision.py
@@ -27,7 +27,7 @@ class TrainerAMPMixin(ABC):
                 "You set `use_amp=True` but do not have apex installed. "
                 "Install apex first using this guide: https://github.com/NVIDIA/apex#linux "
                 "and rerun with use_amp=True. "
-                "This run will NOT use 16 bit precision"    
+                "This run will NOT use 16 bit precision"
             )
 
         if self.use_amp:

--- a/pytorch_lightning/trainer/auto_mix_precision.py
+++ b/pytorch_lightning/trainer/auto_mix_precision.py
@@ -26,7 +26,7 @@ class TrainerAMPMixin(ABC):
             raise ModuleNotFoundError(
                 "You set `use_amp=True` but do not have apex installed."
                 " Install apex first using this guide: https://github.com/NVIDIA/apex#linux"
-                " and rerun with use_amp=True."
+                " and rerun with `use_amp=True`."
                 " This run will NOT use 16 bit precision."
             )
 

--- a/pytorch_lightning/trainer/auto_mix_precision.py
+++ b/pytorch_lightning/trainer/auto_mix_precision.py
@@ -24,10 +24,10 @@ class TrainerAMPMixin(ABC):
         # TODO: replace `use_amp` by `precision` all below for v0.9.0
         if self.use_amp and not APEX_AVAILABLE:  # pragma: no-cover
             raise ModuleNotFoundError(
-                "You set `use_amp=True` but do not have apex installed. "
-                "Install apex first using this guide: https://github.com/NVIDIA/apex#linux "
-                "and rerun with use_amp=True. "
-                "This run will NOT use 16 bit precision"
+                "You set `use_amp=True` but do not have apex installed."
+                " Install apex first using this guide: https://github.com/NVIDIA/apex#linux"
+                " and rerun with use_amp=True."
+                " This run will NOT use 16 bit precision."
             )
 
         if self.use_amp:


### PR DESCRIPTION
make the error message readable by adding spaces, fixing a typo "his -> this", moving link

Currently one gets:
```
ModuleNotFoundError: You set `use_amp=True` but do not have apex installed.Install apex first using this guide and rerun with use_amp=True:https://github.com/NVIDIA/apex#linux his run will NOT use 16 bit precision
```