### PR TITLE
Add wandb autoclass in logger.rst

### DIFF
--- a/docs/source/loggers.rst
+++ b/docs/source/loggers.rst
@@ -317,6 +317,12 @@ Comet
 .. autoclass:: pytorch_lightning.loggers.comet.CometLogger
     :noindex:
 
+CSVLogger
+^^^^^^^^^
+
+.. autoclass:: pytorch_lightning.loggers.csv_logs.CSVLogger
+    :noindex:
+
 MLFlow
 ^^^^^^
 
@@ -341,8 +347,8 @@ Test-tube
 .. autoclass:: pytorch_lightning.loggers.test_tube.TestTubeLogger
     :noindex:
 
-CSVLogger
-^^^^^^^^^
+Weights and Biases
+^^^^^^^^^^^^^^^^^^
 
-.. autoclass:: pytorch_lightning.loggers.csv_logs.CSVLogger
+.. autoclass:: pytorch_lightning.loggers.wandb.WandbLogger
     :noindex:


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fix that `WandbLogger` is not listed in [Supported Loggers Page](https://pytorch-lightning.readthedocs.io/en/latest/loggers.html#supported-loggers)

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
