### PR TITLE
save last model after saving top_k when save_last=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed LR finder and `hparams` compatibility ([#2821](https://github.com/PyTorchLightning/pytorch-lightning/pull/2821))
 
+- Fixed `ModelCheckpoint` not saving the latest information when `save_last=True` ([#2881](https://github.com/PyTorchLightning/pytorch-lightning/pull/2881))
+
 ## [0.8.5] - 2020-07-09
 
 ### Added

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -17,6 +17,10 @@ from pytorch_lightning import _logger as log
 from pytorch_lightning.callbacks.base import Callback
 from pytorch_lightning.utilities import rank_zero_warn, rank_zero_only
 
+CHECKPOINT_NAME_LAST = "last.ckpt"
+CHECKPOINT_STATE_BEST_SCORE = "checkpoint_callback_best_model_score"
+CHECKPOINT_STATE_BEST_PATH = "checkpoint_callback_best_model_path"
+
 
 class ModelCheckpoint(Callback):
     r"""
@@ -302,10 +306,6 @@ class ModelCheckpoint(Callback):
 
         self.epoch_last_check = epoch
 
-        if self.save_last:
-            filepath = os.path.join(self.dirpath, self.prefix + 'last.ckpt')
-            self._save_model(filepath, trainer, pl_module)
-
         filepath = self.format_checkpoint_name(epoch, metrics)
         version_cnt = 0
         while os.path.isfile(filepath):
@@ -338,6 +338,10 @@ class ModelCheckpoint(Callback):
                 log.info(f'\nEpoch {epoch:05d}: saving model to {filepath}')
 
             assert trainer.global_rank == 0, 'tried to make a checkpoint from non global_rank=0'
+            self._save_model(filepath, trainer, pl_module)
+
+        if self.save_last:
+            filepath = os.path.join(self.dirpath, self.prefix + CHECKPOINT_NAME_LAST)
             self._save_model(filepath, trainer, pl_module)
 
     def _do_check_save(self, filepath, current, epoch, trainer, pl_module):

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -17,10 +17,6 @@ from pytorch_lightning import _logger as log
 from pytorch_lightning.callbacks.base import Callback
 from pytorch_lightning.utilities import rank_zero_warn, rank_zero_only
 
-CHECKPOINT_NAME_LAST = "last.ckpt"
-CHECKPOINT_STATE_BEST_SCORE = "checkpoint_callback_best_model_score"
-CHECKPOINT_STATE_BEST_PATH = "checkpoint_callback_best_model_path"
-
 
 class ModelCheckpoint(Callback):
     r"""
@@ -99,6 +95,10 @@ class ModelCheckpoint(Callback):
         checkpoint_callback.best_model_path
 
     """
+
+    CHECKPOINT_NAME_LAST = "last.ckpt"
+    CHECKPOINT_STATE_BEST_SCORE = "checkpoint_callback_best_model_score"
+    CHECKPOINT_STATE_BEST_PATH = "checkpoint_callback_best_model_path"
 
     def __init__(self, filepath: Optional[str] = None, monitor: str = 'val_loss', verbose: bool = False,
                  save_last: bool = False, save_top_k: int = 1, save_weights_only: bool = False,
@@ -341,7 +341,7 @@ class ModelCheckpoint(Callback):
             self._save_model(filepath, trainer, pl_module)
 
         if self.save_last:
-            filepath = os.path.join(self.dirpath, self.prefix + CHECKPOINT_NAME_LAST)
+            filepath = os.path.join(self.dirpath, self.prefix + ModelCheckpoint.CHECKPOINT_NAME_LAST)
             self._save_model(filepath, trainer, pl_module)
 
     def _do_check_save(self, filepath, current, epoch, trainer, pl_module):

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -96,6 +96,7 @@ import torch.distributed as torch_distrib
 import pytorch_lightning
 from pytorch_lightning import _logger as log
 from pytorch_lightning.callbacks import ModelCheckpoint, EarlyStopping
+from pytorch_lightning.callbacks.model_checkpoint import CHECKPOINT_STATE_BEST_SCORE, CHECKPOINT_STATE_BEST_PATH
 from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.overrides.data_parallel import (
@@ -355,8 +356,8 @@ class TrainerIOMixin(ABC):
             if checkpoint_callbacks:
                 # we add the official checkpoint callback to the end of the list
                 # extra user provided callbacks will not be persisted yet
-                checkpoint['checkpoint_callback_best_model_score'] = self.checkpoint_callback.best_model_score
-                checkpoint['checkpoint_callback_best_model_path'] = self.checkpoint_callback.best_model_path
+                checkpoint[CHECKPOINT_STATE_BEST_SCORE] = self.checkpoint_callback.best_model_score
+                checkpoint[CHECKPOINT_STATE_BEST_PATH] = self.checkpoint_callback.best_model_path
 
             if early_stopping_callbacks and checkpoint_callbacks:
                 # we add the official early stopping callback to the end of the list
@@ -437,8 +438,8 @@ class TrainerIOMixin(ABC):
         early_stopping_callbacks = [c for c in self.callbacks if isinstance(c, EarlyStopping)]
 
         if checkpoint_callbacks:
-            if 'checkpoint_callback_best_model_score' in checkpoint:
-                checkpoint_callbacks[-1].best_model_score = checkpoint['checkpoint_callback_best_model_score']
+            if CHECKPOINT_STATE_BEST_SCORE in checkpoint:
+                checkpoint_callbacks[-1].best_model_score = checkpoint[CHECKPOINT_STATE_BEST_SCORE]
             else:
                 # Old naming until version 0.7.6
                 rank_zero_warn(
@@ -446,7 +447,7 @@ class TrainerIOMixin(ABC):
                     'this will not be supported in the future.'
                 )
                 checkpoint_callbacks[-1].best_model_score = checkpoint['checkpoint_callback_best']
-            checkpoint_callbacks[-1].best_model_path = checkpoint['checkpoint_callback_best_model_path']
+            checkpoint_callbacks[-1].best_model_path = checkpoint[CHECKPOINT_STATE_BEST_PATH]
 
         if early_stopping_callbacks:
             state = checkpoint['early_stop_callback_state_dict']

--- a/pytorch_lightning/trainer/training_io.py
+++ b/pytorch_lightning/trainer/training_io.py
@@ -96,7 +96,6 @@ import torch.distributed as torch_distrib
 import pytorch_lightning
 from pytorch_lightning import _logger as log
 from pytorch_lightning.callbacks import ModelCheckpoint, EarlyStopping
-from pytorch_lightning.callbacks.model_checkpoint import CHECKPOINT_STATE_BEST_SCORE, CHECKPOINT_STATE_BEST_PATH
 from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.overrides.data_parallel import (
@@ -356,8 +355,8 @@ class TrainerIOMixin(ABC):
             if checkpoint_callbacks:
                 # we add the official checkpoint callback to the end of the list
                 # extra user provided callbacks will not be persisted yet
-                checkpoint[CHECKPOINT_STATE_BEST_SCORE] = self.checkpoint_callback.best_model_score
-                checkpoint[CHECKPOINT_STATE_BEST_PATH] = self.checkpoint_callback.best_model_path
+                checkpoint[ModelCheckpoint.CHECKPOINT_STATE_BEST_SCORE] = self.checkpoint_callback.best_model_score
+                checkpoint[ModelCheckpoint.CHECKPOINT_STATE_BEST_PATH] = self.checkpoint_callback.best_model_path
 
             if early_stopping_callbacks and checkpoint_callbacks:
                 # we add the official early stopping callback to the end of the list
@@ -438,8 +437,8 @@ class TrainerIOMixin(ABC):
         early_stopping_callbacks = [c for c in self.callbacks if isinstance(c, EarlyStopping)]
 
         if checkpoint_callbacks:
-            if CHECKPOINT_STATE_BEST_SCORE in checkpoint:
-                checkpoint_callbacks[-1].best_model_score = checkpoint[CHECKPOINT_STATE_BEST_SCORE]
+            if ModelCheckpoint.CHECKPOINT_STATE_BEST_SCORE in checkpoint:
+                checkpoint_callbacks[-1].best_model_score = checkpoint[ModelCheckpoint.CHECKPOINT_STATE_BEST_SCORE]
             else:
                 # Old naming until version 0.7.6
                 rank_zero_warn(
@@ -447,7 +446,7 @@ class TrainerIOMixin(ABC):
                     'this will not be supported in the future.'
                 )
                 checkpoint_callbacks[-1].best_model_score = checkpoint['checkpoint_callback_best']
-            checkpoint_callbacks[-1].best_model_path = checkpoint[CHECKPOINT_STATE_BEST_PATH]
+            checkpoint_callbacks[-1].best_model_path = checkpoint[ModelCheckpoint.CHECKPOINT_STATE_BEST_PATH]
 
         if early_stopping_callbacks:
             state = checkpoint['early_stop_callback_state_dict']

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 
 import tests.base.develop_utils as tutils
-from pytorch_lightning import Trainer
+from pytorch_lightning import Trainer, seed_everything
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.callbacks.model_checkpoint import CHECKPOINT_NAME_LAST, CHECKPOINT_STATE_BEST_SCORE, \
     CHECKPOINT_STATE_BEST_PATH
@@ -99,6 +99,8 @@ def test_model_checkpoint_no_extraneous_invocations(tmpdir):
 
 
 def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
+    """ Tests that the checkpoint saved as 'last.ckpt' contains the latest information. """
+    seed_everything(100)
     model = EvalModelTemplate()
     num_epochs = 3
     model_checkpoint = ModelCheckpoint(filepath=tmpdir, save_top_k=num_epochs, save_last=True)
@@ -109,7 +111,6 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
         max_epochs=num_epochs,
     )
     trainer.fit(model)
-    print(tmpdir)
     path_last_epoch = model_checkpoint.format_checkpoint_name(num_epochs - 1, {})
     path_last = tmpdir / CHECKPOINT_NAME_LAST
     ckpt_last_epoch = torch.load(str(path_last_epoch))

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -116,7 +116,8 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
     trainer.fit(model)
     path_last_epoch = model_checkpoint.format_checkpoint_name(num_epochs - 1, {})
     path_last = tmpdir / CHECKPOINT_NAME_LAST
+    assert path_last_epoch != path_last
     ckpt_last_epoch = torch.load(str(path_last_epoch))
     ckpt_last = torch.load(str(path_last))
-    assert ckpt_last[CHECKPOINT_STATE_BEST_SCORE] == ckpt_last_epoch[CHECKPOINT_STATE_BEST_SCORE]
-    assert ckpt_last[CHECKPOINT_STATE_BEST_PATH] == ckpt_last_epoch[CHECKPOINT_STATE_BEST_PATH]
+    assert ckpt_last_epoch[CHECKPOINT_STATE_BEST_SCORE] == ckpt_last[CHECKPOINT_STATE_BEST_SCORE]
+    assert ckpt_last_epoch[CHECKPOINT_STATE_BEST_PATH] == ckpt_last[CHECKPOINT_STATE_BEST_PATH]

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -115,8 +115,10 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
     ckpt_last_epoch = torch.load(str(path_last_epoch))
     ckpt_last = torch.load(str(path_last))
     matching_keys = (
+        "epoch",
+        "global_step",
         ModelCheckpoint.CHECKPOINT_STATE_BEST_SCORE,
-        ModelCheckpoint.CHECKPOINT_STATE_BEST_PATH
+        ModelCheckpoint.CHECKPOINT_STATE_BEST_PATH,
     )
     for key in matching_keys:
         assert ckpt_last_epoch[key] == ckpt_last[key]

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -10,8 +10,11 @@ import torch
 import tests.base.develop_utils as tutils
 from pytorch_lightning import Trainer, seed_everything
 from pytorch_lightning.callbacks import ModelCheckpoint
-from pytorch_lightning.callbacks.model_checkpoint import CHECKPOINT_NAME_LAST, CHECKPOINT_STATE_BEST_SCORE, \
-    CHECKPOINT_STATE_BEST_PATH
+from pytorch_lightning.callbacks.model_checkpoint import (
+    CHECKPOINT_NAME_LAST,
+    CHECKPOINT_STATE_BEST_SCORE,
+    CHECKPOINT_STATE_BEST_PATH,
+)
 from pytorch_lightning.loggers import TensorBoardLogger
 from tests.base import EvalModelTemplate
 

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -10,11 +10,6 @@ import torch
 import tests.base.develop_utils as tutils
 from pytorch_lightning import Trainer, seed_everything
 from pytorch_lightning.callbacks import ModelCheckpoint
-from pytorch_lightning.callbacks.model_checkpoint import (
-    CHECKPOINT_NAME_LAST,
-    CHECKPOINT_STATE_BEST_SCORE,
-    CHECKPOINT_STATE_BEST_PATH,
-)
 from pytorch_lightning.loggers import TensorBoardLogger
 from tests.base import EvalModelTemplate
 
@@ -115,9 +110,13 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
     )
     trainer.fit(model)
     path_last_epoch = model_checkpoint.format_checkpoint_name(num_epochs - 1, {})
-    path_last = tmpdir / CHECKPOINT_NAME_LAST
+    path_last = tmpdir / ModelCheckpoint.CHECKPOINT_NAME_LAST
     assert path_last_epoch != path_last
     ckpt_last_epoch = torch.load(str(path_last_epoch))
     ckpt_last = torch.load(str(path_last))
-    assert ckpt_last_epoch[CHECKPOINT_STATE_BEST_SCORE] == ckpt_last[CHECKPOINT_STATE_BEST_SCORE]
-    assert ckpt_last_epoch[CHECKPOINT_STATE_BEST_PATH] == ckpt_last[CHECKPOINT_STATE_BEST_PATH]
+    matching_keys = (
+        ModelCheckpoint.CHECKPOINT_STATE_BEST_SCORE,
+        ModelCheckpoint.CHECKPOINT_STATE_BEST_PATH
+    )
+    for key in matching_keys:
+        assert ckpt_last_epoch[key] == ckpt_last[key]


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #2680

The checkpoint named "last.ckpt" should be saved last, literally, after saving all the top_k, because these will update the state for `best_model_score` and `best_model_path`, and if we don't save last these infos won't land in the checkpoint.

Note: **Test fails on master**

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
