### PR TITLE
Replace log_gpu_memory with gpu_stats_callback

### DIFF
--- a/pytorch_lightning/accelerators/accelerator_connector.py
+++ b/pytorch_lightning/accelerators/accelerator_connector.py
@@ -35,7 +35,6 @@ class AcceleratorConnector:
             auto_select_gpus,
             gpus,
             num_nodes,
-            log_gpu_memory,
             sync_batchnorm,
             benchmark,
             replace_sampler_ddp,
@@ -60,7 +59,6 @@ class AcceleratorConnector:
 
         # Transfer params
         self.trainer.num_nodes = num_nodes
-        self.trainer.log_gpu_memory = log_gpu_memory
 
         # sync-bn backend
         self.trainer.sync_batchnorm = sync_batchnorm

--- a/pytorch_lightning/core/memory.py
+++ b/pytorch_lightning/core/memory.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-import shutil
-import subprocess
 from collections import OrderedDict
 from typing import Tuple, Dict, Union, List, Any
 
@@ -299,59 +296,6 @@ def _format_summary_table(*cols) -> str:
         summary += "\n" + " | ".join(line)
 
     return summary
-
-
-def get_memory_profile(mode: str) -> Union[Dict[str, int], Dict[int, int]]:
-    """ Get a profile of the current memory usage.
-
-    Args:
-        mode: There are two modes:
-
-            - 'all' means return memory for all gpus
-            - 'min_max' means return memory for max and min
-
-    Return:
-        A dictionary in which the keys are device ids as integers and
-        values are memory usage as integers in MB.
-        If mode is 'min_max', the dictionary will also contain two additional keys:
-
-        - 'min_gpu_mem': the minimum memory usage in MB
-        - 'max_gpu_mem': the maximum memory usage in MB
-    """
-    memory_map = get_gpu_memory_map()
-
-    if mode == "min_max":
-        min_index, min_memory = min(memory_map.items(), key=lambda item: item[1])
-        max_index, max_memory = max(memory_map.items(), key=lambda item: item[1])
-
-        memory_map = {"min_gpu_mem": min_memory, "max_gpu_mem": max_memory}
-
-    return memory_map
-
-
-def get_gpu_memory_map() -> Dict[str, int]:
-    """
-    Get the current gpu usage.
-
-    Return:
-        A dictionary in which the keys are device ids as integers and
-        values are memory usage as integers in MB.
-    """
-    result = subprocess.run(
-        [shutil.which("nvidia-smi"), "--query-gpu=memory.used", "--format=csv,nounits,noheader"],
-        encoding="utf-8",
-        # capture_output=True,          # valid for python version >=3.7
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,  # for backward compatibility with python version 3.6
-        check=True,
-    )
-
-    # Convert lines into a dictionary
-    gpu_memory = [float(x) for x in result.stdout.strip().split(os.linesep)]
-    gpu_memory_map = {
-        f"gpu_id: {gpu_id}/memory.used (MB)": memory for gpu_id, memory in enumerate(gpu_memory)
-    }
-    return gpu_memory_map
 
 
 def get_human_readable_count(number: int) -> str:

--- a/pytorch_lightning/trainer/connectors/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector.py
@@ -61,11 +61,6 @@ class LoggerConnector:
             grad_norm_dic (dict): Gradient norms
             step (int): Step for which metrics should be logged. Default value corresponds to `self.global_step`
         """
-        # add gpu memory
-        if self.trainer.on_gpu and self.trainer.log_gpu_memory:
-            mem_map = memory.get_memory_profile(self.trainer.log_gpu_memory)
-            metrics.update(mem_map)
-
         # add norms
         metrics.update(grad_norm_dic)
 

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -28,7 +28,6 @@ class TrainerLoggingMixin(ABC):
     #  the proper values/initialisation should be done in child class
     current_epoch: int
     on_gpu: bool
-    log_gpu_memory: ...
     logger: Union[LightningLoggerBase, bool]
     global_step: int
     global_rank: int

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -158,6 +158,20 @@ class Trainer(
         self.model = None
         self.shown_warnings = set()
 
+        # init accelerator related flags
+        self.accelerator_connector.on_trainer_init(
+            num_processes,
+            tpu_cores,
+            distributed_backend,
+            auto_select_gpus,
+            gpus,
+            num_nodes,
+            sync_batchnorm,
+            benchmark,
+            replace_sampler_ddp,
+            deterministic
+        )
+
         # init callbacks
         self.callback_connector.on_trainer_init(
             callbacks,
@@ -191,20 +205,6 @@ class Trainer(
             accumulate_grad_batches,
             truncated_bptt_steps,
             terminate_on_nan
-        )
-
-        # init accelerator related flags
-        self.accelerator_connector.on_trainer_init(
-            num_processes,
-            tpu_cores,
-            distributed_backend,
-            auto_select_gpus,
-            gpus,
-            num_nodes,
-            sync_batchnorm,
-            benchmark,
-            replace_sampler_ddp,
-            deterministic
         )
 
         # init train loop related flags

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -19,7 +19,7 @@ from typing import Dict, Iterable, List, Optional, Union
 import torch
 from torch.utils.data import DataLoader
 
-from pytorch_lightning.callbacks import Callback, EarlyStopping, ModelCheckpoint
+from pytorch_lightning.callbacks import Callback, EarlyStopping, ModelCheckpoint, GPUStatsMonitor
 from pytorch_lightning.core.datamodule import LightningDataModule
 from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.core.memory import ModelSummary
@@ -83,6 +83,7 @@ class Trainer(
         logger: Union[LightningLoggerBase, Iterable[LightningLoggerBase], bool] = True,
         checkpoint_callback: Union[ModelCheckpoint, bool] = True,
         early_stop_callback: Optional[Union[EarlyStopping, bool]] = False,
+        gpu_stats_callback: Optional[Union[GPUStatsMonitor, bool]] = False,
         callbacks: Optional[List[Callback]] = None,
         default_root_dir: Optional[str] = None,
         gradient_clip_val: float = 0,
@@ -92,7 +93,6 @@ class Trainer(
         gpus: Optional[Union[List[int], str, int]] = None,
         auto_select_gpus: bool = False,
         tpu_cores: Optional[Union[List[int], str, int]] = None,
-        log_gpu_memory: Optional[str] = None,
         progress_bar_refresh_rate: int = 1,
         overfit_batches: Union[int, float] = 0.0,
         track_grad_norm: Union[int, float, str] = -1,
@@ -129,6 +129,7 @@ class Trainer(
         amp_backend: str = 'native',
         amp_level: str = 'O2',  # backward compatible, todo: remove in v1.0.0
         overfit_pct: float = None,  # backward compatible, todo: remove in v1.0.0
+        log_gpu_memory: Optional[str] = None,  # backward compatible
     ):
         super().__init__()
 
@@ -160,6 +161,7 @@ class Trainer(
         # init callbacks
         self.callback_connector.on_trainer_init(
             callbacks,
+            gpu_stats_callback if gpu_stats_callback else bool(log_gpu_memory),
             early_stop_callback,
             checkpoint_callback,
             progress_bar_refresh_rate,
@@ -199,7 +201,6 @@ class Trainer(
             auto_select_gpus,
             gpus,
             num_nodes,
-            log_gpu_memory,
             sync_batchnorm,
             benchmark,
             replace_sampler_ddp,


### PR DESCRIPTION
## What does this PR do?

- Replaces log_gpu_memory with gpu_stats_callback

Fixes #3333

## TODO:

Update docs

## Questions:

- How should we test this?
- Do we want to support `log_gpu_memory=min_max` functionality?
- Should we call it `device_stats_callback` instead? In case we have cpu or tpu monitors in the future

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? 