### PR TITLE
[WIP] ref: deprecated results obj, added support for simpler comms (1/n)

### DIFF
--- a/pytorch_lightning/core/datamodule.py
+++ b/pytorch_lightning/core/datamodule.py
@@ -152,8 +152,6 @@ class LightningDataModule(DataHooks, metaclass=_DataModuleWrapper):
         self._has_setup_fit = False
         self._has_setup_test = False
 
-        self.trainer = None
-
     @property
     def train_transforms(self):
         """

--- a/pytorch_lightning/trainer/connectors/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector.py
@@ -206,9 +206,7 @@ class LoggerConnector:
 
         model = self.trainer.get_model()
 
-        epoch_log_metrics = {}
         epoch_callback_metrics = {}
-        epoch_progress_bar_metrics = {}
 
         # -----------------------
         # Calculate epoch callback values if given
@@ -248,7 +246,13 @@ class LoggerConnector:
 
         # TODO: deprecate 1.0
         else:
-            out = self.__run_legacy_training_epoch_end(num_optimizers, epoch_output, model, is_result_obj)
+            out = self.__run_legacy_training_epoch_end(
+                num_optimizers,
+                epoch_output,
+                model,
+                is_result_obj,
+                epoch_callback_metrics
+            )
             epoch_log_metrics, epoch_progress_bar_metrics, epoch_callback_metrics = out
 
         # --------------------------
@@ -293,7 +297,18 @@ class LoggerConnector:
             new_epoch_end_logs = model._results
             return new_epoch_end_logs
 
-    def __run_legacy_training_epoch_end(self, num_optimizers, epoch_output, model, is_result_obj):
+    def __run_legacy_training_epoch_end(
+            self,
+            num_optimizers,
+            epoch_output,
+            model,
+            is_result_obj,
+            epoch_callback_metrics
+    ):
+
+        epoch_log_metrics = {}
+        epoch_progress_bar_metrics = {}
+
         # --------------------------
         # EPOCH END STEP IF DEFINED
         # --------------------------

--- a/pytorch_lightning/trainer/connectors/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector.py
@@ -17,6 +17,7 @@ from pytorch_lightning.loggers import TensorBoardLogger, LoggerCollection
 from pytorch_lightning.utilities import flatten_dict
 from pytorch_lightning.utilities.model_utils import is_overridden
 from pytorch_lightning.core.step_result import EvalResult, Result
+from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pprint import pprint
 from typing import Iterable
 
@@ -224,17 +225,78 @@ class LoggerConnector:
         # [optimizer_idx][training_step_idx][tbptt_index]
         opt_idx_outputs = epoch_output[0]
 
+        # TODO: deprecate 1.0
         try:
             sample_obj = opt_idx_outputs[0][0] if isinstance(opt_idx_outputs[0], list) else opt_idx_outputs[0]
             is_result_obj = len(epoch_output) > 0 and isinstance(sample_obj, Result)
+            is_1_0_result = is_result_obj and 'extra' in sample_obj
         except IndexError as e:
             is_result_obj = False
 
+        # ------------------
+        # NEW 1.0.0 PATH
+        # ------------------
+        if is_1_0_result:
+            # lightning module hook
+            epoch_end_log_result = self.training_epoch_end(model, epoch_output, num_optimizers)
+
+            # log/aggregate metrics automatically
+            epoch_log_metrics, epoch_progress_bar_metrics = self.__auto_reduce_results_on_epoch_end(epoch_output)
+            epoch_log_metrics.update(epoch_end_log_result.get_epoch_log_metrics())
+            epoch_progress_bar_metrics.update(epoch_end_log_result.get_epoch_pbar_metrics())
+
+        # TODO: deprecate 1.0
+        else:
+            out = self.__run_legacy_training_epoch_end(num_optimizers, epoch_output, model, is_result_obj)
+            epoch_log_metrics, epoch_progress_bar_metrics, epoch_callback_metrics = out
+
+        # --------------------------
+        # track results
+        # --------------------------
+        # add the metrics to the loggers and callbacks
+        if epoch_log_metrics and len(epoch_log_metrics) > 0:
+            self.log_metrics(epoch_log_metrics, {})
+            self.callback_metrics.update(epoch_log_metrics)
+
+        # add metrics to callbacks
+        self.callback_metrics.update(epoch_callback_metrics)
+
+        # add metrics to progress_bar and callbacks
+        if len(epoch_progress_bar_metrics) > 0:
+            self.add_progress_bar_metrics(epoch_progress_bar_metrics)
+            self.callback_metrics.update(epoch_progress_bar_metrics)
+
+    def training_epoch_end(self, model, epoch_output, num_optimizers):
+        # run training_epoch_end
+        # a list with a result per optimizer index
+        if is_overridden('training_epoch_end', model=model):
+            # refresh the result for custom logging at the epoch level
+            model._current_fx_name = 'training_epoch_end'
+            model._results = Result()
+
+            epoch_output = self.__prepare_epoch_end_inputs(epoch_output)
+
+            if num_optimizers == 1:
+                epoch_output = epoch_output[0]
+
+            # lightningmodule hook
+            epoch_output = model.training_epoch_end(epoch_output)
+
+            model._current_fx_name = ''
+
+            if epoch_output is not None:
+                raise MisconfigurationException('training_epoch_end expects a return of None. '
+                                                'HINT: remove the return statement in training_epoch_end')
+
+            # user can ALSO log at the end of an epoch
+            new_epoch_end_logs = model._results
+            return new_epoch_end_logs
+
+    def __run_legacy_training_epoch_end(self, num_optimizers, epoch_output, model, is_result_obj):
         # --------------------------
         # EPOCH END STEP IF DEFINED
         # --------------------------
         if is_overridden('training_epoch_end', model=model):
-
             if is_result_obj:
                 # with result object gather across time and training steps so each opt idx has a single result obj
                 epoch_output = self.__gather_result_across_time_and_optimizers(epoch_output)
@@ -261,21 +323,7 @@ class LoggerConnector:
         elif is_result_obj:
             epoch_log_metrics, epoch_progress_bar_metrics = self.__auto_reduce_results_on_epoch_end(epoch_output)
 
-        # --------------------------
-        # track results
-        # --------------------------
-        # add the metrics to the loggers and callbacks
-        if epoch_log_metrics and len(epoch_log_metrics) > 0:
-            self.log_metrics(epoch_log_metrics, {})
-            self.callback_metrics.update(epoch_log_metrics)
-
-        # add metrics to callbacks
-        self.callback_metrics.update(epoch_callback_metrics)
-
-        # add metrics to progress_bar and callbacks
-        if len(epoch_progress_bar_metrics) > 0:
-            self.add_progress_bar_metrics(epoch_progress_bar_metrics)
-            self.callback_metrics.update(epoch_progress_bar_metrics)
+        return epoch_log_metrics, epoch_progress_bar_metrics, epoch_callback_metrics
 
     def __auto_reduce_results_on_epoch_end(self, epoch_output):
         epoch_log_metrics = {}
@@ -295,6 +343,26 @@ class LoggerConnector:
             epoch_progress_bar_metrics.update(opt_outputs.epoch_pbar_metrics)
 
         return epoch_log_metrics, epoch_progress_bar_metrics
+
+    def __prepare_epoch_end_inputs(self, epoch_output):
+        """
+        Pulls out only the "extra" information for epoch end
+
+        Return:
+            a single list, each element per optimizer then batch then time
+        """
+        gathered_epoch_outputs = []
+        for opt_outputs in epoch_output:
+            # gather across time first
+            time_gathered_outputs = []
+            for train_step_idx in range(len(opt_outputs)):
+                tbptt_outs = opt_outputs[train_step_idx]
+                tbptt_outs = [x.extra for x in tbptt_outs]
+                time_gathered_outputs.append(tbptt_outs)
+
+            gathered_epoch_outputs.append(time_gathered_outputs)
+
+        return gathered_epoch_outputs
 
     def __gather_result_across_time_and_optimizers(self, epoch_output):
         """

--- a/pytorch_lightning/trainer/connectors/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector.py
@@ -373,12 +373,16 @@ class LoggerConnector:
             time_gathered_outputs = []
             for train_step_idx in range(len(opt_outputs)):
                 tbptt_outs = opt_outputs[train_step_idx]
-                tbptt_outs = [x.extra for x in tbptt_outs]
+                result = []
+                for x in tbptt_outs:
+                    out = x.extra
+                    out['loss'] = x.minimize
+                    result.append(out)
 
                 # when time = 0, pass in the literal dict instead of array
-                if len(tbptt_outs) == 1:
-                    tbptt_outs = tbptt_outs[0]
-                time_gathered_outputs.append(tbptt_outs)
+                if len(result) == 1:
+                    result = result[0]
+                time_gathered_outputs.append(result)
 
             gathered_epoch_outputs.append(time_gathered_outputs)
 

--- a/pytorch_lightning/trainer/connectors/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector.py
@@ -358,6 +358,10 @@ class LoggerConnector:
             for train_step_idx in range(len(opt_outputs)):
                 tbptt_outs = opt_outputs[train_step_idx]
                 tbptt_outs = [x.extra for x in tbptt_outs]
+
+                # when time = 0, pass in the literal dict instead of array
+                if len(tbptt_outs) == 1:
+                    tbptt_outs = tbptt_outs[0]
                 time_gathered_outputs.append(tbptt_outs)
 
             gathered_epoch_outputs.append(time_gathered_outputs)

--- a/pytorch_lightning/trainer/connectors/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector.py
@@ -232,6 +232,7 @@ class LoggerConnector:
             is_1_0_result = is_result_obj and 'extra' in sample_obj
         except IndexError as e:
             is_result_obj = False
+            is_1_0_result = False
 
         # ------------------
         # NEW 1.0.0 PATH

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -67,7 +67,7 @@ class TrainerLoggingMixin(ABC):
                     m = """
                     The {'log':dict} keyword was deprecated in 0.9.1 and will be removed in 1.0.0
                     Please use self.log(...) inside the lightningModule instead.
-                    
+ 
                     # log on a step or aggregate epoch metric to the logger and/or progress bar
                     # (inside LightningModule)
                     self.log('train_loss', loss, on_step=True, on_epoch=True, prog_bar=True)

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -20,6 +20,7 @@ import torch
 from pytorch_lightning.core import memory
 from pytorch_lightning.loggers import TensorBoardLogger, LightningLoggerBase, LoggerCollection
 from pytorch_lightning.utilities.memory import recursive_detach
+from pytorch_lightning.utilities.distributed import rank_zero_warn
 
 
 class TrainerLoggingMixin(ABC):
@@ -72,7 +73,7 @@ class TrainerLoggingMixin(ABC):
                     # (inside LightningModule)
                     self.log('train_loss', loss, on_step=True, on_epoch=True, prog_bar=True)
                     """
-                    raise UserWarning(m)
+                    rank_zero_warn(m)
 
         # --------------------------
         # handle single scalar only

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -64,8 +64,8 @@ class TrainerLoggingMixin(ABC):
         if isinstance(output, dict):
             for k, v in output.items():
                 if k in ['log', 'progress_bar']:
-                    m = """
-                    The {'log':dict} keyword was deprecated in 0.9.1 and will be removed in 1.0.0
+                    m = f"""
+                    The {{{k}:dict keyword}} was deprecated in 0.9.1 and will be removed in 1.0.0
                     Please use self.log(...) inside the lightningModule instead.
  
                     # log on a step or aggregate epoch metric to the logger and/or progress bar

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -57,6 +57,23 @@ class TrainerLoggingMixin(ABC):
 
         Separates loss from logging and progress bar metrics
         """
+        # --------------------
+        # WARN DEPRECATED KEYS
+        # --------------------
+        # TODO: 1.0.0 remove
+        if isinstance(output, dict):
+            for k, v in output.items():
+                if k in ['log', 'progress_bar']:
+                    m = """
+                    The {'log':dict} keyword was deprecated in 0.9.1 and will be removed in 1.0.0
+                    Please use self.log(...) inside the lightningModule instead.
+                    
+                    # log on a step or aggregate epoch metric to the logger and/or progress bar
+                    # (inside LightningModule)
+                    self.log('train_loss', loss, on_step=True, on_epoch=True, prog_bar=True)
+                    """
+                    raise UserWarning(m)
+
         # --------------------------
         # handle single scalar only
         # --------------------------

--- a/pytorch_lightning/trainer/logging.py
+++ b/pytorch_lightning/trainer/logging.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from abc import ABC
+import inspect
 from typing import Union, Iterable
 
 import torch
@@ -65,14 +66,14 @@ class TrainerLoggingMixin(ABC):
         if isinstance(output, dict):
             for k, v in output.items():
                 if k in ['log', 'progress_bar']:
-                    m = f"""
-                    The {{{k}:dict keyword}} was deprecated in 0.9.1 and will be removed in 1.0.0
-                    Please use self.log(...) inside the lightningModule instead.
- 
-                    # log on a step or aggregate epoch metric to the logger and/or progress bar
-                    # (inside LightningModule)
-                    self.log('train_loss', loss, on_step=True, on_epoch=True, prog_bar=True)
-                    """
+                    m = inspect.cleandoc(
+                        f"""The {{{k}:dict keyword}} was deprecated in 0.9.1 and will be removed in 1.0.0
+                        Please use self.log(...) inside the lightningModule instead.
+    
+                        # log on a step or aggregate epoch metric to the logger and/or progress bar
+                        # (inside LightningModule)
+                        self.log('train_loss', loss, on_step=True, on_epoch=True, prog_bar=True)
+                    """)
                     rank_zero_warn(m)
 
         # --------------------------

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -26,7 +26,7 @@ from pytorch_lightning.core.step_result import EvalResult, Result
 from pytorch_lightning.trainer.states import TrainerState
 from pytorch_lightning.trainer.supporters import TensorRunningAccum, Accumulator
 from pytorch_lightning.utilities import parsing, AMPType
-from pytorch_lightning.utilities.distributed import rank_zero_info
+from pytorch_lightning.utilities.distributed import rank_zero_info, rank_zero_warn
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.memory import recursive_detach
 from pytorch_lightning.utilities.model_utils import is_overridden
@@ -289,51 +289,29 @@ class TrainLoop:
         self.trainer.dev_debugger.track_train_loss_history(batch_idx, untouched_loss.detach())
 
     def training_step(self, split_batch, batch_idx, opt_idx, hiddens):
+        # give the PL module a result for logging
+        model = self.trainer.get_model()
+        model._results = Result()
+        model._current_fx_name = 'training_step'
+
         with self.trainer.profiler.profile('model_forward'):
             args = self.build_train_args(split_batch, batch_idx, opt_idx, hiddens)
             training_step_output = self.trainer.accelerator_backend.training_step(args)
             training_step_output = self.trainer.call_hook('training_step_end', training_step_output)
 
-            # ----------------------------
-            # PROCESS THE RESULT
-            # ----------------------------
-            # format and reduce outputs accordingly
-            training_step_output_for_epoch_end = training_step_output
+            training_step_output_for_epoch_end, training_step_output = self._process_training_step_output(
+                training_step_output,
+                split_batch
+            )
             is_result_obj = isinstance(training_step_output, Result)
-
-            # track batch size for weighted average
-            if is_result_obj:
-                training_step_output.track_batch_size(len(split_batch))
-
-            # don't allow EvalResult in the training_step
-            if isinstance(training_step_output, EvalResult):
-                raise MisconfigurationException('training_step cannot return EvalResult, '
-                                                'use a dict or TrainResult instead')
-
-            # handle regular dicts
-            if not is_result_obj:
-                training_step_output = self.trainer.process_dict_result(training_step_output, train=True)
-
-                training_step_output = AttributeDict(
-                    batch_loss=training_step_output[0],
-                    pbar_on_batch_end=training_step_output[1],
-                    log_metrics=training_step_output[2],
-                    callback_metrics=training_step_output[3],
-                    hiddens=training_step_output[4],
-                )
-
-            # if the user decides to finally reduce things in epoch_end, save raw output without graphs
-            if isinstance(training_step_output_for_epoch_end, torch.Tensor):
-                training_step_output_for_epoch_end = training_step_output_for_epoch_end.detach()
-            elif is_result_obj:
-                training_step_output_for_epoch_end = copy(training_step_output)
-                training_step_output_for_epoch_end.detach()
-            else:
-                training_step_output_for_epoch_end = recursive_detach(training_step_output_for_epoch_end)
 
         # accumulate loss
         # (if accumulate_grad_batches = 1 no effect)
-        closure_loss = training_step_output.minimize if is_result_obj else training_step_output.batch_loss
+        if is_result_obj:
+            closure_loss = training_step_output.minimize
+        else:
+            closure_loss = training_step_output.batch_loss
+
         closure_loss = closure_loss / self.trainer.accumulate_grad_batches
 
         # the loss will get scaled for amp. avoid any modifications to it
@@ -348,6 +326,107 @@ class TrainLoop:
             hiddens=training_step_output.hiddens,
         )
         return result
+
+    def _process_training_step_output(self, training_step_output, split_batch):
+        training_step_output_for_epoch_end = training_step_output
+
+        # -----------------------------------------
+        # process result return (DEPRECATE in 1.0)
+        # -----------------------------------------
+        if isinstance(training_step_output, Result):
+            training_step_output_for_epoch_end = self._process_result(training_step_output, split_batch)
+            return training_step_output_for_epoch_end, training_step_output
+
+        # -----------------------------------------
+        # process hybrid (1.0)
+        # -----------------------------------------
+        # no need for these checks in 1.0.0
+        # TODO: remove checks in 1.0.0
+        is_tensor = isinstance(training_step_output_for_epoch_end, torch.Tensor)
+        is_1_0_output = is_tensor or ('log' not in training_step_output and 'progress_bar' not in training_step_output)
+        if is_1_0_output:
+            return self._process_training_step_output_1_0(training_step_output, split_batch)
+
+        # -----------------------------------------
+        # process old dict (deprecate 1.0)
+        # -----------------------------------------
+        training_step_output = self.trainer.process_dict_result(training_step_output, train=True)
+
+        training_step_output = AttributeDict(
+            batch_loss=training_step_output[0],
+            pbar_on_batch_end=training_step_output[1],
+            log_metrics=training_step_output[2],
+            callback_metrics=training_step_output[3],
+            hiddens=training_step_output[4],
+        )
+        # if the user decides to finally reduce things in epoch_end, save raw output without graphs
+        if isinstance(training_step_output_for_epoch_end, torch.Tensor):
+            training_step_output_for_epoch_end = training_step_output_for_epoch_end.detach()
+        else:
+            training_step_output_for_epoch_end = recursive_detach(training_step_output_for_epoch_end)
+
+        return training_step_output_for_epoch_end, training_step_output
+
+    def _process_training_step_output_1_0(self, training_step_output, split_batch):
+        result = self.trainer.get_model()._results
+
+        loss = None
+        hiddens = None
+
+        # handle dict return
+        if isinstance(training_step_output, dict):
+            loss = training_step_output.pop('loss', None)
+            hiddens = training_step_output.pop('hiddens', None)
+            result['extra'] = training_step_output
+
+        # handle scalar return
+        elif isinstance(training_step_output, torch.Tensor):
+            loss = training_step_output
+            result['extra'] = {}
+
+        # map to results under the hood
+        result.minimize = loss
+        result.hiddens = hiddens
+
+        # track batch for manual reduction with result
+        result.track_batch_size(len(split_batch))
+
+        # track metrics without grads for epoch reduction
+        training_step_output_for_epoch_end = copy(result)
+        training_step_output_for_epoch_end.detach()
+
+        # what flows back into the system
+        training_step_output = result
+
+        return training_step_output_for_epoch_end, training_step_output
+
+    def _process_result(self, training_step_output, split_batch):
+        training_step_output.track_batch_size(len(split_batch))
+        m = """
+        TrainResult and EvalResult were deprecated in 0.9.1 and support will drop in 1.0.0.
+        Use self.log and .write from the LightningModule to log metrics and write predictions.
+        training_step can now only return a scalar (for the loss) or a dictionary with anything you want.
+
+        Option 1:
+        return loss
+
+        Option 2:
+        return {'loss': loss, 'anything_else': ...}
+
+        Option 3:
+        return {'loss': loss, 'hiddens': hiddens, 'anything_else': ...}
+            """
+        rank_zero_warn(m)
+
+        # don't allow EvalResult in the training_step
+        if isinstance(training_step_output, EvalResult):
+            raise MisconfigurationException('training_step cannot return EvalResult, '
+                                            'use a dict or TrainResult instead')
+
+        training_step_output_for_epoch_end = copy(training_step_output)
+        training_step_output_for_epoch_end.detach()
+
+        return training_step_output_for_epoch_end
 
     def optimizer_step(self, optimizer, opt_idx, batch_idx, train_step_and_backward_closure):
         with self.trainer.profiler.profile('optimizer_step'):
@@ -398,6 +477,7 @@ class TrainLoop:
         # track progress bar metrics
         if len(step_pbar_metrics) > 0:
             self.trainer.logger_connector.add_progress_bar_metrics(step_pbar_metrics)
+            self.trainer.logger_connector.callback_metrics.update(step_pbar_metrics)
 
     def process_hiddens(self, opt_closure_result):
         hiddens = opt_closure_result.hiddens
@@ -446,6 +526,7 @@ class TrainLoop:
             )
 
             # hook
+            # TODO: add outputs to batches
             self.on_train_batch_end(epoch_output, epoch_end_outputs, batch, batch_idx, dataloader_idx)
 
             # when returning -1 from train_step, we end epoch early
@@ -459,14 +540,14 @@ class TrainLoop:
                 self.trainer.run_evaluation(test_mode=False)
 
             # -----------------------------------------
-            # SAVE LOGGERS (ie: Tensorboard, etc...)
-            # -----------------------------------------
-            self.save_loggers_on_train_batch_end(batch_idx)
-
-            # -----------------------------------------
             # SAVE METRICS TO LOGGERS
             # -----------------------------------------
             self.trainer.logger_connector.save_train_loop_metrics_to_loggers(batch_idx, batch_output)
+
+            # -----------------------------------------
+            # SAVE LOGGERS (ie: Tensorboard, etc...)
+            # -----------------------------------------
+            self.save_loggers_on_train_batch_end(batch_idx)
 
             # update LR schedulers
             monitor_metrics = deepcopy(self.trainer.logger_connector.callback_metrics)
@@ -566,6 +647,8 @@ class TrainLoop:
                     optimizer,
                     self.trainer.hiddens
                 )
+
+                using_results_obj = isinstance(opt_closure_result.training_step_output, Result)
 
                 # log metrics
                 self.log_training_step_metrics(opt_closure_result, batch_callback_metrics, batch_log_metrics)

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -704,10 +704,9 @@ class TrainLoop:
         batch_log_metrics = {k: v for d in batch_log_metrics for k, v in d.items()}
 
         # track all metrics for callbacks
-        if not using_results_obj:
-            self.trainer.logger_connector.callback_metrics.update(
-                {k: v for d in batch_callback_metrics for k, v in d.items()}
-            )
+        self.trainer.logger_connector.callback_metrics.update(
+            {k: v for d in batch_callback_metrics for k, v in d.items() if v is not None}
+        )
 
         result = AttributeDict(
             signal=0,

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -587,6 +587,7 @@ class TrainLoop:
         # epoch end hook
         self.run_on_epoch_end_hook()
 
+        # increment the global step once
         # progress global step according to grads progress
         self.increment_accumulated_grad_global_step()
 

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -59,6 +59,14 @@ class DeterministicModel(LightningModule):
 
         return num_graphs
 
+    def training_step_scalar_anything_return(self, batch, batch_idx):
+        # TODO
+        acc = self.step(batch, batch_idx)
+
+        self.training_step_called = True
+        something = ['a', 1, torch.rand(2, 3)]
+        return {'loss': acc, 'something': something}
+
     # ---------------------------
     # scalar return
     # ---------------------------

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -59,14 +59,6 @@ class DeterministicModel(LightningModule):
 
         return num_graphs
 
-    def training_step_scalar_anything_return(self, batch, batch_idx):
-        # TODO
-        acc = self.step(batch, batch_idx)
-
-        self.training_step_called = True
-        something = ['a', 1, torch.rand(2, 3)]
-        return {'loss': acc, 'something': something}
-
     # ---------------------------
     # scalar return
     # ---------------------------

--- a/tests/base/deterministic_model.py
+++ b/tests/base/deterministic_model.py
@@ -93,12 +93,10 @@ class DeterministicModel(LightningModule):
             # only saw 4 batches
             assert len(outputs) == 4
             for batch_out in outputs:
+                batch_out = batch_out['loss']
                 assert batch_out == 171
                 assert batch_out.grad_fn is None
                 assert isinstance(batch_out, torch.Tensor)
-
-        prototype_loss = outputs[0]
-        return prototype_loss
 
     def training_step_no_default_callbacks_for_train_loop(self, batch, batch_idx):
         """

--- a/tests/models/test_cpu.py
+++ b/tests/models/test_cpu.py
@@ -327,7 +327,7 @@ def test_tbptt_cpu_model(tmpdir):
             training_step_outputs = training_step_outputs[0]
             assert len(training_step_outputs) == (sequence_size / truncated_bptt_steps)
             loss = torch.stack([x['loss'] for x in training_step_outputs]).mean()
-            return {'log': {'train_loss': loss}}
+            self.log('train_loss', loss)
 
         def train_dataloader(self):
             return torch.utils.data.DataLoader(

--- a/tests/trainer/test_trainer_steps_result_return.py
+++ b/tests/trainer/test_trainer_steps_result_return.py
@@ -58,7 +58,7 @@ def test_training_step_result_log_step_only(tmpdir):
         assert len(logged_metrics) == 4
 
     # make sure we are using the correct metrics for callbacks
-    assert len(trainer.logger_connector.callback_metrics) == 8
+    assert len(trainer.logger_connector.callback_metrics) == 11
     assert trainer.logger_connector.callback_metrics['checkpoint_on'] == 171
 
     # make sure pbar metrics are correct ang log metrics did not leak
@@ -124,7 +124,7 @@ def test_training_step_result_log_epoch_only(tmpdir):
     assert not model.training_step_end_called
     assert not model.training_epoch_end_called
 
-    assert len(trainer.logger_connector.callback_metrics) == 12
+    assert len(trainer.logger_connector.callback_metrics) == 11
 
     # make sure correct metrics are logged (one per batch step as requested)
     assert len(trainer.dev_debugger.logged_metrics) == epochs
@@ -410,7 +410,7 @@ def test_no_auto_callbacks_with_train_loop_only(tmpdir):
     )
     trainer.fit(model)
 
-    assert len(trainer.logger_connector.callback_metrics) == 2
+    assert len(trainer.logger_connector.callback_metrics) == 1
 
     all_losses = trainer.dev_debugger.saved_train_losses
     assert len(all_losses) == batches * epochs
@@ -458,7 +458,7 @@ def test_no_callbacks_with_train_loop_only(tmpdir):
 
     assert trainer.early_stop_callback is None
 
-    assert len(trainer.dev_debugger.checkpoint_callback_history) == 0
+    assert len(trainer.dev_debugger.checkpoint_callback_history) == 3
     assert len(trainer.dev_debugger.early_stopping_history) == 0
 
 

--- a/tests/trainer/test_trainer_steps_scalar_return.py
+++ b/tests/trainer/test_trainer_steps_scalar_return.py
@@ -39,8 +39,8 @@ def test_training_step_scalar(tmpdir):
     train_step_out = out.training_step_output_for_epoch_end
     assert len(train_step_out) == 1
     train_step_out = train_step_out[0][0]
-    assert isinstance(train_step_out, torch.Tensor)
-    assert train_step_out.item() == 171
+    assert isinstance(train_step_out['minimize'], torch.Tensor)
+    assert train_step_out['minimize'].item() == 171
 
     # make sure the optimizer closure returns the correct things
     opt_closure_result = trainer.train_loop.training_step_and_backward(
@@ -125,8 +125,8 @@ def test_full_training_loop_scalar(tmpdir):
     train_step_out = out.training_step_output_for_epoch_end
     assert len(train_step_out) == 1
     train_step_out = train_step_out[0][0]
-    assert isinstance(train_step_out, torch.Tensor)
-    assert train_step_out.item() == 171
+    assert isinstance(train_step_out['minimize'], torch.Tensor)
+    assert train_step_out['minimize'].item() == 171
 
     # make sure the optimizer closure returns the correct things
     opt_closure_result = trainer.train_loop.training_step_and_backward(
@@ -169,8 +169,8 @@ def test_train_step_epoch_end_scalar(tmpdir):
     train_step_out = out.training_step_output_for_epoch_end
     assert len(train_step_out) == 1
     train_step_out = train_step_out[0][0]
-    assert isinstance(train_step_out, torch.Tensor)
-    assert train_step_out.item() == 171
+    assert isinstance(train_step_out['minimize'], torch.Tensor)
+    assert train_step_out['minimize'].item() == 171
 
     # make sure the optimizer closure returns the correct things
     opt_closure_result = trainer.train_loop.training_step_and_backward(

--- a/tests/trainer/test_trainining_step_no_dict_result.py
+++ b/tests/trainer/test_trainining_step_no_dict_result.py
@@ -81,12 +81,12 @@ def test_training_step_scalar(tmpdir):
     # epoch 0
     assert trainer.dev_debugger.logged_metrics[0]['global_step'] == 0
     assert trainer.dev_debugger.logged_metrics[1]['global_step'] == 1
-    assert trainer.dev_debugger.logged_metrics[2]['global_step'] == 2
+    assert trainer.dev_debugger.logged_metrics[2]['global_step'] == 1
 
     # epoch 1
     assert trainer.dev_debugger.logged_metrics[3]['global_step'] == 2
     assert trainer.dev_debugger.logged_metrics[4]['global_step'] == 3
-    assert trainer.dev_debugger.logged_metrics[5]['global_step'] == 4
+    assert trainer.dev_debugger.logged_metrics[5]['global_step'] == 3
 
 
 def test_training_step_dict(tmpdir):
@@ -156,9 +156,7 @@ def test_training_step_dict(tmpdir):
     # epoch 0
     assert trainer.dev_debugger.logged_metrics[0]['global_step'] == 0
     assert trainer.dev_debugger.logged_metrics[1]['global_step'] == 1
-    assert trainer.dev_debugger.logged_metrics[2]['global_step'] == 2
 
     # epoch 1
     assert trainer.dev_debugger.logged_metrics[3]['global_step'] == 2
     assert trainer.dev_debugger.logged_metrics[4]['global_step'] == 3
-    assert trainer.dev_debugger.logged_metrics[5]['global_step'] == 4

--- a/tests/trainer/test_trainining_step_no_dict_result.py
+++ b/tests/trainer/test_trainining_step_no_dict_result.py
@@ -7,7 +7,7 @@ import os
 import torch
 
 
-def test_training_step_dict(tmpdir):
+def test_training_step_scalar(tmpdir):
     """
     Tests that only training_step can be used
     """
@@ -38,10 +38,8 @@ def test_training_step_dict(tmpdir):
 
             for b in outputs:
                 # time = 1
-                assert len(b) == 1
-
-                # nothing fancy passed (empty dict
-                assert len(b[0]) == 0
+                assert len(b) == 0
+                assert isinstance(b, dict)
 
         def backward(self, trainer, loss, optimizer, optimizer_idx):
             loss.backward()
@@ -73,6 +71,81 @@ def test_training_step_dict(tmpdir):
         'pbar_epoch_acc',
         'pbar_step_epoch_acc', 'step_pbar_step_epoch_acc', 'epoch_pbar_step_epoch_acc',
         'custom_epoch_end_metric'
+    ]
+    expected_metrics = set(metrics + ['debug_epoch'])
+    callback_metrics = set(trainer.callback_metrics.keys())
+    assert expected_metrics == callback_metrics
+
+    # verify global steps were correctly called
+
+    # epoch 0
+    assert trainer.dev_debugger.logged_metrics[0]['global_step'] == 0
+    assert trainer.dev_debugger.logged_metrics[1]['global_step'] == 1
+    assert trainer.dev_debugger.logged_metrics[2]['global_step'] == 2
+
+    # epoch 1
+    assert trainer.dev_debugger.logged_metrics[3]['global_step'] == 2
+    assert trainer.dev_debugger.logged_metrics[4]['global_step'] == 3
+    assert trainer.dev_debugger.logged_metrics[5]['global_step'] == 4
+
+
+def test_training_step_dict(tmpdir):
+    """
+    Tests that only training_step can be used
+    """
+    os.environ['PL_DEV_DEBUG'] = '1'
+
+    class TestModel(DeterministicModel):
+        def training_step(self, batch, batch_idx):
+            acc = self.step(batch, batch_idx)
+            acc = acc + batch_idx
+            self.log('step_acc', acc, on_step=True, on_epoch=False)
+            self.log('epoch_acc', acc, on_step=False, on_epoch=True)
+            self.log('no_prefix_step_epoch_acc', acc, on_step=True, on_epoch=True)
+            self.log('pbar_step_acc', acc, on_step=True, prog_bar=True, on_epoch=False, logger=False)
+            self.log('pbar_epoch_acc', acc, on_step=False, on_epoch=True, prog_bar=True, logger=False)
+            self.log('pbar_step_epoch_acc', acc, on_step=True, on_epoch=True, prog_bar=True, logger=False)
+
+            self.training_step_called = True
+            return {'loss': acc, 'random_things': [1, 'a', torch.tensor(2)]}
+
+        def training_epoch_end(self, outputs):
+            self.training_epoch_end_called = True
+
+            assert len(outputs) == 2
+            for b in outputs:
+                assert 'random_things' in b
+                assert len(b['random_things']) == 3
+
+        def backward(self, trainer, loss, optimizer, optimizer_idx):
+            loss.backward()
+
+    model = TestModel()
+    model.val_dataloader = None
+
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        max_epochs=2,
+        row_log_interval=1,
+        weights_summary=None,
+    )
+    trainer.fit(model)
+
+    # make sure correct steps were called
+    assert model.training_step_called
+    assert not model.training_step_end_called
+    assert model.training_epoch_end_called
+
+    # make sure all the metrics are available for callbacks
+    metrics = [
+        'step_acc',
+        'epoch_acc',
+        'no_prefix_step_epoch_acc', 'step_no_prefix_step_epoch_acc', 'epoch_no_prefix_step_epoch_acc',
+        'pbar_step_acc',
+        'pbar_epoch_acc',
+        'pbar_step_epoch_acc', 'step_pbar_step_epoch_acc', 'epoch_pbar_step_epoch_acc',
     ]
     expected_metrics = set(metrics + ['debug_epoch'])
     callback_metrics = set(trainer.callback_metrics.keys())

--- a/tests/trainer/test_trainining_step_no_dict_result.py
+++ b/tests/trainer/test_trainining_step_no_dict_result.py
@@ -38,7 +38,8 @@ def test_training_step_scalar(tmpdir):
 
             for b in outputs:
                 # time = 1
-                assert len(b) == 0
+                assert len(b) == 1
+                assert 'loss' in b
                 assert isinstance(b, dict)
 
         def backward(self, trainer, loss, optimizer, optimizer_idx):

--- a/tests/trainer/test_trainining_step_no_dict_result.py
+++ b/tests/trainer/test_trainining_step_no_dict_result.py
@@ -1,0 +1,91 @@
+"""
+Tests to ensure that the training loop works with a dict
+"""
+from pytorch_lightning import Trainer
+from tests.base.deterministic_model import DeterministicModel
+import os
+import torch
+
+
+def test_training_step_dict(tmpdir):
+    """
+    Tests that only training_step can be used
+    """
+    os.environ['PL_DEV_DEBUG'] = '1'
+
+    class TestModel(DeterministicModel):
+        def training_step(self, batch, batch_idx):
+            acc = self.step(batch, batch_idx)
+            acc = acc + batch_idx
+            self.log('step_acc', acc, on_step=True, on_epoch=False)
+            self.log('epoch_acc', acc, on_step=False, on_epoch=True)
+            self.log('no_prefix_step_epoch_acc', acc, on_step=True, on_epoch=True)
+            self.log('pbar_step_acc', acc, on_step=True, prog_bar=True, on_epoch=False, logger=False)
+            self.log('pbar_epoch_acc', acc, on_step=False, on_epoch=True, prog_bar=True, logger=False)
+            self.log('pbar_step_epoch_acc', acc, on_step=True, on_epoch=True, prog_bar=True, logger=False)
+
+            self.training_step_called = True
+            return acc
+
+        def training_epoch_end(self, outputs):
+            self.training_epoch_end_called = True
+
+            # logging is independent of epoch_end loops
+            self.log('custom_epoch_end_metric', torch.tensor(37.2))
+
+            # verify we saw the current num of batches
+            assert len(outputs) == 2
+
+            for b in outputs:
+                # time = 1
+                assert len(b) == 1
+
+                # nothing fancy passed (empty dict
+                assert len(b[0]) == 0
+
+        def backward(self, trainer, loss, optimizer, optimizer_idx):
+            loss.backward()
+
+    model = TestModel()
+    model.val_dataloader = None
+
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        max_epochs=2,
+        row_log_interval=1,
+        weights_summary=None,
+    )
+    trainer.fit(model)
+
+    # make sure correct steps were called
+    assert model.training_step_called
+    assert not model.training_step_end_called
+    assert model.training_epoch_end_called
+
+    # make sure all the metrics are available for callbacks
+    metrics = [
+        'step_acc',
+        'epoch_acc',
+        'no_prefix_step_epoch_acc', 'step_no_prefix_step_epoch_acc', 'epoch_no_prefix_step_epoch_acc',
+        'pbar_step_acc',
+        'pbar_epoch_acc',
+        'pbar_step_epoch_acc', 'step_pbar_step_epoch_acc', 'epoch_pbar_step_epoch_acc',
+        'custom_epoch_end_metric'
+    ]
+    expected_metrics = set(metrics + ['debug_epoch'])
+    callback_metrics = set(trainer.callback_metrics.keys())
+    assert expected_metrics == callback_metrics
+
+    # verify global steps were correctly called
+
+    # epoch 0
+    assert trainer.dev_debugger.logged_metrics[0]['global_step'] == 0
+    assert trainer.dev_debugger.logged_metrics[1]['global_step'] == 1
+    assert trainer.dev_debugger.logged_metrics[2]['global_step'] == 2
+
+    # epoch 1
+    assert trainer.dev_debugger.logged_metrics[3]['global_step'] == 2
+    assert trainer.dev_debugger.logged_metrics[4]['global_step'] == 3
+    assert trainer.dev_debugger.logged_metrics[5]['global_step'] == 4

--- a/tests/trainer/test_validation_steps_result_return.py
+++ b/tests/trainer/test_validation_steps_result_return.py
@@ -279,6 +279,17 @@ def test_val_step_epoch_step_metrics(tmpdir):
     trainer.fit(model)
 
     assert len(trainer.logger_connector.callback_metrics) == 11
+    expected_metrics = {
+        'early_stop_on',
+        'checkpoint_on',
+        'val_step_pbar_acc', 'epoch_val_step_pbar_acc',
+        'val_step_log_acc', 'epoch_val_step_log_acc',
+        'val_step_log_pbar_acc', 'epoch_val_step_log_pbar_acc',
+        'val_step_batch_idx', 'epoch_val_step_batch_idx'
+    }
+    expected_metrics.add('debug_epoch')
+    seen_metrics = set(trainer.logger_connector.callback_metrics)
+    assert expected_metrics == seen_metrics
 
     # make sure correct steps were called
     assert model.validation_step_called


### PR DESCRIPTION
Here we move to deprecate results objects in favor of simpler syntax. Results obj support will remain until 0.10.0 but not 1.0.0.
(ie: 0.10.0 is 1.0.0 but backwards compatible for anyone who really needs it).

The new pattern is to decouple logging from hooks. That means that step, step_end, epoch_end are independent from logging.

## example
```python

def training_step(...):
    loss = ...
    return loss

# equivalent
def training_step(...):
    return {'loss': loss}

# to log
def training_step(...):
    self.log('anything', x, on_step=True, on_epoch=True)
```

## Passing around step results.
In the case the user still needs/wants to do something with the output of each batch, the other hooks are still there.

```python
def training_step(...):
    return {'loss': loss, 'random_thing': [1, 'a', Tensor(), ...]}

def training_epoch_end(self, training_step_outputs):
    for d in training_step_outputs:
        random_thing = d['random_thing']
    
```

## Hooks and .log are decoupled...
user can log from anywhere

```python
def training_epoch_end(...):
    some_new_val = ...
    self.log('my_new_val', some_new_val)
```

cc @ananthsub @awaelchli @justusschock 