### PR TITLE
Fix early stopping on_training_epoch end with structured results

### DIFF
--- a/pytorch_lightning/trainer/logger_connector.py
+++ b/pytorch_lightning/trainer/logger_connector.py
@@ -211,6 +211,7 @@ class LoggerConnector:
             if isinstance(epoch_output, Result):
                 epoch_log_metrics = epoch_output.epoch_log_metrics
                 epoch_progress_bar_metrics = epoch_output.epoch_pbar_metrics
+                epoch_callback_metrics = epoch_output.get_callback_metrics()
             else:
                 _processed_outputs = self.trainer.process_output(epoch_output)
                 epoch_progress_bar_metrics = _processed_outputs[1]

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -194,6 +194,7 @@ class DeterministicModel(LightningModule):
         result.epoch_step_epoch_log_acc2 = result.epoch_step_epoch_log_acc2.prod()
         result.step_step_epoch_pbar_acc3 = result.step_step_epoch_pbar_acc3.prod()
         result.epoch_step_epoch_pbar_acc3 = result.epoch_step_epoch_pbar_acc3.prod()
+        result.checkpoint_on = result.checkpoint_on.mean()
         result.log('epoch_end_log_acc', torch.tensor(1212).type_as(result.epoch_step_epoch_log_acc2),
                    logger=True, on_epoch=True)
         result.log('epoch_end_pbar_acc', torch.tensor(1213).type_as(result.epoch_step_epoch_log_acc2),


### PR DESCRIPTION
## What does this PR do?

First, adds a test which tries to set ``early_stop_on`` in a ``TrainResult`` in ``training_epoch_end`` and tests if early stopping is triggered.
The test fails.

Second, fixes the issue by storing the ``callback_metrics`` for structured results in ``logger_connecter.py``.

Third, fixes a bug in a test model, which returns a tensor with more than one element for ``checkpoint_on``.
This bug was hidden before, since ``checkpoint_on`` was also discarded alongside ``early_stop_on``.

Fixes  #3413

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes? --> Will be done in #3193
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
