### PR TITLE
Remove limitation of batch scaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Removed limitation of batch scaler not being able to work with dataloader passed to fit ([#4006](https://github.com/PyTorchLightning/pytorch-lightning/pull/4006))
 
 ### Deprecated
 
@@ -364,7 +365,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed adding val step argument to metrics ([#2986](https://github.com/PyTorchLightning/pytorch-lightning/pull/2986))
 - Fixed an issue that caused `Trainer.test()` to stall in ddp mode ([#2997](https://github.com/PyTorchLightning/pytorch-lightning/pull/2997))
 - Fixed gathering of results with tensors of varying shape ([#3020](https://github.com/PyTorchLightning/pytorch-lightning/pull/3020))
-- Fixed batch size auto-scaling feature to set the new value on the correct model attribute ([#3043](https://github.com/PyTorchLightning/pytorch-lightning/pull/3043)) 
+- Fixed batch size auto-scaling feature to set the new value on the correct model attribute ([#3043](https://github.com/PyTorchLightning/pytorch-lightning/pull/3043))
 - Fixed automatic batch scaling not working with half precision ([#3045](https://github.com/PyTorchLightning/pytorch-lightning/pull/3045))
 - Fixed setting device to root gpu ([#3042](https://github.com/PyTorchLightning/pytorch-lightning/pull/3042))
 

--- a/docs/source/training_tricks.rst
+++ b/docs/source/training_tricks.rst
@@ -68,24 +68,21 @@ it encounters an OOM, after which it will do a binary search that will finetune 
 batch size. Additionally, it should be noted that the batch size scaler cannot
 search for batch sizes larger than the size of the training dataset.
 
+This feature works both with dataloaders/datamodule being passed directly to fit
+or being part of the model. If they are passed to fit, they are directly overriden
+by a new dataloader/datamodule with the optimized batch size, and the result is
+saved to the model attribute `batch_size`. If the dataloader/datamodule is part of
+the model, it is expected that a `batch_size` field is either located as a model attribute
+i.e. `model.batch_size` or as a field in your `hparams` i.e. `model.hparams.batch_size`.
+The field should exist and will be overridden by the results of this algorithm.
+Additionally, your `train_dataloader()` method should depend on this field
+for this feature to work i.e.
 
-.. note::
+.. code-block:: python
 
-    This feature expects that a `batch_size` field is either located as a model attribute
-    i.e. `model.batch_size` or as a field in your `hparams` i.e. `model.hparams.batch_size`.
-    The field should exist and will be overridden by the results of this algorithm.
-    Additionally, your `train_dataloader()` method should depend on this field
-    for this feature to work i.e.
+    def train_dataloader(self):
+        return DataLoader(train_dataset, batch_size=self.batch_size|self.hparams.batch_size)
 
-    .. code-block:: python
-
-        def train_dataloader(self):
-            return DataLoader(train_dataset, batch_size=self.batch_size|self.hparams.batch_size)
-
-.. warning::
-
-    Due to these constraints, this features does *NOT* work when passing dataloaders directly
-    to `.fit()`.
 
 The scaling algorithm has a number of parameters that the user can control by
 invoking the trainer method `.scale_batch_size` themself (see description below).

--- a/pytorch_lightning/trainer/connectors/data_connector.py
+++ b/pytorch_lightning/trainer/connectors/data_connector.py
@@ -16,7 +16,7 @@ from pytorch_lightning.core.datamodule import LightningDataModule
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from typing import List, Optional, Union
 from torch.utils.data import DataLoader
-from pytorch_lightning.utilities.model_utils import is_overridden
+from pytorch_lightning.utilities.model_utils import is_overridden, _PatchDataLoader
 
 
 class DataConnector(object):
@@ -123,25 +123,3 @@ class DataConnector(object):
 
             self.trainer.datamodule = datamodule
             datamodule.trainer = self.trainer
-
-
-class _PatchDataLoader(object):
-    r"""
-    Callable object for patching dataloaders passed into trainer.fit().
-    Use this class to override model.*_dataloader() and be pickle-compatible.
-
-    Args:
-        dataloader: Dataloader object to return when called.
-
-    """
-
-    def __init__(self, dataloader: Union[List[DataLoader], DataLoader]):
-        self.dataloader = dataloader
-
-        # cannot pickle __code__ so cannot verify if PatchDataloader
-        # exists which shows dataloader methods have been overwritten.
-        # so, we hack it by using the string representation
-        self.patch_loader_code = str(self.__call__.__code__)
-
-    def __call__(self) -> Union[List[DataLoader], DataLoader]:
-        return self.dataloader

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -23,7 +23,7 @@ from torch.utils.data.distributed import DistributedSampler
 from pytorch_lightning.accelerators.base_accelerator import Accelerator
 from pytorch_lightning.core import LightningModule
 from pytorch_lightning.utilities import rank_zero_warn
-from pytorch_lightning.utilities.data import has_iterable_dataset, has_len, replace_sampler
+from pytorch_lightning.utilities.data import has_iterable_dataset, has_len, replace_dataloader_args
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.debugging import InternalDebugger
 from pytorch_lightning.utilities.model_utils import is_overridden
@@ -124,7 +124,7 @@ class TrainerDataLoadingMixin(ABC):
 
             # replace with distributed sampler
             sampler = self._get_distributed_sampler(dataloader, train)
-            dataloader = replace_sampler(dataloader, sampler=sampler)
+            dataloader = replace_dataloader_args(dataloader, sampler=sampler)
 
         return dataloader
 
@@ -160,7 +160,7 @@ class TrainerDataLoadingMixin(ABC):
             if hasattr(self.train_dataloader, 'sampler') and isinstance(self.train_dataloader.sampler, RandomSampler):
                 rank_zero_warn('You requested to overfit but enabled training dataloader shuffling.'
                                ' We are turning it off for you.')
-                self.train_dataloader = replace_sampler(
+                self.train_dataloader = replace_dataloader_args(
                     self.train_dataloader, sampler=SequentialSampler(self.train_dataloader.dataset))
 
         # debugging
@@ -247,7 +247,9 @@ class TrainerDataLoadingMixin(ABC):
                 if self.overfit_batches > 0:
                     rank_zero_warn('You requested to overfit but enabled test/val dataloader shuffling.'
                                    ' We are turning it off for you.')
-                    dataloaders[loader_i] = replace_sampler(loader, sampler=SequentialSampler(loader.dataset))
+                    dataloaders[loader_i] = replace_dataloader_args(
+                        loader, sampler=SequentialSampler(loader.dataset)
+                    )
 
                 else:
                     rank_zero_warn(f'Your {mode}_dataloader has `shuffle=True`, it is best practice to turn'

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -160,8 +160,8 @@ class TrainerDataLoadingMixin(ABC):
             if hasattr(self.train_dataloader, 'sampler') and isinstance(self.train_dataloader.sampler, RandomSampler):
                 rank_zero_warn('You requested to overfit but enabled training dataloader shuffling.'
                                ' We are turning it off for you.')
-                self.train_dataloader = self.replace_sampler(
-                    self.train_dataloader, SequentialSampler(self.train_dataloader.dataset))
+                self.train_dataloader = replace_sampler(
+                    self.train_dataloader, sampler=SequentialSampler(self.train_dataloader.dataset))
 
         # debugging
         self.dev_debugger.track_load_dataloader_call('train_dataloader', dataloaders=[self.train_dataloader])
@@ -247,7 +247,7 @@ class TrainerDataLoadingMixin(ABC):
                 if self.overfit_batches > 0:
                     rank_zero_warn('You requested to overfit but enabled test/val dataloader shuffling.'
                                    ' We are turning it off for you.')
-                    dataloaders[loader_i] = self.replace_sampler(loader, SequentialSampler(loader.dataset))
+                    dataloaders[loader_i] = replace_sampler(loader, sampler=SequentialSampler(loader.dataset))
 
                 else:
                     rank_zero_warn(f'Your {mode}_dataloader has `shuffle=True`, it is best practice to turn'

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -23,7 +23,7 @@ from torch.utils.data.distributed import DistributedSampler
 from pytorch_lightning.accelerators.base_accelerator import Accelerator
 from pytorch_lightning.core import LightningModule
 from pytorch_lightning.utilities import rank_zero_warn
-from pytorch_lightning.utilities.data import has_iterable_dataset, has_len
+from pytorch_lightning.utilities.data import has_iterable_dataset, has_len, replace_sampler
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.debugging import InternalDebugger
 from pytorch_lightning.utilities.model_utils import is_overridden
@@ -124,20 +124,10 @@ class TrainerDataLoadingMixin(ABC):
 
             # replace with distributed sampler
             sampler = self._get_distributed_sampler(dataloader, train)
-            dataloader = self.replace_sampler(dataloader, sampler)
+            dataloader = replace_sampler(dataloader, sampler=sampler)
 
         return dataloader
 
-    def replace_sampler(self, dataloader, sampler):
-        skip_keys = ['sampler', 'batch_sampler', 'dataset_kind']
-
-        dl_args = {
-            k: v for k, v in dataloader.__dict__.items() if not k.startswith('_') and k not in skip_keys
-        }
-
-        dl_args['sampler'] = sampler
-        dataloader = type(dataloader)(**dl_args)
-        return dataloader
 
     def _get_distributed_sampler(self, dataloader, train):
         if self.use_tpu:

--- a/pytorch_lightning/tuner/batch_size_scaling.py
+++ b/pytorch_lightning/tuner/batch_size_scaling.py
@@ -29,7 +29,6 @@ from pytorch_lightning.loggers.base import DummyLogger
 from pytorch_lightning import _logger as log
 
 
-
 def scale_batch_size(trainer,
                      model: LightningModule,
                      mode: str = 'power',
@@ -82,9 +81,9 @@ def scale_batch_size(trainer,
         datamodule: A instance of :class:`LightningDataModule`.
     """
     # Make copy of dataloader passed to fit that we work with while doing the search
-    fit_kwargs={'train_dataloader': deepcopy(train_dataloader),
-                'val_dataloaders': deepcopy(val_dataloaders),
-                'datamodule': deepcopy(datamodule)}
+    fit_kwargs = {'train_dataloader': deepcopy(train_dataloader),
+                  'val_dataloaders': deepcopy(val_dataloaders),
+                  'datamodule': deepcopy(datamodule)}
     in_model = True
     if not lightning_hasattr(model, batch_arg_name):
         rank_zero_warn(f'Did not find a field, saving result under model.{batch_arg_name}')

--- a/pytorch_lightning/tuner/tuning.py
+++ b/pytorch_lightning/tuner/tuning.py
@@ -109,12 +109,11 @@ class Tuner:
 
             datamodule: A instance of :class:`LightningDataModule`.
         """
-        fit_kwargs = {'train_dataloader': train_dataloader}
         scale_batch_size(self.trainer, model, mode, steps_per_trial,
                          init_val, max_trials, batch_arg_name,
-                         fit_kwargs=fit_kwargs)
-        import pdb
-        pdb.set_trace()
+                         train_dataloader=train_dataloader,
+                         val_dataloaders=val_dataloaders,
+                         datamodule=datamodule)
         return
 
 

--- a/pytorch_lightning/tuner/tuning.py
+++ b/pytorch_lightning/tuner/tuning.py
@@ -33,8 +33,7 @@ class Tuner:
              model: LightningModule,
              train_dataloader: Optional[DataLoader] = None,
              val_dataloaders: Optional[Union[DataLoader, List[DataLoader]]] = None,
-             datamodule: Optional[LightningDataModule] = None
-        ):
+             datamodule: Optional[LightningDataModule] = None):
         # setup data, etc...
         self.trainer.train_loop.setup_fit(model, train_dataloader, val_dataloaders, datamodule)
 
@@ -115,7 +114,6 @@ class Tuner:
                          val_dataloaders=val_dataloaders,
                          datamodule=datamodule)
         return
-
 
     def lr_find(
             self,

--- a/pytorch_lightning/tuner/tuning.py
+++ b/pytorch_lightning/tuner/tuning.py
@@ -29,7 +29,12 @@ class Tuner:
         self.trainer.auto_lr_find = auto_lr_find
         self.trainer.auto_scale_batch_size = auto_scale_batch_size
 
-    def tune(self, model, train_dataloader, val_dataloaders, datamodule):
+    def tune(self,
+             model: LightningModule,
+             train_dataloader: Optional[DataLoader] = None,
+             val_dataloaders: Optional[Union[DataLoader, List[DataLoader]]] = None,
+             datamodule: Optional[LightningDataModule] = None
+        ):
         # setup data, etc...
         self.trainer.train_loop.setup_fit(model, train_dataloader, val_dataloaders, datamodule)
 
@@ -61,7 +66,9 @@ class Tuner:
                          init_val: int = 2,
                          max_trials: int = 25,
                          batch_arg_name: str = 'batch_size',
-                         **fit_kwargs):
+                         train_dataloader: Optional[DataLoader] = None,
+                         val_dataloaders: Optional[Union[DataLoader, List[DataLoader]]] = None,
+                         datamodule: Optional[LightningDataModule] = None):
         r"""
         Will iteratively try to find the largest batch size for a given model
         that does not give an out of memory (OOM) error.
@@ -94,13 +101,22 @@ class Tuner:
                 - `model.datamodule`
                 - `trainer.datamodule` (the datamodule passed to the tune method)
 
-            **fit_kwargs: remaining arguments to be passed to .fit(), e.g., dataloader
-                or datamodule.
+            train_dataloader: A Pytorch DataLoader with training samples. If the model has
+                a predefined train_dataloader method this will be skipped.
 
+            val_dataloaders: Either a single Pytorch Dataloader or a list of them, specifying validation samples.
+                If the model has a predefined val_dataloaders method this will be skipped
+
+            datamodule: A instance of :class:`LightningDataModule`.
         """
-        return scale_batch_size(
-            self.trainer, model, mode, steps_per_trial, init_val, max_trials, batch_arg_name, **fit_kwargs
-        )
+        fit_kwargs = {'train_dataloader': train_dataloader}
+        scale_batch_size(self.trainer, model, mode, steps_per_trial,
+                         init_val, max_trials, batch_arg_name,
+                         fit_kwargs=fit_kwargs)
+        import pdb
+        pdb.set_trace()
+        return
+
 
     def lr_find(
             self,

--- a/pytorch_lightning/utilities/data.py
+++ b/pytorch_lightning/utilities/data.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from distutils.version import LooseVersion
 import torch
 from torch.utils.data import DataLoader, IterableDataset
@@ -47,7 +46,8 @@ def has_len(dataloader: DataLoader) -> bool:
     return has_len
 
 
-def replace_sampler(dataloader: DataLoader, **kwargs_replace):
+def replace_dataloader_args(dataloader: DataLoader, **kwargs_replace):
+    """ Instanciate a new dataloader with some changed arguments """
     skip_keys = ['sampler', 'batch_sampler', 'dataset_kind']
 
     dl_args = {

--- a/pytorch_lightning/utilities/data.py
+++ b/pytorch_lightning/utilities/data.py
@@ -53,7 +53,7 @@ def replace_dataloader_args(dataloader: DataLoader, **kwargs_replace):
     dl_args = {
         k: v for k, v in dataloader.__dict__.items() if not k.startswith('_') and k not in skip_keys
     }
-    for k,v in kwargs_replace.items():
+    for k, v in kwargs_replace.items():
         dl_args[k] = v
     dataloader = type(dataloader)(**dl_args)
     return dataloader

--- a/pytorch_lightning/utilities/data.py
+++ b/pytorch_lightning/utilities/data.py
@@ -45,3 +45,15 @@ def has_len(dataloader: DataLoader) -> bool:
             ' this can lead to unintended side effects since the samples will be duplicated.'
         )
     return has_len
+
+
+def replace_sampler(dataloader: DataLoader, **kwargs_replace):
+    skip_keys = ['sampler', 'batch_sampler', 'dataset_kind']
+
+    dl_args = {
+        k: v for k, v in dataloader.__dict__.items() if not k.startswith('_') and k not in skip_keys
+    }
+    for k,v in kwargs_replace.items():
+        dl_args[k] = v
+    dataloader = type(dataloader)(**dl_args)
+    return dataloader

--- a/pytorch_lightning/utilities/model_utils.py
+++ b/pytorch_lightning/utilities/model_utils.py
@@ -1,6 +1,31 @@
+from typing import Union, List
+
+from torch.utils.data import DataLoader
+
 from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.core.datamodule import LightningDataModule
-from typing import Union
+
+
+class _PatchDataLoader(object):
+    r"""
+    Callable object for patching dataloaders passed into trainer.fit().
+    Use this class to override model.*_dataloader() and be pickle-compatible.
+
+    Args:
+        dataloader: Dataloader object to return when called.
+
+    """
+
+    def __init__(self, dataloader: Union[List[DataLoader], DataLoader]):
+        self.dataloader = dataloader
+
+        # cannot pickle __code__ so cannot verify if PatchDataloader
+        # exists which shows dataloader methods have been overwritten.
+        # so, we hack it by using the string representation
+        self.patch_loader_code = str(self.__call__.__code__)
+
+    def __call__(self) -> Union[List[DataLoader], DataLoader]:
+        return self.dataloader
 
 
 def is_overridden(method_name: str, model: Union[LightningModule, LightningDataModule]) -> bool:

--- a/tests/trainer/test_trainer_tricks.py
+++ b/tests/trainer/test_trainer_tricks.py
@@ -8,7 +8,7 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.utilities import AMPType, NATIVE_AMP_AVALAIBLE
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.base import EvalModelTemplate
-from tests.base.datamodules import MNISTDataModule
+from tests.base.datamodules import MNISTDataModule, TrialMNISTDataModule
 
 
 def test_num_training_batches(tmpdir):
@@ -285,30 +285,42 @@ def test_call_to_trainer_method(tmpdir, scale_method):
     )
 
     after_batch_size = trainer.tuner.scale_batch_size(model, mode=scale_method, max_trials=5)
-    model.batch_size = after_batch_size
-    trainer.fit(model)
 
     assert before_batch_size != after_batch_size, \
         'Batch size was not altered after running auto scaling of batch size'
 
-
-def test_error_on_dataloader_passed_to_fit(tmpdir):
-    """Verify that when the auto scale batch size feature raises an error
-       if a train dataloader is passed to fit """
-
-    # only train passed to fit
+@pytest.mark.parametrize('fit_arg', ['train_dataloader'])#, 'datamodule'])
+def test_auto_scale_batch_size_with_only_fit_arg(tmpdir, fit_arg):
+    """ Verify that auto scale batch size feature also works when a
+        train dataloader is passed to tune """
     model = EvalModelTemplate()
+    model.train_dataloader = None
+    model.val_dataloader = None
+    model.test_dataloader = None
+
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_epochs=1,
-        limit_val_batches=0.1,
-        limit_train_batches=0.2,
         auto_scale_batch_size='power',
     )
-    fit_options = dict(train_dataloader=model.dataloader(train=True))
 
-    with pytest.raises(MisconfigurationException):
-        trainer.tune(model, **fit_options)
+    if fit_arg == 'train_dataloader':
+        train_dataloader = model.dataloader(train=True)
+        before_batch_size = train_dataloader.batch_size
+        del model.batch_size, model.hparams['batch_size']
+        trainer.tune(model, train_dataloader=train_dataloader)
+        after_batch_size = train_dataloader.batch_size
+
+    elif fit_arg == 'datamodule':
+        datamodule = TrialMNISTDataModule(data_dir=tmpdir)
+        datamodule.setup()
+        before_batch_size = datamodule.train_dataloader().batch_size
+        del model.batch_size, model.hparams['batch_size']
+        trainer.tune(model, datamodule=datamodule)
+        after_batch_size = datamodule.train_dataloader().batch_size
+
+    assert before_batch_size != after_batch_size, \
+        'Batch size was not altered after running auto scaling of batch size'
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires GPU machine")

--- a/tests/trainer/test_trainer_tricks.py
+++ b/tests/trainer/test_trainer_tricks.py
@@ -289,7 +289,8 @@ def test_call_to_trainer_method(tmpdir, scale_method):
     assert before_batch_size != after_batch_size, \
         'Batch size was not altered after running auto scaling of batch size'
 
-@pytest.mark.parametrize('fit_arg', ['train_dataloader'])#, 'datamodule'])
+
+@pytest.mark.parametrize('fit_arg', ['train_dataloader', 'datamodule'])
 def test_auto_scale_batch_size_with_only_fit_arg(tmpdir, fit_arg):
     """ Verify that auto scale batch size feature also works when a
         train dataloader is passed to tune """
@@ -321,6 +322,10 @@ def test_auto_scale_batch_size_with_only_fit_arg(tmpdir, fit_arg):
 
     assert before_batch_size != after_batch_size, \
         'Batch size was not altered after running auto scaling of batch size'
+    assert hasattr(model, "batch_size"), \
+        'Batch size field was not created'
+    assert model.batch_size == after_batch_size, \
+        'Model attribute batch size not the same as dataloader batch size'
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires GPU machine")


### PR DESCRIPTION
## What does this PR do?

Getting rid of the current limitation that batch scaler cannot be used in combination with a train dataloader passed directly.
This limitation was set in place, to secure that the user had a field `self.batch_size` that we could alter.
To remove this limitation we instead replaces the dataloader with a newly instantiated dataloader with altered batch size.

Fixes #4000 

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
