### PR TITLE
Add load_from_checkpoint function to Loading docs

### DIFF
--- a/docs/source/weights_loading.rst
+++ b/docs/source/weights_loading.rst
@@ -176,7 +176,7 @@ you can restore the model like this
     # uses in_dim=128, out_dim=10
     model = LitModel.load_from_checkpoint(PATH, in_dim=128, out_dim=10)
 
-.. autofunction:: pytorch_lightning.core.lightning.LightningModule.load_from_checkpoint
+.. automethod:: pytorch_lightning.core.lightning.LightningModule.load_from_checkpoint
    :noindex:
 
 Restoring Training State

--- a/docs/source/weights_loading.rst
+++ b/docs/source/weights_loading.rst
@@ -176,6 +176,8 @@ you can restore the model like this
     # uses in_dim=128, out_dim=10
     model = LitModel.load_from_checkpoint(PATH, in_dim=128, out_dim=10)
 
+.. autofunction:: pytorch_lightning.core.lightning.LightningModule.load_from_checkpoint
+   :noindex:
 
 Restoring Training State
 ========================


### PR DESCRIPTION
<!--
Please note that we have freeze state on adding new features till v1.0 release.
Anyway, any new feature suggestion is welcome and you are free to draft a PR,
 but be aware that several refactoring will take place for this major release yielding in significant collision solving.
A recommendation for feature draft is draw just outline, do not implement all details and propagate the changes to codebase...
-->

## What does this PR do?

Adds auto-doc of `LightningModule.load_from_checkpoint` function to the Saving
and Loading page. Now it is unclear what parameters this function takes.

![Screen Shot 2020-10-16 at 11 30 03 AM](https://user-images.githubusercontent.com/11153048/96278071-0bfabe00-0fa3-11eb-8fbe-069d1feff44e.png)

