### PR TITLE
Fix result gathering with varying tensor shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed an issue that caused `Trainer.test()` to stall in ddp mode ([#2997](https://github.com/PyTorchLightning/pytorch-lightning/pull/2997))
 
+- Fixed gathering of results with tensors of varying shape ([#3020](https://github.com/PyTorchLightning/pytorch-lightning/pull/3020))
+
 ## [0.8.5] - 2020-07-09
 
 ### Added

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -411,7 +411,6 @@ def recursive_stack(result: MutableMapping):
 def collate_tensors(items: Union[List, Tuple]) -> Union[Tensor, List, Tuple]:
     if not items or not isinstance(items, (list, tuple)) or any(not isinstance(item, Tensor) for item in items):
         # items is not a sequence, empty, or contains non-tensors
-        print('here')
         return items
 
     if all(item.shape == items[0].shape for item in items):

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -413,11 +413,11 @@ def collate_tensors(items: Union[List, Tuple]) -> Union[Tensor, List, Tuple]:
         # items is not a sequence, empty, or contains non-tensors
         return items
 
-    if all(item.shape == items[0].shape for item in items):
-        # all tensors have the same shape
+    if all(item.ndim == 0 for item in items):
+        # all tensors are scalars, we need to stack
         return torch.stack(items)
 
-    if all(item.shape[1:] == items[0].shape[1:] for item in items):
+    if all(item.ndim >= 1 and item.shape[1:] == items[0].shape[1:] for item in items):
         # we can concatenate along the first dimension
         return torch.cat(items)
 

--- a/tests/core/test_results.py
+++ b/tests/core/test_results.py
@@ -223,3 +223,16 @@ def test_result_gather_different_shapes():
     expected = [torch.tensor(1), torch.zeros(2, 3), torch.zeros(1, 2, 3)]
     assert isinstance(result["foo"], list)
     assert all(torch.eq(r, e).all() for r, e in zip(result["foo"], expected))
+
+
+def test_result_gather_mixed_types():
+    """ Test that a collection of mixed types gets gathered into a list. """
+    outputs = [
+        {"foo": 1.2},
+        {"foo": ["bar", None]},
+        {"foo": torch.tensor(1)},
+    ]
+    result = Result.gather(outputs)
+    expected = [1.2, ["bar", None], torch.tensor(1)]
+    assert isinstance(result["foo"], list)
+    assert result["foo"] == expected

--- a/tests/core/test_results.py
+++ b/tests/core/test_results.py
@@ -184,6 +184,7 @@ def test_result_gather_stack():
         {"foo": torch.zeros(4, 5)},
     ]
     result = Result.gather(outputs)
+    assert isinstance(result["foo"], torch.Tensor)
     assert list(result["foo"].shape) == [3, 4, 5]
 
 
@@ -195,6 +196,7 @@ def test_result_gather_concatenate():
         {"foo": torch.zeros(3, 5)},
     ]
     result = Result.gather(outputs)
+    assert isinstance(result["foo"], torch.Tensor)
     assert list(result["foo"].shape) == [11, 5]
 
 
@@ -206,6 +208,7 @@ def test_result_gather_scalar():
         {"foo": torch.tensor(3)},
     ]
     result = Result.gather(outputs)
+    assert isinstance(result["foo"], torch.Tensor)
     assert list(result["foo"].shape) == [3]
 
 
@@ -218,4 +221,5 @@ def test_result_gather_different_shapes():
     ]
     result = Result.gather(outputs)
     expected = [torch.tensor(1), torch.zeros(2, 3), torch.zeros(1, 2, 3)]
+    assert isinstance(result["foo"], list)
     assert all(torch.eq(r, e).all() for r, e in zip(result["foo"], expected))

--- a/tests/core/test_results.py
+++ b/tests/core/test_results.py
@@ -177,7 +177,7 @@ def test_result_obj_predictions_ddp_spawn(tmpdir):
 
 
 def test_result_gather_stack():
-    """ Test that tensors get stacked when they all have the same shape. """
+    """ Test that tensors get concatenated when they all have the same shape. """
     outputs = [
         {"foo": torch.zeros(4, 5)},
         {"foo": torch.zeros(4, 5)},
@@ -185,19 +185,19 @@ def test_result_gather_stack():
     ]
     result = Result.gather(outputs)
     assert isinstance(result["foo"], torch.Tensor)
-    assert list(result["foo"].shape) == [3, 4, 5]
+    assert list(result["foo"].shape) == [12, 5]
 
 
 def test_result_gather_concatenate():
-    """ Test that tensors that cannot be stacked get concatenated along the first dim. """
+    """ Test that tensors get concatenated when they have varying size in first dimension. """
     outputs = [
         {"foo": torch.zeros(4, 5)},
-        {"foo": torch.zeros(4, 5)},
+        {"foo": torch.zeros(8, 5)},
         {"foo": torch.zeros(3, 5)},
     ]
     result = Result.gather(outputs)
     assert isinstance(result["foo"], torch.Tensor)
-    assert list(result["foo"].shape) == [11, 5]
+    assert list(result["foo"].shape) == [15, 5]
 
 
 def test_result_gather_scalar():

--- a/tests/core/test_results.py
+++ b/tests/core/test_results.py
@@ -174,3 +174,34 @@ def test_result_obj_predictions_ddp_spawn(tmpdir):
         predictions = torch.load(prediction_file)
         size += len(predictions)
     assert size == len(dm.mnist_test)
+
+
+def test_result_gather_stack():
+    outputs = [
+        {"result": torch.zeros(4, 5)},
+        {"result": torch.zeros(4, 5)},
+        {"result": torch.zeros(4, 5)},
+    ]
+    result = Result.gather(outputs)
+    assert list(result["result"].shape) == [3, 4, 5]
+
+
+def test_result_gather_concatenate():
+    outputs = [
+        {"result": torch.zeros(4, 5)},
+        {"result": torch.zeros(4, 5)},
+        {"result": torch.zeros(3, 5)},
+    ]
+    result = Result.gather(outputs)
+    assert list(result["result"].shape) == [11, 5]
+
+
+def test_result_gather_scalar():
+    outputs = [
+        {"result": torch.tensor(1)},
+        {"result": torch.tensor(2)},
+        {"result": torch.tensor(3)},
+    ]
+    result = Result.gather(outputs)
+    assert list(result["result"].shape) == [3]
+


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Fixes #3019 

The critical test fails on master, but I added also more tests for the old behaviour.

Solution: 
- By default, we need to concatenate, because stacking would only work when the dataloader returns equal batch sizes. This is not the case in general. 
- If the tensors are scalar, we stack.
- If stacking and concatenating both don't work, we gather into a list. At this point the user should be aware what they return and need to deal with it in their *_epoch_end. 

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
