### PR TITLE
[docs] Add copy and toggle buttons to sphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -96,7 +96,9 @@ extensions = [
     # 'm2r',
     'nbsphinx',
     'sphinx_autodoc_typehints',
+    'sphinx_copybutton',
     'sphinx_paramlinks',
+    'sphinx_togglebutton',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,3 +10,5 @@ https://github.com/PyTorchLightning/lightning_sphinx_theme/archive/master.zip#eg
 # pip_shims
 sphinx-autodoc-typehints
 sphinx-paramlinks<0.4.0
+sphinx-togglebutton
+sphinx-copybutton


### PR DESCRIPTION
See docs for [copy button](https://sphinx-copybutton.readthedocs.io/en/latest/) and [toggle](https://sphinx-togglebutton.readthedocs.io/en/latest/).
