### PR TITLE
Small documentation fix

### DIFF
--- a/docs/source/transfer_learning.rst
+++ b/docs/source/transfer_learning.rst
@@ -55,8 +55,7 @@ Example: Imagenet (computer Vision)
             # init a pretrained resnet
             num_target_classes = 10
             self.feature_extractor = models.resnet50(
-                                        pretrained=True,
-                                        num_classes=num_target_classes)
+                                        pretrained=True,)
             self.feature_extractor.eval()
 
             # use the pretrained model to classify cifar-10 (10 image classes)

--- a/docs/source/transfer_learning.rst
+++ b/docs/source/transfer_learning.rst
@@ -54,8 +54,7 @@ Example: Imagenet (computer Vision)
         def __init__(self):
             # init a pretrained resnet
             num_target_classes = 10
-            self.feature_extractor = models.resnet50(
-                                        pretrained=True,)
+            self.feature_extractor = models.resnet50(pretrained=True)
             self.feature_extractor.eval()
 
             # use the pretrained model to classify cifar-10 (10 image classes)


### PR DESCRIPTION
## What does this PR do?

Small documentation fix in transfer learning.
Basically torchivison models DO NOT take `num_classes` input, we need to set it as docs have done in next line.


# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

## Did you have fun?
Yep ! Eager to add better PRs next time.
