### PR TITLE
Revert accidental change merged with PR #3433

### DIFF
--- a/docs/source/introduction_guide.rst
+++ b/docs/source/introduction_guide.rst
@@ -297,7 +297,7 @@ When your models need to know about the data, it's best to process the data befo
 
 An alternative to using a DataModule is to defer initialization of the models modules to the `setup` method of your LightningModule as follows:
 
-.. code-block:: python
+.. testcode::
 
     class LitMNIST(LightningModule):
 


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?

As requested by @Borda PR https://github.com/PyTorchLightning/pytorch-lightning/pull/3433 included an accidental change of docs/source/introduction_guide.rst line 300 `.. testcode::` was changed to `.. code-block:: python`. This PR reverts this change.

.. testcode::
.. code-block:: python

Fixes: #3406
