### PR TITLE
constant root seed in reset_seed (tests)

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,10 +9,6 @@ TEMP_PATH = os.path.join(PACKAGE_ROOT, 'test_temp')
 
 # generate a list of random seeds for each test
 RANDOM_PORTS = list(np.random.randint(12000, 19000, 1000))
-ROOT_SEED = 1234
-torch.manual_seed(ROOT_SEED)
-np.random.seed(ROOT_SEED)
-RANDOM_SEEDS = list(np.random.randint(0, 10000, 1000))
 
 if not os.path.isdir(TEMP_PATH):
     os.mkdir(TEMP_PATH)

--- a/tests/base/develop_utils.py
+++ b/tests/base/develop_utils.py
@@ -72,8 +72,8 @@ def assert_ok_model_acc(trainer, key='test_acc', thr=0.5):
     assert acc > thr, f"Model failed to get expected {thr} accuracy. {key} = {acc}"
 
 
-def reset_seed():
-    seed_everything(3141)
+def reset_seed(seed=0):
+    seed_everything(seed)
 
 
 def set_random_master_port():

--- a/tests/base/develop_utils.py
+++ b/tests/base/develop_utils.py
@@ -7,7 +7,7 @@ import numpy as np
 from pytorch_lightning import seed_everything
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.loggers import TensorBoardLogger, TestTubeLogger
-from tests import TEMP_PATH, RANDOM_PORTS, RANDOM_SEEDS
+from tests import TEMP_PATH, RANDOM_PORTS
 from tests.base.model_template import EvalModelTemplate
 
 
@@ -73,8 +73,7 @@ def assert_ok_model_acc(trainer, key='test_acc', thr=0.5):
 
 
 def reset_seed():
-    seed = RANDOM_SEEDS.pop()
-    seed_everything(seed)
+    seed_everything(3141)
 
 
 def set_random_master_port():


### PR DESCRIPTION
## What does this PR do?

If a new test is added that calls reset_seed, the seed changes for all other tests that follow this new one, causing in rare cases that assertions with sensitivity to numerical precision fail. when we call reset_seed, we expect the seed to be set to the initial value.

