### PR TITLE
fix hparams assign in init

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1608,7 +1608,7 @@ class LightningModule(
     @property
     def hparams_initial(self) -> AttributeDict:
         if not hasattr(self, "_hparams_initial"):
-            self._hparams_initial = AttributeDict()
+            return AttributeDict()
         # prevent any change
         return copy.deepcopy(self._hparams_initial)
 
@@ -1617,6 +1617,9 @@ class LightningModule(
         hparams_assignment_name = self.__get_hparams_assignment_variable()
         self._hparams_name = hparams_assignment_name
         self._set_hparams(hp)
+        # this resolves case when user does not uses `save_hyperparameters` and do hard assignement in init
+        if not hasattr(self, "_hparams_initial"):
+            self._hparams_initial = copy.deepcopy(self._hparams)
 
     def __get_hparams_assignment_variable(self):
         """"""


### PR DESCRIPTION
## What does this PR do?

adding saving `hparams` even without using `save_hyperparameters` just with hard assign in class init (any fist init...)

Fixes #4179 
Fixes #4186 

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
