### PR TITLE
Complete mocking Comet and remove dep

### DIFF
--- a/pytorch_lightning/loggers/comet.py
+++ b/pytorch_lightning/loggers/comet.py
@@ -81,7 +81,8 @@ class CometLogger(LightningLoggerBase):
 
     **OFFLINE MODE**
 
-    Example:
+    .. code-block:: python
+
         from pytorch_lightning.loggers import CometLogger
         # arguments made to CometLogger are passed on to the comet_ml.Experiment class
         comet_logger = CometLogger(

--- a/pytorch_lightning/loggers/comet.py
+++ b/pytorch_lightning/loggers/comet.py
@@ -63,34 +63,35 @@ class CometLogger(LightningLoggerBase):
 
     **ONLINE MODE**
 
-    Example:
-        >>> import os
-        >>> from pytorch_lightning import Trainer
-        >>> from pytorch_lightning.loggers import CometLogger
-        >>> # arguments made to CometLogger are passed on to the comet_ml.Experiment class
-        >>> comet_logger = CometLogger(
-        ...     api_key=os.environ.get('COMET_API_KEY'),
-        ...     workspace=os.environ.get('COMET_WORKSPACE'),  # Optional
-        ...     save_dir='.',  # Optional
-        ...     project_name='default_project',  # Optional
-        ...     rest_api_key=os.environ.get('COMET_REST_API_KEY'),  # Optional
-        ...     experiment_name='default'  # Optional
-        ... )
+    .. code-block:: python
+
+        import os
+        from pytorch_lightning import Trainer
+        from pytorch_lightning.loggers import CometLogger
+        # arguments made to CometLogger are passed on to the comet_ml.Experiment class
+        comet_logger = CometLogger(
+            api_key=os.environ.get('COMET_API_KEY'),
+            workspace=os.environ.get('COMET_WORKSPACE'),  # Optional
+            save_dir='.',  # Optional
+            project_name='default_project',  # Optional
+            rest_api_key=os.environ.get('COMET_REST_API_KEY'),  # Optional
+            experiment_name='default'  # Optional
+        )
         >>> trainer = Trainer(logger=comet_logger)
 
     **OFFLINE MODE**
 
     Example:
-        >>> from pytorch_lightning.loggers import CometLogger
-        >>> # arguments made to CometLogger are passed on to the comet_ml.Experiment class
-        >>> comet_logger = CometLogger(
-        ...     save_dir='.',
-        ...     workspace=os.environ.get('COMET_WORKSPACE'),  # Optional
-        ...     project_name='default_project',  # Optional
-        ...     rest_api_key=os.environ.get('COMET_REST_API_KEY'),  # Optional
-        ...     experiment_name='default'  # Optional
-        ... )
-        >>> trainer = Trainer(logger=comet_logger)
+        from pytorch_lightning.loggers import CometLogger
+        # arguments made to CometLogger are passed on to the comet_ml.Experiment class
+        comet_logger = CometLogger(
+            save_dir='.',
+            workspace=os.environ.get('COMET_WORKSPACE'),  # Optional
+            project_name='default_project',  # Optional
+            rest_api_key=os.environ.get('COMET_REST_API_KEY'),  # Optional
+            experiment_name='default'  # Optional
+        )
+        trainer = Trainer(logger=comet_logger)
 
     Args:
         api_key: Required in online mode. API key, found on Comet.ml. If not given, this

--- a/pytorch_lightning/loggers/comet.py
+++ b/pytorch_lightning/loggers/comet.py
@@ -77,7 +77,7 @@ class CometLogger(LightningLoggerBase):
             rest_api_key=os.environ.get('COMET_REST_API_KEY'),  # Optional
             experiment_name='default'  # Optional
         )
-        >>> trainer = Trainer(logger=comet_logger)
+        trainer = Trainer(logger=comet_logger)
 
     **OFFLINE MODE**
 

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,7 +1,6 @@
 # extended list of package dependencies to reach full functionality
 
 # TODO: this shall be removed as we mock them in tests
-comet-ml>=3.1.12
 mlflow>=1.0.0
 test_tube>=0.7.5
 

--- a/tests/loggers/test_all.py
+++ b/tests/loggers/test_all.py
@@ -33,20 +33,27 @@ def _get_logger_args(logger_class, save_dir):
     return logger_args
 
 
-@pytest.mark.parametrize("logger_class", [
-    TensorBoardLogger,
-    CometLogger,
-    MLFlowLogger,
-    NeptuneLogger,
-    TestTubeLogger,
-    WandbLogger,
-])
-@mock.patch('pytorch_lightning.loggers.neptune.neptune')
-@mock.patch('pytorch_lightning.loggers.wandb.wandb')
-def test_loggers_fit_test(wandb, neptune, tmpdir, monkeypatch, logger_class):
+def test_loggers_fit_test_all(tmpdir, monkeypatch):
+    _patch_comet_atexit(monkeypatch)
+    with mock.patch('pytorch_lightning.loggers.comet.comet_ml'), \
+         mock.patch('pytorch_lightning.loggers.comet.CometOfflineExperiment'):
+        _test_loggers_fit_test(tmpdir, CometLogger)
+
+    _test_loggers_fit_test(tmpdir, MLFlowLogger)
+
+    with mock.patch('pytorch_lightning.loggers.neptune.neptune'):
+        _test_loggers_fit_test(tmpdir, NeptuneLogger)
+
+    _test_loggers_fit_test(tmpdir, TensorBoardLogger)
+    _test_loggers_fit_test(tmpdir, TestTubeLogger)
+
+    with mock.patch('pytorch_lightning.loggers.wandb.wandb'):
+        _test_loggers_fit_test(tmpdir, WandbLogger)
+
+
+def _test_loggers_fit_test(tmpdir, logger_class):
     """Verify that basic functionality of all loggers."""
     os.environ['PL_DEV_DEBUG'] = '0'
-    _patch_comet_atexit(monkeypatch)
 
     model = EvalModelTemplate()
 
@@ -66,6 +73,10 @@ def test_loggers_fit_test(wandb, neptune, tmpdir, monkeypatch, logger_class):
         # required mocks for Trainer
         logger.experiment.id = 'foo'
         logger.experiment.project_name.return_value = 'bar'
+
+    if logger_class == CometLogger:
+        logger.experiment.id = 'foo'
+        logger.experiment.project_name = 'bar'
 
     trainer = Trainer(
         max_epochs=1,
@@ -97,17 +108,22 @@ def test_loggers_fit_test(wandb, neptune, tmpdir, monkeypatch, logger_class):
         assert log_metric_names == expected
 
 
-@pytest.mark.parametrize("logger_class", [
-    TensorBoardLogger,
-    CometLogger,
-    MLFlowLogger,
-    TestTubeLogger,
-    WandbLogger,
-])
-@mock.patch('pytorch_lightning.loggers.wandb.wandb')
-def test_loggers_save_dir_and_weights_save_path(wandb, tmpdir, monkeypatch, logger_class):
-    """ Test the combinations of save_dir, weights_save_path and default_root_dir.  """
+def test_loggers_save_dir_and_weights_save_path_all(tmpdir, monkeypatch):
     _patch_comet_atexit(monkeypatch)
+    with mock.patch('pytorch_lightning.loggers.comet.comet_ml'), \
+         mock.patch('pytorch_lightning.loggers.comet.CometOfflineExperiment'):
+        _test_loggers_save_dir_and_weights_save_path(tmpdir, CometLogger)
+
+    _test_loggers_save_dir_and_weights_save_path(tmpdir, TensorBoardLogger)
+    _test_loggers_save_dir_and_weights_save_path(tmpdir, MLFlowLogger)
+    _test_loggers_save_dir_and_weights_save_path(tmpdir, TestTubeLogger)
+
+    with mock.patch('pytorch_lightning.loggers.wandb.wandb'):
+        _test_loggers_save_dir_and_weights_save_path(tmpdir, WandbLogger)
+
+
+def _test_loggers_save_dir_and_weights_save_path(tmpdir, logger_class):
+    """ Test the combinations of save_dir, weights_save_path and default_root_dir.  """
 
     class TestLogger(logger_class):
         # for this test it does not matter what these attributes are

--- a/tests/loggers/test_all.py
+++ b/tests/loggers/test_all.py
@@ -157,15 +157,23 @@ def test_loggers_save_dir_and_weights_save_path(wandb, tmpdir, monkeypatch, logg
 
 
 @pytest.mark.parametrize("logger_class", [
-    TensorBoardLogger,
     CometLogger,
     MLFlowLogger,
     NeptuneLogger,
+    TensorBoardLogger,
     TestTubeLogger,
     # The WandbLogger gets tested for pickling in its own test.
 ])
-@mock.patch('pytorch_lightning.loggers.neptune.neptune')
-def test_loggers_pickle(neptune, tmpdir, monkeypatch, logger_class):
+def test_loggers_pickle_all(tmpdir, monkeypatch, logger_class):
+    """ Test that the logger objects can be pickled. This test only makes sense if the packages are installed. """
+    _patch_comet_atexit(monkeypatch)
+    try:
+        _test_loggers_pickle(tmpdir, monkeypatch, logger_class)
+    except (ImportError, ModuleNotFoundError):
+        pytest.xfail(f"pickle test requires {logger_class.__class__} dependencies to be installed.")
+
+
+def _test_loggers_pickle(tmpdir, monkeypatch, logger_class):
     """Verify that pickling trainer with logger works."""
     _patch_comet_atexit(monkeypatch)
 

--- a/tests/loggers/test_comet.py
+++ b/tests/loggers/test_comet.py
@@ -91,7 +91,6 @@ def test_comet_logger_experiment_name(comet):
 def test_comet_logger_dirs_creation(comet, comet_experiment, tmpdir, monkeypatch):
     """ Test that the logger creates the folders and files in the right place. """
     _patch_comet_atexit(monkeypatch)
-
     comet.config.get_api_key.return_value = None
     comet.generate_guid.return_value = "4321"
 

--- a/tests/loggers/test_comet.py
+++ b/tests/loggers/test_comet.py
@@ -91,6 +91,7 @@ def test_comet_logger_experiment_name(comet):
 def test_comet_logger_dirs_creation(comet, comet_experiment, tmpdir, monkeypatch):
     """ Test that the logger creates the folders and files in the right place. """
     _patch_comet_atexit(monkeypatch)
+    
     comet.config.get_api_key.return_value = None
     comet.generate_guid.return_value = "4321"
 

--- a/tests/loggers/test_comet.py
+++ b/tests/loggers/test_comet.py
@@ -91,7 +91,7 @@ def test_comet_logger_experiment_name(comet):
 def test_comet_logger_dirs_creation(comet, comet_experiment, tmpdir, monkeypatch):
     """ Test that the logger creates the folders and files in the right place. """
     _patch_comet_atexit(monkeypatch)
-    
+
     comet.config.get_api_key.return_value = None
     comet.generate_guid.return_value = "4321"
 


### PR DESCRIPTION
Following  #3860, this adds the remaining mocks to comet tests and removes the comet dependency for CI testing.