### PR TITLE
Fix checkpointing to remote file paths

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -53,6 +53,7 @@ from pytorch_lightning.trainer.training_tricks import TrainerTrainingTricksMixin
 from pytorch_lightning.utilities import parsing, rank_zero_info, rank_zero_only, rank_zero_warn, AMPType
 from pytorch_lightning.utilities.debugging import InternalDebugger
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
+from pytorch_lightning.utilities.cloud_io import is_remote_path
 
 # warnings to ignore in trainer
 warnings.filterwarnings(
@@ -880,7 +881,7 @@ class Trainer(
         The default location to save artifacts of loggers, checkpoints etc.
         It is used as a fallback if logger or checkpoint callback do not define specific save paths.
         """
-        if "://" in str(self._default_root_dir):
+        if is_remote_path(self._default_root_dir):
             # it is a remote uri, use as is
             return self._default_root_dir
         return os.path.normpath(self._default_root_dir)
@@ -891,7 +892,7 @@ class Trainer(
         The default root location to save weights (checkpoints), e.g., when the
         :class:`~pytorch_lightning.callbacks.model_checkpoint.ModelCheckpoint` does not define a file path.
         """
-        if "://" in str(self._weights_save_path):
+        if is_remote_path(self._weights_save_path):
             # it is a remote uri, use as is
             return self._weights_save_path
         return os.path.normpath(self._weights_save_path)

--- a/pytorch_lightning/utilities/cloud_io.py
+++ b/pytorch_lightning/utilities/cloud_io.py
@@ -28,6 +28,14 @@ def load(path_or_url: str, map_location=None):
     return torch.hub.load_state_dict_from_url(path_or_url, map_location=map_location)
 
 
+def is_remote_path(path: pathlike):
+    """Determine if a path is a local path or a remote path like s3://bucket/path
+
+    This should catch paths like s3:// hdfs:// and gcs://
+    """
+    return "://" in str(path)
+
+
 def modern_gfile():
     """Check the version number of tensorboard.
 
@@ -61,6 +69,7 @@ def cloud_open(path: pathlike, mode: str, newline: str = None):
 
 def makedirs(path: pathlike):
     if hasattr(gfile, "makedirs") and modern_gfile():
-        return gfile.makedirs(str(path))
+        if not gfile.exists(str(path)):
+            return gfile.makedirs(str(path))
     # otherwise minimal dependencies are installed and only local files will work
     return os.makedirs(path, exist_ok=True)


### PR DESCRIPTION
## What does this PR do?
Fixes #2916

Better handling of file paths when checkpointing. 

- Never try to makedirs on directories which exist
- When writing checkpoints, write to a buffer then write the buffer to the desired out. This prevents the temporary `.part` file from being created. Which if remote could be slower.
- Warn in a corner case with certain dependencies that remote directories are supported but delete operations are not. 

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [X] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
