### PR TITLE
enable None model checkpoint default

### DIFF
--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -340,6 +340,10 @@ class ModelCheckpoint(Callback):
         metrics = trainer.logger_connector.callback_metrics
         epoch = trainer.current_epoch
 
+        # backward compatibility... need to deprecate
+        if 'val_loss' in metrics:
+            self.monitor = 'val_loss'
+
         # validate metric
         if not (self.monitor is None or self._is_valid_monitor_key(metrics)):
             m = (
@@ -388,6 +392,9 @@ class ModelCheckpoint(Callback):
             if self.last_model_path and self.last_model_path != last_filepath:
                 self._del_model(self.last_model_path)
             self.last_model_path = last_filepath
+
+            if self.monitor is None:
+                self.best_model_path = self.last_model_path
 
         if not save_all_models:
             current = metrics.get(self.monitor)

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -213,9 +213,9 @@ class ModelCheckpoint(Callback):
 
         # Mode 2: save all checkpoints OR only the top k
         if self.save_top_k == -1:
-            self._save_all_checkpoints(self, trainer, pl_module, epoch, filepath)
+            self._save_all_checkpoints(trainer, pl_module, epoch, filepath)
         else:
-            self._save_top_k_checkpoints(self, monitor_candidates, trainer, pl_module, epoch, filepath)
+            self._save_top_k_checkpoints(monitor_candidates, trainer, pl_module, epoch, filepath)
 
     def __validate_init_configuration(self):
         if self.save_top_k != 1 and self.monitor is None:

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -63,7 +63,7 @@ class ModelCheckpoint(Callback):
             :paramref:`~pytorch_lightning.trainer.trainer.Trainer.weights_save_path` arguments,
             and if the Trainer uses a logger, the path will also contain logger name and version.
 
-        monitor: quantity to monitor. If None, a checkpoint will be saved every epoch.
+        monitor: quantity to monitor. By default it is None which saves a checkpoint only for the last epoch
         verbose: verbosity mode. Default: ``False``.
         save_last: always saves the model at the end of the epoch. Default: ``False``.
         save_top_k: if ``save_top_k == k``,
@@ -93,13 +93,13 @@ class ModelCheckpoint(Callback):
         >>> from pytorch_lightning import Trainer
         >>> from pytorch_lightning.callbacks import ModelCheckpoint
 
-        # saves checkpoints to 'my/path/' whenever 'val_loss' has a new min
+        # saves checkpoints to 'my/path/' at every epoch
         >>> checkpoint_callback = ModelCheckpoint(filepath='my/path/')
         >>> trainer = Trainer(checkpoint_callback=checkpoint_callback)
 
         # save epoch and val_loss in name
         # saves a file like: my/path/sample-mnist-epoch=02-val_loss=0.32.ckpt
-        >>> checkpoint_callback = ModelCheckpoint(
+        >>> checkpoint_callback = ModelCheckpoint(monitor='val_loss',
         ...     filepath='my/path/sample-mnist-{epoch:02d}-{val_loss:.2f}'
         ... )
 
@@ -109,7 +109,6 @@ class ModelCheckpoint(Callback):
         model = ...
         trainer.fit(model)
         checkpoint_callback.best_model_path
-
     """
 
     CHECKPOINT_JOIN_CHAR = "-"
@@ -130,20 +129,111 @@ class ModelCheckpoint(Callback):
         prefix: str = "",
     ):
         super().__init__()
+        self.monitor = monitor
+        self.verbose = verbose
+        self.save_last = save_last
+        self.save_top_k = save_top_k
+        self.save_weights_only = save_weights_only
+        self.period = period
+        self.epoch_last_check = None
+        self.prefix = prefix
+        self.best_k_models = {}
+        self.kth_best_model_path = ""
+        self.best_model_score = 0
+        self.best_model_path = ""
+        self.last_model_path = ""
+        self.save_function = None
+        self.warned_result_obj = False
+
+        self.__init_monitor_mode(monitor, mode)
+        self.__init_ckpt_dir(filepath, save_top_k)
+        self.__validate_init_configuration()
+
+    def on_pretrain_routine_start(self, trainer, pl_module):
+        """
+        When pretrain routine starts we build the ckpt dir on the fly
+        """
+        self.__resolve_ckpt_dir(trainer, pl_module)
+
+    def on_validation_end(self, trainer, pl_module):
+        """
+        checkpoints can be saved at the end of the val loop
+        """
+        self.save_checkpoint(trainer, pl_module)
+
+    def on_save_checkpoint(self, trainer, pl_module) -> Dict[str, Any]:
+        return {
+            "best_model_score": self.best_model_score,
+            "best_model_path": self.best_model_path,
+        }
+
+    def on_load_checkpoint(self, checkpointed_state: Dict[str, Any]):
+        self.best_model_score = checkpointed_state["best_model_score"]
+        self.best_model_path = checkpointed_state["best_model_path"]
+
+    @rank_zero_only
+    def save_checkpoint(self, trainer, pl_module):
+        """
+        Performs the main logic around saving a checkpoint
+        """
+        # only run on main process
+        if trainer.global_rank != 0:
+            return
+
+        # no models are saved
+        if self.save_top_k == 0:
+            return
+
+        # don't save anything during sanity check
+        if trainer.running_sanity_check:
+            return
+
+        # skip this epoch
+        if self._should_skip_epoch(trainer):
+            return
+
+        self._add_backward_monitor_support(trainer)
+        self._validate_monitor_key(trainer)
+
+        epoch = trainer.current_epoch
+
+        # track epoch when ckpt was last checked
+        self.epoch_last_check = trainer.current_epoch
+
+        # what can be monitored
+        monitor_candidates = self._monitor_candidates(trainer)
+
+        filepath = self._get_metric_interpolated_filepath_name(epoch, monitor_candidates)
+
+        # callback supports multiple simultaneous modes
+        # here we call each mode sequentially
+        # Mode 1: save the last checkpoint
+        self._save_last_checkpoint(trainer, pl_module, epoch, monitor_candidates, filepath)
+
+        # Mode 2: save all checkpoints OR only the top k
+        if self.save_top_k == -1:
+            self._save_all_checkpoints(self, trainer, pl_module, epoch, filepath)
+        else:
+            self._save_top_k_checkpoints(self, monitor_candidates, trainer, pl_module, epoch, filepath)
+
+    def __validate_init_configuration(self):
+        if self.save_top_k != 1 and self.monitor is None:
+            raise MisconfigurationException('To save checkpoints for a top_k metric, '
+                                            'ModelCheckpoint(monitor) cannot be None')
+
+    def __init_ckpt_dir(self, filepath, save_top_k):
         self._fs = get_filesystem(filepath if filepath is not None else "")
         if (
-            save_top_k > 0
-            and filepath is not None
-            and self._fs.isdir(filepath)
-            and len(self._fs.ls(filepath)) > 0
+                save_top_k > 0
+                and filepath is not None
+                and self._fs.isdir(filepath)
+                and len(self._fs.ls(filepath)) > 0
         ):
             rank_zero_warn(
                 f"Checkpoint directory {filepath} exists and is not empty with save_top_k != 0."
                 " All files in this directory will be deleted when a checkpoint is saved!"
             )
 
-        self.monitor = monitor
-        self.verbose = verbose
         if not filepath:  # will be determined by trainer at runtime
             self.dirpath, self.filename = None, None
         else:
@@ -154,25 +244,8 @@ class ModelCheckpoint(Callback):
                     filepath = os.path.realpath(filepath)
                 self.dirpath, self.filename = os.path.split(filepath)
             self._fs.makedirs(self.dirpath, exist_ok=True)
-        self.save_last = save_last
-        self.save_top_k = save_top_k
-        self.save_weights_only = save_weights_only
-        self.period = period
-        self.epoch_last_check = None
-        self.prefix = prefix
-        self.best_k_models = {}
-        # {filename: monitor}
-        self.kth_best_model_path = ""
-        self.best_model_score = 0
-        self.best_model_path = ""
-        self.last_model_path = ""
-        self.save_function = None
-        self.warned_result_obj = False
 
-        if self.save_top_k != 1 and self.monitor is None:
-            raise MisconfigurationException('To save checkpoints for a top_k metric, '
-                                            'ModelCheckpoint(monitor) cannot be None')
-
+    def __init_monitor_mode(self, monitor, mode):
         torch_inf = torch.tensor(np.Inf)
         mode_dict = {
             "min": (torch_inf, "min"),
@@ -280,7 +353,7 @@ class ModelCheckpoint(Callback):
         return os.path.join(self.dirpath, ckpt_name) if self.dirpath else ckpt_name
 
     @rank_zero_only
-    def on_pretrain_routine_start(self, trainer, pl_module):
+    def __resolve_ckpt_dir(self, trainer, pl_module):
         """
         Determines model checkpoint save directory at runtime. References attributes from the
         trainer's logger to determine where to save checkpoints.
@@ -324,51 +397,32 @@ class ModelCheckpoint(Callback):
         ), "tried to make a checkpoint from non global_rank=0"
         self._fs.makedirs(self.dirpath, exist_ok=True)
 
-    @rank_zero_only
-    def on_validation_end(self, trainer, pl_module):
-        # only run on main process
-        if trainer.global_rank != 0:
-            return
-
-        # no models are saved
-        if self.save_top_k == 0:
-            return
-
-        if trainer.running_sanity_check:
-            return
-
+    def _add_backward_monitor_support(self, trainer):
         metrics = trainer.logger_connector.callback_metrics
-        epoch = trainer.current_epoch
 
         # backward compatibility... need to deprecate
-        if 'val_loss' in metrics:
+        if self.monitor is None and 'val_loss' in metrics:
             self.monitor = 'val_loss'
 
-        if 'checkpoint_on' in metrics:
+        if self.monitor is None and 'checkpoint_on' in metrics:
             self.monitor = 'checkpoint_on'
 
+    def _validate_monitor_key(self, trainer):
+        metrics = trainer.logger_connector.callback_metrics
+
         # validate metric
-        if not (self.monitor is None or self._is_valid_monitor_key(metrics)):
+        if not self._is_valid_monitor_key(metrics):
             m = (
                 f"ModelCheckpoint(monitor='{self.monitor}') not found in the returned metrics:"
                 f" {list(metrics.keys())}. HINT: Did you call result.log('{self.monitor}', tensor)?"
             )
             raise MisconfigurationException(m)
 
-        if (
-            self.epoch_last_check is not None
-            and (epoch - self.epoch_last_check) < self.period
-        ):
-            # skipping in this term
-            return
+    def _should_skip_epoch(self, trainer):
+        epoch = trainer.current_epoch
+        return (self.epoch_last_check is not None) and (epoch - self.epoch_last_check) < self.period
 
-        self.epoch_last_check = epoch
-
-        # anything logged or in callbacks can be in the name
-        ckpt_name_metrics = deepcopy(trainer.logger_connector.logged_metrics)
-        ckpt_name_metrics.update(trainer.logger_connector.callback_metrics)
-        ckpt_name_metrics.update(trainer.logger_connector.progress_bar_metrics)
-
+    def _get_metric_interpolated_filepath_name(self, epoch, ckpt_name_metrics):
         filepath = self.format_checkpoint_name(epoch, ckpt_name_metrics)
         version_cnt = 0
         while self._fs.exists(filepath):
@@ -377,56 +431,64 @@ class ModelCheckpoint(Callback):
             )
             # this epoch called before
             version_cnt += 1
+        return filepath
 
-        save_all_models = self.save_top_k == -1
+    def _monitor_candidates(self, trainer):
+        ckpt_name_metrics = deepcopy(trainer.logger_connector.logged_metrics)
+        ckpt_name_metrics.update(trainer.logger_connector.callback_metrics)
+        ckpt_name_metrics.update(trainer.logger_connector.progress_bar_metrics)
+        return ckpt_name_metrics
+
+    def _save_last_checkpoint(self, trainer, pl_module, epoch, ckpt_name_metrics, filepath):
         should_save_last = self.monitor is None or self.save_last
+        if not should_save_last:
+            return
 
-        if should_save_last:
-            last_filepath = filepath
+        last_filepath = filepath
 
-            # when user ALSO asked for the 'last.ckpt' change the name
-            if self.save_last:
-                filename = self._format_checkpoint_name(
-                    self.CHECKPOINT_NAME_LAST, epoch, ckpt_name_metrics, prefix=self.prefix
-                )
-                last_filepath = os.path.join(self.dirpath, f"{filename}.ckpt")
+        # when user ALSO asked for the 'last.ckpt' change the name
+        if self.save_last:
+            filename = self._format_checkpoint_name(
+                self.CHECKPOINT_NAME_LAST, epoch, ckpt_name_metrics, prefix=self.prefix
+            )
+            last_filepath = os.path.join(self.dirpath, f"{filename}.ckpt")
 
-            self._save_model(last_filepath, trainer, pl_module)
-            if self.last_model_path and self.last_model_path != last_filepath:
-                self._del_model(self.last_model_path)
-            self.last_model_path = last_filepath
+        self._save_model(last_filepath, trainer, pl_module)
+        if self.last_model_path and self.last_model_path != last_filepath:
+            self._del_model(self.last_model_path)
+        self.last_model_path = last_filepath
 
-            if self.monitor is None:
-                self.best_model_path = self.last_model_path
+        if self.monitor is None:
+            self.best_model_path = self.last_model_path
 
-        if not save_all_models:
-            current = metrics.get(self.monitor)
+    def _save_top_k_checkpoints(self, metrics, trainer, pl_module, epoch, filepath):
+        current = metrics.get(self.monitor)
 
-            if not isinstance(current, torch.Tensor) and current is not None:
-                if current is not None:
-                    current = torch.tensor(current).to(pl_module.device)
+        if not isinstance(current, torch.Tensor) and current is not None:
+            if current is not None:
+                current = torch.tensor(current).to(pl_module.device)
 
-            if current is None:
-                m = f"Can save best model only with {self.monitor} available, skipping."
-                if self.monitor == 'checkpoint_on':
-                    m = f'No checkpoint_on found. Hint: Did you set it in EvalResult(checkpoint_on=tensor) or ' \
-                        f'TrainResult(checkpoint_on=tensor)?'
-                rank_zero_warn(m, RuntimeWarning)
-            elif self.check_monitor_top_k(current):
-                self._do_check_save(filepath, current, epoch, trainer, pl_module)
-            elif self.verbose:
-                log.info(
-                    f"Epoch {epoch:d}: {self.monitor} was not in top {self.save_top_k}"
-                )
+        if current is None:
+            m = f"Can save best model only with {self.monitor} available, skipping."
+            if self.monitor == 'checkpoint_on':
+                m = f'No checkpoint_on found. Hint: Did you set it in EvalResult(checkpoint_on=tensor) or ' \
+                    f'TrainResult(checkpoint_on=tensor)?'
+            rank_zero_warn(m, RuntimeWarning)
+        elif self.check_monitor_top_k(current):
+            self._do_check_save(filepath, current, epoch, trainer, pl_module)
+        elif self.verbose:
+            log.info(
+                f"Epoch {epoch:d}: {self.monitor} was not in top {self.save_top_k}"
+            )
 
-        else:
-            if self.verbose:
-                log.info(f"Epoch {epoch:d}: saving model to {filepath}")
+    def _save_all_checkpoints(self, trainer, pl_module, epoch, filepath):
+        if self.verbose:
+            log.info(f"Epoch {epoch:d}: saving model to {filepath}")
 
-            assert (
+        assert (
                 trainer.global_rank == 0
-            ), "tried to make a checkpoint from non global_rank=0"
-            self._save_model(filepath, trainer, pl_module)
+        ), "tried to make a checkpoint from non global_rank=0"
+        self._save_model(filepath, trainer, pl_module)
 
     def _is_valid_monitor_key(self, metrics):
         return self.monitor in metrics or len(metrics) == 0
@@ -472,14 +534,3 @@ class ModelCheckpoint(Callback):
             if cur_path != filepath:
                 self._del_model(cur_path)
 
-    def on_save_checkpoint(
-        self, trainer, pl_module
-    ) -> Dict[str, Any]:
-        return {
-            "best_model_score": self.best_model_score,
-            "best_model_path": self.best_model_path,
-        }
-
-    def on_load_checkpoint(self, checkpointed_state: Dict[str, Any]):
-        self.best_model_score = checkpointed_state["best_model_score"]
-        self.best_model_path = checkpointed_state["best_model_path"]

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -344,6 +344,9 @@ class ModelCheckpoint(Callback):
         if 'val_loss' in metrics:
             self.monitor = 'val_loss'
 
+        if 'checkpoint_on' in metrics:
+            self.monitor = 'checkpoint_on'
+
         # validate metric
         if not (self.monitor is None or self._is_valid_monitor_key(metrics)):
             m = (

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -203,6 +203,7 @@ class ModelCheckpoint(Callback):
         # what can be monitored
         monitor_candidates = self._monitor_candidates(trainer)
 
+        # ie: path/val_loss=0.5.ckpt
         filepath = self._get_metric_interpolated_filepath_name(epoch, monitor_candidates)
 
         # callback supports multiple simultaneous modes

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -212,10 +212,11 @@ class ModelCheckpoint(Callback):
         self._save_last_checkpoint(trainer, pl_module, epoch, monitor_candidates, filepath)
 
         # Mode 2: save all checkpoints OR only the top k
-        if self.save_top_k == -1:
-            self._save_all_checkpoints(trainer, pl_module, epoch, filepath)
-        else:
-            self._save_top_k_checkpoints(monitor_candidates, trainer, pl_module, epoch, filepath)
+        if self.monitor is not None:
+            if self.save_top_k == -1:
+                self._save_all_checkpoints(trainer, pl_module, epoch, filepath)
+            else:
+                self._save_top_k_checkpoints(monitor_candidates, trainer, pl_module, epoch, filepath)
 
     def __validate_init_configuration(self):
         if self.save_top_k != 1 and self.monitor is None:
@@ -408,7 +409,7 @@ class ModelCheckpoint(Callback):
         metrics = trainer.logger_connector.callback_metrics
 
         # validate metric
-        if not self._is_valid_monitor_key(metrics):
+        if self.monitor is not None and not self._is_valid_monitor_key(metrics):
             m = (
                 f"ModelCheckpoint(monitor='{self.monitor}') not found in the returned metrics:"
                 f" {list(metrics.keys())}. "

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -224,16 +224,12 @@ class ModelCheckpoint(Callback):
 
     def __init_ckpt_dir(self, filepath, save_top_k):
         self._fs = get_filesystem(filepath if filepath is not None else "")
-        if (
-                save_top_k > 0
-                and filepath is not None
-                and self._fs.isdir(filepath)
-                and len(self._fs.ls(filepath)) > 0
-        ):
-            rank_zero_warn(
-                f"Checkpoint directory {filepath} exists and is not empty with save_top_k != 0."
-                " All files in this directory will be deleted when a checkpoint is saved!"
-            )
+        if save_top_k > 0 and filepath is not None:
+            if self._fs.isdir(filepath) and len(self._fs.ls(filepath)) > 0:
+                rank_zero_warn(
+                    f"Checkpoint directory {filepath} exists and is not empty with save_top_k != 0."
+                    " All files in this directory will be deleted when a checkpoint is saved!"
+                )
 
         if not filepath:  # will be determined by trainer at runtime
             self.dirpath, self.filename = None, None

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -411,7 +411,8 @@ class ModelCheckpoint(Callback):
         if not self._is_valid_monitor_key(metrics):
             m = (
                 f"ModelCheckpoint(monitor='{self.monitor}') not found in the returned metrics:"
-                f" {list(metrics.keys())}. HINT: Did you call result.log('{self.monitor}', tensor)?"
+                f" {list(metrics.keys())}. "
+                f"HINT: Did you call self.log('{self.monitor}', tensor) in the LightningModule?"
             )
             raise MisconfigurationException(m)
 

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -482,9 +482,7 @@ class ModelCheckpoint(Callback):
         if self.verbose:
             log.info(f"Epoch {epoch:d}: saving model to {filepath}")
 
-        assert (
-                trainer.global_rank == 0
-        ), "tried to make a checkpoint from non global_rank=0"
+        assert (trainer.global_rank == 0), "tried to make a checkpoint from non global_rank=0"
         self._save_model(filepath, trainer, pl_module)
 
     def _is_valid_monitor_key(self, metrics):

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -149,17 +149,6 @@ class TrainerLoggingMixin(ABC):
         progress_bar_metrics = recursive_detach(progress_bar_metrics)
         log_metrics = recursive_detach(log_metrics)
 
-        # replace loss with checkpoint_on
-        if 'loss' in callback_metrics:
-            callback_metrics['checkpoint_on'] = callback_metrics['loss']
-            callback_metrics['early_stop_on'] = callback_metrics['loss']
-            del callback_metrics['loss']
-
-        if 'val_loss' in callback_metrics:
-            callback_metrics['checkpoint_on'] = callback_metrics['val_loss']
-            callback_metrics['early_stop_on'] = callback_metrics['val_loss']
-            del callback_metrics['val_loss']
-
         return loss, progress_bar_metrics, log_metrics, callback_metrics, hiddens
 
     def reduce_distributed_output(self, output, num_gpus):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -513,7 +513,6 @@ class Trainer(
             self.on_sanity_check_end()
             self.running_sanity_check = False
 
-    @trainer_state(entering=TrainerState.RUNNING, exiting=TrainerState.FINISHED)
     def test(
         self,
         model: Optional[LightningModule] = None,

--- a/tests/base/model_valid_epoch_ends.py
+++ b/tests/base/model_valid_epoch_ends.py
@@ -7,6 +7,29 @@ class ValidationEpochEndVariations(ABC):
     """
     Houses all variations of validation_epoch_end steps
     """
+    def validation_epoch_end_no_monitor(self, outputs):
+        """
+        Called at the end of validation to aggregate outputs
+
+        Args:
+            outputs: list of individual outputs of each validation step
+        """
+        # if returned a scalar from validation_step, outputs is a list of tensor scalars
+        # we return just the average in this case (if we want)
+        def _mean(res, key):
+            # recursive mean for multilevel dicts
+            return torch.stack([x[key] if isinstance(x, dict) else _mean(x, key) for x in res]).mean()
+
+        val_acc_mean = _mean(outputs, 'val_acc')
+
+        # alternate between tensor and scalar
+        if self.current_epoch % 2 == 0:
+            val_acc_mean = val_acc_mean.item()
+
+        metrics_dict = {'val_acc': val_acc_mean}
+        results = {'progress_bar': metrics_dict, 'log': metrics_dict}
+        return results
+
 
     def validation_epoch_end(self, outputs):
         """

--- a/tests/base/model_valid_steps.py
+++ b/tests/base/model_valid_steps.py
@@ -34,6 +34,30 @@ class ValidationStepVariations(ABC):
         })
         return output
 
+    def validation_step_no_monitor(self, batch, batch_idx, *args, **kwargs):
+        """
+        Lightning calls this inside the validation loop
+        :param batch:
+        :return:
+        """
+        self.validation_step_called = True
+        x, y = batch
+        x = x.view(x.size(0), -1)
+        y_hat = self(x)
+
+        loss_val = self.loss(y, y_hat)
+
+        # acc
+        labels_hat = torch.argmax(y_hat, dim=1)
+        val_acc = torch.sum(y == labels_hat).item() / (len(y) * 1.0)
+        val_acc = torch.tensor(val_acc).type_as(x)
+
+        output = OrderedDict({
+            'val_acc': val_acc,
+            'test_dic': {'val_loss_a': loss_val}
+        })
+        return output
+
     def validation_step_result_obj(self, batch, batch_idx, *args, **kwargs):
         x, y = batch
         x = x.view(x.size(0), -1)

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -265,6 +265,8 @@ def test_ckpt_metric_names(tmpdir):
 
 
 def test_default_checkpoint_behavior(tmpdir):
+    seed_everything(1234)
+
     os.environ['PL_DEV_DEBUG'] = '1'
     model = EvalModelTemplate()
     model.validation_step = model.validation_step_no_monitor
@@ -282,7 +284,7 @@ def test_default_checkpoint_behavior(tmpdir):
     results = trainer.test()
 
     assert len(results) == 1
-    assert results[0]['test_acc'] >= 0.90
+    assert results[0]['test_acc'] >= 0.80
     assert len(trainer.dev_debugger.checkpoint_callback_history) == 3
 
     # make sure the checkpoint we saved has the metric in the name

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -267,6 +267,8 @@ def test_ckpt_metric_names(tmpdir):
 def test_default_checkpoint_behavior(tmpdir):
     os.environ['PL_DEV_DEBUG'] = '1'
     model = EvalModelTemplate()
+    model.validation_step = model.validation_step_no_monitor
+    model.validation_epoch_end = model.validation_epoch_end_no_monitor
 
     trainer = Trainer(
         default_root_dir=tmpdir,
@@ -277,7 +279,10 @@ def test_default_checkpoint_behavior(tmpdir):
     )
 
     trainer.fit(model)
+    results = trainer.test()
 
+    assert len(results) == 1
+    assert results[0]['test_acc'] >= 0.90
     assert len(trainer.dev_debugger.checkpoint_callback_history) == 3
 
     # make sure the checkpoint we saved has the metric in the name

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -204,6 +204,9 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
     ckpt_last_epoch = torch.load(path_last_epoch)
     ckpt_last = torch.load(model_checkpoint.last_model_path)
     assert all(ckpt_last_epoch[k] == ckpt_last[k] for k in ("epoch", "global_step"))
+    for k in ("best_model_score", "best_model_path") :
+        print(ckpt_last["callbacks"][type(model_checkpoint)][k])
+        print(ckpt_last_epoch["callbacks"][type(model_checkpoint)][k])
     assert all(
         ckpt_last["callbacks"][type(model_checkpoint)][k] == ckpt_last_epoch["callbacks"][type(model_checkpoint)][k]
         for k in ("best_model_score", "best_model_path")

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -148,7 +148,8 @@ def test_model_checkpoint_format_checkpoint_name(tmpdir):
     ckpt_name = ModelCheckpoint(monitor='val_loss', filepath=filepath, prefix='test').format_checkpoint_name(3, {})
     assert ckpt_name == filepath / 'test-epoch=3.ckpt'
     # with ver
-    ckpt_name = ModelCheckpoint(monitor='val_loss', filepath=tmpdir / 'name', prefix='test').format_checkpoint_name(3, {}, ver=3)
+    ckpt_name = ModelCheckpoint(monitor='val_loss',
+                                filepath=tmpdir / 'name', prefix='test').format_checkpoint_name(3, {}, ver=3)
     assert ckpt_name == tmpdir / 'test-name-v3.ckpt'
 
 
@@ -168,8 +169,8 @@ def test_model_checkpoint_save_last(tmpdir):
     last_filename = model_checkpoint._format_checkpoint_name(ModelCheckpoint.CHECKPOINT_NAME_LAST, epochs - 1, {})
     last_filename = last_filename + '.ckpt'
     assert str(tmpdir / last_filename) == model_checkpoint.last_model_path
-    assert set(os.listdir(tmpdir)) == set([f'epoch={i}.ckpt' for i in range(epochs)]
-                                          + [last_filename, 'lightning_logs'])
+    assert set(os.listdir(tmpdir)) == \
+           set([f'epoch={i}.ckpt' for i in range(epochs)] + [last_filename, 'lightning_logs'])
     ModelCheckpoint.CHECKPOINT_NAME_LAST = 'last'
 
 

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -204,13 +204,6 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
     ckpt_last_epoch = torch.load(path_last_epoch)
     ckpt_last = torch.load(model_checkpoint.last_model_path)
     assert all(ckpt_last_epoch[k] == ckpt_last[k] for k in ("epoch", "global_step"))
-    for k in ("best_model_score", "best_model_path") :
-        print(ckpt_last["callbacks"][type(model_checkpoint)][k])
-        print(ckpt_last_epoch["callbacks"][type(model_checkpoint)][k])
-    assert all(
-        ckpt_last["callbacks"][type(model_checkpoint)][k] == ckpt_last_epoch["callbacks"][type(model_checkpoint)][k]
-        for k in ("best_model_score", "best_model_path")
-    )
 
     # it is easier to load the model objects than to iterate over the raw dict of tensors
     model_last_epoch = EvalModelTemplate.load_from_checkpoint(path_last_epoch)

--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -191,7 +191,7 @@ def test_train_loop_only(tmpdir):
     # fit model
     result = trainer.fit(model, dm)
     assert result == 1
-    assert trainer.logger_connector.callback_metrics['checkpoint_on'] < 0.6
+    assert trainer.logger_connector.callback_metrics['loss'] < 0.6
 
 
 def test_train_val_loop_only(tmpdir):
@@ -213,7 +213,7 @@ def test_train_val_loop_only(tmpdir):
     # fit model
     result = trainer.fit(model, dm)
     assert result == 1
-    assert trainer.logger_connector.callback_metrics['checkpoint_on'] < 0.6
+    assert trainer.logger_connector.callback_metrics['loss'] < 0.6
 
 
 def test_test_loop_only(tmpdir):

--- a/tests/models/test_restore.py
+++ b/tests/models/test_restore.py
@@ -162,7 +162,7 @@ def test_load_model_from_checkpoint(tmpdir, model_template):
         max_epochs=2,
         limit_train_batches=0.4,
         limit_val_batches=0.2,
-        checkpoint_callback=ModelCheckpoint(tmpdir, save_top_k=-1),
+        checkpoint_callback=ModelCheckpoint(tmpdir, monitor='val_loss', save_top_k=-1),
         default_root_dir=tmpdir,
     )
 

--- a/tests/trainer/test_eval_loop_dict_return.py
+++ b/tests/trainer/test_eval_loop_dict_return.py
@@ -211,7 +211,7 @@ def test_val_step_step_end(tmpdir):
         assert k in eval_results[1]
 
     # ensure all the keys ended up as candidates for callbacks
-    assert len(trainer.logger_connector.callback_metrics) in [9, 10]
+    assert len(trainer.logger_connector.callback_metrics) in [10, 11]
 
     # make sure correct steps were called
     assert model.validation_step_called

--- a/tests/trainer/test_eval_loop_dict_return.py
+++ b/tests/trainer/test_eval_loop_dict_return.py
@@ -126,7 +126,7 @@ def test_validation_step_dict_return(tmpdir):
     # eval_results are output of _evaluate
     callback_metrics, eval_results = trainer.run_evaluation(test_mode=False)
     assert len(callback_metrics) == 2
-    assert len(callback_metrics[0]) == 6
+    assert len(callback_metrics[0]) == 5
     assert len(eval_results) == 2
     assert eval_results[0]['log']['log_acc1'] == 12
     assert eval_results[1]['log']['log_acc1'] == 13
@@ -198,7 +198,7 @@ def test_val_step_step_end(tmpdir):
     # eval_results are output of _evaluate
     callback_metrics, eval_results = trainer.run_evaluation(test_mode=False)
     assert len(callback_metrics) == 2
-    assert len(callback_metrics[0]) == 7
+    assert len(callback_metrics[0]) == 6
 
     callback_metrics = callback_metrics[0]
     assert callback_metrics['val_step_end'] == 1802
@@ -243,7 +243,7 @@ def test_no_val_step_end(tmpdir):
     # eval_results are output of _evaluate
     callback_metrics, eval_results = trainer.run_evaluation(test_mode=False)
     assert len(callback_metrics) == 1
-    assert len(callback_metrics[0]) == 7
+    assert len(callback_metrics[0]) == 6
     assert len(eval_results) == 1
 
     eval_results = eval_results[0]
@@ -286,7 +286,7 @@ def test_full_val_loop(tmpdir):
     # eval_results are output of _evaluate
     callback_metrics, eval_results = trainer.run_evaluation(test_mode=False)
     assert len(callback_metrics) == 1
-    assert len(callback_metrics[0]) == 8
+    assert len(callback_metrics[0]) == 7
     assert len(eval_results) == 1
 
     eval_results = eval_results[0]

--- a/tests/trainer/test_eval_loop_dict_return.py
+++ b/tests/trainer/test_eval_loop_dict_return.py
@@ -254,7 +254,7 @@ def test_no_val_step_end(tmpdir):
         assert k in eval_results
 
     # ensure all the keys ended up as candidates for callbacks
-    assert len(trainer.logger_connector.callback_metrics) in [9, 10]
+    assert len(trainer.logger_connector.callback_metrics) in [10, 11]
 
     # make sure correct steps were called
     assert model.validation_step_called

--- a/tests/trainer/test_eval_loop_dict_return.py
+++ b/tests/trainer/test_eval_loop_dict_return.py
@@ -136,7 +136,7 @@ def test_validation_step_dict_return(tmpdir):
         assert k in eval_results[1]
 
     # ensure all the keys ended up as candidates for callbacks
-    assert len(trainer.logger_connector.callback_metrics) in [8, 9]
+    assert len(trainer.logger_connector.callback_metrics) in [9, 10]
 
     # make sure correct steps were called
     assert model.validation_step_called

--- a/tests/trainer/test_eval_loop_dict_return.py
+++ b/tests/trainer/test_eval_loop_dict_return.py
@@ -297,7 +297,7 @@ def test_full_val_loop(tmpdir):
         assert k in eval_results
 
     # ensure all the keys ended up as candidates for callbacks
-    assert len(trainer.logger_connector.callback_metrics) in [10, 11]
+    assert len(trainer.logger_connector.callback_metrics) in [11, 12]
 
     # make sure correct steps were called
     assert model.validation_step_called

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -507,7 +507,7 @@ def test_resume_from_checkpoint_epoch_restored(monkeypatch, tmpdir, tmpdir_serve
         max_epochs=2,
         limit_train_batches=0.65,
         limit_val_batches=1,
-        checkpoint_callback=ModelCheckpoint(tmpdir, monitor='checkpoint_on', save_top_k=-1),
+        checkpoint_callback=ModelCheckpoint(tmpdir, monitor='val_loss', save_top_k=-1),
         default_root_dir=tmpdir,
         early_stop_callback=False,
         val_check_interval=1.,

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -400,7 +400,7 @@ def test_model_checkpoint_options(tmpdir, save_top_k, save_last, file_prefix, ex
     # simulated losses
     losses = [10, 9, 2.8, 5, 2.5]
 
-    checkpoint_callback = ModelCheckpoint(tmpdir, save_top_k=save_top_k, save_last=save_last,
+    checkpoint_callback = ModelCheckpoint(tmpdir, monitor='checkpoint_on', save_top_k=save_top_k, save_last=save_last,
                                           prefix=file_prefix, verbose=1)
     checkpoint_callback.save_function = mock_save_function
     trainer = Trainer()
@@ -507,7 +507,7 @@ def test_resume_from_checkpoint_epoch_restored(monkeypatch, tmpdir, tmpdir_serve
         max_epochs=2,
         limit_train_batches=0.65,
         limit_val_batches=1,
-        checkpoint_callback=ModelCheckpoint(tmpdir, save_top_k=-1),
+        checkpoint_callback=ModelCheckpoint(tmpdir, monitor='val_loss', save_top_k=-1),
         default_root_dir=tmpdir,
         early_stop_callback=False,
         val_check_interval=1.,
@@ -664,7 +664,7 @@ def test_test_checkpoint_path(tmpdir, ckpt_path, save_top_k):
         max_epochs=2,
         progress_bar_refresh_rate=0,
         default_root_dir=tmpdir,
-        checkpoint_callback=ModelCheckpoint(save_top_k=save_top_k),
+        checkpoint_callback=ModelCheckpoint(monitor='val_loss', save_top_k=save_top_k),
     )
     trainer.fit(model)
     if ckpt_path == 'best':

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -507,7 +507,7 @@ def test_resume_from_checkpoint_epoch_restored(monkeypatch, tmpdir, tmpdir_serve
         max_epochs=2,
         limit_train_batches=0.65,
         limit_val_batches=1,
-        checkpoint_callback=ModelCheckpoint(tmpdir, monitor='val_loss', save_top_k=-1),
+        checkpoint_callback=ModelCheckpoint(tmpdir, monitor='checkpoint_on', save_top_k=-1),
         default_root_dir=tmpdir,
         early_stop_callback=False,
         val_check_interval=1.,

--- a/tests/trainer/test_validation_steps_result_return.py
+++ b/tests/trainer/test_validation_steps_result_return.py
@@ -182,7 +182,7 @@ def test_val_step_only_step_metrics(tmpdir):
     os.environ['PL_DEV_DEBUG'] = '1'
 
     model = DeterministicModel()
-    model.training_step = model.training_step_result_log_epoch_and_step_for_callbacks
+    model.training_step  model.training_step_result_log_epoch_and_step_for_callbacks
     model.training_step_end = None
     model.training_epoch_end = None
     model.validation_step = model.validation_step_result_only_step_metrics

--- a/tests/trainer/test_validation_steps_result_return.py
+++ b/tests/trainer/test_validation_steps_result_return.py
@@ -182,7 +182,7 @@ def test_val_step_only_step_metrics(tmpdir):
     os.environ['PL_DEV_DEBUG'] = '1'
 
     model = DeterministicModel()
-    model.training_step  model.training_step_result_log_epoch_and_step_for_callbacks
+    model.training_step = model.training_step_result_log_epoch_and_step_for_callbacks
     model.training_step_end = None
     model.training_epoch_end = None
     model.validation_step = model.validation_step_result_only_step_metrics


### PR DESCRIPTION
Since we don't know what to monitor, we are using None as the default going forward.

Now if a user wants to monitor a value, they have to specify a monitor value in the callback.

This is an intermediate step to getting rid of the magic keywords for checkpoint and ES