### PR TITLE
Fixes #2095: Add checkpoint saving on graceful shutdown (ctr+c)

### DIFF
--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -1132,6 +1132,10 @@ class TrainerTrainLoopMixin(ABC):
 
         self._teardown_already_run = True
 
+        # Save latest checkpoint
+        log.info('Saving latest checkpoint..')
+        self.check_checkpoint_callback(should_check_val=False)
+
         # Train end events
         with self.profiler.profile('on_train_end'):
             # callbacks


### PR DESCRIPTION
## #2095 Add checkpoint saving feature on ctr+c interrupt

Fixes # 2095

Added a logging message that says that checkpoint is being saved while attempting graceful shutdown.
Called the checkpoint callback which handles rest of the procedure for saving the checkpoint.


# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [N/A Did you make sure to update the documentation with your changes?
- N/A Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- N/A If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
Yes, enjoyed my first contribution towards this amazing project.