### PR TITLE
Pass epoch argument to Comet Logger

### DIFF
--- a/pytorch_lightning/loggers/comet.py
+++ b/pytorch_lightning/loggers/comet.py
@@ -231,7 +231,7 @@ class CometLogger(LightningLoggerBase):
 
         metrics_without_epoch = metrics.copy()
         epoch = metrics_without_epoch.pop('epoch', None)
-        
+
         self.experiment.log_metrics(metrics_without_epoch, step=step, epoch=epoch)
 
     def reset_experiment(self):

--- a/pytorch_lightning/loggers/comet.py
+++ b/pytorch_lightning/loggers/comet.py
@@ -229,7 +229,8 @@ class CometLogger(LightningLoggerBase):
             if is_tensor(val):
                 metrics[key] = val.cpu().detach()
 
-        self.experiment.log_metrics(metrics, step=step)
+        epoch = metrics.pop('epoch', None)
+        self.experiment.log_metrics(metrics, step=step, epoch=epoch)
 
     def reset_experiment(self):
         self._experiment = None

--- a/pytorch_lightning/loggers/comet.py
+++ b/pytorch_lightning/loggers/comet.py
@@ -229,8 +229,10 @@ class CometLogger(LightningLoggerBase):
             if is_tensor(val):
                 metrics[key] = val.cpu().detach()
 
-        epoch = metrics.pop('epoch', None)
-        self.experiment.log_metrics(metrics, step=step, epoch=epoch)
+        metrics_without_epoch = metrics.copy()
+        epoch = metrics_without_epoch.pop('epoch', None)
+        
+        self.experiment.log_metrics(metrics_without_epoch, step=step, epoch=epoch)
 
     def reset_experiment(self):
         self._experiment = None

--- a/tests/loggers/test_comet.py
+++ b/tests/loggers/test_comet.py
@@ -108,6 +108,7 @@ def test_comet_logger_dirs_creation(tmpdir, monkeypatch):
 
 
 def test_comet_epoch_logging(tmpdir, monkeypatch):
+    """ Test that CometLogger removes the epoch key from the metrics dict and passes it as argument. """
     import atexit
     monkeypatch.setattr(atexit, "register", lambda _: None)
     with patch("pytorch_lightning.loggers.comet.CometOfflineExperiment.log_metrics") as log_metrics:

--- a/tests/loggers/test_comet.py
+++ b/tests/loggers/test_comet.py
@@ -105,3 +105,12 @@ def test_comet_logger_dirs_creation(tmpdir, monkeypatch):
 
     assert trainer.checkpoint_callback.dirpath == (tmpdir / 'test' / version / 'checkpoints')
     assert set(os.listdir(trainer.checkpoint_callback.dirpath)) == {'epoch=0.ckpt'}
+
+
+def test_comet_epoch_logging(tmpdir, monkeypatch):
+    import atexit
+    monkeypatch.setattr(atexit, "register", lambda _: None)
+    with patch("pytorch_lightning.loggers.comet.CometOfflineExperiment.log_metrics") as log_metrics:
+        logger = CometLogger(project_name="test", save_dir=tmpdir)
+        logger.log_metrics({"test": 1, "epoch": 1}, step=123)
+        log_metrics.assert_called_once_with({"test": 1}, epoch=1, step=123)


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Fixes #3437

CometLogger handles the epoch plotting differently. We need to pass it as an argument to the log_metrics method instead of as part of the dictionary.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
