### PR TITLE
Fix docstring early_stop_callback arguments

### DIFF
--- a/pytorch_lightning/trainer/__init__.py
+++ b/pytorch_lightning/trainer/__init__.py
@@ -417,8 +417,8 @@ early_stop_callback (:class:`pytorch_lightning.callbacks.EarlyStopping`)
   Will raise an error if a :class:`~pytorch_lightning.core.step_result.Result` is returned
   and ``early_stopping_on`` was not specified.
 - ``False``: Early stopping will be disabled.
-- ``None``: Same as, if ``True`` is specified.
-- Default: ``None``.
+- ``None``: Equivalent to ``True``.
+- Default: ``False``.
 
 .. testcode::
 
@@ -1094,4 +1094,5 @@ Trainer class API
 from pytorch_lightning.trainer.trainer import Trainer
 from pytorch_lightning.utilities.seed import seed_everything
 
-__all__ = ['Trainer', 'seed_everything']
+__all__ = ["Trainer", "seed_everything"]
+


### PR DESCRIPTION
## What does this PR do?

As discussed in https://github.com/PyTorchLightning/pytorch-lightning/issues/3291#issuecomment-697217439, the PR fixes documentation for the Trainer's `early_stop_callback` argument. Before this PR the default argument was set to `None`. Now it is set to `False`. Moreover, the PR fixes grammatical error for the `None` value.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
