### PR TITLE
save initial arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `hparams` saving - save the state when `save_hyperparameters()` is called [in `__init__`] ([#4163](https://github.com/PyTorchLightning/pytorch-lightning/pull/4163))
+
 
 
 ## [1.0.1] - 2020-10-14

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1599,13 +1599,13 @@ class LightningModule(
         return torchscript_module
 
     @property
-    def hparams(self) -> Union[AttributeDict, str]:
+    def hparams(self) -> Union[AttributeDict, dict, Namespace]:
         if not hasattr(self, "_hparams"):
             self._hparams = AttributeDict()
         return self._hparams
 
     @property
-    def hparams_initial(self) -> Union[AttributeDict, str]:
+    def hparams_initial(self) -> AttributeDict:
         if not hasattr(self, "_hparams_initial"):
             self._hparams_initial = AttributeDict()
         return self._hparams_initial

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1608,7 +1608,8 @@ class LightningModule(
     def hparams_initial(self) -> AttributeDict:
         if not hasattr(self, "_hparams_initial"):
             self._hparams_initial = AttributeDict()
-        return self._hparams_initial
+        # prevent any change
+        return copy.deepcopy(self._hparams_initial)
 
     @hparams.setter
     def hparams(self, hp: Union[dict, Namespace, Any]):

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import collections
+import copy
 import inspect
 import os
 import re
@@ -1448,9 +1449,11 @@ class LightningModule(
         init_args = get_init_args(frame)
         assert init_args, "failed to inspect the self init"
         if not args:
+            # take all arguments
             hp = init_args
             self._hparams_name = "kwargs" if hp else None
         else:
+            # take only listed arguments in `save_hparams`
             isx_non_str = [i for i, arg in enumerate(args) if not isinstance(arg, str)]
             if len(isx_non_str) == 1:
                 hp = args[isx_non_str[0]]
@@ -1463,6 +1466,8 @@ class LightningModule(
         # `hparams` are expected here
         if hp:
             self._set_hparams(hp)
+        # make deep copy so  there is not other runtime changes reflected
+        self._hparams_initial = copy.deepcopy(self._hparams)
 
     def _set_hparams(self, hp: Union[dict, Namespace, str]) -> None:
         if isinstance(hp, Namespace):
@@ -1598,6 +1603,12 @@ class LightningModule(
         if not hasattr(self, "_hparams"):
             self._hparams = AttributeDict()
         return self._hparams
+
+    @property
+    def hparams_initial(self) -> Union[AttributeDict, str]:
+        if not hasattr(self, "_hparams_initial"):
+            self._hparams_initial = AttributeDict()
+        return self._hparams_initial
 
     @hparams.setter
     def hparams(self, hp: Union[dict, Namespace, Any]):

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -129,7 +129,7 @@ class TrainLoop:
         # log hyper-parameters
         if self.trainer.logger is not None:
             # save exp to get started (this is where the first experiment logs are written)
-            self.trainer.logger.log_hyperparams(ref_model.hparams)
+            self.trainer.logger.log_hyperparams(ref_model.hparams_initial)
             self.trainer.logger.log_graph(ref_model)
             self.trainer.logger.save()
 


### PR DESCRIPTION
## What does this PR do?

the case is that some arguments can be DataModules which have in runtime assigned Trainer instance, that yield to saving error, but this instance is not needed for model reconstruction, so we save as `hpramas` only values from the init time, namely when the `save_hyperparameters` is called

Otherwise, the `save_hyperparameters` shall be renamed to `register_hyperparameters_for_saving`

Preventing #4156

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
