### PR TITLE
add parsing OS env vars

### DIFF
--- a/pytorch_lightning/trainer/connectors/env_vars_connector.py
+++ b/pytorch_lightning/trainer/connectors/env_vars_connector.py
@@ -1,0 +1,42 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from functools import wraps
+from typing import Callable
+
+from pytorch_lightning.utilities.argparse_utils import parse_env_variables, get_init_arguments_and_types
+
+
+def overwrite_by_env_vars(fn: Callable) -> Callable:
+    """
+    Decorator for :class:`~pytorch_lightning.trainer.trainer.Trainer` methods for which
+    input arguments should be moved automatically to the correct device.
+
+    """
+    @wraps(fn)
+    def overwrite_by_env_vars(self, *args, **kwargs):
+        # get the class
+        cls = self.__class__
+        if args:  # inace any args passed move them to kwargs
+            # parse only the argument names
+            cls_arg_names = [arg[0] for arg in get_init_arguments_and_types(cls)]
+            # convert args to kwargs
+            kwargs.update({k: v for k, v in zip(cls_arg_names, args)})
+        # update the kwargs by env variables
+        kwargs.update(vars(parse_env_variables(cls)))
+
+        # all args were already moved to kwargs
+        return fn(self, **kwargs)
+
+    return overwrite_by_env_vars

--- a/pytorch_lightning/trainer/connectors/env_vars_connector.py
+++ b/pytorch_lightning/trainer/connectors/env_vars_connector.py
@@ -34,6 +34,7 @@ def overwrite_by_env_vars(fn: Callable) -> Callable:
             # convert args to kwargs
             kwargs.update({k: v for k, v in zip(cls_arg_names, args)})
         # update the kwargs by env variables
+        # todo: maybe add a warning that some init args were overwritten by Env arguments
         kwargs.update(vars(parse_env_variables(cls)))
 
         # all args were already moved to kwargs

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -113,6 +113,10 @@ class TrainerProperties(ABC):
         return argparse_utils.parse_argparser(cls, arg_parser)
 
     @classmethod
+    def match_env_arguments(cls) -> Namespace:
+        return argparse_utils.parse_env_variables(cls)
+
+    @classmethod
     def add_argparse_args(cls, parent_parser: ArgumentParser) -> ArgumentParser:
         return argparse_utils.add_argparse_args(cls, parent_parser)
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -28,6 +28,7 @@ from pytorch_lightning.loggers import LightningLoggerBase
 from pytorch_lightning.profiler import BaseProfiler
 from pytorch_lightning.trainer.callback_hook import TrainerCallbackHookMixin
 from pytorch_lightning.trainer.configuration_validator import ConfigValidator
+from pytorch_lightning.trainer.connectors.env_vars_connector import overwrite_by_env_vars
 from pytorch_lightning.trainer.data_loading import TrainerDataLoadingMixin
 from pytorch_lightning.trainer.logging import TrainerLoggingMixin
 from pytorch_lightning.trainer.model_hooks import TrainerModelHooksMixin
@@ -79,6 +80,7 @@ class Trainer(
     TrainerTrainingTricksMixin,
     TrainerDataLoadingMixin,
 ):
+    @overwrite_by_env_vars
     def __init__(
         self,
         logger: Union[LightningLoggerBase, Iterable[LightningLoggerBase], bool] = True,

--- a/pytorch_lightning/utilities/argparse_utils.py
+++ b/pytorch_lightning/utilities/argparse_utils.py
@@ -84,7 +84,7 @@ def parse_env_variables(cls, template: str = "PL_%(cls_name)s_%(cls_argument)s")
     cls_arg_defaults = get_init_arguments_and_types(cls)
 
     env_args = {}
-    for arg_name, arg_type, arg_val in cls_arg_defaults:
+    for arg_name, _, _ in cls_arg_defaults:
         env = template % {'cls_name': cls.__name__.upper(), 'cls_argument': arg_name.upper()}
         val = os.environ.get(env)
         if not (val is None or val == ''):

--- a/pytorch_lightning/utilities/argparse_utils.py
+++ b/pytorch_lightning/utilities/argparse_utils.py
@@ -79,6 +79,7 @@ def parse_env_variables(cls, template: str = "PL_%(cls_name)s_%(cls_argument)s")
         >>> os.environ["PL_TRAINER_BLABLABLA"] = '1.23'
         >>> parse_env_variables(Trainer)
         Namespace(gpus=42)
+        >>> del os.environ["PL_TRAINER_GPUS"]
     """
     cls_arg_defaults = get_init_arguments_and_types(cls)
 
@@ -86,7 +87,7 @@ def parse_env_variables(cls, template: str = "PL_%(cls_name)s_%(cls_argument)s")
     for arg_name, arg_type, arg_val in cls_arg_defaults:
         env = template % {'cls_name': cls.__name__.upper(), 'cls_argument': arg_name.upper()}
         val = os.environ.get(env)
-        if val is not None:
+        if not (val is None or val == ''):
             try:  # converting to native types like int/float/bool
                 val = eval(val)
             except Exception:

--- a/pytorch_lightning/utilities/argparse_utils.py
+++ b/pytorch_lightning/utilities/argparse_utils.py
@@ -25,12 +25,11 @@ def from_argparse_args(cls, args: Union[Namespace, ArgumentParser], **kwargs):
         >>> trainer = Trainer.from_argparse_args(args, logger=False)
     """
     # fist check if any args are defined in environment for the class and set as default
-    params = vars(parse_env_variables(cls))
 
     if isinstance(args, ArgumentParser):
         args = cls.parse_argparser(args)
     # if other arg passed,  update parameters
-    params.update(vars(args))
+    params = vars(args)
 
     # we only want to pass in valid Trainer args, the rest may be user specific
     valid_kwargs = inspect.signature(cls.__init__).parameters

--- a/tests/trainer/flags/test_env_vars.py
+++ b/tests/trainer/flags/test_env_vars.py
@@ -1,0 +1,28 @@
+import os
+
+from pytorch_lightning import Trainer
+
+
+def test_passing_env_variables(tmpdir):
+    """Testing overwriting trainer arguments """
+    trainer = Trainer()
+    assert trainer.logger is not None
+    assert trainer.max_steps is None
+    trainer = Trainer(False, max_steps=42)
+    assert trainer.logger is None
+    assert trainer.max_steps == 42
+
+    os.environ['PL_TRAINER_LOGGER'] = 'False'
+    os.environ['PL_TRAINER_MAX_STEPS'] = '7'
+    trainer = Trainer()
+    assert trainer.logger is None
+    assert trainer.max_steps == 7
+
+    os.environ['PL_TRAINER_LOGGER'] = 'True'
+    trainer = Trainer(False, max_steps=42)
+    assert trainer.logger is not None
+    assert trainer.max_steps == 7
+
+    # this has to be cleaned
+    del os.environ['PL_TRAINER_LOGGER']
+    del os.environ['PL_TRAINER_MAX_STEPS']


### PR DESCRIPTION
## What does this PR do?

allow passing some arguments in env si they do not need to be defined again and again

Note: there is no other easy way as we pretty much need all arguments and then kind of return all 40 back
also, we cannot do the assignment with connector without rewriting all connectors as you need to pass `self.my_atribute`

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
