### PR TITLE
Fix ddp for test

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1351,7 +1351,6 @@ class Trainer(
 
         # run tests
         self.tested_ckpt_path = ckpt_path
-        self.set_random_port(force=True)
         self.testing = True
         os.environ['PL_TESTING_MODE'] = '1'
         self.model = model
@@ -1374,7 +1373,6 @@ class Trainer(
 
         # run test
         # sets up testing so we short circuit to eval
-        self.set_random_port(force=True)
         self.testing = True
         self.model = model
         results = self.fit(model)


### PR DESCRIPTION
## What does this PR do?
DDP for Trainer.test is broken. The problem is that when each distributed process is spawn, at the start of the test function, a random port is set. When we get to the init_process_group part, because each process has a different port set, the program hangs.

These lines were introduced in https://github.com/PyTorchLightning/pytorch-lightning/pull/2512/files. I'm wondering why they were added in the first place?

# Before submitting

- [X] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [X] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests? 
- [X] Did you verify new and existing tests pass locally with your changes?
- [X] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
