### PR TITLE
check if the file for metatags (hparams_file) already exists

### DIFF
--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -215,8 +215,9 @@ class TensorBoardLogger(LightningLoggerBase):
         # prepare the file path
         hparams_file = os.path.join(dir_path, self.NAME_HPARAMS_FILE)
 
-        # save the metatags file
-        save_hparams_to_yaml(hparams_file, self.hparams)
+        # save the metatags file if it doesn't exist
+        if not os.path.isfile(hparams_file):
+            save_hparams_to_yaml(hparams_file, self.hparams)
 
     @rank_zero_only
     def finalize(self, status: str) -> None:


### PR DESCRIPTION
Fixes #3114

Updated pytorch-lightning/pytorch_lightning/loggers/tensorboard.py, to check if the file for metatags (hparams_file) already exists.