### PR TITLE
Use checkpoint_connector.hpc_save in SLURMConnector

### DIFF
--- a/pytorch_lightning/trainer/connectors/slurm_connector.py
+++ b/pytorch_lightning/trainer/connectors/slurm_connector.py
@@ -85,7 +85,7 @@ class SLURMConnector:
         if self.trainer.is_global_zero:
             # save weights
             log.info('handling SIGUSR1')
-            self.trainer.hpc_save(self.trainer.weights_save_path, self.trainer.logger)
+            self.trainer.checkpoint_connector.hpc_save(self.trainer.weights_save_path, self.trainer.logger)
 
             # find job id
             job_id = os.environ['SLURM_JOB_ID']


### PR DESCRIPTION
## What does this PR do?

Fixes #4208. Simply change `SLURMConnector` to use `trainer.checkpoint_connector.hpc_save` instead of `trainer.hpc_save`.

Note that I have not tested this as I don't have access to a SLURM cluster at the moment.


# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
