### PR TITLE
Documentation fix in pseudocode - training_epoch_end expects a return of None 

### DIFF
--- a/docs/source/lightning_module.rst
+++ b/docs/source/lightning_module.rst
@@ -448,7 +448,7 @@ The matching pseudocode is:
         optimizer.step()
         optimizer.zero_grad()
 
-    epoch_out = training_epoch_end(outs)
+    training_epoch_end(outs)
 
 Training with DataParallel
 ^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
`*_epoch_out` methods expects a return of None.



## What does this PR do?

Small documentation fix.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?



## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
