### PR TITLE
Fix tbptt_reduce_fx when non-floating tensors are logged

### DIFF
--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -420,7 +420,7 @@ class Result(Dict):
                 tbptt_reduce_fx = torch.mean
             else:
                 tbptt_reduce_fx = meta[k]['tbptt_reduce_fx']
-            result[k] = tbptt_reduce_fx(value)
+            result[k] = tbptt_reduce_fx(value.float())
 
         result['meta'] = meta
         return result

--- a/tests/trainer/logging/test_train_loop_logging_1_0.py
+++ b/tests/trainer/logging/test_train_loop_logging_1_0.py
@@ -245,49 +245,33 @@ def test__training_step__step_end__epoch_end__log(tmpdir, batches, log_interval,
     assert len(trainer.dev_debugger.logged_metrics) == ((batches / log_interval) * max_epochs) + max_epochs
 
 
-@pytest.mark.parametrize(
-    ["dtype", "expected"],
-    [
-        (torch.float, float),
-        (torch.int, int),
-        (torch.long, int),
-    ],
-)
-def test__training_step__log_max_reduce_fx(tmpdir, dtype, expected):
+@pytest.mark.parametrize(['batches', 'fx', 'result'], [(1, min, 0), (2, max, 1), (11, max, 10)])
+def test__training_step__log_max_reduce_fx(tmpdir, batches, fx, result):
     """
     Tests that log works correctly with different tensor types
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
-
-    class TestModel(DeterministicModel):
+    class TestModel(BoringModel):
         def training_step(self, batch, batch_idx):
-            acc = self.step(batch, batch_idx)
-            self.log('foo', torch.tensor(batch_idx, dtype=dtype), on_step=False, on_epoch=True, reduce_fx=max)
+            acc = self.step(batch[0])
+            self.log('foo', torch.tensor(batch_idx).long(), on_step=False, on_epoch=True, reduce_fx=fx)
             return acc
 
         def validation_step(self, batch, batch_idx):
-            self.log('bar', torch.tensor(batch_idx, dtype=dtype), on_step=False, on_epoch=True, reduce_fx=max)
-
-        def validation_step_end(self, val_step_output):
-            pass
-
-        def validation_epoch_end(self, outputs):
-            pass
+            output = self.layer(batch)
+            loss = self.loss(batch, output)
+            self.log('bar', torch.tensor(batch_idx).float(), on_step=False, on_epoch=True, reduce_fx=fx)
+            return {"x": loss}
 
     model = TestModel()
     trainer = Trainer(
         default_root_dir=tmpdir,
-        limit_train_batches=2,
-        limit_val_batches=2,
+        limit_train_batches=batches,
+        limit_val_batches=batches,
         max_epochs=2,
         weights_summary=None,
     )
     trainer.fit(model)
 
     # make sure types are correct
-    # TODO: why is one a value and the other a tensor?
-    # TODO: shouldn't both be the same type?
-    assert type(trainer.logged_metrics['foo']) == expected
-    assert trainer.logged_metrics['bar'].dtype == dtype
-    # make sure all the metrics are available for callbacks
-    assert set(trainer.logged_metrics.keys()) == {'epoch', 'foo', 'bar'}
+    assert trainer.logged_metrics['foo'] == result
+    assert trainer.logged_metrics['bar'] == result


### PR DESCRIPTION
## What does this PR do?

Fixes #3778

## Questions:

- Not sure if that is the best file for the test
- See `TODO` at the end of the test

## Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [n/a] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [n/a] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?