### PR TITLE
fix missing return statement. Do not normalize remote paths

### DIFF
--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -289,7 +289,8 @@ class ModelCheckpoint(Callback):
         self.dirpath = ckpt_path
 
         assert trainer.global_rank == 0, 'tried to make a checkpoint from non global_rank=0'
-        os.makedirs(self.dirpath, exist_ok=True)
+        if not gfile.exists(self.dirpath):
+            makedirs(self.dirpath)
 
     @rank_zero_only
     def on_validation_end(self, trainer, pl_module):

--- a/pytorch_lightning/trainer/__init__.py
+++ b/pytorch_lightning/trainer/__init__.py
@@ -308,10 +308,12 @@ Example::
 default_root_dir
 ^^^^^^^^^^^^^^^^
 
-Default path for logs and weights when no logger
-or :class:`pytorch_lightning.callbacks.ModelCheckpoint` callback passed.
-On certain clusters you might want to separate where logs and checkpoints
-are stored. If you don't then use this argument for convenience.
+Default path for logs and weights when no logger or
+:class:`pytorch_lightning.callbacks.ModelCheckpoint` callback passed.  On
+certain clusters you might want to separate where logs and checkpoints are
+stored. If you don't then use this argument for convenience. Paths can be local
+paths or remote paths such as `s3://bucket/path` or 'hdfs://path/'. Credentials
+will need to be set up use remote filepaths.
 
 Example::
 

--- a/pytorch_lightning/trainer/__init__.py
+++ b/pytorch_lightning/trainer/__init__.py
@@ -313,7 +313,7 @@ Default path for logs and weights when no logger or
 certain clusters you might want to separate where logs and checkpoints are
 stored. If you don't then use this argument for convenience. Paths can be local
 paths or remote paths such as `s3://bucket/path` or 'hdfs://path/'. Credentials
-will need to be set up use remote filepaths.
+will need to be set up to use remote filepaths.
 
 Example::
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -220,6 +220,7 @@ class Trainer(
 
             default_root_dir: Default path for logs and weights when no logger/ckpt_callback passed.
                 Default: ``os.getcwd()``.
+                Can be remote file paths such as `s3://mybucket/path` or 'hdfs://path/'
 
             gradient_clip_val: 0 means don't clip.
 
@@ -305,7 +306,9 @@ class Trainer(
             weights_save_path: Where to save weights if specified. Will override default_root_dir
                     for checkpoints only. Use this if for whatever reason you need the checkpoints
                     stored in a different place than the logs written in `default_root_dir`.
+                    Can be remote file paths such as `s3://mybucket/path` or 'hdfs://path/'
                     Defaults to `default_root_dir`.
+
 
             amp_level: The optimization level to use (O1, O2, etc...).
                 .. warning:: .. deprecated:: v0.7.4

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -877,6 +877,9 @@ class Trainer(
         The default location to save artifacts of loggers, checkpoints etc.
         It is used as a fallback if logger or checkpoint callback do not define specific save paths.
         """
+        if "://" in str(self._default_root_dir):
+            # it is a remote uri, use as is
+            return self._default_root_dir
         return os.path.normpath(self._default_root_dir)
 
     @property
@@ -885,6 +888,9 @@ class Trainer(
         The default root location to save weights (checkpoints), e.g., when the
         :class:`~pytorch_lightning.callbacks.model_checkpoint.ModelCheckpoint` does not define a file path.
         """
+        if "://" in str(self._weights_save_path):
+            # it is a remote uri, use as is
+            return self._weights_save_path
         return os.path.normpath(self._weights_save_path)
 
     # -----------------------------

--- a/pytorch_lightning/utilities/cloud_io.py
+++ b/pytorch_lightning/utilities/cloud_io.py
@@ -1,4 +1,4 @@
-import sys
+import platform
 import os
 from typing import Union
 from pathlib import Path
@@ -35,11 +35,12 @@ def modern_gfile():
     file operations
     """
     tb_version = version.parse(tensorboard.version.VERSION)
-    modern_gfile = tb_version >= version.parse('2.0')
+    modern_gfile = tb_version >= version.parse("2.0")
+    return modern_gfile
 
 
-def cloud_open(path: pathlike, mode: str, newline:str = None):
-    if sys.platform == "win32":
+def cloud_open(path: pathlike, mode: str, newline: str = None):
+    if platform.system() == "Windows":
         log.debug(
             "gfile does not handle newlines correctly on windows so remote files are not"
             "supported falling back to normal local file open."

--- a/pytorch_lightning/utilities/cloud_io.py
+++ b/pytorch_lightning/utilities/cloud_io.py
@@ -43,7 +43,7 @@ def cloud_open(path: pathlike, mode: str, newline: str = None):
     if platform.system() == "Windows":
         log.debug(
             "gfile does not handle newlines correctly on windows so remote files are not"
-            "supported falling back to normal local file open."
+            " supported falling back to normal local file open."
         )
         return open(path, mode, newline=newline)
     if not modern_gfile():


### PR DESCRIPTION
## What does this PR do?
Fixes two issues found with #2164 merged yesterday. Local paths worked, but remote directory writing broke in a rebase. My bad.

This was now tested by training and passing `--default_root_dir='s3://mybucket/` at training and verified all files write successfully to an `s3` bucket. `v_num` successfully increments on multiple runs. Pointing a tensorboard at the s3 bucket successfully live updates while model is training. 

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [X] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
yup!
