### PR TITLE
Speed up gradient clipping and allow parameters on multiple devices.

### DIFF
--- a/pytorch_lightning/trainer/training_tricks.py
+++ b/pytorch_lightning/trainer/training_tricks.py
@@ -64,27 +64,29 @@ class TrainerTrainingTricksMixin(ABC):
 
         # this code is a modification of torch.nn.utils.clip_grad_norm_
         # with TPU support based on https://github.com/pytorch/xla/blob/master/TROUBLESHOOTING.md
-        if self.gradient_clip_val > 0:
-            model = self.get_model()
-            parameters = model.parameters()
-            max_norm = float(self.gradient_clip_val)
-            norm_type = float(2.0)
-            if isinstance(parameters, torch.Tensor):
-                parameters = [parameters]
-            parameters = list(filter(lambda p: p.grad is not None, parameters))
-            if norm_type == math.inf:
-                total_norm = max(p.grad.data.abs().max() for p in parameters)
-            else:
-                device = parameters[0].device
-                total_norm = torch.zeros([], device=device if parameters else None)
-                for p in parameters:
-                    param_norm = p.grad.data.pow(norm_type).sum()
-                    total_norm.add_(param_norm)
-                total_norm = (total_norm ** (1. / norm_type))
-            eps = EPSILON_FP16 if self.precision == 16 else EPSILON
-            clip_coef = torch.tensor(max_norm, device=device) / (total_norm + eps)
-            for p in parameters:
-                p.grad.data.mul_(torch.where(clip_coef < 1, clip_coef, torch.tensor(1., device=device)))
+        if self.gradient_clip_val <= 0:
+            return
+        model = self.get_model()
+        parameters = model.parameters()
+        max_norm = float(self.gradient_clip_val)
+        norm_type = float(2.0)
+        if isinstance(parameters, torch.Tensor):
+            parameters = [parameters]
+        parameters = list(filter(lambda p: p.grad is not None, parameters))
+        if norm_type == math.inf:
+            total_norm = max(p.grad.data.abs().max() for p in parameters)
+        else:
+            device = parameters[0].device
+            out = torch.empty(len(parameters), device=device)
+            for i, p in enumerate(parameters):
+                torch.norm(p.grad.data.to(device), norm_type, out=out[i])
+            total_norm = torch.norm(out, norm_type)
+
+        eps = EPSILON_FP16 if self.precision == 16 else EPSILON
+        clip_coef = torch.tensor(max_norm, device=device) / (total_norm + eps)
+        clip_coef = torch.min(clip_coef, torch.ones_like(clip_coef))
+        for p in parameters:
+            p.grad.data.mul_(clip_coef.to(p.grad.data.device))
 
     def print_nan_gradients(self) -> None:
         model = self.get_model()

--- a/tests/models/test_tpu.py
+++ b/tests/models/test_tpu.py
@@ -240,6 +240,25 @@ def test_early_stop_checkpoints_on_tpu(tmpdir):
 
 @pytest.mark.skipif(not TPU_AVAILABLE, reason="test requires TPU machine")
 @pl_multi_process_test
+def test_tpu_grad_norm(tmpdir):
+    """Test if grad_norm works on TPU."""
+    trainer_options = dict(
+        default_root_dir=tmpdir,
+        progress_bar_refresh_rate=0,
+        max_epochs=1,
+        distributed_backend='tpu',
+        tpu_cores=1,
+        limit_train_batches=0.4,
+        limit_val_batches=0.4,
+        gradient_clip_val=0.1,
+    )
+
+    model = EvalModelTemplate()
+    tpipes.run_model_test(trainer_options, model, on_gpu=False, with_hpc=False)
+
+
+@pytest.mark.skipif(not TPU_AVAILABLE, reason="test requires TPU machine")
+@pl_multi_process_test
 def test_dataloaders_passed_to_fit(tmpdir):
     """Test if dataloaders passed to trainer works on TPU"""
 


### PR DESCRIPTION
## What does this PR do?
This PR speeds up gradient clipping.

The speed up is achieved by:
- Moving `torch.where` out of the loop (and replacing with `min` for simplicity).
- Replacing manual sum and pow with `torch.norm`. While this does some
  unnecessary computation (computing pow(root)) this is still a lot faster.
- Pre-allocating the output gives a slight speed up.

Note that calling .to for all parameters results in a small speed
penalty (~4 ms in my case) but allows parameters on different devices
(matching the pytorch implementation).

Overall this reduces the time used for gradient clipping from 206ms to
74 ms for my model (Resnet50 + few additional vars, all vars on GPU).

I've made sure that this works on TPU in a colab.

Fixes #2766 

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests? 
- [X] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?