### PR TITLE
Allow logging of metrics in both validation_step and validation_epoch_end

### DIFF
--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -311,7 +311,7 @@ class Result(Dict):
         recursive_stack(result)
 
         if meta:
-            meta['_internal']['batch_sizes'] = [x.get_batch_sizes()[0] for x in outputs]
+            meta['_internal']['batch_sizes'] = [*x.get_batch_sizes() for x in outputs]
             result['meta'] = meta
         return result
 

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -311,7 +311,8 @@ class Result(Dict):
         recursive_stack(result)
 
         if meta:
-            meta['_internal']['batch_sizes'] = [*x.get_batch_sizes() for x in outputs]
+            # import pdb; pdb.set_trace()
+            meta['_internal']['batch_sizes'] = [x.get_batch_sizes()[0] for x in outputs]
             result['meta'] = meta
         return result
 

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -354,7 +354,8 @@ class Result(Dict):
         batch_sizes = torch.tensor(result.get_batch_sizes())
 
         for k, value in result.items():
-            if k == 'meta':
+            if k == 'meta' or value.dim() == 0:
+                # meta and scalars cannot be reduced
                 continue
             if k in ['checkpoint_on', 'early_stop_on', 'minimize']:
                 reduced_val = torch.mean(value)

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -311,7 +311,6 @@ class Result(Dict):
         recursive_stack(result)
 
         if meta:
-            # import pdb; pdb.set_trace()
             meta['_internal']['batch_sizes'] = [x.get_batch_sizes()[0] for x in outputs]
             result['meta'] = meta
         return result

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -198,10 +198,10 @@ class EvaluationLoop(object):
             if is_overridden('validation_epoch_end', model=model):
                 eval_results = model.validation_epoch_end(eval_results)
 
-        if not isinstance(eval_results, list) or len(eval_results) == 0:
+        if not isinstance(eval_results, list):
             eval_results = [eval_results]
 
-        is_result_obj = isinstance(eval_results[0], Result)
+        is_result_obj = len(eval_results) > 0  and isinstance(eval_results[0], Result)
         if is_result_obj:
             eval_results = self.__auto_reduce_result_objs(eval_results)
 

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -182,65 +182,42 @@ class EvaluationLoop(object):
     def __run_eval_epoch_end(self, num_dataloaders, using_eval_result):
         model = self.trainer.get_model()
 
-        # with a single dataloader don't pass an array
-        outputs = self.outputs
-        eval_results = outputs
-        if num_dataloaders == 1:
-            eval_results = outputs[0]
+        eval_results = self.outputs
+        if using_eval_result:
+            eval_results = self.__gather_epoch_end_eval_results(eval_results)
 
-        user_reduced = False
+        # with a single dataloader don't pass an array
+        if num_dataloaders == 1:
+            eval_results = eval_results[0]
 
         if self.testing:
             if is_overridden('test_epoch_end', model=model):
-                if using_eval_result:
-                    eval_results = self.__gather_epoch_end_eval_results(outputs)
-
                 eval_results = model.test_epoch_end(eval_results)
-                user_reduced = True
 
         else:
             if is_overridden('validation_epoch_end', model=model):
-                if using_eval_result:
-                    eval_results = self.__gather_epoch_end_eval_results(outputs)
-
                 eval_results = model.validation_epoch_end(eval_results)
-                user_reduced = True
-
-        if using_eval_result and not user_reduced:
-            eval_results = self.__auto_reduce_result_objs(outputs)
 
         if not isinstance(eval_results, list):
             eval_results = [eval_results]
+
+        if using_eval_result:
+            eval_results = self.__auto_reduce_result_objs(eval_results)
 
         return eval_results
 
     def __gather_epoch_end_eval_results(self, outputs):
         eval_results = []
         for epoch_output in outputs:
-            result = epoch_output[0].__class__.gather(epoch_output)
-            if 'checkpoint_on' in result:
-                result.checkpoint_on = result.checkpoint_on.mean()
-            if 'early_stop_on' in result:
-                result.early_stop_on = result.early_stop_on.mean()
+            eval_results.append(EvalResult.gather(epoch_output))
 
-            eval_results.append(result)
-
-        # with 1 dataloader don't pass in a list
-        if len(eval_results) == 1:
-            eval_results = eval_results[0]
         return eval_results
 
     def __auto_reduce_result_objs(self, outputs):
         # outputs has a list of results per dataloader
         eval_results = []
-        for dl_output in outputs:
-            result = dl_output[0]
-            result = result.__class__.reduce_on_epoch_end(dl_output)
-            if 'checkpoint_on' in result:
-                result.checkpoint_on = result.checkpoint_on.mean()
-            if 'early_stop_on' in result:
-                result.early_stop_on = result.early_stop_on.mean()
-            eval_results.append(result)
+        for result in outputs:
+            eval_results.append(EvalResult.reduce_on_epoch_end(result))
 
         return eval_results
 

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -201,7 +201,8 @@ class EvaluationLoop(object):
         if not isinstance(eval_results, list):
             eval_results = [eval_results]
 
-        if using_eval_result:
+        is_result_obj = isinstance(eval_results[0], Result)
+        if is_result_obj:
             eval_results = self.__auto_reduce_result_objs(eval_results)
 
         return eval_results

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -198,7 +198,7 @@ class EvaluationLoop(object):
             if is_overridden('validation_epoch_end', model=model):
                 eval_results = model.validation_epoch_end(eval_results)
 
-        if not isinstance(eval_results, list):
+        if not isinstance(eval_results, list) or len(eval_results) == 0:
             eval_results = [eval_results]
 
         is_result_obj = isinstance(eval_results[0], Result)


### PR DESCRIPTION
## What does this PR do?
Allows logging of metrics in both `validation_step` and `validation_epoch_end`. (Works for `test_step` & `test_epoch_end` as well.)
By collating `validation_step` metrics and reducing metrics with `on_epoch` flag at the start of `evaluate_loop.__run_eval_epoch_end` it is possible to continue logging metrics onto the resulting EvalResult object during `validation_epoch_end`.
Behaviour doesn't change when `using_result_obj==False`

**Current behaviour**:
```
if overridden (`validation_epoch_end`) 
    collate results and call user specified epoch end method.
else 
    collate and reduce metrics as specified in `validation_step`.
```
The user needs to create a new EvalResult object in `validation_epoch_end` since no reduction will take place and continued use of the input EvalResult object with fail when the logger attempts to write non-scalar values. As a result, all metrics (including callback_metrics) that are only defined in during `valdiation_step` are lost or need to be manually reduced and logged to the new EvalResult obj by the user when `validation_epoch_end` is overridden.

**New behaviour**:
```
collate and reduce metrics as specified in `validation_step`
if overridden (`validation_epoch_end`) 
    call user defined method
```
By reducing the results before the call to `validation_epoch_end` it is possible to continue logging onto the now collated and reduced (for step metrics with flag `on_epoch=True`) EvalResult object. 
The only change compared to the current workflow requires setting the `result.log(..., on_epoch=False)` in the `validation_step` if the non-reduced metrics are required for processing `on_epoch`. However, I think the new behaviour better matches what is intuitively expected based on flag names.

Fixes #3215 

# Before submitting

- [x] Was this discussed/~approved~ via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
