### PR TITLE
Set pep8speaks' max-line-length to 120 (same as black)

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -5,7 +5,7 @@ scanner:
     linter: pycodestyle  # Other option is flake8
 
 pycodestyle:  # Same as scanner.linter value. Other option is flake8
-    max-line-length: 119  # Default is 79 in PEP 8
+    max-line-length: 120  # Default is 79 in PEP 8
     ignore:  # Errors and warnings to ignore
         - W504  # line break after binary operator
         - E402  # module level import not at top of file


### PR DESCRIPTION
## What does this PR do?

Sets pep8speaks' max-line-length to 120 (same as black)

Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/3168

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?