### PR TITLE
Support returning None in training_step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Changed `class_reduction` similar to sklearn for classification metrics ([#3322](https://github.com/PyTorchLightning/pytorch-lightning/pull/3322))
 
+- Support returning `None` in `training_step` ([#3527](https://github.com/PyTorchLightning/pytorch-lightning/pull/3527))
+
 ### Deprecated
 
 

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -266,9 +266,11 @@ class LightningModule(ABC, DeviceDtypeModuleMixin, GradInformation, ModelIO, Mod
                 result = pl.TrainResult(minimize=loss, hiddens=hiddens)
                 return result
 
-        Notes:
-            The loss value shown in the progress bar is smoothed (averaged) over the last values,
-            so it differs from the actual loss returned in train/validation step.
+        Note:
+            - The loss value shown in the progress bar is smoothed (averaged) over the last values,
+              so it differs from the actual loss returned in train/validation step.
+            - If :meth:`training_step` returns `None`, training will skip to the next batch.
+
         """
         rank_zero_warn('`training_step` must be implemented to be used with the Lightning Trainer')
 

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -449,7 +449,6 @@ class DeterministicModel(LightningModule):
     # --------------------------
     def training_step_none_return(self, batch, batch_idx):
         self.training_step_called = True
-        return
 
     # -----------------------------
     # DATA

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -444,6 +444,13 @@ class DeterministicModel(LightningModule):
         result['val_epoch_end'] = torch.tensor(1233)
         return result
 
+    # --------------------------
+    # None returns
+    # --------------------------
+    def training_step_none_return(self, batch, batch_idx):
+        self.training_step_called = True
+        return
+
     # -----------------------------
     # DATA
     # -----------------------------

--- a/tests/trainer/test_trainer_steps_result_return.py
+++ b/tests/trainer/test_trainer_steps_result_return.py
@@ -380,6 +380,36 @@ def test_training_step_epoch_end_result(tmpdir):
     assert opt_closure_result['loss'] == (42.0 * 3) + (15.0 * 3)
 
 
+def test_training_step_none_return(tmpdir):
+    """
+    Tests that training_step can return None
+    """
+    # enable internal debugging actions
+    os.environ['PL_DEV_DEBUG'] = '1'
+
+    model = DeterministicModel()
+    model.training_step = model.training_step_none_return
+    model.training_step_end = None
+    model.training_epoch_end = None
+    model.val_dataloader = None
+
+    batches = 3
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_train_batches=batches,
+        limit_val_batches=batches,
+        row_log_interval=1,
+        max_epochs=2,
+        weights_summary=None,
+    )
+    trainer.fit(model)
+
+    # make sure correct steps were called
+    assert model.training_step_called
+    assert not model.training_step_end_called
+    assert not model.training_epoch_end_called
+
+
 def test_no_auto_callbacks_with_train_loop_only(tmpdir):
     """
     Make sure early stop + checkpoint work with only a train loop


### PR DESCRIPTION
## What does this PR do?

- Supports returning `None` in `training_step`
- Adds a test

Fixes #3491

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?