### PR TITLE
Make trainer.state a read-only property

### DIFF
--- a/pytorch_lightning/trainer/states.py
+++ b/pytorch_lightning/trainer/states.py
@@ -42,20 +42,20 @@ def trainer_state(*, entering: Optional[TrainerState] = None, exiting: Optional[
             if not isinstance(self, pytorch_lightning.Trainer):
                 return fn(self, *args, **kwargs)
 
-            state_before = self.state
+            state_before = self._state
             if entering is not None:
-                self.state = entering
+                self._state = entering
             result = fn(self, *args, **kwargs)
 
             # The INTERRUPTED state can be set inside the run function. To indicate that run was interrupted
             # we retain INTERRUPTED state
-            if self.state == TrainerState.INTERRUPTED:
+            if self._state == TrainerState.INTERRUPTED:
                 return result
 
             if exiting is not None:
-                self.state = exiting
+                self._state = exiting
             else:
-                self.state = state_before
+                self._state = state_before
             return result
 
         return wrapped_fn

--- a/pytorch_lightning/trainer/states.py
+++ b/pytorch_lightning/trainer/states.py
@@ -52,10 +52,7 @@ def trainer_state(*, entering: Optional[TrainerState] = None, exiting: Optional[
             if self._state == TrainerState.INTERRUPTED:
                 return result
 
-            if exiting is not None:
-                self._state = exiting
-            else:
-                self._state = state_before
+            self._state = exiting if exiting is not None else state_before
             return result
 
         return wrapped_fn

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -402,7 +402,7 @@ class Trainer(
         self.interrupted = False
         self.should_stop = False
         self.running_sanity_check = False
-        self.state = TrainerState.INITIALIZING
+        self._state = TrainerState.INITIALIZING
 
         self._default_root_dir = default_root_dir or os.getcwd()
         self._weights_save_path = weights_save_path or self._default_root_dir
@@ -610,6 +610,10 @@ class Trainer(
 
         # Callback system
         self.on_init_end()
+
+    @property
+    def state(self) -> TrainerState:
+        return self._state
 
     @property
     def is_global_zero(self) -> bool:

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -255,7 +255,7 @@ class TrainerTrainLoopMixin(ABC):
     terminate_on_nan: bool
     tpu_id: int
     interactive_ddp_procs: ...
-    state: TrainerState
+    _state: TrainerState
     amp_backend: AMPType
     on_tpu: bool
 
@@ -421,7 +421,7 @@ class TrainerTrainLoopMixin(ABC):
             # user could press ctrl+c many times... only shutdown once
             if not self.interrupted:
                 self.interrupted = True
-                self.state = TrainerState.INTERRUPTED
+                self._state = TrainerState.INTERRUPTED
                 self.on_keyboard_interrupt()
 
                 self.run_training_teardown()

--- a/tests/trainer/test_states.py
+++ b/tests/trainer/test_states.py
@@ -31,7 +31,6 @@ def test_state_decorator_nothing_passed(tmpdir):
         return self.state
 
     trainer = Trainer(default_root_dir=tmpdir)
-    trainer.state = TrainerState.INITIALIZING
 
     snapshot_state = test_method(trainer)
 
@@ -47,7 +46,6 @@ def test_state_decorator_entering_only(tmpdir):
         return self.state
 
     trainer = Trainer(default_root_dir=tmpdir)
-    trainer.state = TrainerState.INITIALIZING
 
     snapshot_state = test_method(trainer)
 
@@ -63,7 +61,6 @@ def test_state_decorator_exiting_only(tmpdir):
         return self.state
 
     trainer = Trainer(default_root_dir=tmpdir)
-    trainer.state = TrainerState.INITIALIZING
 
     snapshot_state = test_method(trainer)
 
@@ -79,7 +76,6 @@ def test_state_decorator_entering_and_exiting(tmpdir):
         return self.state
 
     trainer = Trainer(default_root_dir=tmpdir)
-    trainer.state = TrainerState.INITIALIZING
 
     snapshot_state = test_method(trainer)
 
@@ -92,10 +88,9 @@ def test_state_decorator_interrupt(tmpdir):
 
     @trainer_state(exiting=TrainerState.FINISHED)
     def test_method(self):
-        self.state = TrainerState.INTERRUPTED
+        self._state = TrainerState.INTERRUPTED
 
     trainer = Trainer(default_root_dir=tmpdir)
-    trainer.state = TrainerState.INITIALIZING
 
     test_method(trainer)
     assert trainer.state == TrainerState.INTERRUPTED


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Follow-up on https://github.com/PyTorchLightning/pytorch-lightning/pull/2541 to make trainer state read-only.

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
