### PR TITLE
Minor fix to example in docstring of lr_finder

### DIFF
--- a/pytorch_lightning/tuner/lr_finder.py
+++ b/pytorch_lightning/tuner/lr_finder.py
@@ -116,7 +116,7 @@ def lr_find(
         trainer = pl.Trainer()
 
         # Run lr finder
-        lr_finder = trainer.lr_find(model, ...)
+        lr_finder = trainer.tuner.lr_find(model, ...)
 
         # Inspect results
         fig = lr_finder.plot(); fig.show()


### PR DESCRIPTION
## What does this PR do?

Corrects example in docstring of `lr_find` from `trainer.lr_find(...)` to `trainer.tuner.lr_find(...)`

Fixes #4103 

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
