### PR TITLE
Add trace functionality to the function to_torchscript

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1582,7 +1582,7 @@ class LightningModule(
                     example_inputs = self.example_input_array
                 # automatically send example inputs to the right device and use trace
                 torchscript_module = torch.jit.trace(func=self.eval(), example_inputs=example_inputs.to(self.device),
-                                                  **kwargs)
+                                                     **kwargs)
             else:
                 raise ValueError(f"The 'method' parameter only supports 'script' or 'trace', but value given was:"
                                  f"{method}")

--- a/tests/models/test_torchscript.py
+++ b/tests/models/test_torchscript.py
@@ -45,7 +45,7 @@ def test_torchscript_input_output(modelclass):
 def test_torchscript_input_output_trace(modelclass):
     """ Test that traced LightningModule forward works. """
     model = modelclass()
-    script = model.to_torchscript(mode='trace')
+    script = model.to_torchscript(method='trace')
     assert isinstance(script, torch.jit.ScriptModule)
     model.eval()
     model_output = model(model.example_input_array)

--- a/tests/models/test_torchscript.py
+++ b/tests/models/test_torchscript.py
@@ -37,6 +37,22 @@ def test_torchscript_input_output(modelclass):
     assert torch.allclose(script_output, model_output)
 
 
+@pytest.mark.parametrize("modelclass", [
+    EvalModelTemplate,
+    ParityModuleRNN,
+    BasicGAN,
+])
+def test_torchscript_input_output_trace(modelclass):
+    """ Test that traced LightningModule forward works. """
+    model = modelclass()
+    script = model.to_torchscript(mode='trace')
+    assert isinstance(script, torch.jit.ScriptModule)
+    model.eval()
+    model_output = model(model.example_input_array)
+    script_output = script(model.example_input_array)
+    assert torch.allclose(script_output, model_output)
+
+
 @pytest.mark.parametrize("device", [
     torch.device("cpu"),
     torch.device("cuda", 0)


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?
Add the ability to also choose to make use of TorchScript's `trace()` method, besides the default `script()`

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->
- (method) Adds the parameters `method` and `example_inputs` to support both modes. See the Issue for the rational. Default values assure that with no arguments provided, the original behaviour is kept.
- (docs) Rewrites function description to match the extended capability
- (tests) Adds a test case for the `trace()` function

Fixes # (issue): https://github.com/PyTorchLightning/pytorch-lightning/issues/4140

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Yes :)

## Notes
- The documentation does not state how to run the tests locally. I did however test the new functionality in my own project.
- The CHANGELOG did not have an entry yet for v1.1, so to prevent conflicts, I have not updated this yet.