### PR TITLE
fix limit reports for codecov comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,7 +9,7 @@ codecov:
   strict_yaml_branch: "yaml-config"
   require_ci_to_pass: yes
   notify:
-    after_n_builds: 19
+    after_n_builds: 21
     wait_for_ci: yes
   # https://docs.codecov.io/docs/codecov-yaml#section-expired-reports
   max_report_age: off
@@ -50,4 +50,4 @@ comment:
   layout: header, diff
   require_changes: false
   behavior: default  # update if exists else create new
-  after_n_builds: 19
+  after_n_builds: 21


### PR DESCRIPTION
## What does this PR do?

with adding some new tests we have not updated the test count - nb coverage reports send to Codecov so it send comment before TPU test arrived and the number was too low...

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
