### PR TITLE
More robust way of collecting init argument names for LightningModules

### DIFF
--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -48,13 +48,13 @@ class ModelIO(object):
 
     @classmethod
     def load_from_checkpoint(
-            cls,
-            checkpoint_path: str,
-            *args,
-            map_location: Optional[Union[Dict[str, str], str, torch.device, int, Callable]] = None,
-            hparams_file: Optional[str] = None,
-            strict: bool = True,
-            **kwargs
+        cls,
+        checkpoint_path: str,
+        *args,
+        map_location: Optional[Union[Dict[str, str], str, torch.device, int, Callable]] = None,
+        hparams_file: Optional[str] = None,
+        strict: bool = True,
+        **kwargs,
     ):
         r"""
         Primary way of loading a model from a checkpoint. When Lightning saves a checkpoint
@@ -156,7 +156,7 @@ class ModelIO(object):
     @classmethod
     def _load_model_state(cls, checkpoint: Dict[str, Any], strict: bool = True, *cls_args, **cls_kwargs):
         cls_spec = inspect.getfullargspec(cls.__init__)
-        cls_init_args_name = inspect.signature(cls).parameters.keys()
+        cls_init_args_name = inspect.signature(cls.__init__).parameters.keys()
         # pass in the values we saved automatically
         if cls.CHECKPOINT_HYPER_PARAMS_KEY in checkpoint:
             model_args = {}

--- a/tests/base/__init__.py
+++ b/tests/base/__init__.py
@@ -1,4 +1,4 @@
 """Models for testing."""
 
 from tests.base.datasets import TrialMNIST
-from tests.base.model_template import EvalModelTemplate
+from tests.base.model_template import EvalModelTemplate, GenericEvalModelTemplate

--- a/tests/base/model_template.py
+++ b/tests/base/model_template.py
@@ -2,6 +2,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from typing import Generic, TypeVar
+
 from pytorch_lightning.core.lightning import LightningModule
 from tests.base.datasets import TrialMNIST, PATH_DATASETS
 from tests.base.model_optimizers import ConfigureOptimizersPool
@@ -28,7 +30,7 @@ class EvalModelTemplate(
     ValDataloaderVariations,
     TestDataloaderVariations,
     ConfigureOptimizersPool,
-    LightningModule
+    LightningModule,
 ):
     """
     This template houses all  combinations of model  configurations  we want to test
@@ -37,17 +39,17 @@ class EvalModelTemplate(
     """
 
     def __init__(
-            self,
-            drop_prob: float = 0.2,
-            batch_size: int = 32,
-            in_features: int = 28 * 28,
-            learning_rate: float = 0.001 * 8,
-            optimizer_name: str = 'adam',
-            data_root: str = PATH_DATASETS,
-            out_features: int = 10,
-            hidden_dim: int = 1000,
-            b1: float = 0.5,
-            b2: float = 0.999
+        self,
+        drop_prob: float = 0.2,
+        batch_size: int = 32,
+        in_features: int = 28 * 28,
+        learning_rate: float = 0.001 * 8,
+        optimizer_name: str = 'adam',
+        data_root: str = PATH_DATASETS,
+        out_features: int = 10,
+        hidden_dim: int = 1000,
+        b1: float = 0.5,
+        b2: float = 0.999,
     ):
         # init superclass
         super().__init__()
@@ -83,17 +85,11 @@ class EvalModelTemplate(
         Simple model for testing
         :return:
         """
-        self.c_d1 = nn.Linear(
-            in_features=self.in_features,
-            out_features=self.hidden_dim
-        )
+        self.c_d1 = nn.Linear(in_features=self.in_features, out_features=self.hidden_dim)
         self.c_d1_bn = nn.BatchNorm1d(self.hidden_dim)
         self.c_d1_drop = nn.Dropout(self.drop_prob)
 
-        self.c_d2 = nn.Linear(
-            in_features=self.hidden_dim,
-            out_features=self.out_features
-        )
+        self.c_d2 = nn.Linear(in_features=self.hidden_dim, out_features=self.out_features)
 
     def forward(self, x):
         x = self.c_d1(x)
@@ -130,8 +126,42 @@ class EvalModelTemplate(
 
         if continue_training:
             args.update(
-                test_tube_do_checkpoint_load=True,
-                hpc_exp_number=hpc_exp_number,
+                test_tube_do_checkpoint_load=True, hpc_exp_number=hpc_exp_number,
             )
 
         return args
+
+
+T = TypeVar('T')
+
+
+class GenericParentEvalModelTemplate(Generic[T], EvalModelTemplate):
+    def __init__(
+        self,
+        drop_prob: float,
+        batch_size: int,
+        in_features: int,
+        learning_rate: float,
+        optimizer_name: str,
+        data_root: str,
+        out_features: int,
+        hidden_dim: int,
+        b1: float,
+        b2: float,
+    ):
+        super().__init__(
+            drop_prob=drop_prob,
+            batch_size=batch_size,
+            in_features=in_features,
+            learning_rate=learning_rate,
+            optimizer_name=optimizer_name,
+            data_root=data_root,
+            out_features=out_features,
+            hidden_dim=hidden_dim,
+            b1=b1,
+            b2=b2,
+        )
+
+
+class GenericEvalModelTemplate(GenericParentEvalModelTemplate[int]):
+    pass


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Fixes #3053 

When a LightningModule inherits from a class that implements `__new__()` such as `typing.Generic`, `inspect.signature(cls)` short-circuits and returns the signature of `__new__()` instead of `__init__()`. So, we need to be more specific and call inspection directly on the init function.

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- N/A Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- N/A If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
