### PR TITLE
Wrap prepare_data and setup only once inside DataModule

### DIFF
--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -68,6 +68,22 @@ def test_can_prepare_data(tmpdir):
     assert trainer.data_connector.can_prepare_data()
 
 
+def test_hooks_no_recursion_error(tmpdir):
+    # hooks were appended in cascade every tine a new data module was instantiated leading to a recursion error.
+    # See https://github.com/PyTorchLightning/pytorch-lightning/issues/3652
+    class DummyDM(LightningDataModule):
+        def setup(self, *args, **kwargs):
+            pass
+
+        def prepare_data(self, *args, **kwargs):
+            pass
+
+    for i in range(1005):
+        dm = DummyDM()
+        dm.setup()
+        dm.prepare_data()
+
+
 def test_base_datamodule(tmpdir):
     dm = TrialMNISTDataModule()
     dm.prepare_data()


### PR DESCRIPTION
Fix #3652

## What does this PR do?

Every time a new instance of DataModule was instantiated `prepare_data` and `setup` were wrapped one more time with check hooks. This lead to a recursion error as described in #3652. This commit ensures `prepare_data` and `setup` are wrapped only once. Tests are provided.

# Before submitting

- [X] Was this discussed/approved via a Github issue? **Reported problem was reproducible**
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes? **no need**
- [X] Did you write any new necessary tests? 
- [X] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? **no need**
