### PR TITLE
add support for precision==64 in Trainer

### DIFF
--- a/pytorch_lightning/accelerators/cpu_backend.py
+++ b/pytorch_lightning/accelerators/cpu_backend.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
+from pytorch_lightning.utilities.casting import cast_model_to_precision
 
 
 class CPUBackend(object):
@@ -28,6 +29,8 @@ class CPUBackend(object):
         # call setup after the ddp process has connected
         self.trainer.call_setup_hook(model)
 
+        model = cast_model_to_precision(model)
+
         # CHOOSE OPTIMIZER
         # allow for lr schedulers as well
         optimizers, lr_schedulers, optimizer_frequencies = self.trainer.init_optimizers(model)
@@ -36,5 +39,6 @@ class CPUBackend(object):
         self.trainer.optimizer_frequencies = optimizer_frequencies
 
     def train(self, model):
+        model = cast_model_to_precision(model)
         results = self.trainer.run_pretrain_routine(model)
         return results

--- a/pytorch_lightning/accelerators/ddp2_backend.py
+++ b/pytorch_lightning/accelerators/ddp2_backend.py
@@ -20,6 +20,7 @@ from pytorch_lightning import _logger as log
 from pytorch_lightning.utilities import AMPType
 from pytorch_lightning.utilities.distributed import rank_zero_only
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
+from pytorch_lightning.utilities.casting import cast_model_to_precision
 
 try:
     from hydra.utils import to_absolute_path, get_original_cwd
@@ -56,6 +57,7 @@ class DDP2Backend(object):
                 raise MisconfigurationException(m)
 
     def train(self, model):
+        model = cast_model_to_precision(model)
         self.ddp_train(process_idx=self.task_idx, mp_queue=None, model=model)
 
     def ddp_train(self, process_idx, mp_queue, model, is_master=False, proc_offset=0):

--- a/pytorch_lightning/accelerators/ddp_backend.py
+++ b/pytorch_lightning/accelerators/ddp_backend.py
@@ -25,6 +25,7 @@ import torch
 from pytorch_lightning import _logger as log
 from pytorch_lightning.utilities import AMPType
 from pytorch_lightning.utilities.distributed import rank_zero_only, find_free_network_port
+from pytorch_lightning.utilities.casting import cast_model_to_precision
 
 try:
     from hydra.utils import to_absolute_path, get_original_cwd
@@ -54,6 +55,7 @@ class DDPBackend(object):
         self.task_idx = int(os.environ['LOCAL_RANK'])
 
     def train(self, model):
+        model = cast_model_to_precision(model)
         self.ddp_train(process_idx=self.task_idx, mp_queue=None, model=model)
 
     def spawn_ddp_children(self, model):

--- a/pytorch_lightning/accelerators/ddp_spawn_backend.py
+++ b/pytorch_lightning/accelerators/ddp_spawn_backend.py
@@ -18,6 +18,7 @@ import torch.multiprocessing as mp
 
 from pytorch_lightning import _logger as log
 from pytorch_lightning.utilities import AMPType
+from pytorch_lightning.utilities.casting import cast_model_to_precision
 from pytorch_lightning.utilities.distributed import rank_zero_only, find_free_network_port
 
 try:
@@ -40,6 +41,7 @@ class DDPSpawnBackend(object):
         self.mp_queue = smp.SimpleQueue()
 
     def train(self, model, nprocs):
+        model = cast_model_to_precision(model)
         mp.spawn(self.ddp_train, nprocs=nprocs, args=(self.mp_queue, model,))
 
     def teardown(self, model):

--- a/pytorch_lightning/accelerators/dp_backend.py
+++ b/pytorch_lightning/accelerators/dp_backend.py
@@ -17,6 +17,7 @@ from torch import optim
 
 from pytorch_lightning.overrides.data_parallel import LightningDataParallel
 from pytorch_lightning.utilities import AMPType
+from pytorch_lightning.utilities.casting import cast_model_to_precision
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 try:
@@ -34,6 +35,8 @@ class DataParallelBackend(object):
     def setup(self, model):
         # call setup after the ddp process has connected
         self.trainer.call_setup_hook(model)
+
+        model = cast_model_to_precision(model)
 
         # put model on correct device
         model.cuda(self.trainer.root_gpu)
@@ -94,6 +97,7 @@ class DataParallelBackend(object):
 
     def train(self):
         model = self.trainer.model
+        model = cast_model_to_precision(model)
         results = self.trainer.run_pretrain_routine(model)
         return results
 

--- a/pytorch_lightning/accelerators/gpu_backend.py
+++ b/pytorch_lightning/accelerators/gpu_backend.py
@@ -15,6 +15,7 @@
 import torch
 from pytorch_lightning.core import LightningModule
 from pytorch_lightning.utilities import AMPType
+from pytorch_lightning.utilities.casting import cast_model_to_precision
 
 try:
     from apex import amp
@@ -33,6 +34,8 @@ class GPUBackend(object):
         # call setup
         self.trainer.call_setup_hook(model)
 
+        model = cast_model_to_precision(model)
+
         torch.cuda.set_device(self.trainer.root_gpu)
         model.cuda(self.trainer.root_gpu)
 
@@ -48,6 +51,7 @@ class GPUBackend(object):
         return model
 
     def train(self, model):
+        model = cast_model_to_precision(model)
         results = self.trainer.run_pretrain_routine(model)
         return results
 
@@ -56,3 +60,4 @@ class GPUBackend(object):
         self.trainer.optimizers = optimizers
         self.trainer.reinit_scheduler_properties(self.trainer.optimizers, self.trainer.lr_schedulers)
         return model
+

--- a/pytorch_lightning/accelerators/tpu_backend.py
+++ b/pytorch_lightning/accelerators/tpu_backend.py
@@ -21,6 +21,7 @@ from pytorch_lightning import _logger as log
 from pytorch_lightning.core import LightningModule
 from pytorch_lightning.utilities import rank_zero_info, rank_zero_only, rank_zero_warn
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
+from pytorch_lightning.utilities.casting import cast_model_to_precision
 
 try:
     import torch_xla
@@ -74,6 +75,7 @@ class TPUBackend(object):
         return results
 
     def train(self, model: LightningModule):
+        model = cast_model_to_precision(model)
         self.trainer.model = model
 
         # train

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -19,7 +19,7 @@ from torch import Tensor
 from torch.nn import Module
 from torch.optim.optimizer import Optimizer
 
-from pytorch_lightning.utilities import move_data_to_device, AMPType
+from pytorch_lightning.utilities import move_data_to_device, cast_float_data_to_dtype, AMPType
 
 try:
     from apex import amp
@@ -380,3 +380,6 @@ class ModelHooks(Module):
             - :func:`~pytorch_lightning.utilities.apply_func.apply_to_collection`
         """
         return move_data_to_device(batch, device)
+
+    def cast_batch_to_dtype(self, batch: Any, dtype: torch.dtype) -> Any:
+        return cast_float_data_to_dtype(batch, dtype)

--- a/pytorch_lightning/core/memory.py
+++ b/pytorch_lightning/core/memory.py
@@ -219,6 +219,7 @@ class ModelSummary(object):
         trainer = self._model.trainer
 
         input_ = model.example_input_array
+        input_ = model.cast_batch_to_dtype(input_, model.dtype)
         input_ = model.transfer_batch_to_device(input_, model.device)
 
         if trainer is not None and trainer.amp_backend == AMPType.NATIVE and not trainer.use_tpu:

--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -190,7 +190,12 @@ class TensorBoardLogger(LightningLoggerBase):
                 self.experiment.add_graph(
                     model,
                     model.transfer_batch_to_device(
-                        model.example_input_array, model.device)
+                        model.cast_batch_to_dtype(
+                            model.example_input_array,
+                            model.dtype
+                        ),
+                        model.device,
+                    )
                 )
             else:
                 rank_zero_warn('Could not log computational graph since the'

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -213,6 +213,10 @@ class TrainerEvaluationLoopMixin(ABC):
         """Warning: this is just empty shell for code implemented in other class."""
 
     @abstractmethod
+    def cast_batch_to_precision(self, *args):
+        """Warning: this is just empty shell for code implemented in other class."""
+
+    @abstractmethod
     def add_progress_bar_metrics(self, *args):
         """Warning: this is just empty shell for code implemented in other class."""
 
@@ -651,6 +655,8 @@ class TrainerEvaluationLoopMixin(ABC):
 
     def evaluation_forward(self, model, batch, batch_idx, dataloader_idx, test_mode: bool = False):
         # make dataloader_idx arg in validation_step optional
+        batch = self.cast_batch_to_precision(batch, precision=self.precision)
+
         args = [batch, batch_idx]
 
         if (test_mode and len(self.test_dataloaders) > 1) or (not test_mode and len(self.val_dataloaders) > 1):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1444,7 +1444,8 @@ class Trainer(
         model.setup(stage_name)
 
     def init_amp(self, amp_type: str):
-        assert self.precision in (16, 32), 'only 32 or 16 bit precision supported'
+        if not (self.precision in (16, 32, 64)):
+            raise Exception('only 64, 32 or 16 bit precision supported')
         self.amp_backend = None
         self._setup_amp_backend(amp_type)
 

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -295,6 +295,10 @@ class TrainerTrainLoopMixin(ABC):
         """Warning: this is just empty shell for code implemented in other class."""
 
     @abstractmethod
+    def cast_batch_to_precision(self, *args):
+        """Warning: this is just empty shell for code implemented in other class."""
+
+    @abstractmethod
     def clip_gradients(self, *args):
         """Warning: this is just empty shell for code implemented in other class."""
 
@@ -1175,6 +1179,8 @@ class TrainerTrainLoopMixin(ABC):
         # ---------------
         # FORWARD
         # ---------------
+        batch = self.cast_batch_to_precision(batch, precision=self.precision)
+
         # enable not needing to add opt_idx to training_step
         args = [batch, batch_idx]
 

--- a/pytorch_lightning/utilities/__init__.py
+++ b/pytorch_lightning/utilities/__init__.py
@@ -4,7 +4,7 @@ from enum import Enum
 import numpy
 import torch
 
-from pytorch_lightning.utilities.apply_func import move_data_to_device
+from pytorch_lightning.utilities.apply_func import move_data_to_device, cast_float_data_to_dtype
 from pytorch_lightning.utilities.distributed import rank_zero_only, rank_zero_warn, rank_zero_info
 from pytorch_lightning.utilities.parsing import AttributeDict, flatten_dict
 

--- a/pytorch_lightning/utilities/casting.py
+++ b/pytorch_lightning/utilities/casting.py
@@ -1,0 +1,25 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+
+def cast_model_to_precision(model):
+    if model.precision in [16, 32]:
+        model.to(dtype=torch.float32)
+    elif model.precision == 64:
+        model.to(dtype=torch.float64)
+    else:
+        raise Exception("unexpected precision")
+    return model


### PR DESCRIPTION
This PR fixes #2497 

cast model to float64 / float32, depending on precision.
In the collection of tensors in a batch, cast each float tensor also to float64 / float32. 
