### PR TITLE
Fix false num_classes warning in metrics

### DIFF
--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -173,7 +173,7 @@ def stat_scores_multiple_classes(
     """
     if pred.ndim == target.ndim + 1:
         pred = to_categorical(pred, argmax_dim=argmax_dim)
-        
+
     num_classes = get_num_classes(pred=pred, target=target,
                                   num_classes=num_classes)
 

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -171,11 +171,11 @@ def stat_scores_multiple_classes(
         >>> sups
         tensor([1., 0., 1., 1.])
     """
-    num_classes = get_num_classes(pred=pred, target=target,
-                                  num_classes=num_classes)
-
     if pred.ndim == target.ndim + 1:
         pred = to_categorical(pred, argmax_dim=argmax_dim)
+        
+    num_classes = get_num_classes(pred=pred, target=target,
+                                  num_classes=num_classes)
 
     tps = torch.zeros((num_classes,), device=pred.device)
     fps = torch.zeros((num_classes,), device=pred.device)


### PR DESCRIPTION



## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Put to_categorical before get_num_classes in metrics/functional/classification.py, which fixes false warning about num_classes.

Fixes #2768

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] (no need) Did you make sure to update the documentation with your changes?
- [ ] (no need) Did you write any new necessary tests? 
- [ ] (no need) Did you verify new and existing tests pass locally with your changes?
- [ ] (no need) If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
