### PR TITLE
Add persistent flag to Metric.add_state

### DIFF
--- a/pytorch_lightning/metrics/metric.py
+++ b/pytorch_lightning/metrics/metric.py
@@ -78,7 +78,7 @@ class Metric(nn.Module, ABC):
         self._reductions = {}
         self._defaults = {}
 
-    def add_state(self, name: str, default, dist_reduce_fx: Optional[Union[str, Callable]] = None):
+    def add_state(self, name: str, default, dist_reduce_fx: Optional[Union[str, Callable]] = None, persistent: bool = True):
         """
         Adds metric state variable. Only used by subclasses.
 
@@ -90,6 +90,7 @@ class Metric(nn.Module, ABC):
                 If value is ``"sum"``, ``"mean"``, or ``"cat"``, we will use ``torch.sum``, ``torch.mean``,
                 and ``torch.cat`` respectively, each with argument ``dim=0``. The user can also pass a custom
                 function in this parameter.
+            persistent (Optional): whether the state will be saved as part of the modules ``state_dict``.
 
         Note:
             Setting ``dist_reduce_fx`` to None will return the metric state synchronized across different processes.
@@ -130,7 +131,7 @@ class Metric(nn.Module, ABC):
             )
 
         if isinstance(default, torch.Tensor):
-            self.register_buffer(name, default)
+            self.register_buffer(name, default, persistent=persistent)
         else:
             setattr(self, name, default)
 

--- a/pytorch_lightning/metrics/metric.py
+++ b/pytorch_lightning/metrics/metric.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Optional, Union
 from collections.abc import Mapping, Sequence
 from collections import namedtuple
 from copy import deepcopy
+from distutils.version import LooseVersion
 
 import os
 import torch
@@ -133,10 +134,10 @@ class Metric(nn.Module, ABC):
             )
 
         if isinstance(default, torch.Tensor):
-            try:
+            if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
                 # persistent keyword is only supported in torch >= 1.6.0
                 self.register_buffer(name, default, persistent=persistent)
-            except TypeError:
+            else:
                 self.register_buffer(name, default)
         else:
             setattr(self, name, default)

--- a/pytorch_lightning/metrics/metric.py
+++ b/pytorch_lightning/metrics/metric.py
@@ -78,7 +78,9 @@ class Metric(nn.Module, ABC):
         self._reductions = {}
         self._defaults = {}
 
-    def add_state(self, name: str, default, dist_reduce_fx: Optional[Union[str, Callable]] = None, persistent: bool = True):
+    def add_state(
+        self, name: str, default, dist_reduce_fx: Optional[Union[str, Callable]] = None, persistent: bool = True
+    ):
         """
         Adds metric state variable. Only used by subclasses.
 

--- a/pytorch_lightning/metrics/metric.py
+++ b/pytorch_lightning/metrics/metric.py
@@ -131,7 +131,11 @@ class Metric(nn.Module, ABC):
             )
 
         if isinstance(default, torch.Tensor):
-            self.register_buffer(name, default, persistent=persistent)
+            try:
+                # persistent keyword is only supported in torch >= 1.6.0
+                self.register_buffer(name, default, persistent=persistent)
+            except TypeError:
+                self.register_buffer(name, default)
         else:
             setattr(self, name, default)
 

--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -1,5 +1,6 @@
 import pickle
 
+from distutils.version import LooseVersion
 import cloudpickle
 import numpy as np
 import pytest
@@ -57,6 +58,19 @@ def test_add_state():
 
     a.add_state("e", torch.tensor(0), custom_fx)
     assert a._reductions["e"](torch.tensor([1, 1])) == -1
+
+
+def test_add_state_persistent():
+    a = Dummy()
+
+    a.add_state("a", torch.tensor(0), "sum", persistent=True)
+    assert "a" in a.state_dict()
+
+    a.add_state("b", torch.tensor(0), "sum", persistent=False)
+
+    if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
+        assert not "b" in a.state_dict()
+
 
 
 def test_reset():

--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -69,7 +69,7 @@ def test_add_state_persistent():
     a.add_state("b", torch.tensor(0), "sum", persistent=False)
 
     if LooseVersion(torch.__version__) >= LooseVersion("1.6.0"):
-        assert not "b" in a.state_dict()
+        assert "b" not in a.state_dict()
 
 
 


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?

Adds `persistent` flag to Metrics, to allow the user to disable state being
added to the `state_dict`.

