### PR TITLE
Fix IoU score for classes not present in target or pred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Changed `class_reduction` similar to sklearn for classification metrics ([#3322](https://github.com/PyTorchLightning/pytorch-lightning/pull/3322))
 
-- Changed IoU score behavior for classes not present in target or pred ([#3098](https://github.com/PyTorchLightning/pytorch-lightning/pull/3098))
+- Changed IoU score behavior for classes absent in target and pred ([#3098](https://github.com/PyTorchLightning/pytorch-lightning/pull/3098))
 
 - Changed IoU `remove_bg` bool to `ignore_index` optional int ([#3098](https://github.com/PyTorchLightning/pytorch-lightning/pull/3098))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Changed IoU score behavior for classes not present in target or pred ([#3098](https://github.com/PyTorchLightning/pytorch-lightning/pull/3098))
 
+- Changed IoU `remove_bg` bool to `ignore_index` optional int ([#3098](https://github.com/PyTorchLightning/pytorch-lightning/pull/3098))
+
 ### Deprecated
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed batch size auto-scaling feature to set the new value on the correct model attribute ([#3043](https://github.com/PyTorchLightning/pytorch-lightning/pull/3043))
 - Fixed automatic batch scaling not working with half precision ([#3045](https://github.com/PyTorchLightning/pytorch-lightning/pull/3045))
 - Fixed setting device to root gpu ([#3042](https://github.com/PyTorchLightning/pytorch-lightning/pull/3042))
+- Fixed IoU score for classes not present in target or pred ([#3098](https://github.com/PyTorchLightning/pytorch-lightning/pull/3098))
 
 ## [0.8.5] - 2020-07-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Changed `class_reduction` similar to sklearn for classification metrics ([#3322](https://github.com/PyTorchLightning/pytorch-lightning/pull/3322))
 
+- Changed IoU score behavior for classes not present in target or pred ([#3098](https://github.com/PyTorchLightning/pytorch-lightning/pull/3098))
+
 ### Deprecated
 
 
@@ -156,7 +158,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed batch size auto-scaling feature to set the new value on the correct model attribute ([#3043](https://github.com/PyTorchLightning/pytorch-lightning/pull/3043))
 - Fixed automatic batch scaling not working with half precision ([#3045](https://github.com/PyTorchLightning/pytorch-lightning/pull/3045))
 - Fixed setting device to root gpu ([#3042](https://github.com/PyTorchLightning/pytorch-lightning/pull/3042))
-- Fixed IoU score for classes not present in target or pred ([#3098](https://github.com/PyTorchLightning/pytorch-lightning/pull/3098))
 
 ## [0.8.5] - 2020-07-09
 

--- a/pytorch_lightning/metrics/classification.py
+++ b/pytorch_lightning/metrics/classification.py
@@ -748,11 +748,11 @@ class DiceCoefficient(TensorMetric):
             include_background: whether to also compute dice for the background
             nan_score: score to return, if a NaN occurs during computation (denom zero)
             no_fg_score: score to return, if no foreground pixel was found in target
-            reduction: a method to reduce metric score over labels (default: takes the mean)
-                Available reduction methods:
-                - elementwise_mean: takes the mean
-                - none: pass array
-                - sum: add elements
+            reduction: a method to reduce metric score over labels.
+
+                - ``'elementwise_mean'``: takes the mean (default)
+                - ``'sum'``: takes the sum
+                - ``'none'``: no reduction will be applied
             reduce_group: the process group to reduce metric results from DDP
         """
         super().__init__(
@@ -822,12 +822,11 @@ class IoU(TensorMetric):
                 classes, [0, 0] for `y_pred`, and [0, 2] for `y_true`, then class 1 would be assigned the
                 `absent_score`. Default is 0.0.
             num_classes: Optionally specify the number of classes
-            reduction: a method to reduce metric score over labels (default: takes the mean)
-                Available reduction methods:
+            reduction: a method to reduce metric score over labels.
 
-                - elementwise_mean: takes the mean
-                - none: pass array
-                - sum: add elements
+                - ``'elementwise_mean'``: takes the mean (default)
+                - ``'sum'``: takes the sum
+                - ``'none'``: no reduction will be applied
         """
         super().__init__(name="iou")
         self.ignore_index = ignore_index

--- a/pytorch_lightning/metrics/classification.py
+++ b/pytorch_lightning/metrics/classification.py
@@ -818,20 +818,9 @@ class IoU(TensorMetric):
                 not in the range [0, num_classes-1], where num_classes is either given or derived from pred and target.
                 By default, no index is ignored, and all classes are used.
             absent_score: score to use for an individual class, if no instances of the class index were present in
-                `y_pred` AND no instances of the class index were present in `y_true`. By default, assign a score of
-                0.0 for this class if absent.
-
-                Ex: if we have the following input:
-
-                - 3 classes
-                - `y_pred` is [0, 0]
-                - `y_true` is [0, 2]
-                - `absent_score` is 1.0
-
-                Then class 0 would get a score of 1 / 2, and class 2 would get a score of 0 / 1. However, class 1 is not
-                actually present in either `y_pred` or `y_true`, so it falls back to the `absent_score` (1.0 in
-                this example). These 3 scores are then reduced according to the `reduction` method in the same way as if
-                class 1 were present and received an empirical score.
+                `y_pred` AND no instances of the class index were present in `y_true`. For example, if we have 3
+                classes, [0, 0] for `y_pred`, and [0, 2] for `y_true`, then class 1 would be assigned the
+                `absent_score`. Default is 0.0.
             num_classes: Optionally specify the number of classes
             reduction: a method to reduce metric score over labels (default: takes the mean)
                 Available reduction methods:

--- a/pytorch_lightning/metrics/classification.py
+++ b/pytorch_lightning/metrics/classification.py
@@ -804,9 +804,18 @@ class IoU(TensorMetric):
 
     """
 
-    def __init__(self, remove_bg: bool = False, reduction: str = "elementwise_mean"):
+    def __init__(
+            self,
+            not_present_score: float = 1.0,
+            num_classes: Optional[int] = None,
+            remove_bg: bool = False,
+            reduction: str = "elementwise_mean",
+    ):
         """
         Args:
+            not_present_score: score to use for a class, if no instance of that class was present in either pred or
+                target
+            num_classes: Optionally specify the number of classes
             remove_bg: Flag to state whether a background class has been included
                 within input parameters. If true, will remove background class. If
                 false, return IoU over all classes.
@@ -819,6 +828,8 @@ class IoU(TensorMetric):
                 - sum: add elements
         """
         super().__init__(name="iou")
+        self.not_present_score = not_present_score
+        self.num_classes = num_classes
         self.remove_bg = remove_bg
         self.reduction = reduction
 
@@ -826,4 +837,11 @@ class IoU(TensorMetric):
         """
         Actual metric calculation.
         """
-        return iou(y_pred, y_true, remove_bg=self.remove_bg, reduction=self.reduction)
+        return iou(
+            pred=y_pred,
+            target=y_true,
+            not_present_score=self.not_present_score,
+            num_classes=self.num_classes,
+            remove_bg=self.remove_bg,
+            reduction=self.reduction,
+        )

--- a/pytorch_lightning/metrics/classification.py
+++ b/pytorch_lightning/metrics/classification.py
@@ -807,7 +807,7 @@ class IoU(TensorMetric):
     def __init__(
             self,
             ignore_index: Optional[int] = None,
-            not_present_score: float = 1.0,
+            not_present_score: float = 0.0,
             num_classes: Optional[int] = None,
             reduction: str = "elementwise_mean",
     ):
@@ -819,7 +819,7 @@ class IoU(TensorMetric):
                 By default, no index is ignored, and all classes are used.
             not_present_score: score to use for an individual class, if no instances of the class index were present in
                 `y_pred` AND no instances of the class index were present in `y_true`. By default, assign a score of
-                1.0 for this class if not present.
+                0.0 for this class if not present.
 
                 Ex: if we have the following input:
 

--- a/pytorch_lightning/metrics/classification.py
+++ b/pytorch_lightning/metrics/classification.py
@@ -806,20 +806,20 @@ class IoU(TensorMetric):
 
     def __init__(
             self,
+            ignore_index: Optional[int] = None,
             not_present_score: float = 1.0,
             num_classes: Optional[int] = None,
-            remove_bg: bool = False,
             reduction: str = "elementwise_mean",
     ):
         """
         Args:
+            ignore_index: optional int specifying a target class to ignore. If given, this class index does not
+                contribute to the returned score, regardless of reduction method. Has no effect if given an int that is
+                not in the range [0, num_classes-1], where num_classes is either given or derived from pred and target.
+                By default, no index is ignored, and all classes are used.
             not_present_score: score to use for a class, if no instance of that class was present in either pred or
                 target
             num_classes: Optionally specify the number of classes
-            remove_bg: Flag to state whether a background class has been included
-                within input parameters. If true, will remove background class. If
-                false, return IoU over all classes.
-                Assumes that background is '0' class in input tensor
             reduction: a method to reduce metric score over labels (default: takes the mean)
                 Available reduction methods:
 
@@ -828,9 +828,9 @@ class IoU(TensorMetric):
                 - sum: add elements
         """
         super().__init__(name="iou")
+        self.ignore_index = ignore_index
         self.not_present_score = not_present_score
         self.num_classes = num_classes
-        self.remove_bg = remove_bg
         self.reduction = reduction
 
     def forward(self, y_pred: torch.Tensor, y_true: torch.Tensor, sample_weight: Optional[torch.Tensor] = None):
@@ -840,8 +840,8 @@ class IoU(TensorMetric):
         return iou(
             pred=y_pred,
             target=y_true,
+            ignore_index=self.ignore_index,
             not_present_score=self.not_present_score,
             num_classes=self.num_classes,
-            remove_bg=self.remove_bg,
             reduction=self.reduction,
         )

--- a/pytorch_lightning/metrics/classification.py
+++ b/pytorch_lightning/metrics/classification.py
@@ -817,8 +817,21 @@ class IoU(TensorMetric):
                 contribute to the returned score, regardless of reduction method. Has no effect if given an int that is
                 not in the range [0, num_classes-1], where num_classes is either given or derived from pred and target.
                 By default, no index is ignored, and all classes are used.
-            not_present_score: score to use for a class, if no instance of that class was present in either pred or
-                target
+            not_present_score: score to use for an individual class, if no instances of the class index were present in
+                `y_pred` AND no instances of the class index were present in `y_true`. By default, assign a score of
+                1.0 for this class if not present.
+
+                Ex: if we have the following input:
+
+                - 3 classes
+                - `y_pred` is [0, 0]
+                - `y_true` is [0, 2]
+                - `not_present_score` is 1.0
+
+                Then class 0 would get a score of 1 / 2, and class 2 would get a score of 0 / 1. However, class 1 is not
+                actually present in either `y_pred` or `y_true`, so it falls back to the `not_present_score` (1.0 in
+                this example). These 3 scores are then reduced according to the `reduction` method in the same way as if
+                class 1 were present and received an empirical score.
             num_classes: Optionally specify the number of classes
             reduction: a method to reduce metric score over labels (default: takes the mean)
                 Available reduction methods:

--- a/pytorch_lightning/metrics/classification.py
+++ b/pytorch_lightning/metrics/classification.py
@@ -807,7 +807,7 @@ class IoU(TensorMetric):
     def __init__(
             self,
             ignore_index: Optional[int] = None,
-            not_present_score: float = 0.0,
+            absent_score: float = 0.0,
             num_classes: Optional[int] = None,
             reduction: str = "elementwise_mean",
     ):
@@ -817,19 +817,19 @@ class IoU(TensorMetric):
                 contribute to the returned score, regardless of reduction method. Has no effect if given an int that is
                 not in the range [0, num_classes-1], where num_classes is either given or derived from pred and target.
                 By default, no index is ignored, and all classes are used.
-            not_present_score: score to use for an individual class, if no instances of the class index were present in
+            absent_score: score to use for an individual class, if no instances of the class index were present in
                 `y_pred` AND no instances of the class index were present in `y_true`. By default, assign a score of
-                0.0 for this class if not present.
+                0.0 for this class if absent.
 
                 Ex: if we have the following input:
 
                 - 3 classes
                 - `y_pred` is [0, 0]
                 - `y_true` is [0, 2]
-                - `not_present_score` is 1.0
+                - `absent_score` is 1.0
 
                 Then class 0 would get a score of 1 / 2, and class 2 would get a score of 0 / 1. However, class 1 is not
-                actually present in either `y_pred` or `y_true`, so it falls back to the `not_present_score` (1.0 in
+                actually present in either `y_pred` or `y_true`, so it falls back to the `absent_score` (1.0 in
                 this example). These 3 scores are then reduced according to the `reduction` method in the same way as if
                 class 1 were present and received an empirical score.
             num_classes: Optionally specify the number of classes
@@ -842,7 +842,7 @@ class IoU(TensorMetric):
         """
         super().__init__(name="iou")
         self.ignore_index = ignore_index
-        self.not_present_score = not_present_score
+        self.absent_score = absent_score
         self.num_classes = num_classes
         self.reduction = reduction
 
@@ -854,7 +854,7 @@ class IoU(TensorMetric):
             pred=y_pred,
             target=y_true,
             ignore_index=self.ignore_index,
-            not_present_score=self.not_present_score,
+            absent_score=self.absent_score,
             num_classes=self.num_classes,
             reduction=self.reduction,
         )

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -964,7 +964,7 @@ def iou(
         pred: torch.Tensor,
         target: torch.Tensor,
         ignore_index: Optional[int] = None,
-        not_present_score: float = 0.0,
+        absent_score: float = 0.0,
         num_classes: Optional[int] = None,
         reduction: str = 'elementwise_mean',
 ) -> torch.Tensor:
@@ -978,19 +978,19 @@ def iou(
             to the returned score, regardless of reduction method. Has no effect if given an int that is not in the
             range [0, num_classes-1], where num_classes is either given or derived from pred and target. By default, no
             index is ignored, and all classes are used.
-        not_present_score: score to use for an individual class, if no instances of the class index were present in
+        absent_score: score to use for an individual class, if no instances of the class index were present in
             `pred` AND no instances of the class index were present in `target`. By default, assign a score of 0.0 for
-            this class if not present.
+            this class if absent.
 
             Ex: if we have the following input:
 
             - 3 classes
             - `pred` is [0, 0]
             - `target` is [0, 2]
-            - `not_present_score` is 1.0
+            - `absent_score` is 1.0
 
             Then class 0 would get a score of 1 / 2, and class 2 would get a score of 0 / 1. However, class 1 is not
-            actually present in either `pred` or `target`, so it falls back to the `not_present_score` (1.0 in
+            actually present in either `pred` or `target`, so it falls back to the `absent_score` (1.0 in
             this example). These 3 scores are then reduced according to the `reduction` method in the same way as if
             class 1 were present and received an empirical score.
         num_classes: Optionally specify the number of classes
@@ -1030,10 +1030,10 @@ def iou(
         fn = fns[class_idx]
         sup = sups[class_idx]
 
-        # If this class is not present in the target (no support) AND not present in the pred (no true or false
-        # positives), then use the not_present_score for this class.
+        # If this class is absent in the target (no support) AND absent in the pred (no true or false
+        # positives), then use the absent_score for this class.
         if sup + tp + fp == 0:
-            scores[class_idx] = not_present_score
+            scores[class_idx] = absent_score
             continue
 
         denom = tp + fp + fn

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -964,7 +964,7 @@ def iou(
         pred: torch.Tensor,
         target: torch.Tensor,
         ignore_index: Optional[int] = None,
-        not_present_score: float = 1.0,
+        not_present_score: float = 0.0,
         num_classes: Optional[int] = None,
         reduction: str = 'elementwise_mean',
 ) -> torch.Tensor:
@@ -979,7 +979,7 @@ def iou(
             range [0, num_classes-1], where num_classes is either given or derived from pred and target. By default, no
             index is ignored, and all classes are used.
         not_present_score: score to use for an individual class, if no instances of the class index were present in
-            `pred` AND no instances of the class index were present in `target`. By default, assign a score of 1.0 for
+            `pred` AND no instances of the class index were present in `target`. By default, assign a score of 0.0 for
             this class if not present.
 
             Ex: if we have the following input:

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -979,20 +979,9 @@ def iou(
             range [0, num_classes-1], where num_classes is either given or derived from pred and target. By default, no
             index is ignored, and all classes are used.
         absent_score: score to use for an individual class, if no instances of the class index were present in
-            `pred` AND no instances of the class index were present in `target`. By default, assign a score of 0.0 for
-            this class if absent.
-
-            Ex: if we have the following input:
-
-            - 3 classes
-            - `pred` is [0, 0]
-            - `target` is [0, 2]
-            - `absent_score` is 1.0
-
-            Then class 0 would get a score of 1 / 2, and class 2 would get a score of 0 / 1. However, class 1 is not
-            actually present in either `pred` or `target`, so it falls back to the `absent_score` (1.0 in
-            this example). These 3 scores are then reduced according to the `reduction` method in the same way as if
-            class 1 were present and received an empirical score.
+            `pred` AND no instances of the class index were present in `target`. For example, if we have 3 classes,
+            [0, 0] for `pred`, and [0, 2] for `target`, then class 1 would be assigned the `absent_score`. Default is
+            0.0.
         num_classes: Optionally specify the number of classes
         reduction: a method to reduce metric score over labels (default: takes the mean)
             Available reduction methods:

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -978,7 +978,21 @@ def iou(
             to the returned score, regardless of reduction method. Has no effect if given an int that is not in the
             range [0, num_classes-1], where num_classes is either given or derived from pred and target. By default, no
             index is ignored, and all classes are used.
-        not_present_score: score to use for a class, if no instance of that class was present in either pred or target
+        not_present_score: score to use for an individual class, if no instances of the class index were present in
+            `pred` AND no instances of the class index were present in `target`. By default, assign a score of 1.0 for
+            this class if not present.
+
+            Ex: if we have the following input:
+
+            - 3 classes
+            - `pred` is [0, 0]
+            - `target` is [0, 2]
+            - `not_present_score` is 1.0
+
+            Then class 0 would get a score of 1 / 2, and class 2 would get a score of 0 / 1. However, class 1 is not
+            actually present in either `pred` or `target`, so it falls back to the `not_present_score` (1.0 in
+            this example). These 3 scores are then reduced according to the `reduction` method in the same way as if
+            class 1 were present and received an empirical score.
         num_classes: Optionally specify the number of classes
         reduction: a method to reduce metric score over labels (default: takes the mean)
             Available reduction methods:
@@ -1016,8 +1030,8 @@ def iou(
         fn = fns[class_idx]
         sup = sups[class_idx]
 
-        # If this class is not present in either the target (no support) or the pred (no true or false positives), then
-        # use the not_present_score for this class.
+        # If this class is not present in the target (no support) AND not present in the pred (no true or false
+        # positives), then use the not_present_score for this class.
         if sup + tp + fp == 0:
             scores[class_idx] = not_present_score
             continue

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -921,12 +921,11 @@ def dice_score(
         bg: whether to also compute dice for the background
         nan_score: score to return, if a NaN occurs during computation
         no_fg_score: score to return, if no foreground pixel was found in target
-        reduction: a method to reduce metric score over labels (default: takes the mean)
-            Available reduction methods:
+        reduction: a method to reduce metric score over labels.
 
-            - elementwise_mean: takes the mean
-            - none: pass array
-            - sum: add elements
+            - ``'elementwise_mean'``: takes the mean (default)
+            - ``'sum'``: takes the sum
+            - ``'none'``: no reduction will be applied
 
     Return:
         Tensor containing dice score
@@ -983,12 +982,11 @@ def iou(
             [0, 0] for `pred`, and [0, 2] for `target`, then class 1 would be assigned the `absent_score`. Default is
             0.0.
         num_classes: Optionally specify the number of classes
-        reduction: a method to reduce metric score over labels (default: takes the mean)
-            Available reduction methods:
+        reduction: a method to reduce metric score over labels.
 
-            - elementwise_mean: takes the mean
-            - none: pass array
-            - sum: add elements
+            - ``'elementwise_mean'``: takes the mean (default)
+            - ``'sum'``: takes the sum
+            - ``'none'``: no reduction will be applied
 
     Return:
         IoU score : Tensor containing single value if reduction is

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -4,7 +4,7 @@ from typing import Callable, Optional, Sequence, Tuple
 import torch
 from torch.nn import functional as F
 
-from pytorch_lightning.metrics.functional.reduction import reduce, class_reduce
+from pytorch_lightning.metrics.functional.reduction import class_reduce, reduce
 from pytorch_lightning.utilities import FLOAT16_EPSILON, rank_zero_warn
 
 

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -1010,7 +1010,6 @@ def iou(
     scores = torch.zeros(num_classes, device=pred.device, dtype=torch.float32)
 
     for class_idx in range(num_classes):
-        # Skip this class if its index is being ignored.
         if class_idx == ignore_index:
             continue
 

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -1037,6 +1037,9 @@ def iou(
             continue
 
         denom = tp + fp + fn
+        # Note that we do not need to worry about division-by-zero here since we know (sup + tp + fp != 0) from above,
+        # which means ((tp+fn) + tp + fp != 0), which means (2tp + fp + fn != 0). Since all vars are non-negative, we
+        # can conclude (tp + fp + fn > 0), meaning the denominator is non-zero for each class.
         score = tp.to(torch.float) / denom
         scores[class_idx] = score
 

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -386,42 +386,42 @@ def test_iou(half_ones, reduction, ignore_index, expected):
 
 # TODO: When the jaccard_score of the sklearn version we use accepts `zero_division` (see
 #       https://github.com/scikit-learn/scikit-learn/pull/17866), consider adding a test here against our
-#       `not_present_score`.
-@pytest.mark.parametrize(['pred', 'target', 'ignore_index', 'not_present_score', 'num_classes', 'expected'], [
-    # Note that -1 is used as the not_present_score in almost all tests here to distinguish it from the range of valid
+#       `absent_score`.
+@pytest.mark.parametrize(['pred', 'target', 'ignore_index', 'absent_score', 'num_classes', 'expected'], [
+    # Note that -1 is used as the absent_score in almost all tests here to distinguish it from the range of valid
     # scores the function can return ([0., 1.] range, inclusive).
-    # 2 classes, class 0 is correct everywhere, class 1 is not present.
+    # 2 classes, class 0 is correct everywhere, class 1 is absent.
     pytest.param([0], [0], None, -1., 2, [1., -1.]),
     pytest.param([0, 0], [0, 0], None, -1., 2, [1., -1.]),
-    # not_present_score not applied if only class 0 is present and it's the only class.
+    # absent_score not applied if only class 0 is present and it's the only class.
     pytest.param([0], [0], None, -1., 1, [1.]),
-    # 2 classes, class 1 is correct everywhere, class 0 is not present.
+    # 2 classes, class 1 is correct everywhere, class 0 is absent.
     pytest.param([1], [1], None, -1., 2, [-1., 1.]),
     pytest.param([1, 1], [1, 1], None, -1., 2, [-1., 1.]),
-    # When 0 index ignored, class 0 does not get a score (not even the not_present_score).
+    # When 0 index ignored, class 0 does not get a score (not even the absent_score).
     pytest.param([1], [1], 0, -1., 2, [1.0]),
-    # 3 classes. Only 0 and 2 are present, and are perfectly predicted. 1 should get not_present_score.
+    # 3 classes. Only 0 and 2 are present, and are perfectly predicted. 1 should get absent_score.
     pytest.param([0, 2], [0, 2], None, -1., 3, [1., -1., 1.]),
     pytest.param([2, 0], [2, 0], None, -1., 3, [1., -1., 1.]),
-    # 3 classes. Only 0 and 1 are present, and are perfectly predicted. 2 should get not_present_score.
+    # 3 classes. Only 0 and 1 are present, and are perfectly predicted. 2 should get absent_score.
     pytest.param([0, 1], [0, 1], None, -1., 3, [1., 1., -1.]),
     pytest.param([1, 0], [1, 0], None, -1., 3, [1., 1., -1.]),
-    # 3 classes, class 0 is 0.5 IoU, class 1 is 0 IoU (in pred but not target; should not get not_present_score), class
-    # 2 is not present.
+    # 3 classes, class 0 is 0.5 IoU, class 1 is 0 IoU (in pred but not target; should not get absent_score), class
+    # 2 is absent.
     pytest.param([0, 1], [0, 0], None, -1., 3, [0.5, 0., -1.]),
-    # 3 classes, class 0 is 0.5 IoU, class 1 is 0 IoU (in target but not pred; should not get not_present_score), class
-    # 2 is not present.
+    # 3 classes, class 0 is 0.5 IoU, class 1 is 0 IoU (in target but not pred; should not get absent_score), class
+    # 2 is absent.
     pytest.param([0, 0], [0, 1], None, -1., 3, [0.5, 0., -1.]),
-    # Sanity checks with not_present_score of 1.0.
+    # Sanity checks with absent_score of 1.0.
     pytest.param([0, 2], [0, 2], None, 1.0, 3, [1., 1., 1.]),
     pytest.param([0, 2], [0, 2], 0, 1.0, 3, [1., 1.]),
 ])
-def test_iou_not_present_score(pred, target, ignore_index, not_present_score, num_classes, expected):
+def test_iou_absent_score(pred, target, ignore_index, absent_score, num_classes, expected):
     iou_val = iou(
         pred=torch.tensor(pred),
         target=torch.tensor(target),
         ignore_index=ignore_index,
-        not_present_score=not_present_score,
+        absent_score=absent_score,
         num_classes=num_classes,
         reduction='none',
     )

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from sklearn.metrics import (
     accuracy_score as sk_accuracy,
+    jaccard_score as sk_jaccard_score,
     precision_score as sk_precision,
     recall_score as sk_recall,
     f1_score as sk_f1_score,
@@ -37,6 +38,7 @@ from pytorch_lightning.metrics.functional.classification import (
 
 @pytest.mark.parametrize(['sklearn_metric', 'torch_metric'], [
     pytest.param(sk_accuracy, accuracy, id='accuracy'),
+    pytest.param(partial(sk_jaccard_score, average='micro'), iou, id='iou'),
     pytest.param(partial(sk_precision, average='micro'), precision, id='precision'),
     pytest.param(partial(sk_recall, average='micro'), recall, id='recall'),
     pytest.param(partial(sk_f1_score, average='micro'), f1_score, id='f1_score'),
@@ -382,6 +384,9 @@ def test_iou(half_ones, reduction, remove_bg, expected):
     assert torch.allclose(iou_val, expected, atol=1e-9)
 
 
+# TODO: When the jaccard_score of the sklearn version we use accepts `zero_division` (see
+#       https://github.com/scikit-learn/scikit-learn/pull/17866), consider adding a test here against our
+#       `not_present_score`.
 @pytest.mark.parametrize(['pred', 'target', 'not_present_score', 'num_classes', 'remove_bg', 'expected'], [
     # Note that -1 is used as the not_present_score in almost all tests here to distinguish it from the range of valid
     # scores the function can return ([0., 1.] range, inclusive).

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -38,7 +38,7 @@ from pytorch_lightning.metrics.functional.classification import (
 
 @pytest.mark.parametrize(['sklearn_metric', 'torch_metric'], [
     pytest.param(sk_accuracy, accuracy, id='accuracy'),
-    pytest.param(partial(sk_jaccard_score, average='micro'), iou, id='iou'),
+    pytest.param(partial(sk_jaccard_score, average='macro'), iou, id='iou'),
     pytest.param(partial(sk_precision, average='micro'), precision, id='precision'),
     pytest.param(partial(sk_recall, average='micro'), recall, id='recall'),
     pytest.param(partial(sk_f1_score, average='micro'), f1_score, id='f1_score'),

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -362,15 +362,15 @@ def test_dice_score(pred, target, expected):
     assert score == expected
 
 
-@pytest.mark.parametrize(['half_ones', 'reduction', 'remove_bg', 'expected'], [
-    pytest.param(False, 'none', False, torch.Tensor([1, 1, 1])),
-    pytest.param(False, 'elementwise_mean', False, torch.Tensor([1])),
-    pytest.param(False, 'none', True, torch.Tensor([1, 1])),
-    pytest.param(True, 'none', False, torch.Tensor([0.5, 0.5, 0.5])),
-    pytest.param(True, 'elementwise_mean', False, torch.Tensor([0.5])),
-    pytest.param(True, 'none', True, torch.Tensor([0.5, 0.5])),
+@pytest.mark.parametrize(['half_ones', 'reduction', 'ignore_index', 'expected'], [
+    pytest.param(False, 'none', None, torch.Tensor([1, 1, 1])),
+    pytest.param(False, 'elementwise_mean', None, torch.Tensor([1])),
+    pytest.param(False, 'none', 0, torch.Tensor([1, 1])),
+    pytest.param(True, 'none', None, torch.Tensor([0.5, 0.5, 0.5])),
+    pytest.param(True, 'elementwise_mean', None, torch.Tensor([0.5])),
+    pytest.param(True, 'none', 0, torch.Tensor([0.5, 0.5])),
 ])
-def test_iou(half_ones, reduction, remove_bg, expected):
+def test_iou(half_ones, reduction, ignore_index, expected):
     pred = (torch.arange(120) % 3).view(-1, 1)
     target = (torch.arange(120) % 3).view(-1, 1)
     if half_ones:
@@ -378,7 +378,7 @@ def test_iou(half_ones, reduction, remove_bg, expected):
     iou_val = iou(
         pred=pred,
         target=target,
-        remove_bg=remove_bg,
+        ignore_index=ignore_index,
         reduction=reduction,
     )
     assert torch.allclose(iou_val, expected, atol=1e-9)
@@ -387,43 +387,67 @@ def test_iou(half_ones, reduction, remove_bg, expected):
 # TODO: When the jaccard_score of the sklearn version we use accepts `zero_division` (see
 #       https://github.com/scikit-learn/scikit-learn/pull/17866), consider adding a test here against our
 #       `not_present_score`.
-@pytest.mark.parametrize(['pred', 'target', 'not_present_score', 'num_classes', 'remove_bg', 'expected'], [
+@pytest.mark.parametrize(['pred', 'target', 'ignore_index', 'not_present_score', 'num_classes', 'expected'], [
     # Note that -1 is used as the not_present_score in almost all tests here to distinguish it from the range of valid
     # scores the function can return ([0., 1.] range, inclusive).
     # 2 classes, class 0 is correct everywhere, class 1 is not present.
-    pytest.param([0], [0], -1., 2, False, [1., -1.]),
-    pytest.param([0, 0], [0, 0], -1., 2, False, [1., -1.]),
+    pytest.param([0], [0], None, -1., 2, [1., -1.]),
+    pytest.param([0, 0], [0, 0], None, -1., 2, [1., -1.]),
     # not_present_score not applied if only class 0 is present and it's the only class.
-    pytest.param([0], [0], -1., 1, False, [1.]),
+    pytest.param([0], [0], None, -1., 1, [1.]),
     # 2 classes, class 1 is correct everywhere, class 0 is not present.
-    pytest.param([1], [1], -1., 2, False, [-1., 1.]),
-    pytest.param([1, 1], [1, 1], -1., 2, False, [-1., 1.]),
-    # When background removed, class 0 does not get a score (not even the not_present_score).
-    pytest.param([1], [1], -1., 2, True, [1.0]),
+    pytest.param([1], [1], None, -1., 2, [-1., 1.]),
+    pytest.param([1, 1], [1, 1], None, -1., 2, [-1., 1.]),
+    # When 0 index ignored, class 0 does not get a score (not even the not_present_score).
+    pytest.param([1], [1], 0, -1., 2, [1.0]),
     # 3 classes. Only 0 and 2 are present, and are perfectly predicted. 1 should get not_present_score.
-    pytest.param([0, 2], [0, 2], -1., 3, False, [1., -1., 1.]),
-    pytest.param([2, 0], [2, 0], -1., 3, False, [1., -1., 1.]),
+    pytest.param([0, 2], [0, 2], None, -1., 3, [1., -1., 1.]),
+    pytest.param([2, 0], [2, 0], None, -1., 3, [1., -1., 1.]),
     # 3 classes. Only 0 and 1 are present, and are perfectly predicted. 2 should get not_present_score.
-    pytest.param([0, 1], [0, 1], -1., 3, False, [1., 1., -1.]),
-    pytest.param([1, 0], [1, 0], -1., 3, False, [1., 1., -1.]),
+    pytest.param([0, 1], [0, 1], None, -1., 3, [1., 1., -1.]),
+    pytest.param([1, 0], [1, 0], None, -1., 3, [1., 1., -1.]),
     # 3 classes, class 0 is 0.5 IoU, class 1 is 0 IoU (in pred but not target; should not get not_present_score), class
     # 2 is not present.
-    pytest.param([0, 1], [0, 0], -1., 3, False, [0.5, 0., -1.]),
+    pytest.param([0, 1], [0, 0], None, -1., 3, [0.5, 0., -1.]),
     # 3 classes, class 0 is 0.5 IoU, class 1 is 0 IoU (in target but not pred; should not get not_present_score), class
     # 2 is not present.
-    pytest.param([0, 0], [0, 1], -1., 3, False, [0.5, 0., -1.]),
+    pytest.param([0, 0], [0, 1], None, -1., 3, [0.5, 0., -1.]),
     # Sanity checks with not_present_score of 1.0.
-    pytest.param([0, 2], [0, 2], 1.0, 3, False, [1., 1., 1.]),
-    pytest.param([0, 2], [0, 2], 1.0, 3, True, [1., 1.]),
+    pytest.param([0, 2], [0, 2], None, 1.0, 3, [1., 1., 1.]),
+    pytest.param([0, 2], [0, 2], 0, 1.0, 3, [1., 1.]),
 ])
-def test_iou_not_present_score(pred, target, not_present_score, num_classes, remove_bg, expected):
+def test_iou_not_present_score(pred, target, ignore_index, not_present_score, num_classes, expected):
     iou_val = iou(
         pred=torch.tensor(pred),
         target=torch.tensor(target),
+        ignore_index=ignore_index,
         not_present_score=not_present_score,
         num_classes=num_classes,
-        remove_bg=remove_bg,
         reduction='none',
+    )
+    assert torch.allclose(iou_val, torch.tensor(expected).to(iou_val))
+
+
+@pytest.mark.parametrize(['pred', 'target', 'ignore_index', 'num_classes', 'reduction', 'expected'], [
+    # Ignoring an index outside of [0, num_classes-1] should have no effect.
+    pytest.param([0, 1, 1, 2, 2], [0, 1, 2, 2, 2], None, 3, 'none', [1, 1 / 2, 2 / 3]),
+    pytest.param([0, 1, 1, 2, 2], [0, 1, 2, 2, 2], -1, 3, 'none', [1, 1 / 2, 2 / 3]),
+    pytest.param([0, 1, 1, 2, 2], [0, 1, 2, 2, 2], 255, 3, 'none', [1, 1 / 2, 2 / 3]),
+    # Ignoring a valid index drops only that index from the result.
+    pytest.param([0, 1, 1, 2, 2], [0, 1, 2, 2, 2], 0, 3, 'none', [1 / 2, 2 / 3]),
+    pytest.param([0, 1, 1, 2, 2], [0, 1, 2, 2, 2], 1, 3, 'none', [1, 2 / 3]),
+    pytest.param([0, 1, 1, 2, 2], [0, 1, 2, 2, 2], 2, 3, 'none', [1, 1 / 2]),
+    # When reducing to mean or sum, the ignored index does not contribute to the output.
+    pytest.param([0, 1, 1, 2, 2], [0, 1, 2, 2, 2], 0, 3, 'elementwise_mean', [7 / 12]),
+    pytest.param([0, 1, 1, 2, 2], [0, 1, 2, 2, 2], 0, 3, 'sum', [7 / 6]),
+])
+def test_iou_ignore_index(pred, target, ignore_index, num_classes, reduction, expected):
+    iou_val = iou(
+        pred=torch.tensor(pred),
+        target=torch.tensor(target),
+        ignore_index=ignore_index,
+        num_classes=num_classes,
+        reduction=reduction,
     )
     assert torch.allclose(iou_val, torch.tensor(expected).to(iou_val))
 

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -373,8 +373,54 @@ def test_iou(half_ones, reduction, remove_bg, expected):
     target = (torch.arange(120) % 3).view(-1, 1)
     if half_ones:
         pred[:60] = 1
-    iou_val = iou(pred, target, remove_bg=remove_bg, reduction=reduction)
+    iou_val = iou(
+        pred=pred,
+        target=target,
+        remove_bg=remove_bg,
+        reduction=reduction,
+    )
     assert torch.allclose(iou_val, expected, atol=1e-9)
+
+
+@pytest.mark.parametrize(['pred', 'target', 'not_present_score', 'num_classes', 'remove_bg', 'expected'], [
+    # Note that -1 is used as the not_present_score in almost all tests here to distinguish it from the range of valid
+    # scores the function can return ([0., 1.] range, inclusive).
+    # 2 classes, class 0 is correct everywhere, class 1 is not present.
+    pytest.param([0], [0], -1., 2, False, [1., -1.]),
+    pytest.param([0, 0], [0, 0], -1., 2, False, [1., -1.]),
+    # not_present_score not applied if only class 0 is present and it's the only class.
+    pytest.param([0], [0], -1., 1, False, [1.]),
+    # 2 classes, class 1 is correct everywhere, class 0 is not present.
+    pytest.param([1], [1], -1., 2, False, [-1., 1.]),
+    pytest.param([1, 1], [1, 1], -1., 2, False, [-1., 1.]),
+    # When background removed, class 0 does not get a score (not even the not_present_score).
+    pytest.param([1], [1], -1., 2, True, [1.0]),
+    # 3 classes. Only 0 and 2 are present, and are perfectly predicted. 1 should get not_present_score.
+    pytest.param([0, 2], [0, 2], -1., 3, False, [1., -1., 1.]),
+    pytest.param([2, 0], [2, 0], -1., 3, False, [1., -1., 1.]),
+    # 3 classes. Only 0 and 1 are present, and are perfectly predicted. 2 should get not_present_score.
+    pytest.param([0, 1], [0, 1], -1., 3, False, [1., 1., -1.]),
+    pytest.param([1, 0], [1, 0], -1., 3, False, [1., 1., -1.]),
+    # 3 classes, class 0 is 0.5 IoU, class 1 is 0 IoU (in pred but not target; should not get not_present_score), class
+    # 2 is not present.
+    pytest.param([0, 1], [0, 0], -1., 3, False, [0.5, 0., -1.]),
+    # 3 classes, class 0 is 0.5 IoU, class 1 is 0 IoU (in target but not pred; should not get not_present_score), class
+    # 2 is not present.
+    pytest.param([0, 0], [0, 1], -1., 3, False, [0.5, 0., -1.]),
+    # Sanity checks with not_present_score of 1.0.
+    pytest.param([0, 2], [0, 2], 1.0, 3, False, [1., 1., 1.]),
+    pytest.param([0, 2], [0, 2], 1.0, 3, True, [1., 1.]),
+])
+def test_iou_not_present_score(pred, target, not_present_score, num_classes, remove_bg, expected):
+    iou_val = iou(
+        pred=torch.tensor(pred),
+        target=torch.tensor(target),
+        not_present_score=not_present_score,
+        num_classes=num_classes,
+        remove_bg=remove_bg,
+        reduction='none',
+    )
+    assert torch.allclose(iou_val, torch.tensor(expected).to(iou_val))
 
 
 # example data taken from

--- a/tests/metrics/test_classification.py
+++ b/tests/metrics/test_classification.py
@@ -226,9 +226,9 @@ def test_dice_coefficient(include_background):
     assert isinstance(dice, torch.Tensor)
 
 
-@pytest.mark.parametrize('remove_bg', [True, False])
-def test_iou(remove_bg):
-    iou = IoU(remove_bg=remove_bg)
+@pytest.mark.parametrize('ignore_index', [0, 1, None])
+def test_iou(ignore_index):
+    iou = IoU(ignore_index=ignore_index)
     assert iou.name == 'iou'
 
     score = iou(torch.randint(0, 1, (10, 25, 25)),

--- a/tests/trainer/test_trainer_tricks.py
+++ b/tests/trainer/test_trainer_tricks.py
@@ -63,7 +63,6 @@ def test_overfit_batch_limits(tmpdir):
     full_train_samples = len(train_loader)
     num_train_samples = int(0.11 * full_train_samples)
 
-
     # ------------------------------------------------------
     # set VAL and Test loaders
     # ------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes #3097
Fixes #2736

- Allow configurable not_present_score for IoU for classes not present in target or pred. Defaults to 1.0.
- Also allow passing `num_classes` parameter through from iou metric class down to its underlying functional iou call.

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
