### PR TITLE
Fix early stopping with training step's return dict

### DIFF
--- a/docs/source/results.rst
+++ b/docs/source/results.rst
@@ -101,16 +101,6 @@ checkpointing or early stopping:
         return TrainResult(some_metric, checkpoint_on=metric_a, early_stop_on=metric_b)
 
 
-In the manual loop, checkpoint and early stop is based only on the loss returned. With the `TrainResult` you
-can change it every batch if you want, or even monitor different metrics for each purpose.
-
-.. code-block:: python
-
-    # early stop + checkpoint can only use the `loss` when done manually via dictionaries
-    def training_step(...):
-        return loss
-    def training_step(...):
-        return {'loss': loss}
 
 logging
 ^^^^^^^

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -164,11 +164,15 @@ class EarlyStopping(Callback):
         if self.monitor == 'val_early_stop_on':
             return
 
-        # early stopping can also work in the train loop when there is no val loop and when using structured results
+        # early stopping can also work in the train loop when there is no val loop
         should_check_early_stop = False
+        # early_stop_on takes precedence over monitor key
         train_es_key = 'early_stop_on'
         if trainer.logger_connector.callback_metrics.get(train_es_key, None) is not None:
             self.monitor = train_es_key
+            should_check_early_stop = True
+        # fallback to monitor key in result dict
+        if trainer.callback_metrics.get(self.monitor, None) is not None:
             should_check_early_stop = True
 
         if should_check_early_stop:

--- a/tests/callbacks/test_early_stopping.py
+++ b/tests/callbacks/test_early_stopping.py
@@ -171,10 +171,7 @@ def test_early_stopping_functionality(tmpdir):
 
 
 def test_early_stopping_functionality_arbitrary_key(tmpdir):
-    """
-    Tests whether early stopping works with a
-    custom key and dictionary results on val step.
-    """
+    """Tests whether early stopping works with a custom key and dictionary results on val step."""
 
     class CurrentModel(EvalModelTemplate):
         def validation_epoch_end(self, outputs):

--- a/tests/callbacks/test_early_stopping.py
+++ b/tests/callbacks/test_early_stopping.py
@@ -137,17 +137,17 @@ def test_early_stopping_no_val_step(tmpdir):
     model.validation_step = None
     model.val_dataloader = None
 
-    stopping = EarlyStopping(monitor='my_train_metric', min_delta=0.1)
+    stopping = EarlyStopping(monitor='my_train_metric', min_delta=0.1, patience=0)
     trainer = Trainer(
         default_root_dir=tmpdir,
         early_stop_callback=stopping,
         overfit_batches=0.20,
-        max_epochs=2,
+        max_epochs=10,
     )
     result = trainer.fit(model)
 
     assert result == 1, 'training failed to complete'
-    assert trainer.current_epoch < trainer.max_epochs
+    assert trainer.current_epoch < trainer.max_epochs - 1
 
 
 def test_early_stopping_functionality(tmpdir):

--- a/tests/callbacks/test_early_stopping.py
+++ b/tests/callbacks/test_early_stopping.py
@@ -191,4 +191,4 @@ def test_early_stopping_functionality_arbitrary_key(tmpdir):
         max_epochs=20,
     )
     trainer.fit(model)
-    assert trainer.current_epoch == 5, 'early_stopping failed'
+    assert trainer.current_epoch >= 5, 'early_stopping failed'

--- a/tests/callbacks/test_early_stopping.py
+++ b/tests/callbacks/test_early_stopping.py
@@ -168,3 +168,27 @@ def test_early_stopping_functionality(tmpdir):
     )
     trainer.fit(model)
     assert trainer.current_epoch == 5, 'early_stopping failed'
+
+
+def test_early_stopping_functionality_arbitrary_key(tmpdir):
+    """
+    Tests whether early stopping works with a
+    custom key and dictionary results on val step.
+    """
+
+    class CurrentModel(EvalModelTemplate):
+        def validation_epoch_end(self, outputs):
+            losses = [8, 4, 2, 3, 4, 5, 8, 10]
+            val_loss = losses[self.current_epoch]
+            return {'jiraffe': torch.tensor(val_loss)}
+
+    model = CurrentModel()
+
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        early_stop_callback=EarlyStopping(monitor='jiraffe'),
+        overfit_batches=0.20,
+        max_epochs=20,
+    )
+    trainer.fit(model)
+    assert trainer.current_epoch == 5, 'early_stopping failed'


### PR DESCRIPTION
## What does this PR do?

Fixes #3199 

In the first commit, I fixed the test, which should check that early stopping works if no val step is executed and a return dict is used in ``training_step``. Subsequently, the test fails since the bug in #3199 is still present.

The second commit, fixes this bug, by checking the ``self.monitor`` key and not only the ``on_early_stop`` key. The aforementioned test passes.

This unveiled another bug in the decision whether early stopping is already done based on validation results.
The earlier code, checked for one key specifically. But since any key could be in validation, it is not possible to derive from the key, whether early stopping is done based on validation results. 
As a result other tests in ``test_early_stopping`` fail.

Therefore, in the third commit, I used a instance variable as flag to indicate whether early stopping is done based on validation results. The flag is set in ``on_validation_epoch_end`` which is executed before ``on_train_epoch_end``.
Lastly, I added a test which asserts that any key could be used during validation (this would have failed, if I just extended the list of keys to check besides ``val_on_early_stop``).

4th commit was necessary, since my check in the 3rd commit always disabled training early stopping if ``validation_step`` was implemented. But it should only do so if early stopping is done based on val step.

5th commit improves docs. Early stopping does not only work with ``loss`` but with any key word.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
