### PR TITLE
Retrieve last logged val from result by key

### DIFF
--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -44,6 +44,12 @@ class Result(Dict):
                 'batch_sizes': []
             }
         }
+        
+    def __getitem__(self, key: Union[str, Any]) -> Any:
+        try:
+            return super().__getitem__(key)
+        except KeyError:
+            return super().__getitem__(f'step_{key}')
 
     def __getattr__(self, key: str) -> Any:
         try:
@@ -60,10 +66,6 @@ class Result(Dict):
             else:
                 return self[key]
         except KeyError:
-            # return last logged value
-            try:
-                return self[f'step_{key}']
-            except KeyError:
                 return None
 
     def __setattr__(self, key: str, val: Union[Tensor, Any]):

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -66,7 +66,7 @@ class Result(Dict):
             else:
                 return self[key]
         except KeyError:
-                return None
+            return None
 
     def __setattr__(self, key: str, val: Union[Tensor, Any]):
         # ensure reserve keys are tensors and detached

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -44,7 +44,7 @@ class Result(Dict):
                 'batch_sizes': []
             }
         }
-        
+
     def __getitem__(self, key: Union[str, Any]) -> Any:
         try:
             return super().__getitem__(key)

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -60,7 +60,11 @@ class Result(Dict):
             else:
                 return self[key]
         except KeyError:
-            return None
+            # return last logged value
+            try:
+                return self[f'step_{key}']
+            except KeyError:
+                return None
 
     def __setattr__(self, key: str, val: Union[Tensor, Any]):
         # ensure reserve keys are tensors and detached

--- a/tests/core/test_results.py
+++ b/tests/core/test_results.py
@@ -236,3 +236,10 @@ def test_result_gather_mixed_types():
     expected = [1.2, ["bar", None], torch.tensor(1)]
     assert isinstance(result["foo"], list)
     assert result["foo"] == expected
+    
+def test_result_retrieve_last_logged_item():
+    result = Result()
+    result.log('a', 5., on_step=True, on_epoch=True)
+    assert result['epoch_a'] == 5.
+    assert result['step_a'] == 5.
+    assert result['a'] == 5.

--- a/tests/core/test_results.py
+++ b/tests/core/test_results.py
@@ -236,7 +236,8 @@ def test_result_gather_mixed_types():
     expected = [1.2, ["bar", None], torch.tensor(1)]
     assert isinstance(result["foo"], list)
     assert result["foo"] == expected
-    
+
+
 def test_result_retrieve_last_logged_item():
     result = Result()
     result.log('a', 5., on_step=True, on_epoch=True)


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

If you log a key to the result object, the last logged step value can be retrieved by indexing with the name, even though it may have changed internally.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
