### PR TITLE
Change reference to depricated result object to self

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -840,7 +840,7 @@ class LightningModule(
 
                 out = self(x)
                 loss = self.softmax(out)
-                result.log('test_loss', loss)
+                self.log('test_loss', loss)
 
             # --------------
             # with test_step_end to do softmax over the full batch


### PR DESCRIPTION
Update docs for test_step_end that used deprecated result object to log.