### PR TITLE
add num_classes argument to confusion matrix

### DIFF
--- a/pytorch_lightning/metrics/classification.py
+++ b/pytorch_lightning/metrics/classification.py
@@ -107,12 +107,14 @@ class ConfusionMatrix(TensorMetric):
 
     def __init__(
             self,
+            num_classes: Optional[int] = None,
             normalize: bool = False,
             reduce_group: Any = None,
             reduce_op: Any = None,
     ):
         """
         Args:
+            num_classes: number of classes
             normalize: whether to compute a normalized confusion matrix
             reduce_group: the process group to reduce metric results from DDP
             reduce_op: the operation to perform for ddp reduction
@@ -121,6 +123,7 @@ class ConfusionMatrix(TensorMetric):
                          reduce_group=reduce_group,
                          reduce_op=reduce_op)
         self.normalize = normalize
+        self.num_classes = num_classes
 
     def forward(self, pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
         """
@@ -134,7 +137,8 @@ class ConfusionMatrix(TensorMetric):
             A Tensor with the confusion matrix.
         """
         return confusion_matrix(pred=pred, target=target,
-                                normalize=self.normalize)
+                                normalize=self.normalize,
+                                num_classes=self.num_classes)
 
 
 class PrecisionRecallCurve(TensorCollectionMetric):

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -279,6 +279,7 @@ def confusion_matrix(
         pred: torch.Tensor,
         target: torch.Tensor,
         normalize: bool = False,
+        num_classes: Optional[int] = None
 ) -> torch.Tensor:
     """
     Computes the confusion matrix C where each entry C_{i,j} is the number of observations
@@ -288,6 +289,7 @@ def confusion_matrix(
         pred: estimated targets
         target: ground truth labels
         normalize: normalizes confusion matrix
+        num_classes: number of classes
 
     Return:
         Tensor, confusion matrix C [num_classes, num_classes ]
@@ -302,7 +304,7 @@ def confusion_matrix(
                 [0., 0., 1., 0.],
                 [0., 0., 0., 1.]])
     """
-    num_classes = get_num_classes(pred, target, None)
+    num_classes = get_num_classes(pred, target, num_classes)
 
     unique_labels = (target.view(-1) * num_classes + pred.view(-1)).to(torch.int)
 

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -182,6 +182,11 @@ def test_confusion_matrix():
     cm = confusion_matrix(pred, target, normalize=True)
     assert torch.allclose(cm, torch.tensor([[1., 0., 0.], [1., 0., 0.], [1., 0., 0.]]))
 
+    target = torch.LongTensor([0, 0, 0, 0, 0])
+    pred = target.clone()
+    cm = confusion_matrix(pred, target, normalize=False, num_classes=3)
+    assert torch.allclose(cm, torch.tensor([[5., 0., 0.], [0., 0., 0.], [0., 0., 0.]]))
+
 
 @pytest.mark.parametrize(['pred', 'target', 'expected_prec', 'expected_rec'], [
     pytest.param(torch.tensor([1., 0., 1., 0.]), torch.tensor([0., 1., 1., 0.]), [0.5, 0.5], [0.5, 0.5]),

--- a/tests/metrics/test_classification.py
+++ b/tests/metrics/test_classification.py
@@ -43,8 +43,8 @@ def test_accuracy(num_classes):
     pytest.param(True, None),
     pytest.param(False, 3)
 ])
-def test_confusion_matrix(normalize):
-    conf_matrix = ConfusionMatrix(normalize=normalize)
+def test_confusion_matrix(normalize, num_classes):
+    conf_matrix = ConfusionMatrix(normalize=normalize, num_classes=num_classes)
     assert conf_matrix.name == 'confusion_matrix'
 
     target = (torch.arange(120) % 3).view(-1, 1)

--- a/tests/metrics/test_classification.py
+++ b/tests/metrics/test_classification.py
@@ -38,7 +38,11 @@ def test_accuracy(num_classes):
     assert isinstance(result, torch.Tensor)
 
 
-@pytest.mark.parametrize('normalize', [False, True])
+@pytest.mark.parametrize(['normalize', 'num_classes'], [
+    pytest.param(False, None),
+    pytest.param(True, None),
+    pytest.param(False, 3)
+])
 def test_confusion_matrix(normalize):
     conf_matrix = ConfusionMatrix(normalize=normalize)
     assert conf_matrix.name == 'confusion_matrix'


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Add `num_classes` argument to `metrics.ConfusionMatrix`and `functional.confusion_matrix`, update` test_confusion_matrix()` . Discussed this issue with @SkafteNicki in Slack.

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
