### PR TITLE
tracks all outputs including TBPTT and multiple optimizers

### DIFF
--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -460,7 +460,12 @@ class TrainResult(Result):
             on_step: if True logs the output of validation_step or test_step
             on_epoch: if True, logs the output of the training loop aggregated
             reduce_fx: Torch.mean by default
+            tbptt_reduce_fx: function to reduce on truncated back prop
+            tbptt_pad_token: token to use for padding
             enable_graph: if True, will not auto detach the graph
+            sync_ddp: if True, reduces the metric across GPUs/TPUs
+            sync_ddp_op: the op to sync across
+            sync_ddp_group: the ddp group
         """
         super().log(name=name,
                     value=value,
@@ -500,13 +505,18 @@ class TrainResult(Result):
             result.log_dict(values)
 
         Args:
-            dictionary:
-            prog_bar:
-            logger:
-            on_step:
-            on_epoch:
-            reduce_fx:
-            enable_graph:
+            dictionary: key value pairs (str, tensors)
+            prog_bar: if True logs to the progress base
+            logger: if True logs to the logger
+            on_step: if True logs the output of validation_step or test_step
+            on_epoch: if True, logs the output of the training loop aggregated
+            reduce_fx: Torch.mean by default
+            tbptt_reduce_fx: function to reduce on truncated back prop
+            tbptt_pad_token: token to use for padding
+            enable_graph: if True, will not auto detach the graph
+            sync_ddp: if True, reduces the metric across GPUs/TPUs
+            sync_ddp_op: the op to sync across
+            sync_ddp_group: the ddp group:
         """
         for k, v in dictionary.items():
             self.log(name=k,
@@ -599,9 +609,14 @@ class EvalResult(Result):
             prog_bar: if True logs to the progress base
             logger: if True logs to the logger
             on_step: if True logs the output of validation_step or test_step
-            on_epoch: if True, logs the output of the validation loop or test loop aggregated
+            on_epoch: if True, logs the output of the training loop aggregated
             reduce_fx: Torch.mean by default
-            enable_graph: if True, will not auto detach the graph :
+            tbptt_reduce_fx: function to reduce on truncated back prop
+            tbptt_pad_token: token to use for padding
+            enable_graph: if True, will not auto detach the graph
+            sync_ddp: if True, reduces the metric across GPUs/TPUs
+            sync_ddp_op: the op to sync across
+            sync_ddp_group: the ddp group
         """
         super().log(name=name,
                     value=value,
@@ -641,13 +656,18 @@ class EvalResult(Result):
             result.log_dict(values)
 
         Args:
-            dictionary:
-            prog_bar:
-            logger:
-            on_step:
-            on_epoch:
-            reduce_fx:
-            enable_graph:
+            dictionary: key value pairs (str, tensors)
+            prog_bar: if True logs to the progress base
+            logger: if True logs to the logger
+            on_step: if True logs the output of validation_step or test_step
+            on_epoch: if True, logs the output of the training loop aggregated
+            reduce_fx: Torch.mean by default
+            tbptt_reduce_fx: function to reduce on truncated back prop
+            tbptt_pad_token: token to use for padding
+            enable_graph: if True, will not auto detach the graph
+            sync_ddp: if True, reduces the metric across GPUs/TPUs
+            sync_ddp_op: the op to sync across
+            sync_ddp_group: the ddp group
         """
         for k, v in dictionary.items():
             self.log(name=k,

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -284,7 +284,6 @@ class Result(Dict):
         for name, value in result.items():
             is_reserved = name in {'checkpoint_on', 'early_stop_on', 'minimize'}
             if isinstance(value, list) and len(value) > 0 and isinstance(value[0], torch.Tensor):
-                max_length = max([len(v) for k, v in result.items() if isinstance(v, list)])
 
                 if is_reserved:
                     padding_key = default_padding_idx
@@ -343,6 +342,10 @@ class Result(Dict):
     @property
     def should_reduce_on_epoch_end(self) -> bool:
         return self['meta']['_internal']['_reduce_on_epoch']
+
+    def drop_hiddens(self):
+        if 'hiddens' in self:
+            del self['hiddens']
 
 
 def recursive_gather(outputs: Sequence[dict], result: Optional[MutableMapping] = None) -> Optional[MutableMapping]:

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -380,6 +380,7 @@ def recursive_padded_stack(result: MutableMapping):
             v = torch.stack(v)
             result[k] = v
 
+
 class TrainResult(Result):
 
     def __init__(

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -371,6 +371,7 @@ def recursive_stack(result: MutableMapping):
             v = torch.stack(v)
             result[k] = v
 
+
 def recursive_padded_stack(result: MutableMapping):
     for k, v in result.items():
         if isinstance(v, dict):

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -509,10 +509,14 @@ class TrainResult(Result):
             enable_graph:
         """
         for k, v in dictionary.items():
-            self.log(k, v,
-                     prog_bar, logger,
-                     on_step, on_epoch,
-                     reduce_fx, enable_graph,
+            self.log(name=k,
+                     value=v,
+                     prog_bar=prog_bar,
+                     logger=logger,
+                     on_step=on_step,
+                     on_epoch=on_epoch,
+                     reduce_fx=reduce_fx,
+                     enable_graph=enable_graph,
                      sync_ddp=sync_ddp,
                      sync_ddp_group=sync_ddp_group,
                      sync_ddp_op=sync_ddp_op,
@@ -646,10 +650,14 @@ class EvalResult(Result):
             enable_graph:
         """
         for k, v in dictionary.items():
-            self.log(k, v,
-                     prog_bar, logger,
-                     on_step, on_epoch,
-                     reduce_fx, enable_graph,
+            self.log(name=k,
+                     value=v,
+                     prog_bar=prog_bar,
+                     logger=logger,
+                     on_step=on_step,
+                     on_epoch=on_epoch,
+                     reduce_fx=reduce_fx,
+                     enable_graph=enable_graph,
                      sync_ddp=sync_ddp,
                      sync_ddp_group=sync_ddp_group,
                      sync_ddp_op=sync_ddp_op,
@@ -661,4 +669,5 @@ class EvalResult(Result):
             'val_early_stop_on': self.early_stop_on,
             'val_checkpoint_on': self.checkpoint_on
         }
+
         return result

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -648,7 +648,8 @@ class TrainerTrainLoopMixin(ABC):
             if is_result_obj:
                 # with result object gather across time and training steps so each opt idx has a single result obj
                 epoch_output = self.__gather_result_across_time_and_optimizers(epoch_output)
-            elif num_optimizers == 1:
+
+            if num_optimizers == 1:
                 epoch_output = epoch_output[0]
 
             # run training_epoch_end

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -611,6 +611,10 @@ class TrainerTrainLoopMixin(ABC):
 
         model = self.get_model()
 
+        # make sure we have something to reduce
+        if len(epoch_output) > 0 and len(epoch_output[0]) == 0:
+            return
+
         # [optimizer_idx][training_step_idx][tbptt_index]
         sample_obj = epoch_output[0][0][0]
         is_result_obj = len(epoch_output) > 0 and isinstance(sample_obj, Result)

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -614,15 +614,6 @@ class TrainerTrainLoopMixin(ABC):
 
         model = self.get_model()
 
-        # make sure we have something to reduce
-        if len(epoch_output) > 0 and len(epoch_output[0]) == 0:
-            return
-
-        # [optimizer_idx][training_step_idx][tbptt_index]
-        opt_idx_outputs = epoch_output[0]
-        sample_obj = opt_idx_outputs[0][0] if isinstance(opt_idx_outputs[0], list) else opt_idx_outputs[0]
-        is_result_obj = len(epoch_output) > 0 and isinstance(sample_obj, Result)
-
         epoch_log_metrics = {}
         epoch_callback_metrics = {}
         epoch_progress_bar_metrics = {}
@@ -635,6 +626,18 @@ class TrainerTrainLoopMixin(ABC):
 
         if early_stopping_accumulator.num_values > 0:
             epoch_callback_metrics['early_stop_on'] = early_stopping_accumulator.mean()
+
+        # ------------------------
+        # determine if using a result obj
+        # ------------------------
+        # [optimizer_idx][training_step_idx][tbptt_index]
+        opt_idx_outputs = epoch_output[0]
+
+        try:
+            sample_obj = opt_idx_outputs[0][0] if isinstance(opt_idx_outputs[0], list) else opt_idx_outputs[0]
+            is_result_obj = len(epoch_output) > 0 and isinstance(sample_obj, Result)
+        except IndexError as e:
+            is_result_obj = False
 
         # --------------------------
         # EPOCH END STEP IF DEFINED

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -175,7 +175,7 @@ from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.core.step_result import EvalResult, Result
 from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.trainer.supporters import TensorRunningAccum, Accumulator
-from pytorch_lightning.utilities import rank_zero_warn, NATIVE_AMP_AVALAIBLE
+from pytorch_lightning.utilities import rank_zero_warn, AMPType
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.memory import recursive_detach
 from pytorch_lightning.utilities.parsing import AttributeDict
@@ -183,9 +183,7 @@ from pytorch_lightning.utilities.parsing import AttributeDict
 try:
     from apex import amp
 except ImportError:
-    APEX_AVAILABLE = False
-else:
-    APEX_AVAILABLE = True
+    amp = None
 
 try:
     import torch_xla.distributed.parallel_loader as xla_pl
@@ -255,6 +253,8 @@ class TrainerTrainLoopMixin(ABC):
     terminate_on_nan: bool
     tpu_id: int
     interactive_ddp_procs: ...
+    amp_type: AMPType
+    on_tpu: bool
 
     # Callback system
     callbacks: List[Callback]
@@ -841,7 +841,7 @@ class TrainerTrainLoopMixin(ABC):
         # ------------------
         # CLIP GRADS
         # ------------------
-        if self.use_amp and NATIVE_AMP_AVALAIBLE and not self.use_tpu:
+        if self.amp_type == AMPType.NATIVE and not self.use_tpu:
             self.scaler.unscale_(optimizer)
         self.clip_gradients(optimizer)
 
@@ -863,7 +863,7 @@ class TrainerTrainLoopMixin(ABC):
                 batch_idx,
                 opt_idx,
                 optimizer,
-                self.hiddens
+                self.hiddens,
             ).loss
 
             # apply TPU optimizer
@@ -875,7 +875,7 @@ class TrainerTrainLoopMixin(ABC):
             elif isinstance(optimizer, torch.optim.LBFGS):
 
                 # native amp + lbfgs is a no go right now
-                if self.use_amp and NATIVE_AMP_AVALAIBLE:
+                if self.amp_type == AMPType.NATIVE:
                     raise MisconfigurationException(
                         'native PyTorch amp and lbfgs are not compatible.'
                         ' To request, please file a Github issue in PyTorch and tag @mcarilli')
@@ -884,12 +884,12 @@ class TrainerTrainLoopMixin(ABC):
 
             # when using 16-bit
             else:
-                native_amp = self.use_amp and NATIVE_AMP_AVALAIBLE
+                native_amp = self.amp_type == AMPType.NATIVE
                 model.optimizer_step(self.current_epoch, batch_idx, optimizer, opt_idx, lambda_closure,
                                      using_native_amp=native_amp)
 
             # in native 16-bit we need to update scaler after optimizer step
-            if self.use_amp and NATIVE_AMP_AVALAIBLE and not self.use_tpu:
+            if self.amp_type == AMPType.NATIVE and not self.use_tpu:
                 self.scaler.update()
 
             # model hook
@@ -906,7 +906,7 @@ class TrainerTrainLoopMixin(ABC):
         # FORWARD (TRAINING STEP + TRAIN STEP END)
         # ---------------------------
         with self.profiler.profile('model_forward'):
-            if self.use_amp and NATIVE_AMP_AVALAIBLE and not self.use_tpu:
+            if self.amp_type == AMPType.NATIVE and not self.use_tpu:
                 with torch.cuda.amp.autocast():
                     training_step_output = self.training_forward(split_batch, batch_idx,
                                                                  opt_idx, hiddens)
@@ -960,10 +960,10 @@ class TrainerTrainLoopMixin(ABC):
         with self.profiler.profile('model_backward'):
             # scale loss for 16 bit
             if self.precision == 16 and not self.on_tpu:
-                closure_loss = model_ref.amp_scale_loss(closure_loss, optimizer, opt_idx)
+                closure_loss = model_ref.amp_scale_loss(closure_loss, optimizer, opt_idx, amp_type=self.amp_type)
 
                 # enter amp context
-                if not NATIVE_AMP_AVALAIBLE:
+                if self.amp_type == AMPType.APEX:
                     context = closure_loss
                     closure_loss = closure_loss.__enter__()
 
@@ -971,7 +971,7 @@ class TrainerTrainLoopMixin(ABC):
             model_ref.backward(self, closure_loss, optimizer, opt_idx)
 
             # exit amp context
-            if self.precision == 16 and not NATIVE_AMP_AVALAIBLE and not self.on_tpu:
+            if self.precision == 16 and self.amp_type == AMPType.APEX and not self.on_tpu:
                 a, b, c = None, None, None
                 error = context.__exit__(a, b, c)
                 if error:

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -186,6 +186,8 @@ class DeterministicModel(LightningModule):
             pass
         else:
             # only saw 4 batches
+            assert isinstance(result, list) and len(result) == 1
+            result = result[0]
             assert isinstance(result, TrainResult)
 
         result.step_step_epoch_log_and_pbar_acc1 = result.step_step_epoch_log_and_pbar_acc1.prod()

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -186,8 +186,6 @@ class DeterministicModel(LightningModule):
             pass
         else:
             # only saw 4 batches
-            assert isinstance(result, list) and len(result) == 1
-            result = result[0]
             assert isinstance(result, TrainResult)
 
         result.step_step_epoch_log_and_pbar_acc1 = result.step_step_epoch_log_and_pbar_acc1.prod()

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -78,6 +78,8 @@ class TrainingStepVariations(ABC):
         result = result[0]
         result.log('train_epoch_end_metric', 1, on_epoch=True)
         self.training_epoch_end_called = True
+
+        import pdb; pdb.set_trace()
         return result
 
     def eval_step_full_loop_result_obj_dp(self, batch, batch_idx, optimizer_idx=None):

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -75,11 +75,9 @@ class TrainingStepVariations(ABC):
         """
         Full loop flow train step (result obj + dp)
         """
-        result = result[0]
         result.log('train_epoch_end_metric', 1, on_epoch=True)
         self.training_epoch_end_called = True
 
-        import pdb; pdb.set_trace()
         return result
 
     def eval_step_full_loop_result_obj_dp(self, batch, batch_idx, optimizer_idx=None):

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -75,7 +75,7 @@ class TrainingStepVariations(ABC):
         """
         Full loop flow train step (result obj + dp)
         """
-        import pdb; pdb.set_trace()
+        result = result[0]
         result.log('train_epoch_end_metric', 1, on_epoch=True)
         self.training_epoch_end_called = True
         return result

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -75,6 +75,7 @@ class TrainingStepVariations(ABC):
         """
         Full loop flow train step (result obj + dp)
         """
+        import pdb; pdb.set_trace()
         result.log('train_epoch_end_metric', 1, on_epoch=True)
         self.training_epoch_end_called = True
         return result

--- a/tests/models/test_cpu.py
+++ b/tests/models/test_cpu.py
@@ -400,6 +400,7 @@ def test_tbptt_cpu_model_result(tmpdir):
             return result
 
         def training_epoch_end(self, training_step_outputs):
+            result = training_step_outputs
             assert isinstance(result, TrainResult)
             assert result.minimize.size(1) == (sequence_size / truncated_bptt_steps)
 

--- a/tests/models/test_cpu.py
+++ b/tests/models/test_cpu.py
@@ -400,7 +400,6 @@ def test_tbptt_cpu_model_result(tmpdir):
             return result
 
         def training_epoch_end(self, training_step_outputs):
-            result = training_step_outputs[0]
             assert isinstance(result, TrainResult)
             assert result.minimize.size(1) == (sequence_size / truncated_bptt_steps)
 

--- a/tests/trainer/test_trainer_steps_dict_return.py
+++ b/tests/trainer/test_trainer_steps_dict_return.py
@@ -35,6 +35,9 @@ def test_training_step_dict(tmpdir):
     assert out.batch_log_metrics['log_acc2'] == 7.0
 
     train_step_out = out.training_step_output_for_epoch_end
+    assert len(train_step_out) == 1
+
+    train_step_out = train_step_out[0][0]
     pbar_metrics = train_step_out['progress_bar']
     assert 'log' in train_step_out
     assert 'progress_bar' in train_step_out
@@ -118,7 +121,10 @@ def test_full_training_loop_dict(tmpdir):
     assert out.batch_log_metrics['log_acc1'] == 14.0
     assert out.batch_log_metrics['log_acc2'] == 9.0
 
+    # get the output of the first optimizer
     train_step_end_out = out.training_step_output_for_epoch_end
+    assert len(train_step_end_out) == 1
+    train_step_end_out = train_step_end_out[0][0]
     pbar_metrics = train_step_end_out['progress_bar']
     assert pbar_metrics['pbar_acc1'] == 19.0
     assert pbar_metrics['pbar_acc2'] == 21.0
@@ -158,7 +164,11 @@ def test_train_step_epoch_end(tmpdir):
     assert out.batch_log_metrics['log_acc1'] == 12.0
     assert out.batch_log_metrics['log_acc2'] == 7.0
 
+    # outputs are for 1 optimizer and no tbptt
     train_step_end_out = out.training_step_output_for_epoch_end
+    assert len(train_step_end_out) == 1
+    train_step_end_out = train_step_end_out[0][0]
+
     pbar_metrics = train_step_end_out['progress_bar']
     assert pbar_metrics['pbar_acc1'] == 17.0
     assert pbar_metrics['pbar_acc2'] == 19.0

--- a/tests/trainer/test_trainer_steps_result_return.py
+++ b/tests/trainer/test_trainer_steps_result_return.py
@@ -74,6 +74,8 @@ def test_training_step_result_log_step_only(tmpdir):
     assert out.batch_log_metrics[f'step_log_acc2_b{batch_idx}'] == 12.0
 
     train_step_out = out.training_step_output_for_epoch_end
+    assert len(train_step_out) == 1
+    train_step_out = train_step_out[0][0]
     assert isinstance(train_step_out, TrainResult)
 
     assert 'minimize' in train_step_out
@@ -146,6 +148,8 @@ def test_training_step_result_log_epoch_only(tmpdir):
     assert len(out.batch_log_metrics) == 0
 
     train_step_out = out.training_step_output_for_epoch_end
+    assert len(train_step_out) == 1
+    train_step_out = train_step_out[0][0]
     assert isinstance(train_step_out, TrainResult)
 
     assert 'minimize' in train_step_out
@@ -277,6 +281,8 @@ def test_training_step_result_log_step_and_epoch(tmpdir):
     assert len(out.batch_log_metrics) == 2
 
     train_step_out = out.training_step_output_for_epoch_end
+    assert len(train_step_out) == 1
+    train_step_out = train_step_out[0][0]
     assert isinstance(train_step_out, TrainResult)
 
     assert 'minimize' in train_step_out
@@ -354,6 +360,8 @@ def test_training_step_epoch_end_result(tmpdir):
     assert len(out.batch_log_metrics) == 2
 
     train_step_out = out.training_step_output_for_epoch_end
+    assert len(train_step_out) == 1
+    train_step_out = train_step_out[0][0]
     assert isinstance(train_step_out, TrainResult)
 
     assert 'minimize' in train_step_out

--- a/tests/trainer/test_trainer_steps_scalar_return.py
+++ b/tests/trainer/test_trainer_steps_scalar_return.py
@@ -37,6 +37,8 @@ def test_training_step_scalar(tmpdir):
     assert len(out.grad_norm_dic) == 0 and isinstance(out.grad_norm_dic, dict)
 
     train_step_out = out.training_step_output_for_epoch_end
+    assert len(train_step_out) == 1
+    train_step_out = train_step_out[0][0]
     assert isinstance(train_step_out, torch.Tensor)
     assert train_step_out.item() == 171
 
@@ -72,6 +74,8 @@ def training_step_scalar_with_step_end(tmpdir):
     assert len(out.grad_norm_dic) == 0 and isinstance(out.grad_norm_dic, dict)
 
     train_step_out = out.training_step_output_for_epoch_end
+    assert len(train_step_out) == 1
+    train_step_out = train_step_out[0][0]
     assert isinstance(train_step_out, torch.Tensor)
     assert train_step_out.item() == 171
 
@@ -117,6 +121,8 @@ def test_full_training_loop_scalar(tmpdir):
     assert len(out.grad_norm_dic) == 0 and isinstance(out.grad_norm_dic, dict)
 
     train_step_out = out.training_step_output_for_epoch_end
+    assert len(train_step_out) == 1
+    train_step_out = train_step_out[0][0]
     assert isinstance(train_step_out, torch.Tensor)
     assert train_step_out.item() == 171
 
@@ -158,6 +164,8 @@ def test_train_step_epoch_end_scalar(tmpdir):
     assert len(out.grad_norm_dic) == 0 and isinstance(out.grad_norm_dic, dict)
 
     train_step_out = out.training_step_output_for_epoch_end
+    assert len(train_step_out) == 1
+    train_step_out = train_step_out[0][0]
     assert isinstance(train_step_out, torch.Tensor)
     assert train_step_out.item() == 171
 


### PR DESCRIPTION
Enables behavior that was previously not possible:

- passes the outputs of every time step back to the user for epoch_end hooks and for each optimizer in training.
- also enables auto-reduce and auto-padding when using a Result object
