### PR TITLE
Add docs for GpuUsageLogger

### DIFF
--- a/docs/source/callbacks.rst
+++ b/docs/source/callbacks.rst
@@ -69,7 +69,7 @@ We successfully extended functionality without polluting our super clean
 
 ----------------
 
-.. automodule:: pytorch_lightning.callbacks.gpu_usage_looger
+.. automodule:: pytorch_lightning.callbacks.gpu_usage_logger
     :noindex:
     :exclude-members:
         _get_gpu_stat,

--- a/docs/source/callbacks.rst
+++ b/docs/source/callbacks.rst
@@ -69,6 +69,15 @@ We successfully extended functionality without polluting our super clean
 
 ----------------
 
+.. automodule:: pytorch_lightning.callbacks.gpu_usage_looger
+    :noindex:
+    :exclude-members:
+        _get_gpu_stat,
+        _log_gpu,
+        _log_memory
+
+----------------
+
 .. automodule:: pytorch_lightning.callbacks.gradient_accumulation_scheduler
    :noindex:
    :exclude-members:

--- a/pytorch_lightning/callbacks/gpu_usage_logger.py
+++ b/pytorch_lightning/callbacks/gpu_usage_logger.py
@@ -28,7 +28,7 @@ class GpuUsageLogger(Callback):
             intra_step_time: Set to ``True`` to log the time of each step. Default: ``False``
             inter_step_time: Set to ``True`` to log the time between the end of one step
                 and the start of the next. Default: ``False``
-            fan_speed: Set to ``False`` to log percentage of fan speed. Default: ``False``.
+            fan_speed: Set to ``True`` to log percentage of fan speed. Default: ``False``.
             temperature: Set to ``True`` to log the memory and gpu temperature in degrees C.
                 Default: ``False``
         Example::


### PR DESCRIPTION
## What does this PR do?

Adds the newly added GpuUsageLogger (https://github.com/PyTorchLightning/pytorch-lightning/pull/2932) to the docs