### PR TITLE
make PyTorch Lightning PEP 561 Compliant 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -28,6 +28,9 @@ exclude *.toml
 exclude *.svg
 recursive-include pytorch_lightning *.py
 
+# Include marker file for PEP 561
+include pytorch_lightning py.typed
+
 # include examples
 recursive-include pl_examples *.py *.md *.sh *.txt
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -29,7 +29,7 @@ exclude *.svg
 recursive-include pytorch_lightning *.py
 
 # Include marker file for PEP 561
-include pytorch_lightning py.typed
+include pytorch_lightning/py.typed
 
 # include examples
 recursive-include pl_examples *.py *.md *.sh *.txt

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,10 @@ setup(
     install_requires=load_requirements(),
     extras_require=extras,
 
+    package_data={
+        "pytorch_lightning": ["py.typed"]
+    },
+
     project_urls={
         "Bug Tracker": "https://github.com/PyTorchLightning/pytorch-lightning/issues",
         "Documentation": "https://pytorch-lightning.rtfd.io/en/latest/",

--- a/setup.py
+++ b/setup.py
@@ -98,10 +98,6 @@ setup(
     install_requires=load_requirements(),
     extras_require=extras,
 
-    package_data={
-        "pytorch_lightning": ["py.typed"]
-    },
-
     project_urls={
         "Bug Tracker": "https://github.com/PyTorchLightning/pytorch-lightning/issues",
         "Documentation": "https://pytorch-lightning.rtfd.io/en/latest/",


### PR DESCRIPTION
Fixes [#3186](https://github.com/PyTorchLightning/pytorch-lightning/issues/3186) by adding a `py.typed` under package `pytorch_lightning` and distributing it as part of package data in `setup.py`.

How would I approach writing a test for this? Would I create an automated check that the package install works under when imported in another file and run with `mypy`?