### PR TITLE
warn user when dropping unpicklable hparams

### DIFF
--- a/pytorch_lightning/utilities/__init__.py
+++ b/pytorch_lightning/utilities/__init__.py
@@ -5,7 +5,7 @@ import torch
 
 from pytorch_lightning.utilities.apply_func import move_data_to_device
 from pytorch_lightning.utilities.distributed import rank_zero_only, rank_zero_warn, rank_zero_info
-from pytorch_lightning.utilities.parsing import AttributeDict, flatten_dict
+from pytorch_lightning.utilities.parsing import AttributeDict, flatten_dict, is_picklable
 
 try:
     from apex import amp

--- a/pytorch_lightning/utilities/parsing.py
+++ b/pytorch_lightning/utilities/parsing.py
@@ -1,4 +1,6 @@
 import inspect
+import pickle
+import warnings
 from argparse import Namespace
 from typing import Dict
 
@@ -31,7 +33,10 @@ def clean_namespace(hparams):
     if isinstance(hparams, Namespace):
         del_attrs = []
         for k in hparams.__dict__:
-            if callable(getattr(hparams, k)):
+            try:
+                pickle.dumps(getattr(hparams, k))
+            except:
+                warnings.warn(f"attribute '{k}' removed from hparams because it cannot be pickled", UserWarning)
                 del_attrs.append(k)
 
         for k in del_attrs:
@@ -40,7 +45,10 @@ def clean_namespace(hparams):
     elif isinstance(hparams, dict):
         del_attrs = []
         for k, v in hparams.items():
-            if callable(v):
+            try:
+                pickle.dumps(v)
+            except:
+                warnings.warn(f"attribute '{k}' removed from hparams because it cannot be pickled", UserWarning)
                 del_attrs.append(k)
 
         for k in del_attrs:

--- a/pytorch_lightning/utilities/parsing.py
+++ b/pytorch_lightning/utilities/parsing.py
@@ -44,7 +44,7 @@ def clean_namespace(hparams):
     if isinstance(hparams, Namespace):
         hparams_dict = hparams.__dict__
 
-    del_attrs = [k for k,v in hparams_dict.items() if not is_picklable(v)]
+    del_attrs = [k for k, v in hparams_dict.items() if not is_picklable(v)]
 
     for k in del_attrs:
         warnings.warn(f"attribute '{k}' removed from hparams because it cannot be pickled", UserWarning)

--- a/pytorch_lightning/utilities/parsing.py
+++ b/pytorch_lightning/utilities/parsing.py
@@ -1,8 +1,9 @@
 import inspect
 import pickle
-import warnings
 from argparse import Namespace
 from typing import Dict
+
+from pytorch_lightning.utilities import rank_zero_warn
 
 
 def str_to_bool(val):
@@ -47,7 +48,7 @@ def clean_namespace(hparams):
     del_attrs = [k for k, v in hparams_dict.items() if not is_picklable(v)]
 
     for k in del_attrs:
-        warnings.warn(f"attribute '{k}' removed from hparams because it cannot be pickled", UserWarning)
+        rank_zero_warn(f"attribute '{k}' removed from hparams because it cannot be pickled", UserWarning)
         del hparams_dict[k]
 
 

--- a/pytorch_lightning/utilities/parsing.py
+++ b/pytorch_lightning/utilities/parsing.py
@@ -35,7 +35,7 @@ def clean_namespace(hparams):
         for k in hparams.__dict__:
             try:
                 pickle.dumps(getattr(hparams, k))
-            except:
+            except pickle.PicklingError:
                 warnings.warn(f"attribute '{k}' removed from hparams because it cannot be pickled", UserWarning)
                 del_attrs.append(k)
 
@@ -47,7 +47,7 @@ def clean_namespace(hparams):
         for k, v in hparams.items():
             try:
                 pickle.dumps(v)
-            except:
+            except pickle.PicklingError:
                 warnings.warn(f"attribute '{k}' removed from hparams because it cannot be pickled", UserWarning)
                 del_attrs.append(k)
 

--- a/tests/models/test_hparams.py
+++ b/tests/models/test_hparams.py
@@ -282,7 +282,7 @@ def test_collect_init_arguments(tmpdir, cls):
     assert model.hparams.batch_size == 179
 
     if isinstance(model, AggSubClassEvalModel):
-        assert isinstance(model.hparams.my_loss, torch.nn.CrossEntropyLoss)
+        assert isinstance(model.hparams.my_loss, torch.nn.CosineEmbeddingLoss)
 
     if isinstance(model, DictConfSubClassEvalModel):
         assert isinstance(model.hparams.dict_conf, Container)

--- a/tests/models/test_hparams.py
+++ b/tests/models/test_hparams.py
@@ -11,7 +11,7 @@ from torch.utils.data import DataLoader
 
 from pytorch_lightning import Trainer, LightningModule
 from pytorch_lightning.core.saving import save_hparams_to_yaml, load_hparams_from_yaml
-from pytorch_lightning.utilities import AttributeDict
+from pytorch_lightning.utilities import AttributeDict, is_picklable
 from tests.base import EvalModelTemplate, TrialMNIST
 
 


### PR DESCRIPTION
## What does this PR do?
PR changes namespace cleaning to be more general. Makes sure it only removes items which can't be pickled, and warns user when doing so.

Fixes #2676 
Fixes #2444

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
