### PR TITLE
Fix AttributeError when using multiple dataloaders

### DIFF
--- a/pytorch_lightning/trainer/connectors/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector.py
@@ -202,11 +202,11 @@ class LoggerConnector:
             self.log_metrics(metrics_to_log, {}, step=self.trainer.global_step)
 
     def __rename_keys_by_dataloader_idx(self, metrics, dataloader_idx, num_loaders):
-        if num_loaders == 1:
-            return metrics
-
-        result = {f'{k}/dataloader_idx_{dataloader_idx}': v for k, v in metrics.items()}
-        return result
+        if num_loaders != 1:
+            for k in metrics:
+                v = metrics.pop(k)
+                metrics[f'{k}/dataloader_idx_{dataloader_idx}'] = v
+        return metrics
 
     def _track_callback_metrics(self, eval_results, using_eval_result):
         if (


### PR DESCRIPTION
See #3994

<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?

 In `LoggerConnector._log_on_evaluation_epoch_end_metrics`, [there's a step](https://github.com/PyTorchLightning/pytorch-lightning/blob/0474464c454a000e4cacfe188c86a0b8317288d5/pytorch_lightning/trainer/connectors/logger_connector.py#L180) that [renames results keys by data loader index](https://github.com/PyTorchLightning/pytorch-lightning/blob/0474464c454a000e4cacfe188c86a0b8317288d5/pytorch_lightning/trainer/connectors/logger_connector.py#L204) if there are multiple data loaders. It takes a `Result`, but if there are multiple data loaders, it returns a plain old `dict`. When this dict comes back, it tries to call `.get_epoch_log_metrics()` and `.get_epoch_pbar_metrics()`, which are `Results ` methods.

Fixes #3994 

# Before submitting

I did none of these things:

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Weeeeeeeeeeeeeeeeeee!!!!!!!!!!!!!!!!
