### PR TITLE
distinguished between overfit_batches examples

### DIFF
--- a/docs/source/debugging.rst
+++ b/docs/source/debugging.rst
@@ -66,8 +66,8 @@ argument of :class:`~pytorch_lightning.trainer.trainer.Trainer`)
     # use only 1% of training data (and use the same training dataloader (with shuffle off) in val and test)
     trainer = Trainer(overfit_batches=0.01)
 
-    # or overfit a number of batches
-    trainer = Trainer(overfit_batches=0.01)
+    # similar, but with a fixed 10 batches no matter the size of the dataset
+    trainer = Trainer(overfit_batches=10)
 
 With this flag, the train, val, and test sets will all be the same train set. We will also replace the sampler
 in the training set to turn off shuffle for you.


### PR DESCRIPTION
# What does this PR do?
Differentiates between two examples given in the documentation of `overfit_batches`. Changes the message on the second example to be more descriptive and changes the argument in the second example to demonstrate integer option.

Fixes #3296

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
