### PR TITLE
Annotate return type of TrainerProperties.from_argparse_args(...)

### DIFF
--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -118,7 +118,7 @@ class TrainerProperties(ABC):
         return depr_arg_names
 
     @classmethod
-    def from_argparse_args(cls: Type['T'], args: Union[Namespace, ArgumentParser], **kwargs) -> 'T':
+    def from_argparse_args(cls: Type['_T'], args: Union[Namespace, ArgumentParser], **kwargs) -> '_T':
         return argparse_utils.from_argparse_args(cls, args, **kwargs)
 
     @classmethod
@@ -194,4 +194,4 @@ class TrainerProperties(ABC):
 
 
 # Used to represent the concrete type TrainerProperties class methods are called on.
-_T = TypeVar('T', bound=TrainerProperties)
+_T = TypeVar('_T', bound=TrainerProperties)

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -14,7 +14,7 @@
 from pytorch_lightning.utilities.cloud_io import get_filesystem
 from pytorch_lightning.trainer.connectors.logger_connector import LoggerConnector
 from pytorch_lightning.trainer.states import TrainerState
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Type, TypeVar
 from pytorch_lightning.utilities import argparse_utils
 from argparse import ArgumentParser, Namespace
 from abc import ABC
@@ -118,7 +118,7 @@ class TrainerProperties(ABC):
         return depr_arg_names
 
     @classmethod
-    def from_argparse_args(cls, args: Union[Namespace, ArgumentParser], **kwargs):
+    def from_argparse_args(cls: Type['T'], args: Union[Namespace, ArgumentParser], **kwargs) -> 'T':
         return argparse_utils.from_argparse_args(cls, args, **kwargs)
 
     @classmethod
@@ -191,3 +191,6 @@ class TrainerProperties(ABC):
 
     def get_model(self):
         return self.model_connector.get_model()
+
+# Used to represent the concrete type TrainerProperties class methods are called on.
+_T = TypeVar('T', bound=TrainerProperties)

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -192,5 +192,6 @@ class TrainerProperties(ABC):
     def get_model(self):
         return self.model_connector.get_model()
 
+
 # Used to represent the concrete type TrainerProperties class methods are called on.
 _T = TypeVar('T', bound=TrainerProperties)


### PR DESCRIPTION
## What does this PR do?

Adds the return type annotation for the `TrainerProperties.from_argparse_args(...)` method.

Currently no annotation is present for the return type of `TrainerProperties.from_argparse_args`. This results in suboptimal developer experience when using it:
```python
trainer = Trainer.from_argparse_args(args)

# trainer's type is inferred to be Any, which means that IDEs cannot autocomplete 
# or show documentation for its methods.
trainer.fit(model)
```

## Alternatives
Instead of using the type variable, an alternative would be to directly annotate `from_argparse_args` as returning an instance of `Trainer`, since it's the only class that inherits from `TrainerProperties`. I went with the type variable because it looked like a more general solution to me, for little additional complexity.

<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
