### PR TITLE
[rfc] Make Result.unpack_batch_size a staticmethod

### DIFF
--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -219,7 +219,7 @@ class Result(Dict):
 
     def track_batch_size(self, batch):
         try:
-            batch_size = self.unpack_batch_size(batch)
+            batch_size = Result.unpack_batch_size(batch)
         except RecursionError as re:
             batch_size = 1
 
@@ -276,7 +276,7 @@ class Result(Dict):
                     result[k] = self[k]
 
             if k in self and not options['on_epoch'] and isinstance(self[k], Metric):
-                # compute metric on epoch anyway so state does not accumulate 
+                # compute metric on epoch anyway so state does not accumulate
                 self[k].compute()
 
         return result
@@ -299,7 +299,7 @@ class Result(Dict):
                     result[k] = self[k]
 
             if k in self and not options['on_epoch'] and isinstance(self[k], Metric):
-                # compute metric on epoch anyway so state does not accumulate 
+                # compute metric on epoch anyway so state does not accumulate
                 self[k].compute()
 
         return result
@@ -353,7 +353,8 @@ class Result(Dict):
             newone[k] = copy(v)
         return newone
 
-    def unpack_batch_size(self, sample):
+    @staticmethod
+    def unpack_batch_size(sample):
         """
         Recursively unpack sample to find a torch.Tensor.
         returns len(tensor) when found, or 1 when it hits an empty or non iterable.
@@ -364,10 +365,10 @@ class Result(Dict):
             return len(sample)
         elif isinstance(sample, dict):
             sample = next(iter(sample.values()), 1)
-            size = self.unpack_batch_size(sample)
+            size = Result.unpack_batch_size(sample)
         elif isinstance(sample, Iterable):
             sample = next(iter(sample), 1)
-            size = self.unpack_batch_size(sample)
+            size = Result.unpack_batch_size(sample)
         else:
             size = 1
         return size


### PR DESCRIPTION
This could be a useful utility elsewhere in lightning for calculating the batch size

<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
