### PR TITLE
fix normalize mode at confusion matrix (replace nans with zeros)

### DIFF
--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -312,7 +312,7 @@ def confusion_matrix(
     cm = bins.reshape(num_classes, num_classes).squeeze().float()
 
     if normalize:
-        cm = cm / cm.sum(-1)
+        cm = cm / cm.sum(-1, keepdim=True)
         nan_elements = cm[torch.isnan(cm)].nelement()
         if nan_elements != 0:
             cm[torch.isnan(cm)] = 0

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -316,7 +316,7 @@ def confusion_matrix(
         nan_elements = cm[torch.isnan(cm)].nelement()
         if nan_elements != 0:
             cm[torch.isnan(cm)] = 0
-            rank_zero_warn(f'You have {nan_elements} nan values at confusion matrix replaced with zeros.')
+            rank_zero_warn(f'{nan_elements} nan values found in confusion matrix have been replaced with zeros.')
 
     return cm
 

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -313,6 +313,10 @@ def confusion_matrix(
 
     if normalize:
         cm = cm / cm.sum(-1)
+        nan_elements = cm[cm.isnan()].nelement()
+        if nan_elements != 0:
+            cm[cm.isnan()] = 0
+            rank_zero_warn(f'You have {nan_elements} nan values at confusion matrix replaced with zeros.')
 
     return cm
 

--- a/pytorch_lightning/metrics/functional/classification.py
+++ b/pytorch_lightning/metrics/functional/classification.py
@@ -313,9 +313,9 @@ def confusion_matrix(
 
     if normalize:
         cm = cm / cm.sum(-1)
-        nan_elements = cm[cm.isnan()].nelement()
+        nan_elements = cm[torch.isnan(cm)].nelement()
         if nan_elements != 0:
-            cm[cm.isnan()] = 0
+            cm[torch.isnan(cm)] = 0
             rank_zero_warn(f'You have {nan_elements} nan values at confusion matrix replaced with zeros.')
 
     return cm

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -186,7 +186,7 @@ def test_confusion_matrix():
     pred = target.clone()
     cm = confusion_matrix(pred, target, normalize=False, num_classes=3)
     assert torch.allclose(cm, torch.tensor([[5., 0., 0.], [0., 0., 0.], [0., 0., 0.]]))
-
+Example taken from https://scikit-learn.org/stable/auto_examples/model_selection/plot_confusion_matrix.html
     target = torch.LongTensor([0] * 13 + [1] * 16 + [2] * 9)
     pred = torch.LongTensor([0] * 13 + [1] * 10 + [2] * 15)
     cm = confusion_matrix(pred, target, normalize=False, num_classes=3)

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -186,7 +186,8 @@ def test_confusion_matrix():
     pred = target.clone()
     cm = confusion_matrix(pred, target, normalize=False, num_classes=3)
     assert torch.allclose(cm, torch.tensor([[5., 0., 0.], [0., 0., 0.], [0., 0., 0.]]))
-Example taken from https://scikit-learn.org/stable/auto_examples/model_selection/plot_confusion_matrix.html
+
+    # Example taken from https://scikit-learn.org/stable/auto_examples/model_selection/plot_confusion_matrix.html
     target = torch.LongTensor([0] * 13 + [1] * 16 + [2] * 9)
     pred = torch.LongTensor([0] * 13 + [1] * 10 + [2] * 15)
     cm = confusion_matrix(pred, target, normalize=False, num_classes=3)

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -191,7 +191,7 @@ def test_confusion_matrix():
     pred = torch.LongTensor([0] * 13 + [1] * 10 + [2] * 15)
     cm = confusion_matrix(pred, target, normalize=False, num_classes=3)
     assert torch.allclose(cm, torch.tensor([[13., 0., 0.], [0., 10., 6.], [0., 0., 9.]]))
-    to_compare = cm / torch.tensor([[13.],[16.],[ 9.]])
+    to_compare = cm / torch.tensor([[13.], [16.], [9.]])
 
     cm = confusion_matrix(pred, target, normalize=True, num_classes=3)
     assert torch.allclose(cm, to_compare)

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -187,6 +187,9 @@ def test_confusion_matrix():
     cm = confusion_matrix(pred, target, normalize=False, num_classes=3)
     assert torch.allclose(cm, torch.tensor([[5., 0., 0.], [0., 0., 0.], [0., 0., 0.]]))
 
+    cm = confusion_matrix(pred, target, normalize=True, num_classes=3)
+    assert torch.allclose(cm, torch.tensor([[1., 0., 0.], [0., 0., 0.], [0., 0., 0.]]))
+
 
 @pytest.mark.parametrize(['pred', 'target', 'expected_prec', 'expected_rec'], [
     pytest.param(torch.tensor([1., 0., 1., 0.]), torch.tensor([0., 1., 1., 0.]), [0.5, 0.5], [0.5, 0.5]),

--- a/tests/metrics/functional/test_classification.py
+++ b/tests/metrics/functional/test_classification.py
@@ -187,8 +187,15 @@ def test_confusion_matrix():
     cm = confusion_matrix(pred, target, normalize=False, num_classes=3)
     assert torch.allclose(cm, torch.tensor([[5., 0., 0.], [0., 0., 0.], [0., 0., 0.]]))
 
+    target = torch.LongTensor([0] * 13 + [1] * 16 + [2] * 9)
+    pred = torch.LongTensor([0] * 13 + [1] * 10 + [2] * 15)
+    cm = confusion_matrix(pred, target, normalize=False, num_classes=3)
+    assert torch.allclose(cm, torch.tensor([[13., 0., 0.], [0., 10., 6.], [0., 0., 9.]]))
+    to_compare = cm / torch.tensor([[13.],[16.],[ 9.]])
+
     cm = confusion_matrix(pred, target, normalize=True, num_classes=3)
-    assert torch.allclose(cm, torch.tensor([[1., 0., 0.], [0., 0., 0.], [0., 0., 0.]]))
+    assert torch.allclose(cm, to_compare)
+
 
 
 @pytest.mark.parametrize(['pred', 'target', 'expected_prec', 'expected_rec'], [

--- a/tests/metrics/test_classification.py
+++ b/tests/metrics/test_classification.py
@@ -51,7 +51,7 @@ def test_confusion_matrix(normalize, num_classes):
     target = (torch.arange(120) % 3).view(-1, 1)
     pred = target.clone()
     cm = conf_matrix(pred, target)
-    assert isinstance(cm, torch.Tensor) and cm[cm.isnan()].nelement() == 0
+    assert isinstance(cm, torch.Tensor) and cm[torch.isnan(cm)].nelement() == 0
 
 
 @pytest.mark.parametrize('pos_label', [1, 2.])

--- a/tests/metrics/test_classification.py
+++ b/tests/metrics/test_classification.py
@@ -61,7 +61,7 @@ def test_confusion_matrix_norm(normalize, num_classes):
     conf_matrix = ConfusionMatrix(normalize=normalize, num_classes=num_classes)
     assert conf_matrix.name == 'confusion_matrix'
 
-    with pytest.warns(UserWarning, match='You have 6 nan values at confusion matrix replaced with zeros.'):
+    with pytest.warns(UserWarning, match='6 nan values found in confusion matrix have been replaced with zeros.'):
         target = torch.LongTensor([0] * 5)
         pred = target.clone()
         cm = conf_matrix(pred, target)

--- a/tests/metrics/test_classification.py
+++ b/tests/metrics/test_classification.py
@@ -41,8 +41,7 @@ def test_accuracy(num_classes):
 @pytest.mark.parametrize(['normalize', 'num_classes'], [
     pytest.param(False, None),
     pytest.param(True, None),
-    pytest.param(False, 3),
-    pytest.param(True, 3)
+    pytest.param(False, 3)
 ])
 def test_confusion_matrix(normalize, num_classes):
     conf_matrix = ConfusionMatrix(normalize=normalize, num_classes=num_classes)
@@ -51,7 +50,20 @@ def test_confusion_matrix(normalize, num_classes):
     target = (torch.arange(120) % 3).view(-1, 1)
     pred = target.clone()
     cm = conf_matrix(pred, target)
-    assert isinstance(cm, torch.Tensor) and cm[torch.isnan(cm)].nelement() == 0
+    assert isinstance(cm, torch.Tensor)
+
+@pytest.mark.parametrize(['normalize', 'num_classes'], [
+    pytest.param(True, 3)
+])
+def test_confusion_matrix_norm(normalize, num_classes):
+    conf_matrix = ConfusionMatrix(normalize=normalize, num_classes=num_classes)
+    assert conf_matrix.name == 'confusion_matrix'
+
+    with pytest.warns(UserWarning, match='You have 6 nan values at confusion matrix replaced with zeros.'):
+        target = torch.LongTensor([0] * 5)
+        pred = target.clone()
+        cm = conf_matrix(pred, target)
+        assert isinstance(cm, torch.Tensor)
 
 
 @pytest.mark.parametrize('pos_label', [1, 2.])

--- a/tests/metrics/test_classification.py
+++ b/tests/metrics/test_classification.py
@@ -57,6 +57,7 @@ def test_confusion_matrix(normalize, num_classes):
     pytest.param(True, 3)
 ])
 def test_confusion_matrix_norm(normalize, num_classes):
+    """ test that user is warned if confusion matrix contains nans that are changed to zeros"""
     conf_matrix = ConfusionMatrix(normalize=normalize, num_classes=num_classes)
     assert conf_matrix.name == 'confusion_matrix'
 

--- a/tests/metrics/test_classification.py
+++ b/tests/metrics/test_classification.py
@@ -52,6 +52,7 @@ def test_confusion_matrix(normalize, num_classes):
     cm = conf_matrix(pred, target)
     assert isinstance(cm, torch.Tensor)
 
+
 @pytest.mark.parametrize(['normalize', 'num_classes'], [
     pytest.param(True, 3)
 ])

--- a/tests/metrics/test_classification.py
+++ b/tests/metrics/test_classification.py
@@ -41,7 +41,8 @@ def test_accuracy(num_classes):
 @pytest.mark.parametrize(['normalize', 'num_classes'], [
     pytest.param(False, None),
     pytest.param(True, None),
-    pytest.param(False, 3)
+    pytest.param(False, 3),
+    pytest.param(True, 3)
 ])
 def test_confusion_matrix(normalize, num_classes):
     conf_matrix = ConfusionMatrix(normalize=normalize, num_classes=num_classes)
@@ -50,7 +51,7 @@ def test_confusion_matrix(normalize, num_classes):
     target = (torch.arange(120) % 3).view(-1, 1)
     pred = target.clone()
     cm = conf_matrix(pred, target)
-    assert isinstance(cm, torch.Tensor)
+    assert isinstance(cm, torch.Tensor) and cm[cm.isnan()].nelement() == 0
 
 
 @pytest.mark.parametrize('pos_label', [1, 2.])


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?

Added same behaviour to `confusion_matrix` as `sklearn.metrics.confusion_matrix` with normalization while all predict and target values from same class (nan -> 0). Discussed it with @Borda at Slack.
Also fixes #2724

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
