### PR TITLE
Do not set PYTHONHASHSEED

### DIFF
--- a/pytorch_lightning/utilities/seed.py
+++ b/pytorch_lightning/utilities/seed.py
@@ -27,7 +27,7 @@ from pytorch_lightning import _logger as log
 def seed_everything(seed: Optional[int] = None) -> int:
     """
     Function that sets seed for pseudo-random number generators in:
-    pytorch, numpy, python.random and sets PYTHONHASHSEED environment variable.
+    pytorch, numpy, python.random
     In addition, sets the env variable `PL_GLOBAL_SEED` which will be passed to
     spawned subprocesses (e.g. ddp_spawn backend).
 
@@ -53,7 +53,6 @@ def seed_everything(seed: Optional[int] = None) -> int:
         )
         seed = _select_seed_randomly(min_seed_value, max_seed_value)
 
-    os.environ["PYTHONHASHSEED"] = str(seed)
     os.environ["PL_GLOBAL_SEED"] = str(seed)
     random.seed(seed)
     np.random.seed(seed)


### PR DESCRIPTION
## What does this PR do?

In the `seed_everything` function, `PYTHONHASHSEED` is assigned a value in order to ensure reproducability.
However, this assignment has no effect because it is not possible to change `PYTHONHASHSEED` inside the process itself.
In order to change it, a value has to be assigned before the program is started.

Because `seed_everything` sets the value in the `os.environ` dictionary, users or logging software might be mislead into believing that `PYTHONHASHSEED` has a specific value, when in fact it has another.

This PR simply removes the assignment. It might also be desirable to emit a warning in the case where `PYTHONHASHSEED` is not set, in order to alert the user. 

Fixes #2156

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?
