### PR TITLE
allow codecov upload to fail

### DIFF
--- a/.github/workflows/ci_test-base.yml
+++ b/.github/workflows/ci_test-base.yml
@@ -88,6 +88,8 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       if: always()
+      # see: https://github.com/actions/toolkit/issues/399
+      continue-on-error: true
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: coverage.xml

--- a/.github/workflows/ci_test-full.yml
+++ b/.github/workflows/ci_test-full.yml
@@ -138,6 +138,8 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       if: always()
+      # see: https://github.com/actions/toolkit/issues/399
+      continue-on-error: true
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: coverage.xml

--- a/.github/workflows/ci_test-tpu.yml
+++ b/.github/workflows/ci_test-tpu.yml
@@ -126,6 +126,8 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
+      # see: https://github.com/actions/toolkit/issues/399
+      continue-on-error: true
       if: always()
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

many times just failing report upload fails the whole job...
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
