### PR TITLE
Split GPUStatsMonitor function

### DIFF
--- a/pytorch_lightning/callbacks/gpu_stats_monitor.py
+++ b/pytorch_lightning/callbacks/gpu_stats_monitor.py
@@ -144,8 +144,7 @@ class GPUStatsMonitor(Callback):
 
         trainer.logger.log_metrics(logs, step=trainer.global_step)
 
-    def _get_gpu_stats(self, gpu_stat_keys):
-        gpu_query = ','.join([m[0] for m in gpu_stat_keys])
+        """Run nvidia-smi to get the gpu stats"""
         format = 'csv,nounits,noheader'
 
         result = subprocess.run(
@@ -166,14 +165,14 @@ class GPUStatsMonitor(Callback):
         stats = [list(map(_to_float, x.split(', '))) for x in stats]
         return stats
 
-    def _parse_gpu_stats(self, stats, keys):
+        """Parse the gpu stats into a loggable dict"""
         logs = {}
         for i, gpu_id in enumerate(self._gpu_ids.split(',')):
             keys = [f'gpu_id: {gpu_id}/{x} ({unit})' for x, unit in keys]
             logs.update(dict(zip(keys, stats[i])))
         return logs
 
-    def _get_gpu_stat_keys(self):
+        """Get the GPU stats keys"""
         stat_keys = []
 
         if self._log_stats.gpu_utilization:
@@ -184,7 +183,7 @@ class GPUStatsMonitor(Callback):
 
         return stat_keys
 
-    def _get_gpu_device_stat_keys(self):
+        """Get the device stats keys"""
         stat_keys = []
 
         if self._log_stats.fan_speed:

--- a/pytorch_lightning/callbacks/gpu_stats_monitor.py
+++ b/pytorch_lightning/callbacks/gpu_stats_monitor.py
@@ -119,28 +119,30 @@ class GPUStatsMonitor(Callback):
     def on_train_batch_start(self, trainer, pl_module, batch, batch_idx, dataloader_idx):
         gpu_stat_keys = self._get_gpu_stat_keys()
         gpu_stats = self._get_gpu_stats(gpu_stat_keys)
+        logs = self._parse_gpu_stats(gpu_stats, gpu_stat_keys)
 
         if self._log_stats.inter_step_time and self._snap_inter_step_time:
             # First log at beginning of second step
-            gpu_stats['batch_time/inter_step (ms)'] = (time.time() - self._snap_inter_step_time) * 1000
+            logs['batch_time/inter_step (ms)'] = (time.time() - self._snap_inter_step_time) * 1000
 
         if self._log_stats.intra_step_time:
             self._snap_intra_step_time = time.time()
 
-        trainer.logger.log_metrics(gpu_stats, step=trainer.global_step)
+        trainer.logger.log_metrics(logs, step=trainer.global_step)
 
     @rank_zero_only
     def on_train_batch_end(self, trainer, pl_module, batch, batch_idx, dataloader_idx):
         gpu_stat_keys = self._get_gpu_stat_keys() + self._get_gpu_device_stat_keys()
         gpu_stats = self._get_gpu_stats(gpu_stat_keys)
+        logs = self._parse_gpu_stats(gpu_stats, gpu_stat_keys)
 
         if self._log_stats.inter_step_time:
             self._snap_inter_step_time = time.time()
 
         if self._log_stats.intra_step_time and self._snap_intra_step_time:
-            gpu_stats['batch_time/intra_step (ms)'] = (time.time() - self._snap_intra_step_time) * 1000
+            logs['batch_time/intra_step (ms)'] = (time.time() - self._snap_intra_step_time) * 1000
 
-        trainer.logger.log_metrics(gpu_stats, step=trainer.global_step)
+        trainer.logger.log_metrics(logs, step=trainer.global_step)
 
     def _get_gpu_stats(self, gpu_stat_keys):
         gpu_query = ','.join([m[0] for m in gpu_stat_keys])
@@ -162,12 +164,13 @@ class GPUStatsMonitor(Callback):
 
         stats = result.stdout.strip().split(os.linesep)
         stats = [list(map(_to_float, x.split(', '))) for x in stats]
+        return stats
 
+    def _parse_gpu_stats(self, stats, keys):
         logs = {}
         for i, gpu_id in enumerate(self._gpu_ids.split(',')):
-            gpu_stat_keys = [f'gpu_id: {gpu_id}/{x} ({unit})' for x, unit in gpu_stat_keys]
-            logs.update(dict(zip(gpu_stat_keys, stats[i])))
-
+            keys = [f'gpu_id: {gpu_id}/{x} ({unit})' for x, unit in keys]
+            logs.update(dict(zip(keys, stats[i])))
         return logs
 
     def _get_gpu_stat_keys(self):

--- a/pytorch_lightning/callbacks/gpu_stats_monitor.py
+++ b/pytorch_lightning/callbacks/gpu_stats_monitor.py
@@ -144,6 +144,7 @@ class GPUStatsMonitor(Callback):
 
         trainer.logger.log_metrics(logs, step=trainer.global_step)
 
+    def _get_gpu_stats(self, queries: List[str]) -> List[List[float]]:
         """Run nvidia-smi to get the gpu stats"""
         format = 'csv,nounits,noheader'
 
@@ -155,7 +156,7 @@ class GPUStatsMonitor(Callback):
             check=True
         )
 
-        def _to_float(x):
+        def _to_float(x: str) -> float:
             try:
                 return float(x)
             except ValueError:
@@ -165,6 +166,7 @@ class GPUStatsMonitor(Callback):
         stats = [list(map(_to_float, x.split(', '))) for x in stats]
         return stats
 
+    def _parse_gpu_stats(self, stats: List[List[float]], keys: List[Tuple[str, str]]) -> Dict[str, float]:
         """Parse the gpu stats into a loggable dict"""
         logs = {}
         for i, gpu_id in enumerate(self._gpu_ids.split(',')):
@@ -172,6 +174,7 @@ class GPUStatsMonitor(Callback):
             logs.update(dict(zip(keys, stats[i])))
         return logs
 
+    def _get_gpu_stat_keys(self) -> List[Tuple[str, str]]:
         """Get the GPU stats keys"""
         stat_keys = []
 
@@ -183,6 +186,7 @@ class GPUStatsMonitor(Callback):
 
         return stat_keys
 
+    def _get_gpu_device_stat_keys(self) -> List[Tuple[str, str]]:
         """Get the device stats keys"""
         stat_keys = []
 

--- a/tests/callbacks/test_gpu_stats_monitor.py
+++ b/tests/callbacks/test_gpu_stats_monitor.py
@@ -93,3 +93,9 @@ def test_gpu_stats_monitor_no_gpu_warning(tmpdir):
 
     with pytest.raises(MisconfigurationException, match='not running on GPU'):
         trainer.fit(model)
+
+
+def test_gpu_stats_monitor_parse_gpu_stats():
+    logs = GPUStatsMonitor._parse_gpu_stats('1,2', [[3, 4, 5], [6, 7]], [('gpu', 'a'), ('memory', 'b')])
+    expected = {'gpu_id: 1/gpu (a)': 3, 'gpu_id: 1/memory (b)': 4, 'gpu_id: 2/gpu (a)': 6, 'gpu_id: 2/memory (b)': 7}
+    assert logs == expected

--- a/tests/callbacks/test_gpu_stats_monitor.py
+++ b/tests/callbacks/test_gpu_stats_monitor.py
@@ -69,7 +69,7 @@ def test_gpu_stats_monitor_no_logger(tmpdir):
         callbacks=[gpu_stats],
         max_epochs=1,
         gpus=1,
-        logger=None
+        logger=False
     )
 
     with pytest.raises(MisconfigurationException, match='Trainer that has no logger.'):


### PR DESCRIPTION
## What does this PR do?

- Splits `_get_gpu_stats` into two. No API changes.

(asked by @Borda)
- Add docstrings
- Add typing annotations

No issue. Doing this so it is easier to subclass.

Im writing a callback to track the gpu memory in the progress bar so with this change I dont have to overwrite all the code to query `nvidia-smi`

## Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you verify new and existing tests pass locally with your changes?