### PR TITLE
Add torch jit ignore decorator to Lightning properties

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -76,6 +76,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
         self._example_input_array = None
         self._datamodule = None
 
+    @torch.jit.ignore
     @property
     def example_input_array(self) -> Any:
         return self._example_input_array
@@ -84,6 +85,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
     def example_input_array(self, example: Any) -> None:
         self._example_input_array = example
 
+    @torch.jit.ignore
     @property
     def datamodule(self) -> Any:
         return self._datamodule
@@ -92,6 +94,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
     def datamodule(self, datamodule: Any) -> None:
         self._datamodule = datamodule
 
+    @torch.jit.ignore
     @property
     def on_gpu(self):
         """
@@ -1720,6 +1723,7 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
 
         torch.onnx.export(self, input_data, file_path, **kwargs)
 
+    @torch.jit.ignore
     @property
     def hparams(self) -> Union[AttributeDict, str]:
         if not hasattr(self, '_hparams'):

--- a/pytorch_lightning/utilities/device_dtype_mixin.py
+++ b/pytorch_lightning/utilities/device_dtype_mixin.py
@@ -11,6 +11,7 @@ class DeviceDtypeModuleMixin(Module):
         self._dtype = torch.get_default_dtype()
         self._device = torch.device('cpu')
 
+    @torch.jit.ignore
     @property
     def dtype(self) -> Union[str, torch.dtype]:
         return self._dtype
@@ -20,6 +21,7 @@ class DeviceDtypeModuleMixin(Module):
         # necessary to avoid infinite recursion
         raise RuntimeError('Cannot set the dtype explicitly. Please use module.to(new_dtype).')
 
+    @torch.jit.ignore
     @property
     def device(self) -> Union[str, torch.device]:
         return self._device


### PR DESCRIPTION
## What does this PR do?

[This PyTorch PR](https://github.com/pytorch/pytorch/pull/42390) adds support to TorchScript for module properties, and as a result, these module properties in Lightning will no longer compile because they use unsupported features in their properties (that are now being compiled)

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.