### PR TITLE
Adding support for the CosineAnnealingWarmRestarts scheduler

### DIFF
--- a/docs/source/optimizers.rst
+++ b/docs/source/optimizers.rst
@@ -39,6 +39,34 @@ Every optimizer you use can be paired with any `LearningRateScheduler <https://p
       ]
       return optimizers, schedulers
 
+    # CosineAnnealingWarmRestarts scheduler stepped each iteration with the fraction of passed data as epoch value to the step function
+    def configure_optimizers(self):
+      optimizers = [Adam(...)]
+      schedulers = [
+         {
+            'scheduler': CosineAnnealingWarmRestarts(optimizers[0], ...),
+            'monitor': 'iter_frac', # Default: val_loss
+            'interval': 'step'
+         }
+      ]
+      return optimizers, schedulers
+
+    # Iter frac implements a lambda function to compute current training idx in the following way
+    curr_epoch + curr_batch/ (1.0 * dataset_len)
+
+    # CosineAnnealingWarmRestarts scheduler stepped each epoch with the current epoch idx as epoch value to the step function
+    def configure_optimizers(self):
+      optimizers = [Adam(...)]
+      schedulers = [
+         {
+            'scheduler': CosineAnnealingWarmRestarts(optimizers[0], ...),
+            'monitor': 'epoch', # Default: val_loss
+            'interval': 'epoch'
+         }
+      ]
+      return optimizers, schedulers
+
+
 ----------
 
 Use multiple optimizers (like GANs)

--- a/pytorch_lightning/accelerator_backends/ddp_spawn_backend.py
+++ b/pytorch_lightning/accelerator_backends/ddp_spawn_backend.py
@@ -49,7 +49,8 @@ class DDPSpawnBackend(object):
         last_path = self.mp_queue.get()
 
         # transfer back the best path to the trainer
-        self.trainer.checkpoint_callback.best_model_path = best_path
+        if self.trainer.checkpoint_callback:
+            self.trainer.checkpoint_callback.best_model_path = best_path
         # todo, pass also bets score
 
         # load last weights

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -271,7 +271,7 @@ class TrainerTrainLoopMixin(ABC):
     get_iter_idx_opts = {'epoch': lambda curr_epoch, curr_batch,
                                          dataset_len: curr_epoch,
                          'iter_frac': lambda curr_epoch, curr_batch, dataset_len:
-                                 (curr_epoch + curr_batch/ (1.0 * dataset_len))
+                         (curr_epoch + curr_batch / (1.0 * dataset_len))
                          }
 
     @abstractmethod

--- a/tests/base/model_optimizers.py
+++ b/tests/base/model_optimizers.py
@@ -62,7 +62,7 @@ class ConfigureOptimizersPool(ABC):
         return [optimizer], [lr_scheduler]
 
     def configure_optimizers__cosine_annealing_warm_restarts(self):
-        eta_min = self.learning_rate/100.0
+        eta_min = self.learning_rate / 100.0
         optimizer = optim.Adam(self.parameters(), lr=self.learning_rate)
         lr_scheduler = optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer,
                                                                       T_0=1, T_mult=2,

--- a/tests/base/model_optimizers.py
+++ b/tests/base/model_optimizers.py
@@ -67,7 +67,7 @@ class ConfigureOptimizersPool(ABC):
         lr_scheduler = optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer,
                                                                       T_0=1, T_mult=2,
                                                                       eta_min=eta_min)
-        return [optimizer], [{'scheduler': lr_scheduler,
+        return optimizer, [{'scheduler': lr_scheduler,
                               'interval': 'step',
                               'monitor': 'iter_frac'}]
 
@@ -77,7 +77,7 @@ class ConfigureOptimizersPool(ABC):
         lr_scheduler = optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer,
                                                                       T_0=1, T_mult=2,
                                                                       eta_min=eta_min)
-        return [optimizer], [{'scheduler': lr_scheduler,
+        return optimizer, [{'scheduler': lr_scheduler,
                               'interval': 'epoch',
                               'monitor': 'epoch'}]
 

--- a/tests/base/model_optimizers.py
+++ b/tests/base/model_optimizers.py
@@ -61,6 +61,26 @@ class ConfigureOptimizersPool(ABC):
         lr_scheduler = optim.lr_scheduler.ReduceLROnPlateau(optimizer)
         return [optimizer], [lr_scheduler]
 
+    def configure_optimizers__cosine_annealing_warm_restarts(self):
+        eta_min = self.learning_rate/100.0
+        optimizer = optim.Adam(self.parameters(), lr=self.learning_rate)
+        lr_scheduler = optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer,
+                                                                      T_0=1, T_mult=2,
+                                                                      eta_min=eta_min)
+        return [optimizer], [{'scheduler': lr_scheduler,
+                              'interval': 'step',
+                              'monitor': 'iter_frac'}]
+
+    def configure_optimizers__cosine_annealing_warm_restarts(self):
+        eta_min = self.learning_rate / 100.0
+        optimizer = optim.Adam(self.parameters(), lr=self.learning_rate)
+        lr_scheduler = optim.lr_scheduler.CosineAnnealingWarmRestarts(optimizer,
+                                                                      T_0=1, T_mult=2,
+                                                                      eta_min=eta_min)
+        return [optimizer], [{'scheduler': lr_scheduler,
+                              'interval': 'epoch',
+                              'monitor': 'epoch'}]
+
     def configure_optimizers__param_groups(self):
         param_groups = [
             {'params': list(self.parameters())[:2], 'lr': self.learning_rate * 0.1},


### PR DESCRIPTION
## Fixes #2849

Seems like there is currently no support for the schedulers taking values to the step function.
This commit adds support for any scheduler (not particularly ```ReduceOnPlateau scheduler```) taking in validation metrics value/epoch/step_progress. 

Step progress is a float value that ```CosineAnnealingWarmRestarts scheduler``` takes in cases when a step function is called after each step, which is found as ```current_epoch+batch_idx/num_training_batches```.

Now, the ```'monitor'``` attribute in the schedulers dictionary can also take strings ```'epoch'``` and ```'iter_frac'``` (denotes step progress). As there will be the need for other input values, the dictionary of additional ```'monitor'``` keys and short lambda functions implementing their computation can be extended or moved to the utils section.
