### PR TITLE
Add stronger typing to gradient accumulation scheduler callback

### DIFF
--- a/pytorch_lightning/callbacks/gradient_accumulation_scheduler.py
+++ b/pytorch_lightning/callbacks/gradient_accumulation_scheduler.py
@@ -21,6 +21,9 @@ Trainer also calls ``optimizer.step()`` for the last indivisible step number.
 
 """
 
+from typing import Dict
+
+from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks.base import Callback
 
 
@@ -44,7 +47,7 @@ class GradientAccumulationScheduler(Callback):
         >>> trainer = Trainer(accumulate_grad_batches={5: 2})
     """
 
-    def __init__(self, scheduling: dict):
+    def __init__(self, scheduling: Dict[int, int]):
         super().__init__()
 
         if not scheduling:  # empty dict error
@@ -56,14 +59,16 @@ class GradientAccumulationScheduler(Callback):
 
         minimal_epoch = min(scheduling.keys())
         if minimal_epoch < 0:
-            raise IndexError(f"Epochs indexing from 1, epoch {minimal_epoch} cannot be interpreted correct")
+            raise IndexError(
+                f"Epochs indexing from 1, epoch {minimal_epoch} cannot be interpreted correct"
+            )
         if minimal_epoch != 0:  # if user didnt define first epoch accumulation factor
             scheduling.update({0: 1})
 
         self.scheduling = scheduling
         self.epochs = sorted(scheduling.keys())
 
-    def on_epoch_start(self, trainer, pl_module):
+    def on_epoch_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
         epoch = trainer.current_epoch
         for i in reversed(range(len(self.epochs))):
             if epoch >= self.epochs[i]:

--- a/pytorch_lightning/callbacks/gradient_accumulation_scheduler.py
+++ b/pytorch_lightning/callbacks/gradient_accumulation_scheduler.py
@@ -23,7 +23,6 @@ Trainer also calls ``optimizer.step()`` for the last indivisible step number.
 
 from typing import Dict
 
-from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.callbacks.base import Callback
 
 
@@ -68,7 +67,7 @@ class GradientAccumulationScheduler(Callback):
         self.scheduling = scheduling
         self.epochs = sorted(scheduling.keys())
 
-    def on_epoch_start(self, trainer: Trainer, pl_module: LightningModule) -> None:
+    def on_epoch_start(self, trainer, pl_module):
         epoch = trainer.current_epoch
         for i in reversed(range(len(self.epochs))):
             if epoch >= self.epochs[i]:


### PR DESCRIPTION

## What does this PR do?
- Add types for gradient accumulation scheduler callback
- `scheduling` is a `Dict[int, int]`
- add types for the `on_epoch_start`
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.