### PR TITLE
Fix for `load_from_checkpoint`

### DIFF
--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -166,31 +166,31 @@ class ModelIO(object):
             # 1. (backward compatibility) Try to restore model hparams from checkpoint using old/past keys
             for _old_hparam_key in CHECKPOINT_PAST_HPARAMS_KEYS:
                 if _old_hparam_key in checkpoint:
-                    cls_kwargs_old.update({_old_hparam_key: checkpoint[_old_hparam_key]})
+                    cls_kwargs_loaded.update({_old_hparam_key: checkpoint[_old_hparam_key]})
 
             # 2. Try to restore model hparams from checkpoint using the new key
             _new_hparam_key = cls.CHECKPOINT_HYPER_PARAMS_KEY
-            cls_kwargs_old.update({_new_hparam_key: checkpoint[_new_hparam_key]})
+            cls_kwargs_loaded.update({_new_hparam_key: checkpoint[_new_hparam_key]})
 
             # 3. Ensure that `cls_kwargs_old` has the right type
-            cls_kwargs_old = _convert_loaded_hparams(cls_kwargs_old, checkpoint.get(cls.CHECKPOINT_HYPER_PARAMS_TYPE))
+            cls_kwargs_loaded = _convert_loaded_hparams(cls_kwargs_loaded, checkpoint.get(cls.CHECKPOINT_HYPER_PARAMS_TYPE))
 
             # 4. Update cls_kwargs_new with cls_kwargs_old
             args_name = checkpoint.get(cls.CHECKPOINT_HYPER_PARAMS_NAME)
             if args_name and args_name in cls_init_args_name:
-                cls_kwargs_new.update({args_name: cls_kwargs_old})
+                cls_kwargs_extra.update({args_name: cls_kwargs_loaded})
             else:
-                cls_kwargs_new.update(cls_kwargs_old)
+                cls_kwargs_extra.update(cls_kwargs_loaded)
 
         if not cls_spec.varkw:
             # filter kwargs according to class init unless it allows any argument via kwargs
-            cls_kwargs_new = {k: v for k, v in cls_kwargs_new.items() if k in cls_init_args_name}
+            cls_kwargs_extra = {k: v for k, v in cls_kwargs_extra.items() if k in cls_init_args_name}
 
         # prevent passing positional arguments if class does not accept any
         if len(cls_spec.args) <= 1 and not cls_spec.kwonlyargs:
             _cls_args_new, _cls_kwargs_new = [], {}
         else:
-            _cls_args_new, _cls_kwargs_new = cls_args_new, cls_kwargs_new
+            _cls_args_new, _cls_kwargs_new = cls_args_extra, cls_kwargs_extra
 
         model = cls(*_cls_args_new, **_cls_kwargs_new)
 

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -161,7 +161,7 @@ class ModelIO(object):
         cls_init_args_name = inspect.signature(cls.__init__).parameters.keys()
         # pass in the values we saved automatically
         if cls.CHECKPOINT_HYPER_PARAMS_KEY in checkpoint:
-            cls_kwargs_old = {}
+            cls_kwargs_loaded = {}
 
             # 1. (backward compatibility) Try to restore model hparams from checkpoint using old/past keys
             for _old_hparam_key in CHECKPOINT_PAST_HPARAMS_KEYS:

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -166,18 +166,18 @@ class ModelIO(object):
             # 1. (backward compatibility) Try to restore model hparams from checkpoint using old/past keys
             for _old_hparam_key in CHECKPOINT_PAST_HPARAMS_KEYS:
                 if _old_hparam_key in checkpoint:
-                    cls_kwargs_old.update({_old_hparam_key: checkpoint[_old_hparam_key]})
+                    cls_kwargs_old.update(checkpoint[_old_hparam_key])
 
             # 2. Try to restore model hparams from checkpoint using the new key
             _new_hparam_key = cls.CHECKPOINT_HYPER_PARAMS_KEY
-            cls_kwargs_old.update({_new_hparam_key: checkpoint[_new_hparam_key]})
+            cls_kwargs_old.update(checkpoint[_new_hparam_key])
 
             # 3. Ensure that `cls_kwargs_old` has the right type
             cls_kwargs_old = _convert_loaded_hparams(cls_kwargs_old, checkpoint.get(cls.CHECKPOINT_HYPER_PARAMS_TYPE))
 
             # 4. Update cls_kwargs_new with cls_kwargs_old
             args_name = checkpoint.get(cls.CHECKPOINT_HYPER_PARAMS_NAME)
-            if args_name and args_name in cls_init_args_name:
+            if args_name in cls_init_args_name and args_name != 'kwargs':
                 cls_kwargs_new.update({args_name: cls_kwargs_old})
             else:
                 cls_kwargs_new.update(cls_kwargs_old)
@@ -192,7 +192,7 @@ class ModelIO(object):
         else:
             _cls_args_new, _cls_kwargs_new = cls_args_new, cls_kwargs_new
 
-        model = cls(*cls_args_new, **cls_kwargs_new)
+        model = cls(*_cls_args_new, **_cls_kwargs_new)
 
         # load the state_dict on the model automatically
         model.load_state_dict(checkpoint['state_dict'], strict=strict)

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -178,19 +178,19 @@ class ModelIO(object):
             # 4. Update cls_kwargs_new with cls_kwargs_old
             args_name = checkpoint.get(cls.CHECKPOINT_HYPER_PARAMS_NAME)
             if args_name and args_name in cls_init_args_name:
-                cls_kwargs_extra.update({args_name: cls_kwargs_loaded})
+                cls_kwargs_new.update({args_name: cls_kwargs_loaded})
             else:
-                cls_kwargs_extra.update(cls_kwargs_loaded)
+                cls_kwargs_new.update(cls_kwargs_loaded)
 
         if not cls_spec.varkw:
             # filter kwargs according to class init unless it allows any argument via kwargs
-            cls_kwargs_extra = {k: v for k, v in cls_kwargs_extra.items() if k in cls_init_args_name}
+            cls_kwargs_extra = {k: v for k, v in cls_kwargs_new.items() if k in cls_init_args_name}
 
         # prevent passing positional arguments if class does not accept any
         if len(cls_spec.args) <= 1 and not cls_spec.kwonlyargs:
             _cls_args_new, _cls_kwargs_new = [], {}
         else:
-            _cls_args_new, _cls_kwargs_new = cls_args_extra, cls_kwargs_extra
+            _cls_args_new, _cls_kwargs_new = cls_kwargs_new, cls_kwargs_extra
 
         model = cls(*_cls_args_new, **_cls_kwargs_new)
 

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -177,10 +177,12 @@ class ModelIO(object):
 
             # 4. Update cls_kwargs_new with cls_kwargs_old
             args_name = checkpoint.get(cls.CHECKPOINT_HYPER_PARAMS_NAME)
-            if args_name in cls_init_args_name and args_name != 'kwargs':
-                cls_kwargs_new.update({args_name: cls_kwargs_old})
-            else:
-                cls_kwargs_new.update(cls_kwargs_old)
+            if args_name == 'kwargs':
+                # in case the class cannot take any extra argument filter only the possible
+                cls_kwargs.update(**model_args)
+            elif args_name:
+                if args_name in cls_init_args_name:
+                    cls_kwargs.update({args_name: model_args})
 
         if not cls_spec.varkw:
             # filter kwargs according to class init unless it allows any argument via kwargs

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -190,7 +190,7 @@ class ModelIO(object):
         if len(cls_spec.args) <= 1 and not cls_spec.kwonlyargs:
             _cls_args_new, _cls_kwargs_new = [], {}
         else:
-            _cls_args_new, _cls_kwargs_new = cls_kwargs_new, cls_kwargs_extra
+            _cls_args_new, _cls_kwargs_new = cls_args_new, cls_kwargs_new
 
         model = cls(*_cls_args_new, **_cls_kwargs_new)
 

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -166,23 +166,21 @@ class ModelIO(object):
             # 1. (backward compatibility) Try to restore model hparams from checkpoint using old/past keys
             for _old_hparam_key in CHECKPOINT_PAST_HPARAMS_KEYS:
                 if _old_hparam_key in checkpoint:
-                    cls_kwargs_old.update(checkpoint[_old_hparam_key])
+                    cls_kwargs_old.update({_old_hparam_key: checkpoint[_old_hparam_key]})
 
             # 2. Try to restore model hparams from checkpoint using the new key
             _new_hparam_key = cls.CHECKPOINT_HYPER_PARAMS_KEY
-            cls_kwargs_old.update(checkpoint[_new_hparam_key])
+            cls_kwargs_old.update({_new_hparam_key: checkpoint[_new_hparam_key]})
 
             # 3. Ensure that `cls_kwargs_old` has the right type
             cls_kwargs_old = _convert_loaded_hparams(cls_kwargs_old, checkpoint.get(cls.CHECKPOINT_HYPER_PARAMS_TYPE))
 
             # 4. Update cls_kwargs_new with cls_kwargs_old
             args_name = checkpoint.get(cls.CHECKPOINT_HYPER_PARAMS_NAME)
-            if args_name == 'kwargs':
-                # in case the class cannot take any extra argument filter only the possible
-                cls_kwargs.update(**model_args)
-            elif args_name:
-                if args_name in cls_init_args_name:
-                    cls_kwargs.update({args_name: model_args})
+            if args_name and args_name in cls_init_args_name:
+                cls_kwargs_new.update({args_name: cls_kwargs_old})
+            else:
+                cls_kwargs_new.update(cls_kwargs_old)
 
         if not cls_spec.varkw:
             # filter kwargs according to class init unless it allows any argument via kwargs

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -166,11 +166,11 @@ class ModelIO(object):
             # 1. (backward compatibility) Try to restore model hparams from checkpoint using old/past keys
             for _old_hparam_key in CHECKPOINT_PAST_HPARAMS_KEYS:
                 if _old_hparam_key in checkpoint:
-                    cls_kwargs_loaded.update({_old_hparam_key: checkpoint[_old_hparam_key]})
+                    cls_kwargs_loaded.update(checkpoint[_old_hparam_key])
 
             # 2. Try to restore model hparams from checkpoint using the new key
             _new_hparam_key = cls.CHECKPOINT_HYPER_PARAMS_KEY
-            cls_kwargs_loaded.update({_new_hparam_key: checkpoint[_new_hparam_key]})
+            cls_kwargs_loaded.update(checkpoint[_new_hparam_key])
 
             # 3. Ensure that `cls_kwargs_old` has the right type
             cls_kwargs_loaded = _convert_loaded_hparams(cls_kwargs_loaded, checkpoint.get(cls.CHECKPOINT_HYPER_PARAMS_TYPE))

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -184,7 +184,7 @@ class ModelIO(object):
 
         if not cls_spec.varkw:
             # filter kwargs according to class init unless it allows any argument via kwargs
-            cls_kwargs_extra = {k: v for k, v in cls_kwargs_new.items() if k in cls_init_args_name}
+            cls_kwargs_new = {k: v for k, v in cls_kwargs_new.items() if k in cls_init_args_name}
 
         # prevent passing positional arguments if class does not accept any
         if len(cls_spec.args) <= 1 and not cls_spec.kwonlyargs:

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -178,8 +178,6 @@ class ModelIO(object):
             elif args_name:
                 if args_name in cls_init_args_name:
                     cls_kwargs.update({args_name: model_args})
-            else:
-                cls_args = (model_args,) + cls_args
 
         if not cls_spec.varkw:
             # filter kwargs according to class init unless it allows any argument via kwargs

--- a/tests/base/model_template.py
+++ b/tests/base/model_template.py
@@ -66,6 +66,7 @@ class EvalModelTemplate(
         self.hidden_dim = hidden_dim
         self.b1 = b1
         self.b2 = b2
+        self.save_hparams = save_hparams
         self.training_step_called = False
         self.training_step_end_called = False
         self.training_epoch_end_called = False

--- a/tests/base/model_template.py
+++ b/tests/base/model_template.py
@@ -50,7 +50,6 @@ class EvalModelTemplate(
             hidden_dim: int = 1000,
             b1: float = 0.5,
             b2: float = 0.999,
-            save_hparams=True,
     ):
         # init superclass
         super().__init__()
@@ -66,7 +65,6 @@ class EvalModelTemplate(
         self.hidden_dim = hidden_dim
         self.b1 = b1
         self.b2 = b2
-        self.save_hparams = save_hparams
         self.training_step_called = False
         self.training_step_end_called = False
         self.training_epoch_end_called = False
@@ -124,7 +122,6 @@ class EvalModelTemplate(
             hidden_dim=1000,
             b1=0.5,
             b2=0.999,
-            save_hparams=True,
         )
 
         if continue_training:

--- a/tests/base/model_template.py
+++ b/tests/base/model_template.py
@@ -125,6 +125,7 @@ class EvalModelTemplate(
             hidden_dim=1000,
             b1=0.5,
             b2=0.999,
+            save_hparams=True
         )
 
         if continue_training:

--- a/tests/base/model_template.py
+++ b/tests/base/model_template.py
@@ -39,21 +39,23 @@ class EvalModelTemplate(
     """
 
     def __init__(
-        self,
-        drop_prob: float = 0.2,
-        batch_size: int = 32,
-        in_features: int = 28 * 28,
-        learning_rate: float = 0.001 * 8,
-        optimizer_name: str = 'adam',
-        data_root: str = PATH_DATASETS,
-        out_features: int = 10,
-        hidden_dim: int = 1000,
-        b1: float = 0.5,
-        b2: float = 0.999,
+            self,
+            drop_prob: float = 0.2,
+            batch_size: int = 32,
+            in_features: int = 28 * 28,
+            learning_rate: float = 0.001 * 8,
+            optimizer_name: str = 'adam',
+            data_root: str = PATH_DATASETS,
+            out_features: int = 10,
+            hidden_dim: int = 1000,
+            b1: float = 0.5,
+            b2: float = 0.999,
+            save_hparams=True,
     ):
         # init superclass
         super().__init__()
-        self.save_hyperparameters()
+        if save_hparams:
+            self.save_hyperparameters()
 
         self.drop_prob = drop_prob
         self.batch_size = batch_size

--- a/tests/base/model_template.py
+++ b/tests/base/model_template.py
@@ -54,8 +54,7 @@ class EvalModelTemplate(
     ):
         # init superclass
         super().__init__()
-        if self._save_hparams:
-            self.save_hyperparameters()
+        self.save_hyperparameters()
 
         self.drop_prob = drop_prob
         self.batch_size = batch_size

--- a/tests/base/model_template.py
+++ b/tests/base/model_template.py
@@ -122,6 +122,7 @@ class EvalModelTemplate(
             hidden_dim=1000,
             b1=0.5,
             b2=0.999,
+            save_hparams=True
         )
 
         if continue_training:

--- a/tests/base/model_template.py
+++ b/tests/base/model_template.py
@@ -37,6 +37,7 @@ class EvalModelTemplate(
 
     >>> model = EvalModelTemplate()
     """
+    _save_hparams = True
 
     def __init__(
             self,
@@ -50,11 +51,10 @@ class EvalModelTemplate(
             hidden_dim: int = 1000,
             b1: float = 0.5,
             b2: float = 0.999,
-            save_hparams=True,
     ):
         # init superclass
         super().__init__()
-        if save_hparams:
+        if self._save_hparams:
             self.save_hyperparameters()
 
         self.drop_prob = drop_prob
@@ -124,7 +124,6 @@ class EvalModelTemplate(
             hidden_dim=1000,
             b1=0.5,
             b2=0.999,
-            save_hparams=True
         )
 
         if continue_training:

--- a/tests/base/model_template.py
+++ b/tests/base/model_template.py
@@ -51,10 +51,11 @@ class EvalModelTemplate(
             hidden_dim: int = 1000,
             b1: float = 0.5,
             b2: float = 0.999,
+            save_hparams=True,
     ):
         # init superclass
         super().__init__()
-        if self._save_hparams:
+        if save_hparams:
             self.save_hyperparameters()
 
         self.drop_prob = drop_prob

--- a/tests/base/model_template.py
+++ b/tests/base/model_template.py
@@ -37,7 +37,6 @@ class EvalModelTemplate(
 
     >>> model = EvalModelTemplate()
     """
-    _save_hparams = True
 
     def __init__(
             self,
@@ -55,7 +54,7 @@ class EvalModelTemplate(
     ):
         # init superclass
         super().__init__()
-        if save_hparams:
+        if self._save_hparams:
             self.save_hyperparameters()
 
         self.drop_prob = drop_prob
@@ -125,7 +124,7 @@ class EvalModelTemplate(
             hidden_dim=1000,
             b1=0.5,
             b2=0.999,
-            save_hparams=True
+            save_hparams=True,
         )
 
         if continue_training:

--- a/tests/models/test_hparams.py
+++ b/tests/models/test_hparams.py
@@ -538,5 +538,6 @@ def test_args(tmpdir):
     trainer.fit(model)
 
     raw_checkpoint_path = _raw_checkpoint_path(trainer)
-    model = SubClassVarArgs.load_from_checkpoint(raw_checkpoint_path)
-    assert model.hparams == hparams
+    with pytest.raises(TypeError, match="__init__\(\) got an unexpected keyword argument 'test'"):
+        model = SubClassVarArgs.load_from_checkpoint(raw_checkpoint_path)
+

--- a/tests/models/test_hparams.py
+++ b/tests/models/test_hparams.py
@@ -539,5 +539,5 @@ def test_args(tmpdir):
 
     raw_checkpoint_path = _raw_checkpoint_path(trainer)
     with pytest.raises(TypeError, match="__init__\(\) got an unexpected keyword argument 'test'"):
-        model = SubClassVarArgs.load_from_checkpoint(raw_checkpoint_path)
+        SubClassVarArgs.load_from_checkpoint(raw_checkpoint_path)
 

--- a/tests/models/test_restore.py
+++ b/tests/models/test_restore.py
@@ -409,12 +409,7 @@ def test_load_model_from_checkpoint_extra_args(tmpdir):
     of the model."""
 
     hparams = EvalModelTemplate.get_default_hparams()
-
-    # Ensure that `self.save_hyperparameters` is not called:
-    _EvalModelTemplateMod = EvalModelTemplate
-    _EvalModelTemplateMod._save_hparams = False
-
-    model = _EvalModelTemplateMod(**hparams)
+    model = EvalModelTemplate(**hparams, save_hparams=False)
 
     trainer_options = dict(
         progress_bar_refresh_rate=0,

--- a/tests/models/test_restore.py
+++ b/tests/models/test_restore.py
@@ -401,7 +401,12 @@ def test_load_model_from_checkpoint_extra_args(tmpdir):
     of the model."""
 
     hparams = EvalModelTemplate.get_default_hparams()
-    model = EvalModelTemplate(**hparams, save_hparams=False)
+
+    # Ensure that `self.save_hyperparameters` is not called:
+    _EvalModelTemplateMod = EvalModelTemplate
+    _EvalModelTemplateMod._save_hparams = False
+
+    model = _EvalModelTemplateMod(**hparams)
 
     trainer_options = dict(
         progress_bar_refresh_rate=0,

--- a/tests/models/test_restore.py
+++ b/tests/models/test_restore.py
@@ -176,6 +176,13 @@ def test_load_model_from_checkpoint(tmpdir, model_template):
 
     # load last checkpoint
     last_checkpoint = sorted(glob.glob(os.path.join(trainer.checkpoint_callback.dirpath, "*.ckpt")))[-1]
+
+    # Since `EvalModelTemplate` has `_save_hparams = True` by default, check that ckpt has hparams
+    ckpt = torch.load(last_checkpoint)
+    assert model_template.CHECKPOINT_HYPER_PARAMS_KEY in ckpt.keys(), 'module_arguments missing from checkpoints'
+
+    # Ensure that model can be correctly restored from checkpoint
+
     pretrained_model = model_template.load_from_checkpoint(last_checkpoint)
 
     # test that hparams loaded correctly
@@ -186,6 +193,7 @@ def test_load_model_from_checkpoint(tmpdir, model_template):
     for (old_name, old_p), (new_name, new_p) in zip(model.named_parameters(), pretrained_model.named_parameters()):
         assert torch.all(torch.eq(old_p, new_p)), 'loaded weights are not the same as the saved weights'
 
+    # Check `test` on pretrained model:
     new_trainer = Trainer(**trainer_options)
     new_trainer.test(pretrained_model)
 

--- a/tests/models/test_restore.py
+++ b/tests/models/test_restore.py
@@ -409,7 +409,12 @@ def test_load_model_from_checkpoint_extra_args(tmpdir):
     of the model."""
 
     hparams = EvalModelTemplate.get_default_hparams()
-    model = EvalModelTemplate(**hparams, save_hparams=False)
+
+    # Ensure that `self.save_hyperparameters` is not called:
+    _EvalModelTemplateMod = EvalModelTemplate
+    _EvalModelTemplateMod._save_hparams = False
+
+    model = _EvalModelTemplateMod(**hparams)
 
     trainer_options = dict(
         progress_bar_refresh_rate=0,

--- a/tests/models/test_restore.py
+++ b/tests/models/test_restore.py
@@ -404,17 +404,9 @@ def test_strict_model_load_less_params(monkeypatch, tmpdir, tmpdir_server, url_c
 
 
 def test_load_model_from_checkpoint_extra_args(tmpdir):
-    """Check if model weights can be loaded from a checkpoint when
-    `self.save_hyperparameters()` was not called in the `__init__` method
-    of the model."""
+    """Check that model args can be passed/changed when `load_from_checkpoint` is called."""
 
-    hparams = EvalModelTemplate.get_default_hparams()
-
-    # Ensure that `self.save_hyperparameters` is not called:
-    _EvalModelTemplateMod = EvalModelTemplate
-    _EvalModelTemplateMod._save_hparams = False
-
-    model = _EvalModelTemplateMod(**hparams)
+    model = EvalModelTemplate()
 
     trainer_options = dict(
         progress_bar_refresh_rate=0,
@@ -425,15 +417,18 @@ def test_load_model_from_checkpoint_extra_args(tmpdir):
         default_root_dir=tmpdir,
     )
 
-    # fit model
+    # Fit model
     trainer = Trainer(**trainer_options)
     trainer.fit(model)
 
-    # load last checkpoint
+    # Load last checkpoint
     last_checkpoint = sorted(glob.glob(os.path.join(trainer.checkpoint_callback.dirpath, "*.ckpt")))[-1]
-    pretrained_model = EvalModelTemplate.load_from_checkpoint(last_checkpoint, **hparams)
+    pretrained_model = EvalModelTemplate.load_from_checkpoint(last_checkpoint, b1=0.5, b2=0.888)
 
-    # assert weights are the same
+    # Assert that model args were changed accordingly
+    # Assert that model weights did not change
+    assert pretrained_model.b1 == 0.5  # `b1` arg did not change
+    assert pretrained_model.b2 == 0.888  # `b2` arg changed
     for (old_name, old_p), (new_name, new_p) in zip(model.named_parameters(), pretrained_model.named_parameters()):
         assert torch.all(torch.eq(old_p, new_p)), 'loaded weights are not the same as the saved weights'
 

--- a/tests/models/test_restore.py
+++ b/tests/models/test_restore.py
@@ -182,7 +182,6 @@ def test_load_model_from_checkpoint(tmpdir, model_template):
     assert model_template.CHECKPOINT_HYPER_PARAMS_KEY in ckpt.keys(), 'module_arguments missing from checkpoints'
 
     # Ensure that model can be correctly restored from checkpoint
-
     pretrained_model = model_template.load_from_checkpoint(last_checkpoint)
 
     # test that hparams loaded correctly


### PR DESCRIPTION
## What does this PR do?

Aims at fixes #2550 and fixes #2769 

This PR should allow users to load model weights from checkpoints even though `self.save_hyperparameters()` may not have been called before training. A test was added reproduce the problem described below.

## Context

In #2550, the user defines his own LightningModule called `MNISTModel` . In the `__init__` method of `MNISTModel`, the call to `self.save_hyperparameters()` is missed. Still, the model is trained and a model checkpoint is created. Later, the user wishes to restore model weights from this checkpoint using: 

```python
model = MNISTModel.load_from_checkpoint('mnist.ckpt', net='cnn', h_dim=200)
````

However, this call to `load_from_checkpoint` raises an error. As described [here](https://github.com/PyTorchLightning/pytorch-lightning/issues/2550#issuecomment-666510693), this error is raised because, in `load_from_checkpoint`, the model to be restored receives multiple values for its class arguments. This problem is also described in #2769  

## PR review    
Anyone in the community is free to review the PR!

cc @Borda @rohitgr7
