### PR TITLE
[WIP] Accept Result checkpoint_on 0 tensors; exclude bool

### DIFF
--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -28,7 +28,7 @@ class Result(Dict):
         self,
         minimize: Optional[Tensor] = None,
         early_stop_on: Optional[Tensor] = None,
-        checkpoint_on: Union[Tensor, bool, None] = None,
+        checkpoint_on: Optional[Tensor] = None,
         hiddens: Optional[Tensor] = None,
     ):
 
@@ -39,7 +39,7 @@ class Result(Dict):
 
         if early_stop_on is not None:
             self.early_stop_on = early_stop_on
-        if checkpoint_on is not None and checkpoint_on:
+        if checkpoint_on is not None:
             self.checkpoint_on = checkpoint_on
         if hiddens is not None:
             self.hiddens = hiddens.detach()
@@ -476,7 +476,7 @@ class TrainResult(Result):
         self,
         minimize: Optional[Tensor] = None,
         early_stop_on: Tensor = None,
-        checkpoint_on: Union[Tensor, bool] = None,
+        checkpoint_on: Optional[Tensor] = None,
         hiddens: Optional[Tensor] = None,
     ):
         """

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -475,7 +475,7 @@ class TrainResult(Result):
     def __init__(
         self,
         minimize: Optional[Tensor] = None,
-        early_stop_on: Tensor = None,
+        early_stop_on: Optional[Tensor] = None,
         checkpoint_on: Optional[Tensor] = None,
         hiddens: Optional[Tensor] = None,
     ):

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -115,7 +115,7 @@ class DeterministicModel(LightningModule):
         Early stop and checkpoint only on these values
         """
         acc = self.step(batch, batch_idx)
-        result = TrainResult(minimize=acc, checkpoint_on=False)
+        result = TrainResult(minimize=acc, checkpoint_on=None)
         assert 'early_step_on' not in result
         assert 'checkpoint_on' not in result
         return result

--- a/tests/core/test_results.py
+++ b/tests/core/test_results.py
@@ -244,3 +244,14 @@ def test_result_retrieve_last_logged_item():
     assert result['epoch_a'] == 5.
     assert result['step_a'] == 5.
     assert result['a'] == 5.
+
+
+@pytest.mark.parametrize("result_cls", [Result, TrainResult, EvalResult])
+@pytest.mark.parametrize("checkpoint_on", [
+    torch.tensor(1.0),
+    torch.tensor(0.0),  # Notably, even a tensor with 0 value (and that therefore is falsy) should be kept.
+])
+def test_result_checkpoint_on_keeps_tensor(result_cls, checkpoint_on):
+    """ Test that checkpoint_on tensor values (both zero and nonzero) are kept after init. """
+    result = result_cls(checkpoint_on=checkpoint_on)
+    assert result.checkpoint_on == checkpoint_on


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/3099

- Result checkpoint_on typing updated to only accept Tensor or None;
  no longer accept bool.
- Remove checkpoint_on truthy check on Result init, which was causing
  0-valued Tensors to be incorrectly dropped.
- Add tests for checkpoint_on keeping zero and nonzero tensor values.
  Also update an existing test that was passing checkpoint_on=False to
  just pass None instead.
- (Also updates `TrainResult`'s `early_stop_on` typing from `Tensor` -> `Optional[Tensor]`; already defaults to None. This felt small and relevant, but can move to a different PR or exclude in general if we want.)

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
