### PR TITLE
Fsspec is inconsistant when doing fs.ls

### DIFF
--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -232,7 +232,8 @@ class TensorBoardLogger(LightningLoggerBase):
             return 0
 
         existing_versions = []
-        for d in self._fs.ls(root_dir):
+        for listing in self._fs.listdir(root_dir):
+            d = listing["name"]
             bn = os.path.basename(d)
             if self._fs.isdir(d) and bn.startswith("version_"):
                 dir_ver = bn.split("_")[1].replace('/', '')

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -194,7 +194,7 @@ class CheckpointConnector:
         folderpath = str(self.trainer.weights_save_path)
         fs = get_filesystem(folderpath)
         if fs.exists(folderpath):
-            files = [os.path.basename(f) for f in fs.ls(folderpath)]
+            files = [os.path.basename(f['name']) for f in fs.listdir(folderpath)]
             hpc_weight_paths = [x for x in files if 'hpc_ckpt' in x]
 
             # if hpc weights exist restore model
@@ -333,7 +333,7 @@ class CheckpointConnector:
 
     def max_ckpt_in_folder(self, path, name_key='ckpt_'):
         fs = get_filesystem(path)
-        files = [os.path.basename(f) for f in fs.ls(path)]
+        files = [os.path.basename(f["name"]) for f in fs.listdir(path)]
         files = [x for x in files if name_key in x]
         if len(files) == 0:
             return 0


### PR DESCRIPTION

## What does this PR do?
FSSpec, which we use for doing IO which may or may not be local, has some inconsistancies in how it lists files. On local and some remote systems `fs.ls(path)` gives a list of strings and others (hdfs for example) it gives a list of dictionaries with the paths and meta data. 

Switching to fs.listdir(path) seems to give consistent behavior on the platforms I tested. Despite fsspec listing that `ls` is an alias for `listdir` in their documentation.

Fixes # (issue)

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [X] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
