### PR TITLE
Get experiment_id from MLFlow only once instead of each training loop.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed batch size auto scaling exceeding the size of the dataset ([#3271](https://github.com/PyTorchLightning/pytorch-lightning/pull/3271))
 
+- Fixed getting `experiment_id` from MLFlow only once instead of each training loop ([#3394](https://github.com/PyTorchLightning/pytorch-lightning/pull/3394))
+
 ## [0.9.0] - YYYY-MM-DD
 
 ### Added

--- a/pytorch_lightning/loggers/mlflow.py
+++ b/pytorch_lightning/loggers/mlflow.py
@@ -109,15 +109,15 @@ class MLFlowLogger(LightningLoggerBase):
             self.logger.experiment.some_mlflow_function()
 
         """
-        if not self._experiment_id:
+        if self._experiment_id is None:
             expt = self._mlflow_client.get_experiment_by_name(self._experiment_name)
-            if expt:
+            if expt is not None:
                 self._experiment_id = expt.experiment_id
             else:
                 log.warning(f'Experiment with name {self._experiment_name} not found. Creating it.')
                 self._experiment_id = self._mlflow_client.create_experiment(name=self._experiment_name)
 
-        if not self._run_id:
+        if self._run_id is None:
             run = self._mlflow_client.create_run(experiment_id=self._experiment_id, tags=self.tags)
             self._run_id = run.info.run_id
         return self._mlflow_client

--- a/pytorch_lightning/loggers/mlflow.py
+++ b/pytorch_lightning/loggers/mlflow.py
@@ -109,13 +109,13 @@ class MLFlowLogger(LightningLoggerBase):
             self.logger.experiment.some_mlflow_function()
 
         """
-        expt = self._mlflow_client.get_experiment_by_name(self._experiment_name)
-
-        if expt:
-            self._experiment_id = expt.experiment_id
-        else:
-            log.warning(f'Experiment with name {self._experiment_name} not found. Creating it.')
-            self._experiment_id = self._mlflow_client.create_experiment(name=self._experiment_name)
+        if not self._experiment_id:
+            expt = self._mlflow_client.get_experiment_by_name(self._experiment_name)
+            if expt:
+                self._experiment_id = expt.experiment_id
+            else:
+                log.warning(f'Experiment with name {self._experiment_name} not found. Creating it.')
+                self._experiment_id = self._mlflow_client.create_experiment(name=self._experiment_name)
 
         if not self._run_id:
             run = self._mlflow_client.create_run(experiment_id=self._experiment_id, tags=self.tags)

--- a/tests/loggers/test_mlflow.py
+++ b/tests/loggers/test_mlflow.py
@@ -43,6 +43,7 @@ def test_mlflow_logger_dirs_creation(tmpdir):
     assert trainer.checkpoint_callback.dirpath == (tmpdir / exp_id / run_id / 'checkpoints')
     assert set(os.listdir(trainer.checkpoint_callback.dirpath)) == {'epoch=0.ckpt'}
 
+
 def test_mlflow_experiment_id_retrieved_once(tmpdir):
     logger = MLFlowLogger('test', save_dir=tmpdir)
     get_experiment_name = logger._mlflow_client.get_experiment_by_name

--- a/tests/loggers/test_mlflow.py
+++ b/tests/loggers/test_mlflow.py
@@ -1,5 +1,8 @@
 import os
 
+from unittest import mock
+from mlflow.tracking import MlflowClient
+
 from pytorch_lightning import Trainer
 from pytorch_lightning.loggers import MLFlowLogger
 from tests.base import EvalModelTemplate
@@ -39,3 +42,12 @@ def test_mlflow_logger_dirs_creation(tmpdir):
     assert set(os.listdir(tmpdir / exp_id / run_id / 'params')) == model.hparams.keys()
     assert trainer.checkpoint_callback.dirpath == (tmpdir / exp_id / run_id / 'checkpoints')
     assert set(os.listdir(trainer.checkpoint_callback.dirpath)) == {'epoch=0.ckpt'}
+
+def test_mlflow_experiment_id_retrieved_once(tmpdir):
+    logger = MLFlowLogger('test', save_dir=tmpdir)
+    get_experiment_name = logger._mlflow_client.get_experiment_by_name
+    with mock.patch.object(MlflowClient, 'get_experiment_by_name', wraps=get_experiment_name) as mocked:
+        _ = logger.experiment
+        _ = logger.experiment
+        _ = logger.experiment
+        assert mocked.call_count == 1


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?
When using the MLFLow logger, the MLFLow client retrieves the experiment id from the MLFlowClient each time `logger.experiment` is called/accessed. This causes overhead during training and validation loops which is dramatic if the server is remote. 

This PR checks whether the experiment_id is already defined (meaning it has already been retrieved) and does not make the call to MLFlow if so.

Fixes #3393 

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
