### PR TITLE
Early stopping doc

### DIFF
--- a/docs/source/early_stopping.rst
+++ b/docs/source/early_stopping.rst
@@ -37,7 +37,7 @@ There are two ways to enable the EarlyStopping callback:
     :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_epoch_end`,
     the callback will look for `val_loss` in the dict
     and raise an error if `val_loss` is not present.
-    Otherwise, if a :class:`~pytorch_lightning.core.step_result.Result` is returned, by
+    Otherwise, if a :class:`~pytorch_lightning.core.step_result.Result` is returned by
     :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_epoch_end`,
     :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step` or
     :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`,

--- a/docs/source/early_stopping.rst
+++ b/docs/source/early_stopping.rst
@@ -33,9 +33,17 @@ callback can be used to monitor a validation metric and stop the training when n
 There are two ways to enable the EarlyStopping callback:
 
 -   Set `early_stop_callback=True`.
-    The callback will look for 'val_loss' in the dict returned by 
-    :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_epoch_end`
+    If a dict is returned by
+    :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_epoch_end`,
+    the callback will look for `val_loss` in the dict
     and raise an error if `val_loss` is not present.
+    Otherwise, if a :class:`~pytorch_lightning.core.step_result.Result` is returned, by
+    :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_epoch_end`,
+    :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step` or
+    :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`,
+    the `early_stop_on` metric, specified in the initialization of the
+    :class:`~pytorch_lightning.core.step_result.Result` object is used
+    and raise an error if it was not specified.
 
     .. testcode::
 

--- a/docs/source/early_stopping.rst
+++ b/docs/source/early_stopping.rst
@@ -36,7 +36,7 @@ There are two ways to enable the EarlyStopping callback:
     If a dict is returned by
     :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_epoch_end`,
     the callback will look for `val_loss` in the dict
-    and raise an error if `val_loss` is not present.
+    and display a warning if `val_loss` is not present.
     Otherwise, if a :class:`~pytorch_lightning.core.step_result.Result` is returned by
     :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_epoch_end`,
     :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step` or

--- a/docs/source/early_stopping.rst
+++ b/docs/source/early_stopping.rst
@@ -43,7 +43,7 @@ There are two ways to enable the EarlyStopping callback:
     :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`,
     the `early_stop_on` metric, specified in the initialization of the
     :class:`~pytorch_lightning.core.step_result.Result` object is used
-    and raise an error if it was not specified.
+    and display a warning if it was not specified.
 
     .. testcode::
 

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -501,7 +501,16 @@ class TrainResult(Result):
         Args:
             minimize: Metric currently being minimized.
             early_stop_on: Metric to early stop on.
+                Should be singleton tensor if combined with default
+                :class:`~pytorch_lightning.callbacks.early_stopping.EarlyStopping`.
+                If this result is returned by
+                :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`,
+                the specified value will be averaged across all steps.
             checkpoint_on: Metric to checkpoint on.
+                Should be singleton tensor if combined with default checkpoint callback.
+                If this result is returned by
+                :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`,
+                the specified value will be averaged across all steps.
             hiddens:
         """
 
@@ -656,7 +665,16 @@ class EvalResult(Result):
 
         Args:
             early_stop_on: Metric to early stop on.
+                Should be singleton tensor if combined with default
+                :class:`~pytorch_lightning.callbacks.early_stopping.EarlyStopping`.
+                If this result is returned by
+                :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step`,
+                the specified value will be averaged across all steps.
             checkpoint_on: Metric to checkpoint on.
+                Should be singleton tensor if combined with default checkpoint callback.
+                If this result is returned by
+                :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step`,
+                the specified value will be averaged across all steps.
             hiddens:
         """
 

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -501,13 +501,13 @@ class TrainResult(Result):
         Args:
             minimize: Metric currently being minimized.
             early_stop_on: Metric to early stop on.
-                Should be singleton tensor if combined with default
+                Should be a one element tensor if combined with default
                 :class:`~pytorch_lightning.callbacks.early_stopping.EarlyStopping`.
                 If this result is returned by
                 :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`,
                 the specified value will be averaged across all steps.
             checkpoint_on: Metric to checkpoint on.
-                Should be singleton tensor if combined with default checkpoint callback.
+                Should be a one elemen tensor if combined with default checkpoint callback.
                 If this result is returned by
                 :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`,
                 the specified value will be averaged across all steps.

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -665,13 +665,13 @@ class EvalResult(Result):
 
         Args:
             early_stop_on: Metric to early stop on.
-                Should be singleton tensor if combined with default
+                Should be a one element tensor if combined with default
                 :class:`~pytorch_lightning.callbacks.early_stopping.EarlyStopping`.
                 If this result is returned by
                 :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step`,
                 the specified value will be averaged across all steps.
             checkpoint_on: Metric to checkpoint on.
-                Should be singleton tensor if combined with default checkpoint callback.
+                Should be a one element tensor if combined with default checkpoint callback.
                 If this result is returned by
                 :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step`,
                 the specified value will be averaged across all steps.

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -507,7 +507,7 @@ class TrainResult(Result):
                 :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`,
                 the specified value will be averaged across all steps.
             checkpoint_on: Metric to checkpoint on.
-                Should be a one elemen tensor if combined with default checkpoint callback.
+                Should be a one element tensor if combined with default checkpoint callback.
                 If this result is returned by
                 :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`,
                 the specified value will be averaged across all steps.

--- a/pytorch_lightning/trainer/__init__.py
+++ b/pytorch_lightning/trainer/__init__.py
@@ -411,10 +411,13 @@ early_stop_callback
 Callback for early stopping.
 early_stop_callback (:class:`pytorch_lightning.callbacks.EarlyStopping`)
 
-- ``True``: A default callback monitoring ``'val_loss'`` is created.
-   Will raise an error if ``'val_loss'`` is not found.
+- ``True``: A default callback monitoring ``'val_loss'`` (if dict is returned in validation loop) or
+   ``early_stopping_on`` (if :class:`~pytorch_lightning.core.step_result.Result` is returned) is created.
+   Will raise an error if a dictionary is returned and ``'val_loss'`` is not found.
+   Will raise an error if a :class:`~pytorch_lightning.core.step_result.Result` is returned
+   and ``early_stopping_on`` was not specified.
 - ``False``: Early stopping will be disabled.
-- ``None``: The default callback monitoring ``'val_loss'`` is created.
+- ``None``: Same as, if ``True`` is specified.
 - Default: ``None``.
 
 .. testcode::

--- a/pytorch_lightning/trainer/__init__.py
+++ b/pytorch_lightning/trainer/__init__.py
@@ -412,10 +412,10 @@ Callback for early stopping.
 early_stop_callback (:class:`pytorch_lightning.callbacks.EarlyStopping`)
 
 - ``True``: A default callback monitoring ``'val_loss'`` (if dict is returned in validation loop) or
-   ``early_stopping_on`` (if :class:`~pytorch_lightning.core.step_result.Result` is returned) is created.
-   Will raise an error if a dictionary is returned and ``'val_loss'`` is not found.
-   Will raise an error if a :class:`~pytorch_lightning.core.step_result.Result` is returned
-   and ``early_stopping_on`` was not specified.
+  ``early_stopping_on`` (if :class:`~pytorch_lightning.core.step_result.Result` is returned) is created.
+  Will raise an error if a dictionary is returned and ``'val_loss'`` is not found.
+  Will raise an error if a :class:`~pytorch_lightning.core.step_result.Result` is returned
+  and ``early_stopping_on`` was not specified.
 - ``False``: Early stopping will be disabled.
 - ``None``: Same as, if ``True`` is specified.
 - Default: ``None``.


### PR DESCRIPTION
## What does this PR do?

Improve documentation for early stopping with Result classes.
Remove some out-of-date or wrong documentation relating early stopping.

Fixes (no issue, only doc improvements)

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements) No. It was only discussed on Slack.
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
