### PR TITLE
docs: use `Args` instead of `Params`

### DIFF
--- a/pytorch_lightning/profiler/profilers.py
+++ b/pytorch_lightning/profiler/profilers.py
@@ -33,8 +33,8 @@ class BaseProfiler(ABC):
 
     def __init__(self, output_streams: list = None):
         """
-        Params:
-            stream_out: callable
+        Args:
+            output_streams: callable
         """
         if output_streams:
             if not isinstance(output_streams, (list, tuple)):
@@ -119,7 +119,7 @@ class SimpleProfiler(BaseProfiler):
 
     def __init__(self, output_filename: str = None):
         """
-        Params:
+        Args:
             output_filename (str): optionally save profile results to file instead of printing
                 to std out when training is finished.
         """


### PR DESCRIPTION
## What does this PR do?
Fixes docs by using `Args:` instead of `Params:`. Also fixes a typo.

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
