### PR TITLE
Make ModelCheckpoint(save_top_k=-1) track the best models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `ModelCheckpoint` `period` to actually save every `period` epochs ([3630](https://github.com/PyTorchLightning/pytorch-lightning/pull/3630))
 
+- Fixed `ModelCheckpoint` with `save_top_k=-1` option not tracking the best models when a monitor metric is available ([3735](https://github.com/PyTorchLightning/pytorch-lightning/pull/3735))
+
 ## [0.9.0] - YYYY-MM-DD
 
 ### Added

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -212,9 +212,6 @@ class ModelCheckpoint(Callback):
 
         # Mode 2: save all checkpoints OR only the top k
         if self.save_top_k:
-            # if self.save_top_k == -1:
-            #     self._save_all_checkpoints(trainer, pl_module, epoch, filepath)
-            # else:
             self._save_top_k_checkpoints(monitor_candidates, trainer, pl_module, epoch, filepath)
 
     def __validate_init_configuration(self):
@@ -493,13 +490,6 @@ class ModelCheckpoint(Callback):
             log.info(
                 f"Epoch {epoch:d}: {self.monitor} was not in top {self.save_top_k}"
             )
-
-    def _save_all_checkpoints(self, trainer, pl_module, epoch, filepath):
-        if self.verbose:
-            log.info(f"Epoch {epoch:d}: saving model to {filepath}")
-
-        assert (trainer.global_rank == 0), "tried to make a checkpoint from non global_rank=0"
-        self._save_model(filepath, trainer, pl_module)
 
     def _is_valid_monitor_key(self, metrics):
         return self.monitor in metrics or len(metrics) == 0

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -294,8 +294,11 @@ class ModelCheckpoint(Callback):
             raise ValueError(".save_function() not set")
 
     def check_monitor_top_k(self, current) -> bool:
+        if self.save_top_k == -1:
+            return True
+
         less_than_k_models = len(self.best_k_models) < self.save_top_k
-        if less_than_k_models or self.save_top_k == -1:
+        if less_than_k_models:
             return True
 
         if not isinstance(current, torch.Tensor):

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -320,11 +320,12 @@ def test_model_checkpoint_topk_zero(tmpdir):
     assert len(os.listdir(tmpdir)) == 0
 
 
-def test_model_checkpoint_topk_neg_one(tmpdir):
+def test_model_checkpoint_topk_all(tmpdir):
+    """ Test that save_top_k=-1 tracks the best models when monitor key is provided. """
     seed_everything(1000)
     epochs = 3
     model = EvalModelTemplate()
-    checkpoint_callback = ModelCheckpoint(monitor=None, filepath=tmpdir, save_top_k=-1)
+    checkpoint_callback = ModelCheckpoint(filepath=tmpdir, monitor="val_loss", save_top_k=-1)
     trainer = Trainer(
         default_root_dir=tmpdir,
         early_stop_callback=False,
@@ -333,11 +334,10 @@ def test_model_checkpoint_topk_neg_one(tmpdir):
         logger=False,
     )
     trainer.fit(model)
-
-    assert checkpoint_callback.best_model_path == tmpdir / 'epoch=2.ckpt'
+    assert checkpoint_callback.best_model_path == tmpdir / "epoch=2.ckpt"
     assert checkpoint_callback.best_model_score > 0
-    assert set(checkpoint_callback.best_k_models.keys()) == set(tmpdir / f'epoch={i}.ckpt' for i in range(epochs))
-    assert checkpoint_callback.kth_best_model_path == tmpdir / 'epoch=0.ckpt'
+    assert set(checkpoint_callback.best_k_models.keys()) == set(tmpdir / f"epoch={i}.ckpt" for i in range(epochs))
+    assert checkpoint_callback.kth_best_model_path == tmpdir / "epoch=0.ckpt"
 
 
 def test_ckpt_metric_names(tmpdir):

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -320,6 +320,26 @@ def test_model_checkpoint_topk_zero(tmpdir):
     assert len(os.listdir(tmpdir)) == 0
 
 
+def test_model_checkpoint_topk_neg_one(tmpdir):
+    seed_everything(1000)
+    epochs = 3
+    model = EvalModelTemplate()
+    checkpoint_callback = ModelCheckpoint(monitor=None, filepath=tmpdir, save_top_k=-1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        early_stop_callback=False,
+        checkpoint_callback=checkpoint_callback,
+        max_epochs=epochs,
+        logger=False,
+    )
+    trainer.fit(model)
+
+    assert checkpoint_callback.best_model_path == tmpdir / 'epoch=2.ckpt'
+    assert checkpoint_callback.best_model_score > 0
+    assert set(checkpoint_callback.best_k_models.keys()) == set(tmpdir / f'epoch={i}.ckpt' for i in range(epochs))
+    assert checkpoint_callback.kth_best_model_path == tmpdir / 'epoch=0.ckpt'
+
+
 def test_ckpt_metric_names(tmpdir):
     model = EvalModelTemplate()
 

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -323,7 +323,7 @@ def test_model_checkpoint_topk_zero(tmpdir):
 def test_model_checkpoint_topk_all(tmpdir):
     """ Test that save_top_k=-1 tracks the best models when monitor key is provided. """
     seed_everything(1000)
-    epochs = 3
+    epochs = 2
     model = EvalModelTemplate()
     checkpoint_callback = ModelCheckpoint(filepath=tmpdir, monitor="val_loss", save_top_k=-1)
     trainer = Trainer(
@@ -334,7 +334,7 @@ def test_model_checkpoint_topk_all(tmpdir):
         logger=False,
     )
     trainer.fit(model)
-    assert checkpoint_callback.best_model_path == tmpdir / "epoch=2.ckpt"
+    assert checkpoint_callback.best_model_path == tmpdir / "epoch=1.ckpt"
     assert checkpoint_callback.best_model_score > 0
     assert set(checkpoint_callback.best_k_models.keys()) == set(tmpdir / f"epoch={i}.ckpt" for i in range(epochs))
     assert checkpoint_callback.kth_best_model_path == tmpdir / "epoch=0.ckpt"

--- a/tests/callbacks/test_model_checkpoint.py
+++ b/tests/callbacks/test_model_checkpoint.py
@@ -336,7 +336,7 @@ def test_model_checkpoint_topk_all(tmpdir):
     trainer.fit(model)
     assert checkpoint_callback.best_model_path == tmpdir / "epoch=1.ckpt"
     assert checkpoint_callback.best_model_score > 0
-    assert set(checkpoint_callback.best_k_models.keys()) == set(tmpdir / f"epoch={i}.ckpt" for i in range(epochs))
+    assert set(checkpoint_callback.best_k_models.keys()) == set(str(tmpdir / f"epoch={i}.ckpt") for i in range(epochs))
     assert checkpoint_callback.kth_best_model_path == tmpdir / "epoch=0.ckpt"
 
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -669,7 +669,7 @@ def test_test_checkpoint_path(tmpdir, ckpt_path, save_top_k):
     trainer.fit(model)
     if ckpt_path == 'best':
         # ckpt_path is 'best', meaning we load the best weights
-        if save_top_k <= 0:
+        if save_top_k == 0:
             with pytest.raises(MisconfigurationException, match='.*is not configured to save the best.*'):
                 trainer.test(ckpt_path=ckpt_path)
         else:


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Fixes #2586

`ModelCheckpoint(save_top_k=-1, montior=None)` saves all models, but it cannot track the best because monitor is not provided. 

This PR enables `ModelCheckpoint(save_top_k=-1, montior="val_loss")` to save all checkpoints while also tracking the best models when a monitor key is provided.

