### PR TITLE
[TPU CI] Use timestamp+pythonVersion to form the docker image tag.

### DIFF
--- a/.github/workflows/ci_test-tpu.yml
+++ b/.github/workflows/ci_test-tpu.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches: [master]
 # TODO: temporal disable TPU testing until we find way how to pass credentials to forked PRs
-  pull_request:
-    branches:
-      - master
+#  pull_request:
+#    branches:
+#      - master
 
 env:
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
@@ -30,8 +30,6 @@ jobs:
     steps:
     - name: Set IMAGETAG
       run: echo "IMAGETAG=$(date +%s)_${{ matrix.python-version }}" >> $GITHUB_ENV
-    - name: temp IMAGETAG check
-      run: echo $IMAGETAG && exit 1
     - name: Install Go
       uses: actions/setup-go@v2
       with:

--- a/.github/workflows/ci_test-tpu.yml
+++ b/.github/workflows/ci_test-tpu.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches: [master]
 # TODO: temporal disable TPU testing until we find way how to pass credentials to forked PRs
-#  pull_request:
-#    branches:
-#      - master
+  pull_request:
+    branches:
+      - master
 
 env:
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
@@ -28,6 +28,10 @@ jobs:
     timeout-minutes: 50
 
     steps:
+    - name: Set IMAGETAG
+      run: echo "IMAGETAG=$(date +%s)_${{ matrix.python-version }}" >> $GITHUB_ENV
+    - name: temp IMAGETAG check
+      run: echo $IMAGETAG && exit 1
     - name: Install Go
       uses: actions/setup-go@v2
       with:
@@ -66,8 +70,8 @@ jobs:
     - name: Build and Push Docker Image
       run: |
         #cd dockers/tpu-tests
-        docker build --tag "$IMAGE:$GITHUB_RUN_ID" -f ./dockers/tpu-tests/Dockerfile --build-arg "PYTHON_VERSION=${{ matrix.python-version }}" .
-        docker push "$IMAGE:$GITHUB_RUN_ID"
+        docker build --tag "$IMAGE:$IMAGETAG" -f ./dockers/tpu-tests/Dockerfile --build-arg "PYTHON_VERSION=${{ matrix.python-version }}" .
+        docker push "$IMAGE:$IMAGETAG"
       shell: bash
 
     - name: Install jsonnet
@@ -82,7 +86,7 @@ jobs:
 
     - name: Deploy the job on the kubernetes cluster
       run: |-
-        job_name=$(jsonnet -J ml-testing-accelerators/ dockers/tpu-tests/tpu_test_cases.jsonnet --ext-str image=$IMAGE --ext-str image-tag=$GITHUB_RUN_ID | kubectl create -f -) && \
+        job_name=$(jsonnet -J ml-testing-accelerators/ dockers/tpu-tests/tpu_test_cases.jsonnet --ext-str image=$IMAGE --ext-str image-tag=$IMAGETAG | kubectl create -f -) && \
         job_name=${job_name#job.batch/} && \
         job_name=${job_name% created} && \
         echo "Waiting on kubernetes job: $job_name in cluster: $GKE_CLUSTER" && \
@@ -103,7 +107,7 @@ jobs:
         # First portion is the test logs. Print these to Github Action stdout.
         cat xx00 && \
         echo "Done with log retrieval attempt." && \
-        gcloud container images delete "$IMAGE:$GITHUB_RUN_ID" --force-delete-tags && \
+        gcloud container images delete "$IMAGE:$IMAGETAG" --force-delete-tags && \
         exit $status_code
       shell: bash
 


### PR DESCRIPTION
## What does this PR do?

Fix a bug in the TPU CI. Right now, runs use $GITHUB_RUN_ID which is the same for all values in `matrix`. This means the python3.6 and python3.7 tests end up with the same tag, which means which can lead to one job using the other's image accidentally or race conditions in image delete that leads to failures like: https://github.com/PyTorchLightning/pytorch-lightning/runs/1195442348?check_suite_focus=true

Fixes # (issue)

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
