### PR TITLE
Add support to Tensorboard logger for OmegaConf hparams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added support returning python scalars in DP ([#1935](https://github.com/PyTorchLightning/pytorch-lightning/pull/1935))
 
+- Added support to Tensorboard logger for OmegaConf `hparams` ([#2846](https://github.com/PyTorchLightning/pytorch-lightning/pull/2846))
+
 ### Changed
 
 - Truncated long version numbers in progress bar ([#2594](https://github.com/PyTorchLightning/pytorch-lightning/pull/2594))

--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -17,7 +17,9 @@ ALLOWED_CONFIG_TYPES = (AttributeDict, MutableMapping, Namespace)
 try:
     from omegaconf import Container
 except ImportError:
-    Container = None
+    OMEGACONF_AVAILABLE = False
+else:
+    OMEGACONF_AVAILABLE = True
 
 # the older shall be on the top
 CHECKPOINT_PAST_HPARAMS_KEYS = (
@@ -327,7 +329,7 @@ def save_hparams_to_yaml(config_yaml, hparams: Union[dict, Namespace]) -> None:
     if not os.path.isdir(os.path.dirname(config_yaml)):
         raise RuntimeError(f'Missing folder: {os.path.dirname(config_yaml)}.')
 
-    if Container is not None and isinstance(hparams, Container):
+    if OMEGACONF_AVAILABLE and isinstance(hparams, Container):
         from omegaconf import OmegaConf
         OmegaConf.save(hparams, config_yaml, resolve=True)
         return

--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -20,8 +20,9 @@ from pytorch_lightning.utilities import rank_zero_only
 try:
     from omegaconf import Container, OmegaConf
 except ImportError:
-    Container = None
-    OmegaConf = None
+    OMEGACONF_AVAILABLE = False
+else:
+    OMEGACONF_AVAILABLE = True
 
 
 class TensorBoardLogger(LightningLoggerBase):
@@ -118,7 +119,7 @@ class TensorBoardLogger(LightningLoggerBase):
         params = self._convert_params(params)
 
         # store params to output
-        if Container is not None and isinstance(params, Container):
+        if OMEGACONF_AVAILABLE and isinstance(params, Container):
             self.hparams = OmegaConf.merge(self.hparams, params)
         else:
             self.hparams.update(params)

--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -17,6 +17,12 @@ from pytorch_lightning.core.saving import save_hparams_to_yaml
 from pytorch_lightning.loggers.base import LightningLoggerBase, rank_zero_experiment
 from pytorch_lightning.utilities import rank_zero_only
 
+try:
+    from omegaconf import Container, OmegaConf
+except ImportError:
+    Container = None
+    OmegaConf = None
+
 
 class TensorBoardLogger(LightningLoggerBase):
     r"""
@@ -112,7 +118,10 @@ class TensorBoardLogger(LightningLoggerBase):
         params = self._convert_params(params)
 
         # store params to output
-        self.hparams.update(params)
+        if Container is not None and isinstance(params, Container):
+            self.hparams = OmegaConf.merge(self.hparams, params)
+        else:
+            self.hparams.update(params)
 
         # format params into the suitable for tensorboard
         params = self._flatten_dict(params)

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -132,7 +132,9 @@ else:
 try:
     from omegaconf import Container
 except ImportError:
-    Container = None
+    OMEGACONF_AVAILABLE = False
+else:
+    OMEGACONF_AVAILABLE = True
 
 
 class TrainerIOMixin(ABC):
@@ -390,7 +392,7 @@ class TrainerIOMixin(ABC):
                 checkpoint[LightningModule.CHECKPOINT_HYPER_PARAMS_NAME] = model._hparams_name
             # add arguments to the checkpoint
             checkpoint[LightningModule.CHECKPOINT_HYPER_PARAMS_KEY] = model.hparams
-            if Container is not None:
+            if OMEGACONF_AVAILABLE:
                 if isinstance(model.hparams, Container):
                     checkpoint[LightningModule.CHECKPOINT_HYPER_PARAMS_TYPE] = type(model.hparams)
 

--- a/tests/loggers/test_tensorboard.py
+++ b/tests/loggers/test_tensorboard.py
@@ -4,18 +4,12 @@ from argparse import Namespace
 import pytest
 import torch
 import yaml
+from omegaconf import OmegaConf
 from packaging import version
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.loggers import TensorBoardLogger
-from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
 from tests.base import EvalModelTemplate
-
-
-try:
-    from omegaconf import OmegaConf
-except ImportError:
-    OmegaConf = None
 
 
 @pytest.mark.skipif(
@@ -159,8 +153,7 @@ def test_tensorboard_log_omegaconf_hparams_and_metrics(tmpdir):
         "layer": torch.nn.BatchNorm1d,
     }
 
-    if OmegaConf is not None:
-        hparams = OmegaConf.create(hparams)
+    hparams = OmegaConf.create(hparams)
 
     metrics = {"abc": torch.tensor([0.54])}
     logger.log_hyperparams(hparams, metrics)

--- a/tests/loggers/test_tensorboard.py
+++ b/tests/loggers/test_tensorboard.py
@@ -8,32 +8,38 @@ from packaging import version
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.loggers import TensorBoardLogger
+from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
 from tests.base import EvalModelTemplate
 
 
-@pytest.mark.skipif(version.parse(torch.__version__) < version.parse('1.5.0'),
-                    reason='Minimal PT version is set to 1.5')
+try:
+    from omegaconf import OmegaConf
+except ImportError:
+    OmegaConf = None
+
+
+@pytest.mark.skipif(
+    version.parse(torch.__version__) < version.parse("1.5.0"),
+    reason="Minimal PT version is set to 1.5",
+)
 def test_tensorboard_hparams_reload(tmpdir):
     model = EvalModelTemplate()
 
-    trainer = Trainer(
-        max_epochs=1,
-        default_root_dir=tmpdir,
-    )
+    trainer = Trainer(max_epochs=1, default_root_dir=tmpdir)
     trainer.fit(model)
 
     folder_path = trainer.logger.log_dir
 
     # make sure yaml is there
-    with open(os.path.join(folder_path, 'hparams.yaml')) as file:
+    with open(os.path.join(folder_path, "hparams.yaml")) as file:
         # The FullLoader parameter handles the conversion from YAML
         # scalar values to Python the dictionary format
         yaml_params = yaml.safe_load(file)
-        assert yaml_params['b1'] == 0.5
+        assert yaml_params["b1"] == 0.5
         assert len(yaml_params.keys()) == 10
 
     # verify artifacts
-    assert len(os.listdir(os.path.join(folder_path, 'checkpoints'))) == 1
+    assert len(os.listdir(os.path.join(folder_path, "checkpoints"))) == 1
     #
     # # verify tb logs
     # event_acc = EventAccumulator(folder_path)
@@ -88,13 +94,13 @@ def test_tensorboard_named_version(tmpdir):
     assert os.listdir(tmpdir / name / expected_version)
 
 
-@pytest.mark.parametrize("name", ['', None])
+@pytest.mark.parametrize("name", ["", None])
 def test_tensorboard_no_name(tmpdir, name):
     """Verify that None or empty name works"""
     logger = TensorBoardLogger(save_dir=tmpdir, name=name)
     logger.log_hyperparams({"a": 1, "b": 2})  # Force data to be written
     assert logger.root_dir == tmpdir
-    assert os.listdir(tmpdir / 'version_0')
+    assert os.listdir(tmpdir / "version_0")
 
 
 @pytest.mark.parametrize("step_idx", [10, None])
@@ -104,7 +110,7 @@ def test_tensorboard_log_metrics(tmpdir, step_idx):
         "float": 0.3,
         "int": 1,
         "FloatTensor": torch.tensor(0.1),
-        "IntTensor": torch.tensor(1)
+        "IntTensor": torch.tensor(1),
     }
     logger.log_metrics(metrics, step_idx)
 
@@ -116,10 +122,10 @@ def test_tensorboard_log_hyperparams(tmpdir):
         "int": 1,
         "string": "abc",
         "bool": True,
-        "dict": {'a': {'b': 'c'}},
+        "dict": {"a": {"b": "c"}},
         "list": [1, 2, 3],
-        "namespace": Namespace(foo=Namespace(bar='buzz')),
-        "layer": torch.nn.BatchNorm1d
+        "namespace": Namespace(foo=Namespace(bar="buzz")),
+        "layer": torch.nn.BatchNorm1d,
     }
     logger.log_hyperparams(hparams)
 
@@ -131,10 +137,30 @@ def test_tensorboard_log_hparams_and_metrics(tmpdir):
         "int": 1,
         "string": "abc",
         "bool": True,
-        "dict": {'a': {'b': 'c'}},
+        "dict": {"a": {"b": "c"}},
         "list": [1, 2, 3],
-        "namespace": Namespace(foo=Namespace(bar='buzz')),
-        "layer": torch.nn.BatchNorm1d
+        "namespace": Namespace(foo=Namespace(bar="buzz")),
+        "layer": torch.nn.BatchNorm1d,
     }
-    metrics = {'abc': torch.tensor([0.54])}
+    metrics = {"abc": torch.tensor([0.54])}
+    logger.log_hyperparams(hparams, metrics)
+
+
+def test_tensorboard_log_omegaconf_hparams_and_metrics(tmpdir):
+    logger = TensorBoardLogger(tmpdir)
+    hparams = {
+        "float": 0.3,
+        "int": 1,
+        "string": "abc",
+        "bool": True,
+        "dict": {"a": {"b": "c"}},
+        "list": [1, 2, 3],
+        "namespace": Namespace(foo=Namespace(bar="buzz")),
+        "layer": torch.nn.BatchNorm1d,
+    }
+
+    if OmegaConf is not None:
+        hparams = OmegaConf.create(hparams)
+
+    metrics = {"abc": torch.tensor([0.54])}
     logger.log_hyperparams(hparams, metrics)

--- a/tests/loggers/test_tensorboard.py
+++ b/tests/loggers/test_tensorboard.py
@@ -149,10 +149,9 @@ def test_tensorboard_log_omegaconf_hparams_and_metrics(tmpdir):
         "bool": True,
         "dict": {"a": {"b": "c"}},
         "list": [1, 2, 3],
-        "namespace": Namespace(foo=Namespace(bar="buzz")),
-        "layer": torch.nn.BatchNorm1d,
+        # "namespace": Namespace(foo=Namespace(bar="buzz")),
+        # "layer": torch.nn.BatchNorm1d,
     }
-
     hparams = OmegaConf.create(hparams)
 
     metrics = {"abc": torch.tensor([0.54])}


### PR DESCRIPTION
## What does this PR do?

Fixes #2844 
We check if we can import omegaconf, and if the hparams are omegaconf instances. if so, we use OmegaConf.merge to preserve the typing, such that saving hparams to yaml actually triggers the OmegaConf branch

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
