### PR TITLE
Call DataModule hooks implicitly in trainer

### DIFF
--- a/docs/source/datamodules.rst
+++ b/docs/source/datamodules.rst
@@ -19,7 +19,7 @@ matching transforms and data processing/downloads steps required.
     ...         MNIST(os.getcwd(), train=True, download=True, transform=transforms.ToTensor())
     ...         MNIST(os.getcwd(), train=False, download=True, transform=transforms.ToTensor())
     ...
-    ...     def setup(self, stage):
+    ...     def setup(self):
     ...         mnist_train = MNIST(os.getcwd(), train=True, download=False, transform=transforms.ToTensor())
     ...         mnist_test = MNIST(os.getcwd(), train=False, download=False, transform=transforms.ToTensor())
     ...         # train/val split
@@ -79,7 +79,7 @@ There are also data operations you might want to perform on every GPU. Use setup
 
     >>> import pytorch_lightning as pl
     >>> class MNISTDataModule(pl.LightningDataModule):
-    ...     def setup(self, stage):
+    ...     def setup(self):
     ...         mnist_train = MNIST(os.getcwd(), train=True, download=False, transform=transforms.ToTensor())
     ...         mnist_test = MNIST(os.getcwd(), train=False, download=False, transform=transforms.ToTensor())
     ...         # train/val split

--- a/docs/source/datamodules.rst
+++ b/docs/source/datamodules.rst
@@ -13,27 +13,50 @@ matching transforms and data processing/downloads steps required.
 
 .. code-block:: python
 
-    class MNISTDataModule(LightningDataModule):
+    import pytorch_lightning as pl
+    from torch.utils.data import random_split, DataLoader
+
+    # Note - you must have torchvision installed for this example
+    from torchvision.datasets import MNIST
+    from torchvision import transforms
+
+
+    class MNISTDataModule(pl.LightningDataModule):
 
         def __init__(self, data_dir: str = './'):
             super().__init__()
             self.data_dir = data_dir
+            self.transform = transforms.Compose([
+                transforms.ToTensor(),
+                transforms.Normalize((0.1307,), (0.3081,))
+            ])
+
+            # self.dims is returned when you call dm.size()
+            # Setting default dims here because we know them.
+            # Could optionally be assigned dynamically in dm.setup() 
+            self.dims = (1, 28, 28)
 
         def prepare_data(self):
             # download
             MNIST(self.data_dir, train=True, download=True)
             MNIST(self.data_dir, train=False, download=True)
 
-        def setup(self, stage):
+        def setup(self, stage=None):
 
             # Assign train/val datasets for use in dataloaders
-            if stage == 'fit':
-                mnist_full = MNIST(self.data_dir, train=True, download=True)
+            if stage == 'fit' or stage is None:
+                mnist_full = MNIST(self.data_dir, train=True, transform=self.transform)
                 self.mnist_train, self.mnist_val = random_split(mnist_full, [55000, 5000])
 
+                # Optionally...
+                # self.dims = tuple(self.mnist_train[0][0].shape)
+
             # Assign test dataset for use in dataloader(s)
-            if stage == 'test':
-                self.mnist_test = MNIST(self.data_dir, train=False, download=True)
+            if stage == 'test' or stage is None:
+                self.mnist_test = MNIST(self.data_dir, train=False, transform=self.transform)
+
+                # Optionally...
+                # self.dims = tuple(self.mnist_test[0][0].shape)
 
         def train_dataloader(self):
             return DataLoader(self.mnist_train, batch_size=32)

--- a/pytorch_lightning/accelerator_backends/cpu_backend.py
+++ b/pytorch_lightning/accelerator_backends/cpu_backend.py
@@ -20,15 +20,15 @@ class CPUBackend(object):
     def __init__(self, trainer):
         self.trainer = trainer
 
-    def setup(self, model, datamodule=None):
+    def setup(self, model):
         # run through amp wrapper
         if self.trainer.use_amp:
             raise MisconfigurationException('amp + cpu is not supported.  Please use a GPU option')
 
         # call setup after the ddp process has connected
         if not self.trainer.testing:
-            if datamodule is not None:
-                datamodule.setup('fit')
+            if self.trainer.datamodule is not None:
+                self.trainer.datamodule.setup('fit')
 
             self.trainer.setup('fit')
 

--- a/pytorch_lightning/accelerator_backends/cpu_backend.py
+++ b/pytorch_lightning/accelerator_backends/cpu_backend.py
@@ -20,14 +20,18 @@ class CPUBackend(object):
     def __init__(self, trainer):
         self.trainer = trainer
 
-    def setup(self, model):
+    def setup(self, model, datamodule=None):
         # run through amp wrapper
         if self.trainer.use_amp:
             raise MisconfigurationException('amp + cpu is not supported.  Please use a GPU option')
 
         # call setup after the ddp process has connected
         if not self.trainer.testing:
+            if datamodule is not None:
+                datamodule.setup('fit')
+
             self.trainer.setup('fit')
+
             model.setup('fit')
 
         # CHOOSE OPTIMIZER

--- a/pytorch_lightning/accelerator_backends/cpu_backend.py
+++ b/pytorch_lightning/accelerator_backends/cpu_backend.py
@@ -31,7 +31,6 @@ class CPUBackend(object):
                 self.trainer.datamodule.setup('fit')
 
             self.trainer.setup('fit')
-
             model.setup('fit')
 
         # CHOOSE OPTIMIZER

--- a/pytorch_lightning/accelerator_backends/cpu_backend.py
+++ b/pytorch_lightning/accelerator_backends/cpu_backend.py
@@ -26,7 +26,7 @@ class CPUBackend(object):
             raise MisconfigurationException('amp + cpu is not supported.  Please use a GPU option')
 
         # call setup after the ddp process has connected
-        self.trainer.call_setup_hook()
+        self.trainer.call_setup_hook(model)
 
         # CHOOSE OPTIMIZER
         # allow for lr schedulers as well

--- a/pytorch_lightning/accelerator_backends/cpu_backend.py
+++ b/pytorch_lightning/accelerator_backends/cpu_backend.py
@@ -26,12 +26,7 @@ class CPUBackend(object):
             raise MisconfigurationException('amp + cpu is not supported.  Please use a GPU option')
 
         # call setup after the ddp process has connected
-        if not self.trainer.testing:
-            if self.trainer.datamodule is not None:
-                self.trainer.datamodule.setup('fit')
-
-            self.trainer.setup('fit')
-            model.setup('fit')
+        self.trainer.call_setup_hook()
 
         # CHOOSE OPTIMIZER
         # allow for lr schedulers as well

--- a/pytorch_lightning/accelerator_backends/ddp_spawn_backend.py
+++ b/pytorch_lightning/accelerator_backends/ddp_spawn_backend.py
@@ -106,7 +106,7 @@ class DDPSpawnBackend(object):
         )
 
         # call setup after the ddp process has connected
-        self.trainer.call_setup_hook()
+        self.trainer.call_setup_hook(model)
 
         # on world_size=0 let everyone know training is starting
         if self.trainer.is_global_zero:

--- a/pytorch_lightning/accelerator_backends/ddp_spawn_backend.py
+++ b/pytorch_lightning/accelerator_backends/ddp_spawn_backend.py
@@ -106,12 +106,7 @@ class DDPSpawnBackend(object):
         )
 
         # call setup after the ddp process has connected
-        if not self.trainer.testing:
-            if self.trainer.datamodule is not None:
-                self.trainer.datamodule.setup('fit')
-            self.trainer.setup('fit')
-
-            model.setup('fit')
+        self.trainer.call_setup_hook()
 
         # on world_size=0 let everyone know training is starting
         if self.trainer.is_global_zero:

--- a/pytorch_lightning/accelerator_backends/ddp_spawn_backend.py
+++ b/pytorch_lightning/accelerator_backends/ddp_spawn_backend.py
@@ -60,7 +60,7 @@ class DDPSpawnBackend(object):
         self.trainer.model = model
         return results
 
-    def ddp_train(self, process_idx, mp_queue, model, is_master=False, proc_offset=0):
+    def ddp_train(self, process_idx, mp_queue, model, is_master=False, proc_offset=0, datamodule=None):
         """
         Entry point for ddp
 
@@ -107,7 +107,10 @@ class DDPSpawnBackend(object):
 
         # call setup after the ddp process has connected
         if not self.trainer.testing:
+            if datamodule is not None:
+                datamodule.setup('fit')
             self.trainer.setup('fit')
+
             model.setup('fit')
 
         # on world_size=0 let everyone know training is starting

--- a/pytorch_lightning/accelerator_backends/ddp_spawn_backend.py
+++ b/pytorch_lightning/accelerator_backends/ddp_spawn_backend.py
@@ -60,7 +60,7 @@ class DDPSpawnBackend(object):
         self.trainer.model = model
         return results
 
-    def ddp_train(self, process_idx, mp_queue, model, is_master=False, proc_offset=0, datamodule=None):
+    def ddp_train(self, process_idx, mp_queue, model, is_master=False, proc_offset=0):
         """
         Entry point for ddp
 
@@ -107,8 +107,8 @@ class DDPSpawnBackend(object):
 
         # call setup after the ddp process has connected
         if not self.trainer.testing:
-            if datamodule is not None:
-                datamodule.setup('fit')
+            if self.trainer.datamodule is not None:
+                self.trainer.datamodule.setup('fit')
             self.trainer.setup('fit')
 
             model.setup('fit')

--- a/pytorch_lightning/accelerator_backends/dp_backend.py
+++ b/pytorch_lightning/accelerator_backends/dp_backend.py
@@ -33,7 +33,7 @@ class DataParallelBackend(object):
 
     def setup(self, model):
         # call setup after the ddp process has connected
-        self.trainer.call_setup_hook()
+        self.trainer.call_setup_hook(model)
 
         # put model on correct device
         model.cuda(self.trainer.root_gpu)

--- a/pytorch_lightning/accelerator_backends/dp_backend.py
+++ b/pytorch_lightning/accelerator_backends/dp_backend.py
@@ -33,11 +33,7 @@ class DataParallelBackend(object):
 
     def setup(self, model):
         # call setup after the ddp process has connected
-        if not self.trainer.testing:
-            if self.trainer.datamodule is not None:
-                self.trainer.datamodule.setup('fit')
-            self.trainer.setup('fit')
-            model.setup('fit')
+        self.trainer.call_setup_hook()
 
         # put model on correct device
         model.cuda(self.trainer.root_gpu)

--- a/pytorch_lightning/accelerator_backends/dp_backend.py
+++ b/pytorch_lightning/accelerator_backends/dp_backend.py
@@ -31,10 +31,13 @@ class DataParallelBackend(object):
         self.trainer = trainer
         self.model_autocast_original_forward = None
 
-    def setup(self, model):
+    def setup(self, model, datamodule=None):
         # call setup after the ddp process has connected
         if not self.trainer.testing:
+            if datamodule is not None:
+                datamodule.setup('fit')
             self.trainer.setup('fit')
+
             model.setup('fit')
 
         # put model on correct device

--- a/pytorch_lightning/accelerator_backends/dp_backend.py
+++ b/pytorch_lightning/accelerator_backends/dp_backend.py
@@ -31,11 +31,11 @@ class DataParallelBackend(object):
         self.trainer = trainer
         self.model_autocast_original_forward = None
 
-    def setup(self, model, datamodule=None):
+    def setup(self, model):
         # call setup after the ddp process has connected
         if not self.trainer.testing:
-            if datamodule is not None:
-                datamodule.setup('fit')
+            if self.trainer.datamodule is not None:
+                self.trainer.datamodule.setup('fit')
             self.trainer.setup('fit')
 
             model.setup('fit')

--- a/pytorch_lightning/accelerator_backends/dp_backend.py
+++ b/pytorch_lightning/accelerator_backends/dp_backend.py
@@ -37,7 +37,6 @@ class DataParallelBackend(object):
             if self.trainer.datamodule is not None:
                 self.trainer.datamodule.setup('fit')
             self.trainer.setup('fit')
-
             model.setup('fit')
 
         # put model on correct device

--- a/pytorch_lightning/accelerator_backends/gpu_backend.py
+++ b/pytorch_lightning/accelerator_backends/gpu_backend.py
@@ -28,12 +28,12 @@ class GPUBackend(object):
     def __init__(self, trainer):
         self.trainer = trainer
 
-    def setup(self, model, datamodule=None):
+    def setup(self, model):
 
         # call setup
         if not self.trainer.testing:
-            if datamodule is not None:
-                datamodule.setup('fit')
+            if self.trainer.datamodule is not None:
+                self.trainer.datamodule.setup('fit')
             self.trainer.setup('fit')
 
             model.setup('fit')

--- a/pytorch_lightning/accelerator_backends/gpu_backend.py
+++ b/pytorch_lightning/accelerator_backends/gpu_backend.py
@@ -31,7 +31,7 @@ class GPUBackend(object):
     def setup(self, model):
 
         # call setup
-        self.trainer.call_setup_hook()
+        self.trainer.call_setup_hook(model)
 
         model.cuda(self.trainer.root_gpu)
 

--- a/pytorch_lightning/accelerator_backends/gpu_backend.py
+++ b/pytorch_lightning/accelerator_backends/gpu_backend.py
@@ -28,11 +28,14 @@ class GPUBackend(object):
     def __init__(self, trainer):
         self.trainer = trainer
 
-    def setup(self, model):
+    def setup(self, model, datamodule=None):
 
         # call setup
         if not self.trainer.testing:
+            if datamodule is not None:
+                datamodule.setup('fit')
             self.trainer.setup('fit')
+
             model.setup('fit')
 
         model.cuda(self.trainer.root_gpu)

--- a/pytorch_lightning/accelerator_backends/gpu_backend.py
+++ b/pytorch_lightning/accelerator_backends/gpu_backend.py
@@ -31,12 +31,7 @@ class GPUBackend(object):
     def setup(self, model):
 
         # call setup
-        if not self.trainer.testing:
-            if self.trainer.datamodule is not None:
-                self.trainer.datamodule.setup('fit')
-            self.trainer.setup('fit')
-
-            model.setup('fit')
+        self.trainer.call_setup_hook()
 
         model.cuda(self.trainer.root_gpu)
 

--- a/pytorch_lightning/accelerator_backends/tpu_backend.py
+++ b/pytorch_lightning/accelerator_backends/tpu_backend.py
@@ -96,14 +96,17 @@ class TPUBackend(object):
 
         self.trainer.model = model
 
-    def tpu_train_in_process(self, tpu_core_idx: int, model: LightningModule, trainer=None, mp_queue=None):
+    def tpu_train_in_process(self, tpu_core_idx: int, model: LightningModule, trainer=None, mp_queue=None, datamodule=None):
         """
         Here we are inside each individual process
         """
         if not trainer:
             trainer = self.trainer
         if not trainer.testing:
+            if datamodule is not None:
+                datamodule.setup('fit')
             trainer.setup('fit')
+
             model.setup('fit')
 
         # setup TPU training

--- a/pytorch_lightning/accelerator_backends/tpu_backend.py
+++ b/pytorch_lightning/accelerator_backends/tpu_backend.py
@@ -106,7 +106,6 @@ class TPUBackend(object):
             if self.trainer.datamodule is not None:
                 self.trainer.datamodule.setup('fit')
             trainer.setup('fit')
-
             model.setup('fit')
 
         # setup TPU training

--- a/pytorch_lightning/accelerator_backends/tpu_backend.py
+++ b/pytorch_lightning/accelerator_backends/tpu_backend.py
@@ -102,11 +102,8 @@ class TPUBackend(object):
         """
         if not trainer:
             trainer = self.trainer
-        if not trainer.testing:
-            if self.trainer.datamodule is not None:
-                self.trainer.datamodule.setup('fit')
-            trainer.setup('fit')
-            model.setup('fit')
+
+        trainer.call_setup_hook()
 
         # setup TPU training
         self.__setup_tpu_training(model, trainer)

--- a/pytorch_lightning/accelerator_backends/tpu_backend.py
+++ b/pytorch_lightning/accelerator_backends/tpu_backend.py
@@ -96,15 +96,15 @@ class TPUBackend(object):
 
         self.trainer.model = model
 
-    def tpu_train_in_process(self, tpu_core_idx: int, model: LightningModule, trainer=None, mp_queue=None, datamodule=None):
+    def tpu_train_in_process(self, tpu_core_idx: int, model: LightningModule, trainer=None, mp_queue=None):
         """
         Here we are inside each individual process
         """
         if not trainer:
             trainer = self.trainer
         if not trainer.testing:
-            if datamodule is not None:
-                datamodule.setup('fit')
+            if self.trainer.datamodule is not None:
+                self.trainer.datamodule.setup('fit')
             trainer.setup('fit')
 
             model.setup('fit')

--- a/pytorch_lightning/accelerator_backends/tpu_backend.py
+++ b/pytorch_lightning/accelerator_backends/tpu_backend.py
@@ -103,7 +103,7 @@ class TPUBackend(object):
         if not trainer:
             trainer = self.trainer
 
-        trainer.call_setup_hook()
+        trainer.call_setup_hook(model)
 
         # setup TPU training
         self.__setup_tpu_training(model, trainer)

--- a/pytorch_lightning/core/datamodule.py
+++ b/pytorch_lightning/core/datamodule.py
@@ -16,7 +16,7 @@ import functools
 import inspect
 from abc import abstractmethod
 from argparse import ArgumentParser, Namespace
-from typing import Any, List, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 from torch.utils.data import DataLoader
 
@@ -32,13 +32,10 @@ class _DataModuleWrapper(type):
             3. Lets you check prepare_data and setup to see if they've been called
         """
 
-        # Wrap cls's prepare_data function with rank_zero_only
-        cls.prepare_data = rank_zero_only(cls.prepare_data)
-
-        # prepare_data and setup wrapped w/ function to track if they've been called.
-        # Usage: your_dm.setup.has_been_called & your_dm.prepare_data.has_been_called
-        cls.prepare_data = track_func_calls(cls.prepare_data)
-        cls.setup = track_func_calls(cls.setup)
+        # Track prepare_data calls and make sure it runs on rank zero
+        cls.prepare_data = track_data_hook_calls(rank_zero_only(cls.prepare_data))
+        # Track setup calls
+        cls.setup = track_data_hook_calls(cls.setup)
 
         # Get instance of LightningDataModule by mocking its __init__ via __call__
         obj = type.__call__(cls, *args, **kwargs)
@@ -46,21 +43,45 @@ class _DataModuleWrapper(type):
         return obj
 
 
-def track_func_calls(fn):
-    """A decorator that checks if a function has been called.
+def track_data_hook_calls(fn):
+    """A decorator that checks if prepare_data/setup have been called.
+
+    - When dm.prepare_data() is called, dm.has_prepared_data gets set to True
+    - When dm.setup('fit') is called, dm.has_setup_fit gets set to True
+    - When dm.setup('test') is called, dm.has_setup_test gets set to True
+    - When dm.setup() is called without stage arg, both dm.has_setup_fit and dm.has_setup_test get set to True
 
     Args:
         fn (function): Function that will be tracked to see if it has been called.
 
     Returns:
-        callable: Your function with an added bool attr fn.has_been_called.
+        function: Decorated function that tracks its call status and saves it to private attrs in its obj instance.
     """
+
     @functools.wraps(fn)
     def wrapped_fn(*args, **kwargs):
-        wrapped_fn.has_been_called = True
-        return fn(*args, **kwargs)
 
-    wrapped_fn.has_been_called = False
+        # The object instance from which setup or prepare_data was called
+        obj = args[0]
+
+        # If calling setup, we check the stage and assign stage-specific bool args
+        if fn.__name__ == 'setup':
+
+            # Get stage either by grabbing from args or checking kwargs.
+            # If not provided, set call status of 'fit' and 'test' to True.
+            # We do this so __attach_datamodule in trainer.py doesn't mistakenly call setup('test') on trainer.test()
+            stage = args[1] if len(args) > 1 else kwargs.get('stage', None)
+
+            if stage == 'fit' or stage is None:
+                obj._has_setup_fit = True
+
+            if stage == 'test' or stage is None:
+                obj._has_setup_test = True
+
+        if fn.__name__ == 'prepare_data':
+            obj._has_prepared_data = True
+
+        return fn(*args, **kwargs)
 
     return wrapped_fn
 
@@ -116,6 +137,11 @@ class LightningDataModule(object, metaclass=_DataModuleWrapper):  # pragma: no c
         self._test_transforms = test_transforms
         self.dims = ()
 
+        # Private attrs to keep track of whether or not data hooks have been called yet
+        self._has_prepared_data = False
+        self._has_setup_fit = False
+        self._has_setup_test = False
+
     @property
     def train_transforms(self):
         """
@@ -159,6 +185,33 @@ class LightningDataModule(object, metaclass=_DataModuleWrapper):  # pragma: no c
 
         return self.dims
 
+    @property
+    def has_prepared_data(self):
+        """Return bool letting you know if datamodule.prepare_data() has been called or not.
+
+        Returns:
+            bool: True if datamodule.prepare_data() has been called. False by default.
+        """
+        return self._has_prepared_data
+
+    @property
+    def has_setup_fit(self):
+        """Return bool letting you know if datamodule.setup('fit') has been called or not.
+
+        Returns:
+            bool: True if datamodule.setup('fit') has been called. False by default.
+        """
+        return self._has_setup_fit
+
+    @property
+    def has_setup_test(self):
+        """Return bool letting you know if datamodule.setup('test') has been called or not.
+
+        Returns:
+            bool: True if datamodule.setup('test') has been called. False by default.
+        """
+        return self._has_setup_test
+
     @abstractmethod
     def prepare_data(self, *args, **kwargs):
         """
@@ -181,14 +234,14 @@ class LightningDataModule(object, metaclass=_DataModuleWrapper):  # pragma: no c
         """
 
     @abstractmethod
-    def setup(self, *args, **kwargs):
+    def setup(self, stage: Optional[str] = None):
         """
         Use this to load your data from file, split it, etc. You are safe to make state assignments here.
         This hook is called on every process when using DDP.
 
         Example::
 
-            def setup(self):
+            def setup(self, stage):
                 data = load_data(...)
                 self.train_ds, self.val_ds, self.test_ds = split_data(data)
         """

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -488,7 +488,7 @@ class TrainerDDPMixin(ABC):
 
         return results
 
-    def ddp_train(self, process_idx, mp_queue, model, is_master=False, proc_offset=0, datamodule=None):
+    def ddp_train(self, process_idx, mp_queue, model, is_master=False, proc_offset=0):
         """
         Entry point for ddp
 
@@ -531,8 +531,8 @@ class TrainerDDPMixin(ABC):
 
         # call setup after the ddp process has connected
         if not self.testing:
-            if datamodule is not None:
-                datamodule.setup('fit')
+            if self.datamodule is not None:
+                self.datamodule.setup('fit')
             self.setup('fit')
             model.setup('fit')
 

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -145,6 +145,7 @@ from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.utilities import NATIVE_AMP_AVALAIBLE
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.distributed import rank_zero_only, rank_zero_warn, rank_zero_info
+from pytorch_lightning.core.datamodule import LightningDataModule
 from pytorch_lightning.core.lightning import LightningModule
 
 
@@ -204,6 +205,7 @@ class TrainerDDPMixin(ABC):
     node_rank: int
     tpu_cores: int
     testing: bool
+    datamodule: Optional[LightningDataModule]
 
     @property
     @abstractmethod

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -536,7 +536,7 @@ class TrainerDDPMixin(ABC):
         model.init_ddp_connection(self.global_rank, self.world_size, self.is_slurm_managing_tasks)
 
         # call setup after the ddp process has connected
-        self.call_setup_hook()
+        self.call_setup_hook(model)
 
         # on world_size=0 let everyone know training is starting
         if self.is_global_zero:

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -212,6 +212,10 @@ class TrainerDDPMixin(ABC):
     def is_global_zero(self) -> bool:
         """Warning: this is just empty shell for code implemented in other class."""
 
+    @abstractmethod
+    def call_setup_hook(self, *args):
+        """Warning: this is just empty shell for code implemented in other class."""
+
     @property
     @abstractmethod
     def num_gpus(self) -> int:
@@ -532,11 +536,7 @@ class TrainerDDPMixin(ABC):
         model.init_ddp_connection(self.global_rank, self.world_size, self.is_slurm_managing_tasks)
 
         # call setup after the ddp process has connected
-        if not self.testing:
-            if self.datamodule is not None:
-                self.datamodule.setup('fit')
-            self.setup('fit')
-            model.setup('fit')
+        self.call_setup_hook()
 
         # on world_size=0 let everyone know training is starting
         if self.is_global_zero:

--- a/pytorch_lightning/trainer/distrib_data_parallel.py
+++ b/pytorch_lightning/trainer/distrib_data_parallel.py
@@ -488,7 +488,7 @@ class TrainerDDPMixin(ABC):
 
         return results
 
-    def ddp_train(self, process_idx, mp_queue, model, is_master=False, proc_offset=0):
+    def ddp_train(self, process_idx, mp_queue, model, is_master=False, proc_offset=0, datamodule=None):
         """
         Entry point for ddp
 
@@ -531,6 +531,8 @@ class TrainerDDPMixin(ABC):
 
         # call setup after the ddp process has connected
         if not self.testing:
+            if datamodule is not None:
+                datamodule.setup('fit')
             self.setup('fit')
             model.setup('fit')
 

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -82,11 +82,14 @@ class TrainerDPMixin(ABC):
     on_colab_kaggle: str
     save_spawn_weights: Callable
     logger: ...
-    datamodule: ...
 
     @property
     @abstractmethod
     def use_amp(self) -> bool:
+        """Warning: this is just empty shell for code implemented in other class."""
+
+    @abstractmethod
+    def call_setup_hook(self, *args):
         """Warning: this is just empty shell for code implemented in other class."""
 
     @abstractmethod
@@ -181,11 +184,7 @@ class TrainerDPMixin(ABC):
 
     def horovod_train(self, model):
         # call setup after the ddp process has connected
-        if not self.testing:
-            if self.datamodule is not None:
-                self.datamodule.setup('fit')
-            self.setup('fit')
-            model.setup('fit')
+        self.call_setup_hook()
 
         if torch.cuda.is_available() and self.on_gpu:
             # Horovod: pin GPU to local rank

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -184,7 +184,7 @@ class TrainerDPMixin(ABC):
 
     def horovod_train(self, model):
         # call setup after the ddp process has connected
-        self.call_setup_hook()
+        self.call_setup_hook(model)
 
         if torch.cuda.is_available() and self.on_gpu:
             # Horovod: pin GPU to local rank

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -82,6 +82,7 @@ class TrainerDPMixin(ABC):
     on_colab_kaggle: str
     save_spawn_weights: Callable
     logger: ...
+    datamodule: ...
 
     @property
     @abstractmethod
@@ -181,6 +182,8 @@ class TrainerDPMixin(ABC):
     def horovod_train(self, model):
         # call setup after the ddp process has connected
         if not self.testing:
+            if self.datamodule is not None:
+                self.datamodule.setup('fit')
             self.setup('fit')
             model.setup('fit')
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -378,6 +378,7 @@ class Trainer(
 
         # training state
         self.model = None
+        self.datamodule = None
         self.testing = False
         self.prepare_data_per_node = prepare_data_per_node
         self.lr_schedulers = []

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1381,7 +1381,7 @@ class Trainer(
             # wait for all processes to catch up
             torch_xla.core.xla_model.rendezvous(f'pl.Trainer.{name}')
 
-    def call_setup_hook(self):
+    def call_setup_hook(self, model):
         # call setup after the ddp process has connected
         stage_name = 'test' if self.testing else 'fit'
         if self.datamodule is not None:
@@ -1389,8 +1389,6 @@ class Trainer(
             if not called:
                 self.datamodule.setup(stage_name)
         self.setup(stage_name)
-
-        model = self.get_model()
         model.setup(stage_name)
 
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1385,7 +1385,9 @@ class Trainer(
         # call setup after the ddp process has connected
         stage_name = 'test' if self.testing else 'fit'
         if self.datamodule is not None:
-            self.datamodule.setup(stage_name)
+            called = self.datamodule.has_setup_test if self.testing else self.datamodule.has_setup_fit
+            if not called:
+                self.datamodule.setup(stage_name)
         self.setup(stage_name)
 
         model = self.get_model()

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1033,7 +1033,7 @@ class Trainer(
 
         else:
             self.accelerator_backend = CPUBackend(self)
-            self.accelerator_backend.setup(model, datamodule=datamodule)
+            self.accelerator_backend.setup(model)
             results = self.accelerator_backend.train(model)
 
         # callbacks
@@ -1093,6 +1093,8 @@ class Trainer(
                 model.val_dataloader = datamodule.val_dataloader
             if self.is_overridden('test_dataloader', datamodule):
                 model.test_dataloader = datamodule.test_dataloader
+
+            self.datamodule = datamodule
 
     def run_pretrain_routine(self, model: LightningModule):
         """Sanity check a few things before starting actual training.

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1076,6 +1076,10 @@ class Trainer(
 
         # If we have a datamodule, attach necessary hooks + dataloaders
         if datamodule:
+            if self.is_overridden('prepare_data', datamodule) and not datamodule.prepare_data.has_been_called:
+                datamodule.prepare_data()
+            if self.is_overridden('setup', datamodule) and not datamodule.setup.has_been_called:
+                datamodule.setup()
             if self.is_overridden('train_dataloader', datamodule):
                 model.train_dataloader = datamodule.train_dataloader
             if self.is_overridden('val_dataloader', datamodule):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1084,14 +1084,10 @@ class Trainer(
         # If we have a datamodule, attach necessary hooks + dataloaders
         if datamodule:
 
-            # # If datamodule.prepare_data() has not been called yet, call it
-            # if self.is_overridden('prepare_data', datamodule) and not datamodule.has_prepared_data:
-            #     datamodule.prepare_data()
-
             # If datamodule.setup('test') has not been called yet, call it
-            if stage == 'test':
-                if self.is_overridden('setup', datamodule) and not datamodule.has_setup_test:
-                    datamodule.setup('test')
+            # if stage == 'test':
+            #     if self.is_overridden('setup', datamodule) and not datamodule.has_setup_test:
+            #         datamodule.setup('test')
 
             # Override loader hooks
             if self.is_overridden('train_dataloader', datamodule):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -955,12 +955,10 @@ class Trainer(
         # on multi-gpu jobs we only want to manipulate (download, etc) on node_rank=0, local_rank=0
         # or in the case where each node needs to do its own manipulation in which case just local_rank=0
         if self.can_prepare_data():
+            if datamodule is not None:
+                datamodule.prepare_data()
             model.prepare_data()
             self._is_data_prepared = True
-
-            # If datamodule.prepare_data() has not been called yet, call it
-            if dm_prepare_data_called:
-                datamodule.prepare_data()
 
         # Run auto batch size scaling
         if self.auto_scale_batch_size:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1033,7 +1033,7 @@ class Trainer(
 
         else:
             self.accelerator_backend = CPUBackend(self)
-            self.accelerator_backend.setup(model)
+            self.accelerator_backend.setup(model, datamodule=datamodule)
             results = self.accelerator_backend.train(model)
 
         # callbacks
@@ -1080,11 +1080,6 @@ class Trainer(
             # If datamodule.prepare_data() has not been called yet, call it
             if self.is_overridden('prepare_data', datamodule) and not datamodule.has_prepared_data:
                 datamodule.prepare_data()
-
-            # If datamodule.setup('fit') has not been called yet, call it
-            if stage == 'fit':
-                if self.is_overridden('setup', datamodule) and not datamodule.has_setup_fit:
-                    datamodule.setup('fit')
 
             # If datamodule.setup('test') has not been called yet, call it
             if stage == 'test':

--- a/tests/base/datamodules.py
+++ b/tests/base/datamodules.py
@@ -5,19 +5,28 @@ from tests.base.datasets import TrialMNIST
 
 
 class TrialMNISTDataModule(LightningDataModule):
+
     def __init__(self, data_dir: str = './'):
         super().__init__()
         self.data_dir = data_dir
+        self.non_picklable = None
 
     def prepare_data(self):
         TrialMNIST(self.data_dir, train=True, download=True)
         TrialMNIST(self.data_dir, train=False, download=True)
 
-    def setup(self):
-        mnist_full = TrialMNIST(root=self.data_dir, train=True, num_samples=64, download=True)
-        self.mnist_train, self.mnist_val = random_split(mnist_full, [128, 64])
-        self.dims = tuple(self.mnist_train[0][0].shape)
-        self.mnist_test = TrialMNIST(root=self.data_dir, train=False, num_samples=32, download=True)
+    def setup(self, stage: str = None):
+
+        if stage == 'fit' or stage is None:
+            mnist_full = TrialMNIST(root=self.data_dir, train=True, num_samples=64, download=True)
+            self.mnist_train, self.mnist_val = random_split(mnist_full, [128, 64])
+            self.dims = self.mnist_train[0][0].shape
+
+        if stage == 'test' or stage is None:
+            self.mnist_test = TrialMNIST(root=self.data_dir, train=False, num_samples=32, download=True)
+            self.dims = getattr(self, 'dims', self.mnist_test[0][0].shape)
+
+        self.non_picklable = lambda x: x**2
 
     def train_dataloader(self):
         return DataLoader(self.mnist_train, batch_size=32)

--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -97,21 +97,6 @@ def test_dm_pickle_after_init(tmpdir):
     pickle.dumps(dm)
 
 
-def test_dm_pickle_after_setup(tmpdir):
-    dm = TrialMNISTDataModule()
-    dm.prepare_data()
-    dm.setup()
-    pickle.dumps(dm)
-
-
-def test_dm_pickle_after_setup_verbose(tmpdir):
-    dm = TrialMNISTDataModule()
-    dm.prepare_data()
-    dm.setup('fit')
-    dm.setup('test')
-    pickle.dumps(dm)
-
-
 def test_train_loop_only(tmpdir):
     dm = TrialMNISTDataModule(tmpdir)
 

--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -279,34 +279,3 @@ def test_full_loop_ddp_spawn(tmpdir):
     result = trainer.test(datamodule=dm)
     result = result[0]
     assert result['test_acc'] > 0.8
-
-
-@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="test requires multi-GPU machine")
-def test_full_loop_ddp_spawn_non_picklable(tmpdir):
-    import os
-    os.environ['CUDA_VISIBLE_DEVICES'] = '0,1'
-
-    reset_seed()
-
-    dm = TrialMNISTDataModule(tmpdir)
-    dm.non_pickle_thing = lambda x: x**2
-
-    model = EvalModelTemplate()
-
-    trainer = Trainer(
-        default_root_dir=tmpdir,
-        max_epochs=3,
-        weights_summary=None,
-        distributed_backend='ddp_spawn',
-        gpus=[0, 1]
-    )
-    trainer.fit(model, dm)
-
-    # fit model
-    result = trainer.fit(model)
-    assert result == 1
-
-    # test
-    result = trainer.test(datamodule=dm)
-    result = result[0]
-    assert result['test_acc'] > 0.8

--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -1,10 +1,13 @@
 import pickle
+from argparse import ArgumentParser
+
 import torch
 import pytest
+
 from pytorch_lightning import Trainer
-from tests.base.datamodules import TrialMNISTDataModule
 from tests.base import EvalModelTemplate
-from argparse import ArgumentParser
+from tests.base.datamodules import TrialMNISTDataModule
+from tests.base.develop_utils import reset_seed
 
 
 def test_base_datamodule(tmpdir):
@@ -80,6 +83,8 @@ def test_train_loop_only(tmpdir):
 
 
 def test_train_val_loop_only(tmpdir):
+    reset_seed()
+
     dm = TrialMNISTDataModule(tmpdir)
 
     model = EvalModelTemplate()
@@ -101,6 +106,8 @@ def test_train_val_loop_only(tmpdir):
 
 
 def test_full_loop(tmpdir):
+    reset_seed()
+
     dm = TrialMNISTDataModule(tmpdir)
 
     model = EvalModelTemplate()
@@ -124,6 +131,8 @@ def test_full_loop(tmpdir):
 
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="test requires multi-GPU machine")
 def test_full_loop_single_gpu(tmpdir):
+    reset_seed()
+
     dm = TrialMNISTDataModule(tmpdir)
 
     model = EvalModelTemplate()
@@ -148,6 +157,8 @@ def test_full_loop_single_gpu(tmpdir):
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="test requires multi-GPU machine")
 def test_full_loop_dp(tmpdir):
+    reset_seed()
+
     dm = TrialMNISTDataModule(tmpdir)
 
     model = EvalModelTemplate()
@@ -175,6 +186,8 @@ def test_full_loop_dp(tmpdir):
 def test_full_loop_ddp_spawn(tmpdir):
     import os
     os.environ['CUDA_VISIBLE_DEVICES'] = '0,1'
+
+    reset_seed()
 
     dm = TrialMNISTDataModule(tmpdir)
 

--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -79,7 +79,7 @@ def test_train_loop_only(tmpdir):
     # fit model
     result = trainer.fit(model)
     assert result == 1
-    assert trainer.callback_metrics['loss'] < 0.50
+    assert trainer.callback_metrics['loss'] < 0.6
 
 
 def test_train_val_loop_only(tmpdir):
@@ -102,7 +102,7 @@ def test_train_val_loop_only(tmpdir):
     # fit model
     result = trainer.fit(model)
     assert result == 1
-    assert trainer.callback_metrics['loss'] < 0.65
+    assert trainer.callback_metrics['loss'] < 0.6
 
 
 def test_full_loop(tmpdir):

--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -16,18 +16,64 @@ def test_base_datamodule(tmpdir):
     dm.setup()
 
 
-def test_dm_has_been_called(tmpdir):
+def test_base_datamodule_with_verbose_setup(tmpdir):
     dm = TrialMNISTDataModule()
-    assert dm.prepare_data.has_been_called is False
-    assert dm.setup.has_been_called is False
+    dm.prepare_data()
+    dm.setup('fit')
+    dm.setup('test')
+
+
+def test_data_hooks_called(tmpdir):
+    dm = TrialMNISTDataModule()
+    assert dm.has_prepared_data is False
+    assert dm.has_setup_fit is False
+    assert dm.has_setup_test is False
 
     dm.prepare_data()
-    assert dm.prepare_data.has_been_called is True
-    assert dm.setup.has_been_called is False
+    assert dm.has_prepared_data is True
+    assert dm.has_setup_fit is False
+    assert dm.has_setup_test is False
 
     dm.setup()
-    assert dm.prepare_data.has_been_called is True
-    assert dm.setup.has_been_called is True
+    assert dm.has_prepared_data is True
+    assert dm.has_setup_fit is True
+    assert dm.has_setup_test is True
+
+
+def test_data_hooks_called_verbose(tmpdir):
+    dm = TrialMNISTDataModule()
+    assert dm.has_prepared_data is False
+    assert dm.has_setup_fit is False
+    assert dm.has_setup_test is False
+
+    dm.prepare_data()
+    assert dm.has_prepared_data is True
+    assert dm.has_setup_fit is False
+    assert dm.has_setup_test is False
+
+    dm.setup('fit')
+    assert dm.has_prepared_data is True
+    assert dm.has_setup_fit is True
+    assert dm.has_setup_test is False
+
+    dm.setup('test')
+    assert dm.has_prepared_data is True
+    assert dm.has_setup_fit is True
+    assert dm.has_setup_test is True
+
+
+def test_data_hooks_called_with_stage_kwarg(tmpdir):
+    dm = TrialMNISTDataModule()
+    dm.prepare_data()
+    assert dm.has_prepared_data is True
+
+    dm.setup(stage='fit')
+    assert dm.has_setup_fit is True
+    assert dm.has_setup_test is False
+
+    dm.setup(stage='test')
+    assert dm.has_setup_fit is True
+    assert dm.has_setup_test is True
 
 
 def test_dm_add_argparse_args(tmpdir):
@@ -55,6 +101,14 @@ def test_dm_pickle_after_setup(tmpdir):
     dm = TrialMNISTDataModule()
     dm.prepare_data()
     dm.setup()
+    pickle.dumps(dm)
+
+
+def test_dm_pickle_after_setup_verbose(tmpdir):
+    dm = TrialMNISTDataModule()
+    dm.prepare_data()
+    dm.setup('fit')
+    dm.setup('test')
     pickle.dumps(dm)
 
 

--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -159,6 +159,21 @@ def test_train_val_loop_only(tmpdir):
     assert trainer.callback_metrics['loss'] < 0.6
 
 
+def test_test_loop_only(tmpdir):
+    reset_seed()
+
+    dm = TrialMNISTDataModule(tmpdir)
+
+    model = EvalModelTemplate()
+
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=3,
+        weights_summary=None,
+    )
+    trainer.test(model, datamodule=dm)
+
+
 def test_full_loop(tmpdir):
     reset_seed()
 

--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -13,6 +13,20 @@ def test_base_datamodule(tmpdir):
     dm.setup()
 
 
+def test_dm_has_been_called(tmpdir):
+    dm = TrialMNISTDataModule()
+    assert dm.prepare_data.has_been_called is False
+    assert dm.setup.has_been_called is False
+
+    dm.prepare_data()
+    assert dm.prepare_data.has_been_called is True
+    assert dm.setup.has_been_called is False
+
+    dm.setup()
+    assert dm.prepare_data.has_been_called is True
+    assert dm.setup.has_been_called is True
+
+
 def test_dm_add_argparse_args(tmpdir):
     parser = ArgumentParser()
     parser = TrialMNISTDataModule.add_argparse_args(parser)
@@ -43,8 +57,6 @@ def test_dm_pickle_after_setup(tmpdir):
 
 def test_train_loop_only(tmpdir):
     dm = TrialMNISTDataModule(tmpdir)
-    dm.prepare_data()
-    dm.setup()
 
     model = EvalModelTemplate()
     model.validation_step = None
@@ -69,8 +81,6 @@ def test_train_loop_only(tmpdir):
 
 def test_train_val_loop_only(tmpdir):
     dm = TrialMNISTDataModule(tmpdir)
-    dm.prepare_data()
-    dm.setup()
 
     model = EvalModelTemplate()
     model.validation_step = None
@@ -87,13 +97,11 @@ def test_train_val_loop_only(tmpdir):
     # fit model
     result = trainer.fit(model)
     assert result == 1
-    assert trainer.callback_metrics['loss'] < 0.50
+    assert trainer.callback_metrics['loss'] < 0.65
 
 
 def test_full_loop(tmpdir):
     dm = TrialMNISTDataModule(tmpdir)
-    dm.prepare_data()
-    dm.setup()
 
     model = EvalModelTemplate()
 
@@ -117,8 +125,6 @@ def test_full_loop(tmpdir):
 @pytest.mark.skipif(torch.cuda.device_count() < 1, reason="test requires multi-GPU machine")
 def test_full_loop_single_gpu(tmpdir):
     dm = TrialMNISTDataModule(tmpdir)
-    dm.prepare_data()
-    dm.setup()
 
     model = EvalModelTemplate()
 
@@ -143,8 +149,6 @@ def test_full_loop_single_gpu(tmpdir):
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="test requires multi-GPU machine")
 def test_full_loop_dp(tmpdir):
     dm = TrialMNISTDataModule(tmpdir)
-    dm.prepare_data()
-    dm.setup()
 
     model = EvalModelTemplate()
 
@@ -173,8 +177,6 @@ def test_full_loop_ddp_spawn(tmpdir):
     os.environ['CUDA_VISIBLE_DEVICES'] = '0,1'
 
     dm = TrialMNISTDataModule(tmpdir)
-    dm.prepare_data()
-    dm.setup()
 
     model = EvalModelTemplate()
 

--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -128,10 +128,9 @@ def test_train_loop_only(tmpdir):
         max_epochs=3,
         weights_summary=None,
     )
-    trainer.fit(model, dm)
 
     # fit model
-    result = trainer.fit(model)
+    result = trainer.fit(model, dm)
     assert result == 1
     assert trainer.callback_metrics['loss'] < 0.6
 
@@ -151,10 +150,9 @@ def test_train_val_loop_only(tmpdir):
         max_epochs=3,
         weights_summary=None,
     )
-    trainer.fit(model, dm)
 
     # fit model
-    result = trainer.fit(model)
+    result = trainer.fit(model, dm)
     assert result == 1
     assert trainer.callback_metrics['loss'] < 0.6
 
@@ -186,10 +184,9 @@ def test_full_loop(tmpdir):
         max_epochs=3,
         weights_summary=None,
     )
-    trainer.fit(model, dm)
 
     # fit model
-    result = trainer.fit(model)
+    result = trainer.fit(model, dm)
     assert result == 1
 
     # test
@@ -212,10 +209,9 @@ def test_full_loop_single_gpu(tmpdir):
         weights_summary=None,
         gpus=1
     )
-    trainer.fit(model, dm)
 
     # fit model
-    result = trainer.fit(model)
+    result = trainer.fit(model, dm)
     assert result == 1
 
     # test
@@ -239,10 +235,9 @@ def test_full_loop_dp(tmpdir):
         distributed_backend='dp',
         gpus=2
     )
-    trainer.fit(model, dm)
 
     # fit model
-    result = trainer.fit(model)
+    result = trainer.fit(model, dm)
     assert result == 1
 
     # test
@@ -269,10 +264,9 @@ def test_full_loop_ddp_spawn(tmpdir):
         distributed_backend='ddp_spawn',
         gpus=[0, 1]
     )
-    trainer.fit(model, dm)
 
     # fit model
-    result = trainer.fit(model)
+    result = trainer.fit(model, dm)
     assert result == 1
 
     # test


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

You can now just pass datamodule to trainer.fit/trainer.test and we'll call `dm.setup` and `dm.prepare_data` if you haven't already.

```python
dm = MyDataModule()
model = CoolSystem()
trainer = Trainer()
trainer.fit(model, dm)
```

Fixes #2751 and #2742 

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
