### PR TITLE
Changes to quick start docs

### DIFF
--- a/docs/source/new-project.rst
+++ b/docs/source/new-project.rst
@@ -1,6 +1,7 @@
 .. testsetup:: *
 
     from pytorch_lightning.core.lightning import LightningModule
+    from pytorch_lightning.core.datamodule import LightningDataModule
     from pytorch_lightning.trainer.trainer import Trainer
     import os
     import torch
@@ -21,13 +22,13 @@ Organizing your code with PyTorch Lightning makes your code:
 * Easier to reproduce
 * less error prone by automtaing most of the training loop and tricky engineering
 * keep all the flexibility (this is all pure PyTorch), but removes a ton of boilerplate
-* scalable to any hardware without changing a thing!
+* scalable to any hardware without changing your model
 
 To illustrate, here's the typical PyTorch project structure organized in a :class:`~pytorch_lightning.core.LightningModule`.
 
 .. raw:: html
 
-    <video width="800" controls autoplay src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/pl_module_vid.m4v"></video>
+    <video width="100%" controls autoplay src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/pl_module_vid.m4v"></video>
 
 
 ----------
@@ -100,60 +101,62 @@ It organizes your research code into :ref:`hooks`.
         def configure_optimizers(self):
             return torch.optim.Adam(self.parameters(), lr=0.0005)
             
-            
-You can use your :class:`~pytorch_lightning.core.LightningModule` just like a PyTorch model. Read more about :ref:`lightning-module`s.
+In the snippet above we override the basic hooks, but a full list of hooks to custumize can be found under :ref:`hooks`.
+
+You can use your :class:`~pytorch_lightning.core.LightningModule` just like a PyTorch model.
+Learn more `here <https://pytorch-lightning.readthedocs.io/en/stable/lightning-module.html>`_.
 
 ----------
 
-*******************************
-Step 3: Define you data loaders
-*******************************
+***************************
+Step 3: Define data loaders
+***************************
 
 LightningDataModule
 ===================
-A :class:`~pytorch_lightning.core.datamodule.LightningDataModule` is simply a collection of all 3 data splits but also captures:
+A :class:`~pytorch_lightning.core.datamodule.LightningDataModule` is a shareable, reusable class that encapsulates all the steps needed to process data: downloading, tokenizeing, processing etc.
 
-- Download instructions
-- Processing
-- Splitting
-- etc...
-
-This is how you refactor your code into reusable DataModules:
+To refactor your code into reusable DataModules:
 
 .. raw:: html
 
-    <video width="800" controls autoplay src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/pt_dm_vid.m4v"></video>
+    <video width="100%" controls autoplay src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/pt_dm_vid.m4v"></video>
 
 |
 
 And the matching code:
 
 |
+
 .. code-block:: python
 
-    class MyDataModule(pl.DataModule):
+  class MNISTDataModule(pl.LightningDataModule):
 
-        def __init__(self):
-            ...
+    def __init__(self, data_dir: str = PATH, batch_size):
+        super().__init__()
+        self.batch_size = batch_size
 
-        def train_dataloader(self):
-            # your train transforms
-            return DataLoader(YOUR_DATASET)
+    def setup(self, stage=None):
+        self.mnist_test = MNIST(self.data_dir, train=False)
+        mnist_full = MNIST(self.data_dir, train=True)
+        self.mnist_train, self.mnist_val = random_split(mnist_full, [55000, 5000])
 
-        def val_dataloader(self):
-            # your val transforms
-            return DataLoader(YOUR_DATASET)
+    def train_dataloader(self):
+        return DataLoader(self.mnist_train, batch_size=self.batch_size)
 
-        def test_dataloader(self):
-            # your test transforms
-            return DataLoader(YOUR_DATASET)
+    def val_dataloader(self):
+        return DataLoader(self.mnist_val, batch_size=self.batch_size)
+
+    def test_dataloader(self):
+        return DataLoader(self.mnist_test, batch_size=self.batch_size)
 
 
-DataModules are specifically useful for building models based on data. Read more on :ref:`data-modules`
+
+:class:`~pytorch_lightning.core.datamodule.LightningDataModule` is designed to enable sharing and reusing data splits and transforms across different projects. DataModules are specifically useful for building models based on data. Read more on :ref:`data-modules`.
 
 PyTorch DataLoader
 ==================
-If you don't want to craete a :class:`~pytorch_lightning.core.datamodule.LightningDataModule` you can use plain PyTorch :class:`~torch.utils.data.DataLoader`, and add them to your :class:`~pytorch_lightning.core.lightningModule`:
+Instead of creating a LightningDataModule you can also use plain PyTorch :class:`~torch.utils.data.DataLoader`, and add them to your :class:`~pytorch_lightning.core.LightningModule` using dataloader hooks:
 
 .. code-block:: python
 
@@ -164,23 +167,31 @@ If you don't want to craete a :class:`~pytorch_lightning.core.datamodule.Lightni
             data_set = MNIST(os.getcwd(), download=True, transform=transforms.ToTensor())
             return DataLoader(data_set)
             
-or just use them directly in your :class:`~pytorch_lightning.trainer.Trainer`.
+or just pass the dataloaders directly to your Lightning :class:`~pytorch_lightning.trainer.Trainer`.
+
+.. code-block:: python
+
+    trainer.fit(model, train_dataloader)
+
 
 ----------
 
-**************************
-Step 4: Fit with a Trainer
-**************************
-Init your :class:`~pytorch_lightning.core.LightningModule`, your :class:`~pytorch_lightning.core.datamodule.LightningDataModule` and then the :class:`~pytorch_lightning.trainer.Trainer`. 
-The Lightning :class:`~pytorch_lightning.trainer.Trainer` automates most of the training engineering code such as:
+**********************************
+Step 4: Fit with Lightning Trainer
+**********************************
+
+Init :class:`~pytorch_lightning.core.LightningModule`, your :class:`~pytorch_lightning.core.datamodule.LightningDataModule` and then the PyTorch Lightning :class:`~pytorch_lightning.trainer.Trainer`. 
+The :class:`~pytorch_lightning.trainer.Trainer` automates most of the training engineering code such as:
 
 * The epoch iteration
 * The batch iteration
 * Calling of optimizer.step()
 
+It also ensures it all works well across any accelerator.
+
 .. raw:: html
 
-    <video width="800" controls autoplay src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/pt_trainer_mov.m4v"></video>
+    <video width="100%" controls autoplay src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/pt_trainer_mov.m4v"></video>
 
 |
 
@@ -192,50 +203,105 @@ Here's an example of using the :class:`~pytorch_lightning.trainer.Trainer`:
     # init model
     model = LitModel()
     # init data
-    data_module = MyDataModule()
+    data_module = MNISTDataModule(batch_size=32)
 
     # most basic trainer, uses good defaults
     trainer = pl.Trainer()
     trainer.fit(model, data_module)
 
-Using GPUs/TPUs
-===============
-It's trivial to use GPUs or TPUs in Lightning. There's NO NEED to change your code, simply change the :class:`~pytorch_lightning.trainer.Trainer` options.
+The :class:`~pytorch_lightning.trainer.Trainer` will provide
 
-.. code-block:: python
-
-    # train on 1, 2, 4, n GPUs
-    trainer = pl.Trainer(gpus=1)
-    trainer = pl.Trainer(gpus=2)
-    trainer = pl.Trainer(gpus=8, num_nodes=n)
-
-    # train on TPUs
-    trainer = pl.Trainer(tpu_cores=8)
-    trainer = pl.Trainer(tpu_cores=128)
-
-    # even mixed precision
-    trainer = pl.Trainer(gpus=2, precision=16)
-    
-The :class:`~pytorch_lightning.core.Trainer` will provide
-
-* Automatic :ref:`weights_loading`
-* Automatic Tensorboard (see :ref:`logging` options)
-* Automatic :ref:`multi_pgu`
+* Automatic :ref:`weights-loading`
+* Automatic Tensorboard (see :ref:`loggers` options)
+* Automatic :ref:`multi-gpu-training` support
 * Automatic :ref:`tpu`
-* Automatic :ref:`apex`
+* Automatic :ref:`16-bit` support
 
 All automated code is rigorously tested and benchmarked.
 
-Main take-aways:
-
-- Lightning sets .train() and enables gradients when entering the training loop.
-- Lightning iterates over the epochs automatically.
-- Lightning iterates the dataloaders automatically.
-- :func:`pytorch_lightning.core.lightning.LightningModule.training_step` gives you full control of the main loop.
-- :func:`pytorch_lightning.core.lightning.LightningModule.backward`, :func:`pytorch_lightning.core.lightning.LightningModule.step`, :func:`pytorch_lightning.core.lightning.LightningModule.zero_grad` are called for you. BUT, you can override this if you need manual control.
-
 Check out more flags in the :ref:`trainer` docs.
 
+Using CPUs/GPUs/TPUs
+====================
+It's trivial to use CPUs, GPUs or TPUs in Lightning. There's NO NEED to change your code, simply change the :class:`~pytorch_lightning.trainer.Trainer` options.
+
+.. code-block:: python
+
+  # train on 1024 CPUs across 128 machines
+    trainer = pl.Trainer(
+        num_processes=8,
+        num_nodes=128
+    )
+
+.. code-block:: python
+
+    # train on 1 GPU
+    trainer = pl.Trainer(gpus=1)
+
+.. code-block:: python
+
+    # train on 256 GPUs
+    trainer = pl.Trainer(
+        gpus=8,
+        num_nodes=32
+    )
+
+.. code-block:: python
+
+    # Multi GPU with mixed precision
+    trainer = pl.Trainer(gpus=2, precision=16)
+
+.. code-block:: python
+
+    # Train on TPUs
+    trainer = pl.Trainer(tpu_cores=8)
+
+Without changing a SINGLE line of your code, you can now do the following with the above code:
+
+.. code-block:: python
+
+    # train on TPUs using 16 bit precision with early stopping
+    # using only half the training data and checking validation every quarter of a training epoch
+    trainer = pl.Trainer(
+        tpu_cores=8,
+        precision=16,
+        early_stop_callback=True,
+        limit_train_batches=0.5,
+        val_check_interval=0.25
+    )
+
+Training loop under the hood
+============================
+This is the training loop pseudocode that lightning does under the hood:
+
+.. code-block:: python
+
+    # init model
+    model = LitModel()
+
+    # enable training
+    torch.set_grad_enabled(True)
+    model.train()
+
+    # get data + optimizer
+    train_dataloader = model.data_module().train_dataloader()
+    optimizer = model.configure_optimizers()
+
+    for epoch in epochs:
+        for batch in train_dataloader:
+            # forward (TRAINING_STEP)
+            loss = model.training_step(batch)
+
+            # backward
+            loss.backward()
+
+            # apply and clear grads
+            optimizer.step()
+            optimizer.zero_grad()
+
+
+- :func:`pytorch_lightning.core.lightning.LightningModule.training_step` gives you full control of the main loop.
+- :func:`pytorch_lightning.core.lightning.LightningModule.backward`, :func:`pytorch_lightning.core.lightning.LightningModule.optimizer_step`, :func:`pytorch_lightning.core.lightning.LightningModule.optimizer_zero_grad` are called for you. BUT, you can override this if you need manual control.
 
 --------------
 
@@ -260,13 +326,13 @@ To add an (optional) validation loop add the following callback to your :class:`
             result.log('val_loss', loss)
             return result
 
-.. note:: :class:`~pytorch_lightning.core.step_result.EvalResult` is a plain Dict, with convenience functions for logging. Read more in :ref:`results`.
+.. note:: :class:`~pytorch_lightning.core.step_result.EvalResult` is a plain Dict, with convenience functions for logging. Read more in :ref:`result`.
 
 And to your :class:`~pytorch_lightning.core.datamodule.LightningDataModule`:
 
-.. code-block:: python
+.. testcode:: python
 
-    class MyDataModule(pl.DataModule):
+    class MyDataModule(LightningDataModule):
 
         def __init__(self):
             ...
@@ -277,6 +343,8 @@ And to your :class:`~pytorch_lightning.core.datamodule.LightningDataModule`:
 
 And now the :class:`~pytorch_lightning.trainer.Trainer` will call the validation loop automatically.
 
+Validation loop under the hood
+------------------------------
 
 Lightning automatically:
 
@@ -284,7 +352,31 @@ Lightning automatically:
 - Disables gradients and sets model to eval() in val loop
 - After val loop ends, enables gradients and sets model to train()
 
+.. code-block:: python
+
+    # ...
+    for batch in train_dataloader:
+        loss = model.training_step()
+        loss.backward()
+        # ...
+
+        if validate_at_some_point:
+            # disable grads + batchnorm + dropout
+            torch.set_grad_enabled(False)
+            model.eval()
+
+            val_outs = []
+            for val_batch in model.data_module.val_dataloader:
+                val_out = model.validation_step(val_batch)
+                val_outs.append(val_out)
+            model.validation_epoch_end(val_outs)
+
+            # enable grads + batchnorm + dropout
+            torch.set_grad_enabled(True)
+            model.train()
+
 -------------
+
 
 Adding a Test loop
 ==================
@@ -304,13 +396,13 @@ You might also need an optional test loop. Similarly, add the following callback
             result.log('test_loss', loss)
             return result
 
-.. note:: :class:`~pytorch_lightning.core.step_result.EvalResult` is a plain Dict, with convenience functions for logging. Read more in :ref:`results`.
+.. note:: :class:`~pytorch_lightning.core.step_result.EvalResult` is a plain Dict, with convenience functions for logging. Read more in :ref:`result`.
 
 And to your :class:`~pytorch_lightning.core.datamodule.LightningDataModule`:
 
-.. code-block:: python
+.. testcode:: python
 
-    class MyDataModule(pl.DataModule):
+    class MyDataModule(LightningDataModule):
 
         def __init__(self):
             ...
@@ -339,147 +431,6 @@ However, this time you need to specifically call test (this is done so you don't
     trainer.test(datamodule=data_module)
 
 
------------------
-
-
-***********
-Ready to go
-***********
-
-Without changing a SINGLE line of your code, you can now do the following with the above code:
-
-.. code-block:: python
-
-    # train on TPUs using 16 bit precision with early stopping
-    # using only half the training data and checking validation every quarter of a training epoch
-    trainer = Trainer(
-        tpu_cores=8,
-        precision=16,
-        early_stop_callback=True,
-        limit_train_batches=0.5,
-        val_check_interval=0.25
-    )
-
-
-.. code-block:: python
-
-    # train on 256 GPUs
-    trainer = Trainer(
-        gpus=8,
-        num_nodes=32
-    )
-
-
-.. code-block:: python
-
-  # train on 1024 CPUs across 128 machines
-    trainer = Trainer(
-        num_processes=8,
-        num_nodes=128
-    )
-
-And the best part is that your code is STILL just PyTorch... meaning you can do anything you
-would normally do.
-
-.. code-block:: python
-
-    model = LitModel()
-    model.eval()
-
-    y_hat = model(x)
-
-    model.anything_you_can_do_with_pytorch()
-
----------------
-
-Once you define and train your first Lightning model, you might want to try other cool features like
-
-- :ref:`logging`
-- `Automatic checkpointing <https://pytorch-lightning.readthedocs.io/en/stable/weights_loading.html>`_
-- `Automatic early stopping <https://pytorch-lightning.readthedocs.io/en/stable/early_stopping.html>`_
-- `Add custom callbacks <https://pytorch-lightning.readthedocs.io/en/stable/callbacks.html>`_
-- `Dry run mode <https://pytorch-lightning.readthedocs.io/en/stable/debugging.html#fast-dev-run>`_ (Hit every line of your code once to see if you have bugs, instead of waiting hours to crash on validation ;)
-- `Automatically overfit your model for a sanity test <https://pytorch-lightning.readthedocs.io/en/stable/debugging.html?highlight=overfit#make-model-overfit-on-subset-of-data>`_
-- `Automatic truncated-back-propagation-through-time <https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.trainer.training_loop.html?highlight=truncated#truncated-backpropagation-through-time>`_
-- `Automatically scale your batch size <https://pytorch-lightning.readthedocs.io/en/stable/training_tricks.html?highlight=batch%20size#auto-scaling-of-batch-size>`_
-- `Automatically find a good learning rate <https://pytorch-lightning.readthedocs.io/en/stable/lr_finder.html>`_
-- `Load checkpoints directly from S3 <https://pytorch-lightning.readthedocs.io/en/stable/weights_loading.html#checkpoint-loading>`_
-- `Profile your code for speed/memory bottlenecks <https://pytorch-lightning.readthedocs.io/en/stable/profiler.html>`_
-- `Scale to massive compute clusters <https://pytorch-lightning.readthedocs.io/en/stable/slurm.html>`_
-- `Use multiple dataloaders per train/val/test loop <https://pytorch-lightning.readthedocs.io/en/stable/multiple_loaders.html>`_
-- `Use multiple optimizers to do Reinforcement learning or even GANs <https://pytorch-lightning.readthedocs.io/en/stable/optimizers.html?highlight=multiple%20optimizers#use-multiple-optimizers-like-gans>`_
-
------------
-
-************************
-Lightning under the hood
-************************
-Lightning is designed for state of the art research ideas by researchers and research engineers from top labs.
-
-A :class:`~pytorch_lightning.core.LightningModule` handles advances cases by allowing you to override any critical part of training
-via :ref:`hooks` that are called on your :class:`~pytorch_lightning.core.LightningModule`.
-
-.. raw:: html
-
-    <video width="800" controls autoplay src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/pt_callbacks_mov.m4v"></video>
-
-----------------
-
-Training loop under the hood
-----------------------------
-This is the training loop pseudocode that lightning does under the hood:
-
-.. code-block:: python
-
-    # init model
-    model = LitModel()
-
-    # enable training
-    torch.set_grad_enabled(True)
-    model.train()
-
-    # get data + optimizer
-    train_dataloader = model.data_module().train_dataloader()
-    optimizer = model.configure_optimizers()
-
-    for epoch in epochs:
-        for batch in train_dataloader:
-            # forward (TRAINING_STEP)
-            loss = model.training_step(batch)
-
-            # backward
-            loss.backward()
-
-            # apply and clear grads
-            optimizer.step()
-            optimizer.zero_grad()
-            
-Validation loop under the hood
-------------------------------
-
-.. code-block:: python
-
-    # ...
-    for batch in train_dataloader:
-        loss = model.training_step()
-        loss.backward()
-        # ...
-
-        if validate_at_some_point:
-            # disable grads + batchnorm + dropout
-            torch.set_grad_enabled(False)
-            model.eval()
-
-            val_outs = []
-            for val_batch in model.data_module.val_dataloader:
-                val_out = model.validation_step(val_batch)
-                val_outs.append(val_out)
-            model.validation_epoch_end(val_outs)
-
-            # enable grads + batchnorm + dropout
-            torch.set_grad_enabled(True)
-            model.train()
-
 Test loop under the hood
 ------------------------
 
@@ -500,12 +451,62 @@ Test loop under the hood
     torch.set_grad_enabled(True)
     model.train()
 
-----------
+-----------------
 
+**********
+Learn more
+**********
 
-***********
+That's it! Once you build your module, data, and call trainer.fit(), Lightning trainer calls each loop at the correct time as needed.
+
+.. raw:: html
+
+    <video width="100%" controls autoplay src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/pt_callbacks_mov.m4v"></video>
+
+A :class:`~pytorch_lightning.core.LightningModule` handles advances cases by allowing you to override any critical part of training
+via :ref:`hooks` that are called on your :class:`~pytorch_lightning.core.LightningModule`.
+
+And the best part is that your code is STILL just PyTorch... meaning you can do anything you
+would normally do.
+
+.. code-block:: python
+
+    model = LitModel()
+    model.eval()
+
+    y_hat = model(x)
+
+    model.anything_you_can_do_with_pytorch()
+
+---------------
+
+Advanced Lightning Features
+===========================
+
+Once you define and train your first Lightning model, you might want to try other cool features like
+
+- :ref:`loggers`
+- `Automatic checkpointing <https://pytorch-lightning.readthedocs.io/en/stable/weights_loading.html>`_
+- `Automatic early stopping <https://pytorch-lightning.readthedocs.io/en/stable/early_stopping.html>`_
+- `Add custom callbacks <https://pytorch-lightning.readthedocs.io/en/stable/callbacks.html>`_
+- `Dry run mode <https://pytorch-lightning.readthedocs.io/en/stable/debugging.html#fast-dev-run>`_ (Hit every line of your code once to see if you have bugs, instead of waiting hours to crash on validation ;)
+- `Automatically overfit your model for a sanity test <https://pytorch-lightning.readthedocs.io/en/stable/debugging.html?highlight=overfit#make-model-overfit-on-subset-of-data>`_
+- `Automatic truncated-back-propagation-through-time <https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.trainer.training_loop.html?highlight=truncated#truncated-backpropagation-through-time>`_
+- `Automatically scale your batch size <https://pytorch-lightning.readthedocs.io/en/stable/training_tricks.html?highlight=batch%20size#auto-scaling-of-batch-size>`_
+- `Automatically find a good learning rate <https://pytorch-lightning.readthedocs.io/en/stable/lr_finder.html>`_
+- `Load checkpoints directly from S3 <https://pytorch-lightning.readthedocs.io/en/stable/weights_loading.html#checkpoint-loading>`_
+- `Profile your code for speed/memory bottlenecks <https://pytorch-lightning.readthedocs.io/en/stable/profiler.html>`_
+- `Scale to massive compute clusters <https://pytorch-lightning.readthedocs.io/en/stable/slurm.html>`_
+- `Use multiple dataloaders per train/val/test loop <https://pytorch-lightning.readthedocs.io/en/stable/multiple_loaders.html>`_
+- `Use multiple optimizers to do Reinforcement learning or even GANs <https://pytorch-lightning.readthedocs.io/en/stable/optimizers.html?highlight=multiple%20optimizers#use-multiple-optimizers-like-gans>`_
+
+Or read our :ref:`introduction-guide` to learn more!
+
+-------------
+
 Masterclass
-***********
+===========
+
 Go pro by tunning in to our Masterclass! New episodes every week.
 
 .. image:: _images/general/PTL101_youtube_thumbnail.jpg
@@ -514,6 +515,4 @@ Go pro by tunning in to our Masterclass! New episodes every week.
     :alt: Masterclass
     :target: https://www.youtube.com/playlist?list=PLaMu-SDt_RB5NUm67hU2pdE75j6KaIOv2
     
-
-Or read our :ref:`introduction-guide` to learn more!
 

--- a/docs/source/new-project.rst
+++ b/docs/source/new-project.rst
@@ -9,30 +9,73 @@
 
 .. _quick-start:
 
+###########
 Quick Start
-===========
+###########
 
-PyTorch Lightning is nothing more than organized PyTorch code.
+New to PyTorch Lightning and want to give it a go? Quick prototyping is our specility- you came to the right place!
 
-Once you've organized it into a LightningModule, it automates most of the training for you.
+Organizing your code with PyTorch Lightning makes your code:
 
-To illustrate, here's the typical PyTorch project structure organized in a LightningModule.
+* more readable by decoupling the research code from the engineering
+* Easier to reproduce
+* less error prone by automtaing most of the training loop and tricky engineering
+* keep all the flexibility (this is all pure PyTorch), but removes a ton of boilerplate
+* scalable to any hardware without changing a thing!
+
+To illustrate, here's the typical PyTorch project structure organized in a :class:`~pytorch_lightning.core.LightningModule`.
 
 .. raw:: html
 
     <video width="800" controls autoplay src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/pl_module_vid.m4v"></video>
 
+   
+In this guide we will go over how to build your Lightning code in 5 steps!
+
+
 ----------
 
-Step 1: Build LightningModule
------------------------------
-A lightningModule defines
+*********************************
+Step 1: Install PyTorch Lightning
+*********************************
 
-- Train loop
-- Val loop
-- Test loop
-- Model + system architecture
-- Optimizer
+
+You can install using `pip <https://pypi.org/project/pytorch-lightning/>`_ 
+
+.. code-block:: bash
+
+    pip install pytorch-lightning
+    
+Or with `conda <https://anaconda.org/conda-forge/pytorch-lightning>`_ (see how to install conda `here <https://docs.conda.io/projects/conda/en/latest/user-guide/install/>`_):
+
+.. code-block:: bash
+
+    conda install pytorch-lightning -c conda-forge
+
+You could also use conda environments
+
+.. code-block:: bash
+
+    conda activate my_env
+    pip install pytorch-lightning
+
+
+----------
+
+******************************
+Step 2: Define LightningModule
+*********************************
+The :class:`~pytorch_lightning.core.LightningModule` holds your research code:
+
+- The Train loop
+- The Validation loop
+- The Test loop
+- The Model + system architecture
+- The Optimizer
+
+A :class:`~pytorch_lightning.core.LightningModule` is a :class:`torch.nn.Module` but with added functionality.
+It organizes your research code into :ref:`hooks`.
+
 
 .. testcode::
     :skipif: not TORCHVISION_AVAILABLE
@@ -58,287 +101,26 @@ A lightningModule defines
 
         def configure_optimizers(self):
             return torch.optim.Adam(self.parameters(), lr=0.0005)
+            
+            
+You can use your :class:`~pytorch_lightning.core.LightningModule` just like a PyTorch model. Read more about :ref:`lightning-module`s.
 
 ----------
 
-Step 2: Fit with a Trainer
---------------------------
-The trainer calls each loop at the correct time as needed. It also ensures it all works
-well across any accelerator.
-
-.. raw:: html
-
-    <video width="800" controls autoplay src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/pt_trainer_mov.m4v"></video>
-
-|
-
-Here's an example of using the Trainer:
-
-.. code-block:: python
-
-    # dataloader
-    dataset = MNIST(os.getcwd(), download=True, transform=transforms.ToTensor())
-    train_loader = DataLoader(dataset)
-
-    # init model
-    model = LitModel()
-
-    # most basic trainer, uses good defaults
-    trainer = pl.Trainer()
-    trainer.fit(model, train_loader)
-
-Using GPUs/TPUs
-^^^^^^^^^^^^^^^
-It's trivial to use GPUs or TPUs in Lightning. There's NO NEED to change your code, simply change the Trainer options.
-
-.. code-block:: python
-
-    # train on 1, 2, 4, n GPUs
-    Trainer(gpus=1)
-    Trainer(gpus=2)
-    Trainer(gpus=8, num_nodes=n)
-
-    # train on TPUs
-    Trainer(tpu_cores=8)
-    Trainer(tpu_cores=128)
-
-    # even half precision
-    Trainer(gpus=2, precision=16)
-
-The code above gives you the following for free:
-
-- Automatic checkpoints
-- Automatic Tensorboard (or the logger of your choice)
-- Automatic CPU/GPU/TPU training
-- Automatic 16-bit precision
-
-All of it 100% rigorously tested and benchmarked
-
---------------
-
-Lightning under the hood
-^^^^^^^^^^^^^^^^^^^^^^^^
-Lightning is designed for state of the art research ideas by researchers and research engineers from top labs.
-
-A LightningModule handles advances cases by allowing you to override any critical part of training
-via hooks that are called on your LightningModule.
-
-.. raw:: html
-
-    <video width="800" controls autoplay src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/pt_callbacks_mov.m4v"></video>
-
-----------------
-
-Training loop under the hood
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-This is the training loop pseudocode that lightning does under the hood:
-
-.. code-block:: python
-
-    # init model
-    model = LitModel()
-
-    # enable training
-    torch.set_grad_enabled(True)
-    model.train()
-
-    # get data + optimizer
-    train_dataloader = model.train_dataloader()
-    optimizer = model.configure_optimizers()
-
-    for epoch in epochs:
-        for batch in train_dataloader:
-            # forward (TRAINING_STEP)
-            loss = model.training_step(batch)
-
-            # backward
-            loss.backward()
-
-            # apply and clear grads
-            optimizer.step()
-            optimizer.zero_grad()
-
-Main take-aways:
-
-- Lightning sets .train() and enables gradients when entering the training loop.
-- Lightning iterates over the epochs automatically.
-- Lightning iterates the dataloaders automatically.
-- Training_step gives you full control of the main loop.
-- .backward(), .step(), .zero_grad() are called for you. BUT, you can override this if you need manual control.
-
-----------
-
-Adding a Validation loop
-------------------------
-To add an (optional) validation loop add the following function
-
-.. testcode::
-
-    class LitModel(LightningModule):
-
-        def validation_step(self, batch, batch_idx):
-            x, y = batch
-            y_hat = self(x)
-            loss = F.cross_entropy(y_hat, y)
-
-            result = pl.EvalResult(checkpoint_on=loss)
-            result.log('val_loss', loss)
-            return result
-
-.. note:: EvalResult is a plain Dict, with convenience functions for logging
-
-And now the trainer will call the validation loop automatically
-
-.. code-block:: python
-
-    # pass in the val dataloader to the trainer as well
-    trainer.fit(
-        model,
-        train_dataloader,
-        val_dataloader
-    )
-
-Validation loop under the hood
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Under the hood in pseudocode, lightning does the following:
-
-.. code-block:: python
-
-    # ...
-    for batch in train_dataloader:
-        loss = model.training_step()
-        loss.backward()
-        # ...
-
-        if validate_at_some_point:
-            # disable grads + batchnorm + dropout
-            torch.set_grad_enabled(False)
-            model.eval()
-
-            val_outs = []
-            for val_batch in model.val_dataloader:
-                val_out = model.validation_step(val_batch)
-                val_outs.append(val_out)
-            model.validation_epoch_end(val_outs)
-
-            # enable grads + batchnorm + dropout
-            torch.set_grad_enabled(True)
-            model.train()
-
-Lightning automatically:
-
-- Enables gradients and sets model to train() in the train loop
-- Disables gradients and sets model to eval() in val loop
-- After val loop ends, enables gradients and sets model to train()
-
--------------
-
-Adding a Test loop
-------------------
-You might also need an optional test loop
-
-.. testcode::
-
-    class LitModel(LightningModule):
-
-        def test_step(self, batch, batch_idx):
-            x, y = batch
-            y_hat = self(x)
-            loss = F.cross_entropy(y_hat, y)
-
-            result = pl.EvalResult()
-            result.log('test_loss', loss)
-            return result
-
-
-However, this time you need to specifically call test (this is done so you don't use the test set by mistake)
-
-.. code-block:: python
-
-    # OPTION 1:
-    # test after fit
-    trainer.fit(model)
-    trainer.test(test_dataloaders=test_dataloader)
-
-    # OPTION 2:
-    # test after loading weights
-    model = LitModel.load_from_checkpoint(PATH)
-    trainer = Trainer()
-    trainer.test(test_dataloaders=test_dataloader)
-
-Test loop under the hood
-^^^^^^^^^^^^^^^^^^^^^^^^
-Under the hood, lightning does the following in (pseudocode):
-
-.. code-block:: python
-
-    # disable grads + batchnorm + dropout
-    torch.set_grad_enabled(False)
-    model.eval()
-
-    test_outs = []
-    for test_batch in model.test_dataloader:
-        test_out = model.test_step(val_batch)
-        test_outs.append(test_out)
-
-    model.test_epoch_end(test_outs)
-
-    # enable grads + batchnorm + dropout
-    torch.set_grad_enabled(True)
-    model.train()
-
----------------
-
-Data
-----
-Lightning operates on standard PyTorch Dataloaders (of any flavor). Use dataloaders in 3 ways.
-
-Data in fit
-^^^^^^^^^^^
-Pass the dataloaders into `trainer.fit()`
-
-.. code-block:: python
-
-    trainer.fit(model, train_dataloader, val_dataloader)
-
-Data in LightningModule
-^^^^^^^^^^^^^^^^^^^^^^^
-For fast research prototyping, it might be easier to link the model with the dataloaders.
-
-.. code-block:: python
-
-    class LitModel(pl.LightningModule):
-
-        def train_dataloader(self):
-            # your train transforms
-            return DataLoader(YOUR_DATASET)
-
-        def val_dataloader(self):
-            # your val transforms
-            return DataLoader(YOUR_DATASET)
-
-        def test_dataloader(self):
-            # your test transforms
-            return DataLoader(YOUR_DATASET)
-
-And fit like so:
-
-.. code-block:: python
-
-    model = LitModel()
-    trainer.fit(model)
-
-DataModule
-^^^^^^^^^^
-A more reusable approach is to define a DataModule which is simply a collection of all 3 data splits but
-also captures:
-
-- download instructions.
-- processing.
-- splitting.
+*******************************
+Step 3: Define you data loaders
+*******************************
+
+LightningDataModule
+===================
+A :class:`~pytorch_lightning.core.datamodule.LightningDataModule` is simply a collection of all 3 data splits but also captures:
+
+- Download instructions
+- Processing
+- Splitting
 - etc...
 
-Here's an illustration that explains how to refactor your code into reusable DataModules.
+This is how you refactor your code into reusable DataModules:
 
 .. raw:: html
 
@@ -349,7 +131,6 @@ Here's an illustration that explains how to refactor your code into reusable Dat
 And the matching code:
 
 |
-
 .. code-block:: python
 
     class MyDataModule(pl.DataModule):
@@ -369,246 +150,207 @@ And the matching code:
             # your test transforms
             return DataLoader(YOUR_DATASET)
 
-And train like so:
+
+DataModules are specifically useful for building models based on data. Read more on :ref:`data-modules`
+
+PyTorch DataLoader
+==================
+If you don't want to craete a :class:`~pytorch_lightning.core.datamodule.LightningDataModule` you can use plain PyTorch :class:`~torch.utils.data.DataLoader`, and add them to your :class:`~pytorch_lightning.core.lightningModule`:
 
 .. code-block:: python
 
-    dm = MyDataModule()
-    trainer.fit(model, dm)
+    class LitModel(pl.LightningModule):
 
-When doing distributed training, Datamodules have two optional arguments for granular control
-over download/prepare/splitting data
+        def train_dataloader(self):
+            # your train transforms
+            data_set = MNIST(os.getcwd(), download=True, transform=transforms.ToTensor())
+            return DataLoader(data_set)
+            
+or just use them directly in your :class:`~pytorch_lightning.trainer.Trainer`.
+
+----------
+
+**************************
+Step 4: Fit with a Trainer
+**************************
+Init your :class:`~pytorch_lightning.core.LightningModule`, your :class:`~pytorch_lightning.core.datamodule.LightningDataModule` and then the :class:`~pytorch_lightning.trainer.Trainer`. 
+The Lightning :class:`~pytorch_lightning.trainer.Trainer` is where the magic happens! It abstracts the most of the training engineering code such as:
+
+* The epoch iteration
+* The batch iteration
+* Calling of optimizer.step()
+
+.. raw:: html
+
+    <video width="800" controls autoplay src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/pt_trainer_mov.m4v"></video>
+
+|
+
+Here's an example of using the :class:`~pytorch_lightning.trainer.Trainer`:
+
 
 .. code-block:: python
 
-    class MyDataModule(pl.DataModule):
+    # init model
+    model = LitModel()
+    # init data
+    data_module = MyDataModule()
 
-        def prepare_data(self):
-            # called only on 1 GPU
-            download()
-            tokenize()
-            etc()
+    # most basic trainer, uses good defaults
+    trainer = pl.Trainer()
+    trainer.fit(model, data_module)
 
-         def setup(self):
-            # called on every GPU (assigning state is OK)
-            self.train = ...
-            self.val = ...
+Using GPUs/TPUs
+===============
+It's trivial to use GPUs or TPUs in Lightning. There's NO NEED to change your code, simply change the :class:`~pytorch_lightning.trainer.Trainer` options.
 
-         def train_dataloader(self):
-            # do more...
-            return self.train
+.. code-block:: python
 
-Building models based on Data
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Datamodules are the recommended approach when building models based on the data.
+    # train on 1, 2, 4, n GPUs
+    trainer = pl.Trainer(gpus=1)
+    trainer = pl.Trainer(gpus=2)
+    trainer = pl.Trainer(gpus=8, num_nodes=n)
 
-First, define the information that you might need.
+    # train on TPUs
+    trainer = pl.Trainer(tpu_cores=8)
+    trainer = pl.Trainer(tpu_cores=128)
+
+    # even mixed precision
+    trainer = pl.Trainer(gpus=2, precision=16)
+    
+The :class:`~pytorch_lightning.core.Trainer` will provide
+
+* Automatic :ref:`weights_loading`
+* Automatic Tensorboard (see :ref:`logging` options)
+* Automatic :ref:`multi_pgu`
+* Automatic :ref:`tpu`
+* Automatic :ref:`apex`
+
+All of it 100% rigorously tested and benchmarked.
+
+Main take-aways:
+
+- Lightning sets .train() and enables gradients when entering the training loop.
+- Lightning iterates over the epochs automatically.
+- Lightning iterates the dataloaders automatically.
+- :func:`pytorch_lightning.core.lightning.LightningModule.training_step` gives you full control of the main loop.
+- :func:`pytorch_lightning.core.lightning.LightningModule.backward`, :func:`pytorch_lightning.core.lightning.LightningModule.step`, :func:`pytorch_lightning.core.lightning.LightningModule.zero_grad` are called for you. BUT, you can override this if you need manual control.
+
+Check out more magical flags in the :ref:`trainer` docs.
+
+
+--------------
+
+************************************
+Step 5: Add validation and test loop
+************************************
+
+Adding a Validation loop
+========================
+To add an (optional) validation loop add the following callback to your :class:`~pytorch_lightning.core.LightningModule`
+
+.. testcode::
+
+    class LitModel(LightningModule):
+
+        def validation_step(self, batch, batch_idx):
+            x, y = batch
+            y_hat = self(x)
+            loss = F.cross_entropy(y_hat, y)
+
+            result = pl.EvalResult(checkpoint_on=loss)
+            result.log('val_loss', loss)
+            return result
+
+.. note:: :class:`~pytorch_lightning.core.step_result.EvalResult` is a plain Dict, with convenience functions for logging. Read more in :ref:`results`.
+
+And to your :class:`~pytorch_lightning.core.datamodule.LightningDataModule`:
 
 .. code-block:: python
 
     class MyDataModule(pl.DataModule):
 
         def __init__(self):
-            super().__init__()
-            self.train_dims = None
-            self.vocab_size = 0
-
-        def prepare_data(self):
-            download_dataset()
-            tokenize()
-            build_vocab()
-
-        def setup(self):
-            vocab = load_vocab
-            self.vocab_size = len(vocab)
-
-            self.train, self.val, self.test = load_datasets()
-            self.train_dims = self.train.next_batch.size()
-
-        def train_dataloader(self):
-            transforms = ...
-            return DataLoader(self.train, transforms)
+            ...
 
         def val_dataloader(self):
-            transforms = ...
-            return DataLoader(self.val, transforms)
+            # your val transforms
+            return DataLoader(YOUR_DATASET)
+
+And now the :class:`~pytorch_lightning.trainer.Trainer` will call the validation loop automatically.
+
+
+Lightning automatically:
+
+- Enables gradients and sets model to train() in the train loop
+- Disables gradients and sets model to eval() in val loop
+- After val loop ends, enables gradients and sets model to train()
+
+-------------
+
+Adding a Test loop
+==================
+You might also need an optional test loop. Similarly, add the following callback to your :class:`~pytorch_lightning.core.LightningModule`
+
+.. testcode::
+
+    class LitModel(LightningModule):
+
+
+        def test_step(self, batch, batch_idx):
+            x, y = batch
+            y_hat = self(x)
+            loss = F.cross_entropy(y_hat, y)
+
+            result = pl.EvalResult()
+            result.log('test_loss', loss)
+            return result
+
+.. note:: :class:`~pytorch_lightning.core.step_result.EvalResult` is a plain Dict, with convenience functions for logging. Read more in :ref:`results`.
+
+And to your :class:`~pytorch_lightning.core.datamodule.LightningDataModule`:
+
+.. code-block:: python
+
+    class MyDataModule(pl.DataModule):
+
+        def __init__(self):
+            ...
 
         def test_dataloader(self):
-            transforms = ...
-            return DataLoader(self.test, transforms)
+            # your val transforms
+            return DataLoader(YOUR_DATASET)
 
-Next, materialize the data and build your model
+
+However, this time you need to specifically call test (this is done so you don't use the test set by mistake).
 
 .. code-block:: python
 
-    # build module
-    dm = MyDataModule()
-    dm.prepare_data()
-    dm.setup()
+    # OPTION 1:
+    # test after fit
+    trainer.fit(model, data_module)
+    trainer.test(datamodule=data_module)
 
-    # pass in the properties you want
-    model = LitModel(image_width=dm.train_dims[0], vocab_length=dm.vocab_size)
 
-    # train
-    trainer.fit(model, dm)
+.. code-block:: python
+
+    # OPTION 2:
+    # test after loading weights
+    model = LitModel.load_from_checkpoint(PATH)
+    trainer = Trainer(model, data_module)
+    trainer.test(datamodule=data_module)
+
 
 -----------------
 
-Logging/progress bar
---------------------
 
-|
+************
+Ready to go!
+************
 
-.. image:: /_images/mnist_imgs/mnist_tb.png
-    :width: 300
-    :align: center
-    :alt: Example TB logs
+That's it!
 
-|
-
-Lightning has built-in logging to any of the supported loggers or progress bar.
-
-Log in train loop
-^^^^^^^^^^^^^^^^^
-To log from the training loop use the `log` method in the `TrainResult`.
-
-.. code-block:: python
-
-    def training_step(self, batch, batch_idx):
-        loss = ...
-        result = pl.TrainResult(minimize=loss)
-        result.log('train_loss', loss)
-        return result
-
-The `TrainResult` gives you options for logging on every step and/or at the end of the epoch.
-It also allows logging to the progress bar.
-
-.. code-block:: python
-
-        # equivalent
-        result.log('train_loss', loss)
-        result.log('train_loss', loss, prog_bar=False, logger=True, on_step=True, on_epoch=False)
-
-Then boot up your logger or tensorboard instance to view training logs
-
-.. code-block:: bash
-
-    tensorboard --logdir ./lightning_logs
-
-.. warning:: Refreshing the progress bar too frequently in Jupyter notebooks or Colab may freeze your UI.
-    We recommend you set `Trainer(progress_bar_refresh_rate=10)`
-
-Log in Val/Test loop
-^^^^^^^^^^^^^^^^^^^^
-To log from the validation or test loop use the `EvalResult`.
-
-.. code-block:: python
-
-    def validation_step(self, batch, batch_idx):
-        loss = ...
-        result = pl.EvalResult()
-        result.log_dict({'val_loss': loss, 'val_acc': acc})
-        return result
-
-Log to the progress bar
-^^^^^^^^^^^^^^^^^^^^^^^
-|
-
-.. code-block:: shell
-
-    Epoch 1:   4%|▎         | 40/1095 [00:03<01:37, 10.84it/s, loss=4.501, v_num=10]
-
-|
-
-In addition to visual logging, you can log to the progress bar by setting `prog_bar` to True
-
-.. code-block:: python
-
-    def training_step(self, batch, batch_idx):
-        loss = ...
-        result = pl.TrainResult(loss)
-        result.log('train_loss', loss, prog_bar=True)
-
------------------
-
-Advanced loop aggregation
--------------------------
-For certain train/val/test loops, you may wish to do more than just logging. In this case,
-you can also implement `__epoch_end` which gives you the output for each step
-
-Here's the motivating Pytorch example:
-
-.. code-block:: python
-
-    validation_step_outputs = []
-    for batch_idx, batch in val_dataloader():
-        out = validation_step(batch, batch_idx)
-        validation_step_outputs.append(out)
-
-    validation_epoch_end(validation_step_outputs)
-
-And the lightning equivalent
-
-.. code-block:: python
-
-    def validation_step(self, batch, batch_idx):
-        loss = ...
-        predictions = ...
-        result = pl.EvalResult(checkpoint_on=loss)
-        result.log('val_loss', loss)
-        result.predictions = predictions
-
-     def validation_epoch_end(self, validation_step_outputs):
-        all_val_losses = validation_step_outputs.val_loss
-        all_predictions = validation_step_outputs.predictions
-
-Why do you need Lightning?
---------------------------
-The MAIN teakeaway points are:
-
-- Lightning is for professional AI researchers/production teams.
-- Lightning is organized PyTorch. It is not an abstraction.
-- You STILL keep pure PyTorch.
-- You DON't lose any flexibility.
-- You can get rid of all of your boilerplate.
-- You make your code generalizable to any hardware.
-- Your code is now readable and easier to reproduce (ie: you help with the reproducibility crisis).
-- Your LightningModule is still just a pure PyTorch module.
-
-Lightning is for you if
-^^^^^^^^^^^^^^^^^^^^^^^
-
-- You're a professional researcher/ml engineer working on non-trivial deep learning.
-- You already know PyTorch and are not a beginner.
-- You want to iterate through research much faster.
-- You want to put models into production much faster.
-- You need full control of all the details but don't need the boilerplate.
-- You want to leverage code written by hundreds of AI researchers, research engs and PhDs from the world's top AI labs.
-- You need GPUs, multi-node training, half-precision and TPUs.
-- You want research code that is rigorously tested (500+ tests) across CPUs/multi-GPUs/multi-TPUs on every pull-request.
-
-Some more cool features
-^^^^^^^^^^^^^^^^^^^^^^^
-Here are (some) of the other things you can do with lightning:
-
-- Automatic checkpointing.
-- Automatic early stopping.
-- Automatically overfit your model for a sanity test.
-- Automatic truncated-back-propagation-through-time.
-- Automatically scale your batch size.
-- Automatically attempt to find a good learning rate.
-- Add arbitrary callbacks
-- Hit every line of your code once to see if you have bugs (instead of waiting hours to crash on validation ;)
-- Load checkpoints directly from S3.
-- Move from CPUs to GPUs or TPUs without code changes.
-- Profile your code for speed/memory bottlenecks.
-- Scale to massive compute clusters.
-- Use multiple dataloaders per train/val/test loop.
-- Use multiple optimizers to do Reinforcement learning or even GANs.
-
-Example:
-^^^^^^^^
-Without changing a SINGLE line of your code, you can now do the following with the above code
+Without changing a SINGLE line of your code, you can now do the following with the above code:
 
 .. code-block:: python
 
@@ -622,13 +364,19 @@ Without changing a SINGLE line of your code, you can now do the following with t
         val_check_interval=0.25
     )
 
+
+.. code-block:: python
+
     # train on 256 GPUs
     trainer = Trainer(
         gpus=8,
         num_nodes=32
     )
 
-    # train on 1024 CPUs across 128 machines
+
+.. code-block:: python
+
+  # train on 1024 CPUs across 128 machines
     trainer = Trainer(
         num_processes=8,
         num_nodes=128
@@ -648,12 +396,128 @@ would normally do.
 
 ---------------
 
-Masterclass
+Once you define and train your first Lightning model, you might want to try other cool features like
+
+- :ref:`logging`
+- `Automatic checkpointing <https://pytorch-lightning.readthedocs.io/en/stable/weights_loading.html>`_
+- `Automatic early stopping <https://pytorch-lightning.readthedocs.io/en/stable/early_stopping.html>`_
+- `Add custom callbacks <https://pytorch-lightning.readthedocs.io/en/stable/callbacks.html>`_
+- `Dry run mode <https://pytorch-lightning.readthedocs.io/en/stable/debugging.html#fast-dev-run>`_ (Hit every line of your code once to see if you have bugs, instead of waiting hours to crash on validation ;)
+- `Automatically overfit your model for a sanity test <https://pytorch-lightning.readthedocs.io/en/stable/debugging.html?highlight=overfit#make-model-overfit-on-subset-of-data>`_
+- `Automatic truncated-back-propagation-through-time <https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.trainer.training_loop.html?highlight=truncated#truncated-backpropagation-through-time>`_
+- `Automatically scale your batch size <https://pytorch-lightning.readthedocs.io/en/stable/training_tricks.html?highlight=batch%20size#auto-scaling-of-batch-size>`_
+- `Automatically find a good learning rate <https://pytorch-lightning.readthedocs.io/en/stable/lr_finder.html>`_
+- `Load checkpoints directly from S3 <https://pytorch-lightning.readthedocs.io/en/stable/weights_loading.html#checkpoint-loading>`_
+- `Profile your code for speed/memory bottlenecks <https://pytorch-lightning.readthedocs.io/en/stable/profiler.html>`_
+- `Scale to massive compute clusters <https://pytorch-lightning.readthedocs.io/en/stable/slurm.html>`_
+- `Use multiple dataloaders per train/val/test loop <https://pytorch-lightning.readthedocs.io/en/stable/multiple_loaders.html>`_
+- `Use multiple optimizers to do Reinforcement learning or even GANs <https://pytorch-lightning.readthedocs.io/en/stable/optimizers.html?highlight=multiple%20optimizers#use-multiple-optimizers-like-gans>`_
+
 -----------
-You can learn Lightning in-depth by watching our Masterclass.
+
+************************
+Lightning under the hood
+************************
+Lightning is designed for state of the art research ideas by researchers and research engineers from top labs.
+
+A :class:`~pytorch_lightning.core.LightningModule` handles advances cases by allowing you to override any critical part of training
+via :ref:`hooks` that are called on your :class:`~pytorch_lightning.core.LightningModule`.
+
+.. raw:: html
+
+    <video width="800" controls autoplay src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/pt_callbacks_mov.m4v"></video>
+
+----------------
+
+Training loop under the hood
+----------------------------
+This is the training loop pseudocode that lightning does under the hood:
+
+.. code-block:: python
+
+    # init model
+    model = LitModel()
+
+    # enable training
+    torch.set_grad_enabled(True)
+    model.train()
+
+    # get data + optimizer
+    train_dataloader = model.data_module().train_dataloader()
+    optimizer = model.configure_optimizers()
+
+    for epoch in epochs:
+        for batch in train_dataloader:
+            # forward (TRAINING_STEP)
+            loss = model.training_step(batch)
+
+            # backward
+            loss.backward()
+
+            # apply and clear grads
+            optimizer.step()
+            optimizer.zero_grad()
+            
+Validation loop under the hood
+------------------------------
+
+.. code-block:: python
+
+    # ...
+    for batch in train_dataloader:
+        loss = model.training_step()
+        loss.backward()
+        # ...
+
+        if validate_at_some_point:
+            # disable grads + batchnorm + dropout
+            torch.set_grad_enabled(False)
+            model.eval()
+
+            val_outs = []
+            for val_batch in model.data_module.val_dataloader:
+                val_out = model.validation_step(val_batch)
+                val_outs.append(val_out)
+            model.validation_epoch_end(val_outs)
+
+            # enable grads + batchnorm + dropout
+            torch.set_grad_enabled(True)
+            model.train()
+
+Test loop under the hood
+------------------------
+
+.. code-block:: python
+
+    # disable grads + batchnorm + dropout
+    torch.set_grad_enabled(False)
+    model.eval()
+
+    test_outs = []
+    for test_batch in model.data_module.test_dataloader:
+        test_out = model.test_step(val_batch)
+        test_outs.append(test_out)
+
+    model.test_epoch_end(test_outs)
+
+    # enable grads + batchnorm + dropout
+    torch.set_grad_enabled(True)
+    model.train()
+
+----------
+
+
+***********
+Masterclass
+***********
+Go pro by tunning in to our Masterclass! New episodes every week.
 
 .. image:: _images/general/PTL101_youtube_thumbnail.jpg
     :width: 500
     :align: center
     :alt: Masterclass
     :target: https://www.youtube.com/playlist?list=PLaMu-SDt_RB5NUm67hU2pdE75j6KaIOv2
+    
+
+Or read our :ref:`introduction-guide` to learn more!
+

--- a/docs/source/new-project.rst
+++ b/docs/source/new-project.rst
@@ -13,7 +13,7 @@
 Quick Start
 ###########
 
-New to PyTorch Lightning and want to give it a go? Quick prototyping is our specility- you came to the right place!
+In this guide we will go over how to build your Lightning code in 5 simple steps.
 
 Organizing your code with PyTorch Lightning makes your code:
 
@@ -28,9 +28,6 @@ To illustrate, here's the typical PyTorch project structure organized in a :clas
 .. raw:: html
 
     <video width="800" controls autoplay src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/pl_module_vid.m4v"></video>
-
-   
-In this guide we will go over how to build your Lightning code in 5 steps!
 
 
 ----------
@@ -174,7 +171,7 @@ or just use them directly in your :class:`~pytorch_lightning.trainer.Trainer`.
 Step 4: Fit with a Trainer
 **************************
 Init your :class:`~pytorch_lightning.core.LightningModule`, your :class:`~pytorch_lightning.core.datamodule.LightningDataModule` and then the :class:`~pytorch_lightning.trainer.Trainer`. 
-The Lightning :class:`~pytorch_lightning.trainer.Trainer` is where the magic happens! It abstracts the most of the training engineering code such as:
+The Lightning :class:`~pytorch_lightning.trainer.Trainer` automates most of the training engineering code such as:
 
 * The epoch iteration
 * The batch iteration
@@ -236,7 +233,7 @@ Main take-aways:
 - :func:`pytorch_lightning.core.lightning.LightningModule.training_step` gives you full control of the main loop.
 - :func:`pytorch_lightning.core.lightning.LightningModule.backward`, :func:`pytorch_lightning.core.lightning.LightningModule.step`, :func:`pytorch_lightning.core.lightning.LightningModule.zero_grad` are called for you. BUT, you can override this if you need manual control.
 
-Check out more magical flags in the :ref:`trainer` docs.
+Check out more flags in the :ref:`trainer` docs.
 
 
 --------------
@@ -347,8 +344,6 @@ However, this time you need to specifically call test (this is done so you don't
 ************
 Ready to go!
 ************
-
-That's it!
 
 Without changing a SINGLE line of your code, you can now do the following with the above code:
 

--- a/docs/source/new-project.rst
+++ b/docs/source/new-project.rst
@@ -61,7 +61,8 @@ You could also use conda environments
 
 ******************************
 Step 2: Define LightningModule
-*********************************
+******************************
+
 The :class:`~pytorch_lightning.core.LightningModule` holds your research code:
 
 - The Train loop
@@ -223,7 +224,7 @@ The :class:`~pytorch_lightning.core.Trainer` will provide
 * Automatic :ref:`tpu`
 * Automatic :ref:`apex`
 
-All of it 100% rigorously tested and benchmarked.
+All automated code is rigorously tested and benchmarked.
 
 Main take-aways:
 
@@ -341,9 +342,9 @@ However, this time you need to specifically call test (this is done so you don't
 -----------------
 
 
-************
-Ready to go!
-************
+***********
+Ready to go
+***********
 
 Without changing a SINGLE line of your code, you can now do the following with the above code:
 


### PR DESCRIPTION
Change quick start guide structure to 5 steps:
1. install
2. define module
3. define data
4. call trainer
5. eval + test

This guide should give a super quick overview for folks that are looking at Lightning for the first time.