### PR TITLE
Removed broken Module Index link

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -130,5 +130,4 @@ Indices and tables
 ------------------
 
 * :ref:`genindex`
-* :ref:`modindex`
 * :ref:`search`


### PR DESCRIPTION
## What does this PR do?

Fixes #4011

The module index link at the bottom of the main page of the docs is broken. This PR simply removes the link.

An alternative is to leave the link up and attempt to fix it. After a little bit of digging, it seems the link only broke recently. If I had to hazard a guess, the removal of the use of `apidoc` in #3908 could be related as I can build the docs locally with a working link from commits before the removal - however, this could also be a coincidence.

Afraid I am not familiar enough with Sphinx to narrow down the issue more.

Also, as a side note - the link for the search page underneath the Module Index link (see #4011) currently leads to an empty page - so could be removed as well.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
