### PR TITLE
Add early stopping deprecation warning for v0.10.0

### DIFF
--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -65,7 +65,7 @@ class EarlyStopping(Callback):
         >>> from pytorch_lightning import Trainer
         >>> from pytorch_lightning.callbacks import EarlyStopping
         >>> early_stopping = EarlyStopping('val_loss')
-        >>> trainer = Trainer(early_stop_callback=early_stopping)
+        >>> trainer = Trainer(callbacks=[early_stopping])
     """
     mode_dict = {
         'min': torch.lt,

--- a/pytorch_lightning/trainer/__init__.py
+++ b/pytorch_lightning/trainer/__init__.py
@@ -411,6 +411,10 @@ early_stop_callback
 Callback for early stopping.
 early_stop_callback (:class:`pytorch_lightning.callbacks.EarlyStopping`)
 
+.. deprecated:
+    Deprecated since v0.10.0 and will be removed in v1.0. Configure the EarlyStopping callback class
+    and add it to the list of callbacks: ``Trainer(callbacks=[EarlyStopping(...)])``
+
 - ``True``: A default callback monitoring ``'early_stop_on'`` (if dict is returned in validation loop) or
   ``early_stopping_on`` (if :class:`~pytorch_lightning.core.step_result.Result` is returned) is created.
   Will raise an error if a dictionary is returned and ``'early_stop_on'`` is not found.

--- a/pytorch_lightning/trainer/connectors/callback_connector.py
+++ b/pytorch_lightning/trainer/connectors/callback_connector.py
@@ -1,5 +1,6 @@
 import os
 from pytorch_lightning.callbacks import ModelCheckpoint, EarlyStopping, ProgressBarBase, ProgressBar
+from pytorch_lightning.utilities import rank_zero_warn
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 
@@ -11,7 +12,7 @@ class CallbackConnector:
     def on_trainer_init(
             self,
             callbacks,
-            early_stop_callback,
+            early_stop_callback,  # TODO: Deprecated in v0.10.0. Remove in v1.0
             checkpoint_callback,
             progress_bar_refresh_rate,
             process_position,
@@ -30,6 +31,7 @@ class CallbackConnector:
 
         # configure early stop callback
         # creates a default one if none passed in
+        # TODO: Deprecated in v0.10.0. Remove early stopping default configuration in v1.0
         early_stop_callback = self.configure_early_stopping(early_stop_callback)
         if early_stop_callback:
             self.trainer.callbacks.append(early_stop_callback)
@@ -43,6 +45,8 @@ class CallbackConnector:
 
         # TODO refactor codebase (tests) to not directly reach into these callbacks
         self.trainer.checkpoint_callback = checkpoint_callback
+
+        # TODO: Deprecated in v0.10.0. Remove in v1.0
         self.trainer.early_stop_callback = early_stop_callback
 
         # init progress bar
@@ -60,8 +64,15 @@ class CallbackConnector:
 
         return checkpoint_callback
 
+    # TODO: Deprecated in v0.10.0. Remove this method in v1.0
     def configure_early_stopping(self, early_stop_callback):
         if early_stop_callback is True or None:
+            rank_zero_warn(
+                "Trainer(early_stop_callback=True) is deprecated since v0.10.0 and will be"
+                " removed in v1.0."
+                " Configure the EarlyStopping callback class and add it to the list of callbacks:"
+                " Trainer(callbacks=[EarlyStopping(...)])."
+            )
             early_stop_callback = EarlyStopping(
                 monitor='early_stop_on',
                 patience=3,

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -82,7 +82,7 @@ class Trainer(
         self,
         logger: Union[LightningLoggerBase, Iterable[LightningLoggerBase], bool] = True,
         checkpoint_callback: Union[ModelCheckpoint, bool] = True,
-        early_stop_callback: Optional[Union[EarlyStopping, bool]] = False,
+        early_stop_callback: Optional[Union[EarlyStopping, bool]] = False,  # todo: remove in v1.0.0
         callbacks: Optional[List[Callback]] = None,
         default_root_dir: Optional[str] = None,
         gradient_clip_val: float = 0,
@@ -173,7 +173,8 @@ class Trainer(
 
             distributed_backend: The distributed backend to use (dp, ddp, ddp2, ddp_spawn, ddp_cpu)
 
-            early_stop_callback (:class:`pytorch_lightning.callbacks.EarlyStopping`)
+            early_stop_callback (:class:`pytorch_lightning.callbacks.EarlyStopping`).
+                Deprecated since v0.10.0 and will be removed in v1.0.
 
             fast_dev_run: runs 1 batch of train, test and val to find any bugs (ie: a sort of unit test).
 


### PR DESCRIPTION
Now:
```python
trainer = Trainer(early_stop_callback=True)
```
From v1.0, it will be removed. Instead, configure it like so:
```python
trainer = Trainer(callbacks=[EarlyStopping(monitor=...)])
```

In follow up PR, will update tests with this change