### PR TITLE
Use fsspec with OmegaConf saving in saving.py

### DIFF
--- a/pytorch_lightning/core/saving.py
+++ b/pytorch_lightning/core/saving.py
@@ -361,11 +361,13 @@ def save_hparams_to_yaml(config_yaml, hparams: Union[dict, Namespace]) -> None:
     # saving with OmegaConf objects
     if OmegaConf is not None:
         if OmegaConf.is_config(hparams):
-            OmegaConf.save(hparams, config_yaml, resolve=True)
+            with fs.open(config_yaml, "w", encoding="utf-8") as fp:
+                OmegaConf.save(hparams, fp, resolve=True)
             return
         for v in hparams.values():
             if OmegaConf.is_config(v):
-                OmegaConf.save(OmegaConf.create(hparams), config_yaml, resolve=True)
+                with fs.open(config_yaml, "w", encoding="utf-8") as fp:
+                    OmegaConf.save(OmegaConf.create(hparams), fp, resolve=True)
                 return
 
     # saving the standard way


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Currently, the config_yaml is restricted to be saved to a local filepath when using an OmegaConf config. However, `Omegaconf.save` accepts an [IO object](https://github.com/omry/omegaconf/blob/master/omegaconf/omegaconf.py#L301-L321). Opening the file and passing the filepointer to OmegaConf enables Lightning to save the config yaml to any storage backends enabled by `fsspec`. 

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
