### PR TITLE
change default save_top_k, save_last to None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Changed IoU `remove_bg` bool to `ignore_index` optional int ([#3098](https://github.com/PyTorchLightning/pytorch-lightning/pull/3098))
 
+- Changed defaults of `save_top_k` and `save_last` to `None` in ModelCheckpoint ([#3680](https://github.com/PyTorchLightning/pytorch-lightning/pull/3680))
+
 ### Deprecated
 
 

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -217,7 +217,7 @@ class ModelCheckpoint(Callback):
         self._save_last_checkpoint(trainer, pl_module, epoch, monitor_candidates, filepath)
 
         # Mode 2: save all checkpoints OR only the top k
-        if self.save_top_k is not None:
+        if self.save_top_k:
             if self.save_top_k == -1:
                 self._save_all_checkpoints(trainer, pl_module, epoch, filepath)
             else:

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -67,7 +67,7 @@ class ModelCheckpoint(Callback):
 
         monitor: quantity to monitor. By default it is None which saves a checkpoint only for the last epoch
         verbose: verbosity mode. Default: ``False``.
-        save_last: always saves the model at the end of the last epoch. Default: ``None``.
+        save_last: When `True`, always saves the model at the end of the epoch to a file `last.ckpt`. Default: ``None``.
         save_top_k: if ``save_top_k == k``,
             the best k models according to
             the quantity monitored will be saved.

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -217,7 +217,7 @@ class ModelCheckpoint(Callback):
         self._save_last_checkpoint(trainer, pl_module, epoch, monitor_candidates, filepath)
 
         # Mode 2: save all checkpoints OR only the top k
-        if self.monitor is not None and self.save_top_k:
+        if self.save_top_k is not None:
             if self.save_top_k == -1:
                 self._save_all_checkpoints(trainer, pl_module, epoch, filepath)
             else:
@@ -479,7 +479,7 @@ class ModelCheckpoint(Callback):
             last_filepath = os.path.join(self.dirpath, f"{filename}.ckpt")
 
         self._save_model(last_filepath, trainer, pl_module)
-        if self.last_model_path and self.last_model_path != last_filepath:
+        if self.last_model_path and self.last_model_path != last_filepath and (self.save_top_k != -1 or self.save_last):
             self._del_model(self.last_model_path)
         self.last_model_path = last_filepath
 

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -415,6 +415,9 @@ class ModelCheckpoint(Callback):
         if self.monitor is None and 'checkpoint_on' in metrics:
             self.monitor = 'checkpoint_on'
 
+        if self.save_top_k is None:
+            self.save_top_k = 1
+
     def _validate_monitor_key(self, trainer):
         metrics = trainer.logger_connector.callback_metrics
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -549,9 +549,9 @@ class Trainer(
 
     def __test_using_best_weights(self, ckpt_path, test_dataloaders):
         model = self.get_model()
-
+        print(self.checkpoint_callback.monitor)
         # if user requests the best checkpoint but we don't have it, error
-        if ckpt_path == 'best' and self.checkpoint_callback.save_top_k <= 0:
+        if ckpt_path == 'best' and self.checkpoint_callback.save_top_k in [-1, 0, None]:
             raise MisconfigurationException(
                 'ckpt_path is "best", but ModelCheckpoint is not configured to save the best model.'
             )

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -560,9 +560,6 @@ class Trainer(
         if ckpt_path is not None:
             # ckpt_path is 'best' so load the best model
             if ckpt_path == 'best':
-                # if not self.checkpoint_callback.best_model_path:
-                #     # if user requests the best checkpoint but we don't have it, error
-                #     raise MisconfigurationException('ckpt_path is "best", but we could not find the best model path')
                 ckpt_path = self.checkpoint_callback.best_model_path
 
             if len(ckpt_path) == 0:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -549,7 +549,6 @@ class Trainer(
 
     def __test_using_best_weights(self, ckpt_path, test_dataloaders):
         model = self.get_model()
-        print(self.checkpoint_callback.monitor)
         # if user requests the best checkpoint but we don't have it, error
         if ckpt_path == 'best' and self.checkpoint_callback.save_top_k in [-1, 0, None]:
             raise MisconfigurationException(

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -550,13 +550,19 @@ class Trainer(
     def __test_using_best_weights(self, ckpt_path, test_dataloaders):
         model = self.get_model()
 
+        # if user requests the best checkpoint but we don't have it, error
+        if ckpt_path == 'best' and not self.checkpoint_callback.best_model_path:
+            raise MisconfigurationException(
+                'ckpt_path is "best", but ModelCheckpoint is not configured to save the best model.'
+            )
+
         # load best weights
         if ckpt_path is not None:
             # ckpt_path is 'best' so load the best model
             if ckpt_path == 'best':
-                if not self.checkpoint_callback.best_model_path:
-                    # if user requests the best checkpoint but we don't have it, error
-                    raise MisconfigurationException('ckpt_path is "best", but we could not find the best model path')
+                # if not self.checkpoint_callback.best_model_path:
+                #     # if user requests the best checkpoint but we don't have it, error
+                #     raise MisconfigurationException('ckpt_path is "best", but we could not find the best model path')
                 ckpt_path = self.checkpoint_callback.best_model_path
 
             if len(ckpt_path) == 0:

--- a/tests/callbacks/test_early_stopping.py
+++ b/tests/callbacks/test_early_stopping.py
@@ -37,7 +37,7 @@ def test_resume_early_stopping_from_checkpoint(tmpdir):
     """
 
     model = EvalModelTemplate()
-    checkpoint_callback = ModelCheckpoint(save_top_k=1)
+    checkpoint_callback = ModelCheckpoint(monitor="val_loss", save_top_k=1)
     early_stop_callback = EarlyStoppingTestRestore()
     trainer = Trainer(
         default_root_dir=tmpdir,

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -279,6 +279,28 @@ def test_model_checkpoint_none_monitor(tmpdir):
     assert set(os.listdir(tmpdir)) == set(expected)
 
 
+def test_model_checkpoint_topk_zero(tmpdir):
+    """ Test that no checkpoints are saved when save_top_k=0. """
+    model = EvalModelTemplate()
+    checkpoint_callback = ModelCheckpoint(filepath=tmpdir, save_top_k=0)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        early_stop_callback=False,
+        checkpoint_callback=checkpoint_callback,
+        max_epochs=2,
+        logger=False,
+    )
+    trainer.fit(model)
+    # these should not be set if monitor is None
+    assert checkpoint_callback.monitor is None
+    assert checkpoint_callback.best_model_path == ''
+    assert checkpoint_callback.best_model_score == 0
+    assert checkpoint_callback.best_k_models == {}
+    assert checkpoint_callback.kth_best_model_path == ''
+    # check that no ckpts were created
+    assert len(set(os.listdir(tmpdir))) == 0
+
+
 def test_ckpt_metric_names(tmpdir):
     model = EvalModelTemplate()
 

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -251,6 +251,7 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
 
 
 def test_model_checkpoint_none_monitor(tmpdir):
+    """ Test that it is possible to save all checkpoints when monitor=None. """
     model = EvalModelTemplate()
     epochs = 2
     checkpoint_callback = ModelCheckpoint(monitor=None, filepath=tmpdir, save_top_k=-1)

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -194,19 +194,15 @@ def test_model_checkpoint_save_last(tmpdir):
 
 
 def test_invalid_top_k(tmpdir):
-    """
-    Make sure that a MisconfigurationException is raised for a negative top_k argument
-    """
+    """ Make sure that a MisconfigurationException is raised for a negative save_top_k argument. """
     with pytest.raises(MisconfigurationException, match=r'.*Must be None or >= -1'):
         ModelCheckpoint(filepath=tmpdir, save_top_k=-3)
 
 
 def test_none_monitor_top_k(tmpdir):
-    """
-    Test warning appears for positive top_k with monitor=None
-    """
+    """ Test that a warning appears for positive top_k with monitor=None. """
     with pytest.raises(
-        MisconfigurationException, match=r'ModelCheckpoint\(save_top_k=3, monitor=None\) is not a valid.*'
+        MisconfigurationException, match='ModelCheckpoint(save_top_k=3, monitor=None) is not a valid.*'
     ):
         ModelCheckpoint(filepath=tmpdir, save_top_k=3)
     # These should not fail
@@ -216,9 +212,7 @@ def test_none_monitor_top_k(tmpdir):
 
 
 def test_none_monitor_save_last(tmpdir):
-    """
-    Test warning appears for save_last=True with monitor=None
-    """
+    """ Test that a warning appears for save_last=True with monitor=None. """
     with pytest.raises(
         MisconfigurationException, match=r'ModelCheckpoint\(save_last=True, monitor=None\) is not a valid.*'
     ):

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -315,7 +315,7 @@ def test_default_checkpoint_behavior(tmpdir):
     )
 
     trainer.fit(model)
-    results = trainer.test(model)
+    results = trainer.test()
 
     assert len(results) == 1
     assert results[0]['test_acc'] >= 0.80

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -296,7 +296,7 @@ def test_default_checkpoint_behavior(tmpdir):
     )
 
     trainer.fit(model)
-    results = trainer.test()
+    results = trainer.test(model)
 
     assert len(results) == 1
     assert results[0]['test_acc'] >= 0.80

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -202,7 +202,7 @@ def test_invalid_top_k(tmpdir):
 def test_none_monitor_top_k(tmpdir):
     """ Test that a warning appears for positive top_k with monitor=None. """
     with pytest.raises(
-        MisconfigurationException, match='ModelCheckpoint(save_top_k=3, monitor=None) is not a valid.*'
+        MisconfigurationException, match=r'ModelCheckpoint\(save_top_k=3, monitor=None\) is not a valid*'
     ):
         ModelCheckpoint(filepath=tmpdir, save_top_k=3)
     # These should not fail

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -253,6 +253,9 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
 def test_model_checkpoint_none_monitor(tmpdir):
     """ Test that it is possible to save all checkpoints when monitor=None. """
     model = EvalModelTemplate()
+    model.validation_step = model.validation_step_no_monitor
+    model.validation_epoch_end = model.validation_epoch_end_no_monitor
+
     epochs = 2
     checkpoint_callback = ModelCheckpoint(monitor=None, filepath=tmpdir, save_top_k=-1)
     trainer = Trainer(
@@ -264,7 +267,8 @@ def test_model_checkpoint_none_monitor(tmpdir):
     trainer.fit(model)
 
     # these should not be set if monitor is None
-    assert checkpoint_callback.best_model_path == ''
+    assert checkpoint_callback.monitor is None
+    assert checkpoint_callback.best_model_path == checkpoint_callback.last_model_path == tmpdir / 'epoch=1.ckpt'
     assert checkpoint_callback.best_model_score == 0
     assert checkpoint_callback.best_k_models == {}
     assert checkpoint_callback.kth_best_model_path == ''

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -253,7 +253,7 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
 def test_model_checkpoint_none_monitor(tmpdir):
     model = EvalModelTemplate()
     epochs = 2
-    checkpoint_callback = ModelCheckpoint(monitor='val_loss', filepath=tmpdir, save_top_k=-1)
+    checkpoint_callback = ModelCheckpoint(monitor=None, filepath=tmpdir, save_top_k=-1)
     trainer = Trainer(
         default_root_dir=tmpdir,
         early_stop_callback=False,


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

We broke save_top_k when monitor default was switched to None. 
save_top_k only makes sense when we have a metric to monitor. 
The only exception is when save_top_k=-1, we want to save all checkpoints of all epochs. This PR re-enables it!


# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
