### PR TITLE
remove duplicate metric vs step log for train loop

### DIFF
--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -477,13 +477,18 @@ class TrainLoop:
     def log_training_step_metrics(self, opt_closure_result, batch_callback_metrics, batch_log_metrics):
         # track callback metrics
         callback_metrics = opt_closure_result.training_step_output.callback_metrics
-        batch_callback_metrics.append(callback_metrics)
 
         # decide which metrics to log (results vs dict return)
         using_results_obj = isinstance(opt_closure_result.training_step_output, Result)
         if using_results_obj:
-            metrics_to_log = opt_closure_result.training_step_output.batch_log_metrics
-            step_pbar_metrics = opt_closure_result.training_step_output.batch_pbar_metrics
+            metrics_to_log = opt_closure_result.training_step_output.get_batch_log_metrics(
+                include_forked_originals=False
+            )
+            step_pbar_metrics = opt_closure_result.training_step_output.get_batch_pbar_metrics(
+                include_forked_originals=False
+            )
+            forked_metrics = opt_closure_result.training_step_output.get_forked_metrics()
+            callback_metrics.update(forked_metrics)
         else:
             metrics_to_log = opt_closure_result.training_step_output.log_metrics
             step_pbar_metrics = opt_closure_result.training_step_output.pbar_on_batch_end
@@ -495,6 +500,8 @@ class TrainLoop:
         if len(step_pbar_metrics) > 0:
             self.trainer.logger_connector.add_progress_bar_metrics(step_pbar_metrics)
             self.trainer.logger_connector.callback_metrics.update(step_pbar_metrics)
+
+        batch_callback_metrics.append(callback_metrics)
 
     def process_hiddens(self, opt_closure_result):
         hiddens = opt_closure_result.hiddens

--- a/tests/trainer/logging/test_eval_loop_logging_1_0.py
+++ b/tests/trainer/logging/test_eval_loop_logging_1_0.py
@@ -64,7 +64,6 @@ def test__validation_step__log(tmpdir):
 
     # make sure all the metrics are available for callbacks
     expected_logged_metrics = {
-        'a',
         'a2',
         'a_step',
         'a_epoch',
@@ -137,7 +136,6 @@ def test__validation_step__step_end__epoch_end__log(tmpdir):
     expected_logged_metrics = {
         'epoch',
         'a',
-        'b',
         'b_step',
         'b_epoch',
         'c',

--- a/tests/trainer/logging/test_train_loop_logging_1_0.py
+++ b/tests/trainer/logging/test_train_loop_logging_1_0.py
@@ -19,7 +19,7 @@ import os
 import torch
 import pytest
 
-from pytorch_lightning import Trainer
+from pytorch_lightning import Trainer, callbacks
 from tests.base.deterministic_model import DeterministicModel
 from torch.utils.data import Dataset
 
@@ -80,6 +80,7 @@ def test__training_step__log(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         weights_summary=None,
+        checkpoint_callback=callbacks.ModelCheckpoint(monitor='l_se')
     )
     trainer.fit(model)
 
@@ -95,7 +96,6 @@ def test__training_step__log(tmpdir):
         'default',
         'l_e',
         'l_s',
-        'l_se',
         'l_se_step',
         'l_se_epoch',
     }
@@ -105,7 +105,6 @@ def test__training_step__log(tmpdir):
     expected_pbar_metrics = {
         'p_e',
         'p_s',
-        'p_se',
         'p_se_step',
         'p_se_epoch',
     }
@@ -116,6 +115,7 @@ def test__training_step__log(tmpdir):
     expected_callback_metrics = set()
     expected_callback_metrics = expected_callback_metrics.union(logged_metrics)
     expected_callback_metrics = expected_callback_metrics.union(pbar_metrics)
+    expected_callback_metrics.update({'p_se', 'l_se'})
     expected_callback_metrics.remove('epoch')
     assert callback_metrics == expected_callback_metrics
 

--- a/tests/trainer/logging/test_train_loop_logging_1_0.py
+++ b/tests/trainer/logging/test_train_loop_logging_1_0.py
@@ -163,7 +163,7 @@ def test__training_step__epoch_end__log(tmpdir):
 
     # make sure all the metrics are available for callbacks
     logged_metrics = set(trainer.logged_metrics.keys())
-    expected_logged_metrics = {'epoch', 'a', 'a_step', 'a_epoch', 'b', 'b1', 'a1', 'a2'}
+    expected_logged_metrics = {'epoch', 'a_step', 'a_epoch', 'b', 'b1', 'a1', 'a2'}
     assert logged_metrics == expected_logged_metrics
 
     pbar_metrics = set(trainer.progress_bar_metrics.keys())
@@ -178,6 +178,7 @@ def test__training_step__epoch_end__log(tmpdir):
     expected_callback_metrics = expected_callback_metrics.union(logged_metrics)
     expected_callback_metrics = expected_callback_metrics.union(pbar_metrics)
     expected_callback_metrics.remove('epoch')
+    expected_callback_metrics.add('a')
     assert callback_metrics == expected_callback_metrics
 
 
@@ -226,8 +227,8 @@ def test__training_step__step_end__epoch_end__log(tmpdir, batches, log_interval,
     # make sure all the metrics are available for callbacks
     logged_metrics = set(trainer.logged_metrics.keys())
     expected_logged_metrics = {
-        'a', 'a_step', 'a_epoch',
-        'b', 'b_step', 'b_epoch',
+        'a_step', 'a_epoch',
+        'b_step', 'b_epoch',
         'c',
         'd/e/f',
         'epoch'
@@ -235,7 +236,7 @@ def test__training_step__step_end__epoch_end__log(tmpdir, batches, log_interval,
     assert logged_metrics == expected_logged_metrics
 
     pbar_metrics = set(trainer.progress_bar_metrics.keys())
-    expected_pbar_metrics = {'b', 'c', 'b_epoch', 'b_step'}
+    expected_pbar_metrics = {'c', 'b_epoch', 'b_step'}
     assert pbar_metrics == expected_pbar_metrics
 
     callback_metrics = set(trainer.callback_metrics.keys())
@@ -243,6 +244,7 @@ def test__training_step__step_end__epoch_end__log(tmpdir, batches, log_interval,
     expected_callback_metrics = set()
     expected_callback_metrics = expected_callback_metrics.union(logged_metrics)
     expected_callback_metrics = expected_callback_metrics.union(pbar_metrics)
+    expected_callback_metrics.update({'a', 'b'})
     expected_callback_metrics.remove('epoch')
     assert callback_metrics == expected_callback_metrics
 
@@ -355,7 +357,7 @@ def test_tbptt_log(tmpdir):
     trainer.fit(model)
 
     generated = set(trainer.logged_metrics.keys())
-    expected = {'a', 'a_step', 'a_epoch', 'epoch'}
+    expected = {'a_step', 'a_epoch', 'epoch'}
     assert generated == expected
 
 

--- a/tests/trainer/optimization/test_manual_optimization.py
+++ b/tests/trainer/optimization/test_manual_optimization.py
@@ -213,7 +213,7 @@ def test_multiple_optimizers_manual_return_and_log(tmpdir):
     num_manual_backward_calls = 3
     assert trainer.dev_debugger.count_events('backward_call') == limit_train_batches * num_manual_backward_calls
 
-    expected = {'a', 'a_step', 'a_epoch', 'epoch'}
+    expected = {'a_step', 'a_epoch', 'epoch'}
     logged = set(trainer.logged_metrics.keys())
     assert expected == logged
 


### PR DESCRIPTION
remove duplicate metric vs step log.

cc @tchaton 

![image](https://user-images.githubusercontent.com/3640001/96134294-3aa46600-0ec9-11eb-90b6-2e422a182409.png)
