### PR TITLE
Updated auto select gpu

### DIFF
--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -25,7 +25,7 @@ import time
 import random
 import torch
 from torch.optim.lr_scheduler import _LRScheduler
-from typing import Union, Callable, Any, List, Optional, Tuple, MutableSequence, NoneType
+from typing import Union, Callable, Any, List, Optional, Tuple, MutableSequence
 
 from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning import _logger as log

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -472,7 +472,7 @@ def pick_single_gpu(exclude_gpus: list):
     raise RuntimeError("No GPUs available.")
 
 
-def pick_single_gpu_realist_workload(exclude_gpus: list, model:LightningModule) -> int:
+def pick_single_gpu_realist_workload(exclude_gpus: list, model: LightningModule) -> int:
     batch = next(iter(model.train_dataloader))
     for i in range(torch.cuda.device_count()):
         if i in exclude_gpus:
@@ -495,7 +495,7 @@ def pick_single_gpu_realist_workload(exclude_gpus: list, model:LightningModule) 
     return -1
 
 
-def pick_multiple_gpus(nb:int, model:Optional[LightningModule] = None) -> list:
+def pick_multiple_gpus(nb: int, model: Optional[LightningModule] = None) -> list:
     r""" Pick available GPUs
 
     Args:

--- a/pytorch_lightning/trainer/distrib_parts.py
+++ b/pytorch_lightning/trainer/distrib_parts.py
@@ -480,10 +480,11 @@ def pick_single_gpu_realist_workload(exclude_gpus: list, model:LightningModule):
         device = torch.device(f"cuda:{i}")
         batch=next(iter(model.train_dataloader))
         try:
-            model_device = model.to(device) 
-            batch_device = batch.to(device)
-            model_device.train() # record grads 
-            model_device(batch_device)
+            with torch.set_grad_enabled(True):
+                model_device = model.to(device) 
+                batch_device = batch.to(device)
+                model_device.train() # record grads 
+                model_device(batch_device)
         except RuntimeError as exception:
             if is_oom_error(exception): # clean after the failed attempt
                 garbage_collection_cuda()

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -966,7 +966,8 @@ class Trainer(
             self._is_data_prepared = True
 
         # Run updated auto GPU selection with the actual model/input data
-        if self.auto_select_gpus: self.update_auto_selected_gpus(model)
+        if self.auto_select_gpus:
+            self.update_auto_selected_gpus(model)
 
         # Run auto batch size scaling
         if self.auto_scale_batch_size:
@@ -1406,12 +1407,12 @@ class Trainer(
         model.setup(stage_name)
 
     def update_auto_selected_gpus(self, model):
-        # Called when model/data is known. Ensure the GPU used have enough VRAM. 
-        self.gpus = pick_multiple_gpus(len(self.gpus), model) # At most the current number of GPUs
+        # Called when model/data is known. Ensure the GPU used have enough VRAM.
+        self.gpus = pick_multiple_gpus(len(self.gpus), model)  # At most the current number of GPUs
 
         self.data_parallel_device_ids = _parse_gpu_ids(self.gpus)
         self.root_gpu = determine_root_gpu_device(self.data_parallel_device_ids)
-        self.on_gpu = True if (self.data_parallel_device_ids and torch.cuda.is_available()) else False 
+        self.on_gpu = True if (self.data_parallel_device_ids and torch.cuda.is_available()) else False
         self.set_nvidia_flags(self.is_slurm_managing_tasks, self.data_parallel_device_ids)
 
 

--- a/pytorch_lightning/trainer/training_tricks.py
+++ b/pytorch_lightning/trainer/training_tricks.py
@@ -269,7 +269,7 @@ def _adjust_batch_size(trainer,
         if hasattr(model, batch_arg_name):
             setattr(model, batch_arg_name, value)
         else:
-            setattr(model.hparams, batch_arg_name, value)        
+            setattr(model.hparams, batch_arg_name, value)
         new_size = value
         if desc:
             log.info(f'Batch size {batch_size} {desc}, trying batch size {new_size}')

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -769,7 +769,7 @@ def test_gpu_choice_workload(tmpdir):
     class CurrentModel(EvalModelTemplate):
         def train_dataloader(self):
             # Aim to overload the VRAM with the whole MNIST
-            from tests.base.dataloaders import MNIST
+            from tests.base.datasets import MNIST
             return torch.utils.data.DataLoader(MNIST(root=self.data_root, train=True, download=True), batch_size=60000)
 
     model = CurrentModel()

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -763,6 +763,20 @@ def test_gpu_choice(tmpdir):
         Trainer(**trainer_options, gpus=num_gpus + 1, auto_select_gpus=True)
 
 
+def test_gpu_choice_workload(tmpdir):
+    """ Test if the training is not allowed by `pick_single_gpu_realist_workload` by using an overly large batch-size """
+    model = EvalModelTemplate()
+    model.train_dataloader.batch_size = 50000 # the size of MNIST trainset
+    trainer = Trainer(
+        max_steps=1,
+        max_epochs=1,
+        default_root_dir=tmpdir,
+    )
+
+    with pytest.raises(RuntimeError, match=r'.*None of the GPUs could accept the given workload.*'):
+        trainer.fit(model)
+        
+
 @pytest.mark.parametrize(['tpu_cores', 'expected_tpu_id', 'error_expected'], [
     pytest.param(1, None, False),
     pytest.param(8, None, False),


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #2075 (issue)
Fixes #1716

New behavior of auto_select_gpu
- the old behavior is run first, i.e. to check if we can use the GPUs
- the new behavior quick in when the model and dataset are defined
- will possibly pick less GPUs than requested if one of them is not available for the workload
- update constants afterward (`root_gpu`, `on_gpu`, trigger `set_nvidia_flags`)

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃

Notes:
- the test does not feel satisfying, looking for ideas to improve it 
- the documentation seems to already convey the effect of this new `auto_select_gpu` behavior, hence no update on that side
- it relies on the definition of the dataloader to work properly, as it is sampled to represent the actual workload
- I have doubts the method is not run too "late" with respect to the env. configuration for the training process
- my first PR on an OSS project with tests and stuff, any comment is welcome !