### PR TITLE
Added missing docs on[ TrainResult and EvalResult source docs.

### DIFF
--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -497,6 +497,7 @@ class TrainResult(Result):
                 return result
 
         Args:
+            minimize:
             early_stop_on:
             checkpoint_on:
             hiddens:

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -497,9 +497,9 @@ class TrainResult(Result):
                 return result
 
         Args:
-            minimize:
-            early_stop_on:
-            checkpoint_on:
+            minimize: Metric currently being minimized.
+            early_stop_on: Metric to early stop on.
+            checkpoint_on: Metric to checkpoint on.
             hiddens:
         """
 
@@ -653,8 +653,8 @@ class EvalResult(Result):
                 return result
 
         Args:
-            early_stop_on:
-            checkpoint_on:
+            early_stop_on: Metric to early stop on.
+            checkpoint_on: Metric to checkpoint on.
             hiddens:
         """
 


### PR DESCRIPTION
Added missing docs on [TrainResult and EvalResult source docs.](https://pytorch-lightning.readthedocs.io/en/latest/api/pytorch_lightning.core.step_result.html)

#3091
