### PR TITLE
update examples

### DIFF
--- a/pl_examples/domain_templates/generative_adversarial_net.py
+++ b/pl_examples/domain_templates/generative_adversarial_net.py
@@ -98,7 +98,8 @@ class GAN(LightningModule):
     def forward(self, z):
         return self.generator(z)
 
-    def adversarial_loss(self, y_hat, y):
+    @staticmethod
+    def adversarial_loss(y_hat, y):
         return F.binary_cross_entropy(y_hat, y)
 
     def training_step(self, batch, batch_idx, optimizer_idx):
@@ -110,15 +111,6 @@ class GAN(LightningModule):
 
         # train generator
         if optimizer_idx == 0:
-
-            # generate images
-            self.generated_imgs = self(z)
-
-            # log sampled images
-            sample_imgs = self.generated_imgs[:6]
-            grid = torchvision.utils.make_grid(sample_imgs)
-            self.logger.experiment.add_image('generated_images', grid, 0)
-
             # ground truth result (ie: all fake)
             # put on GPU because we created this tensor inside training_loop
             valid = torch.ones(imgs.size(0), 1)

--- a/pl_examples/domain_templates/generative_adversarial_net.py
+++ b/pl_examples/domain_templates/generative_adversarial_net.py
@@ -194,9 +194,6 @@ def main(args: Namespace) -> None:
 
 
 if __name__ == '__main__':
-    # ------------------------
-    # 0 PARSE COMMAND LINE ARGUMENTS
-    # ------------------------
     parser = ArgumentParser()
 
     # Add pogram level args, if any.

--- a/pl_examples/domain_templates/generative_adversarial_net.py
+++ b/pl_examples/domain_templates/generative_adversarial_net.py
@@ -213,7 +213,7 @@ def main(args: Namespace) -> None:
 if __name__ == '__main__':
     parser = ArgumentParser()
 
-    # Add pogram level args, if any.
+    # Add program level args, if any.
     # ------------------------
     # Add LightningDataLoader args
     parser = MNISTDataModule.add_argparse_args(parser)


### PR DESCRIPTION
Using `ArgumentParser` and `hparams` as defined in the [Hyperparameters](https://pytorch-lightning.readthedocs.io/en/stable/hyperparameters.html) section of
the documentation. This way we can set trainer flags (such as `precision`,
and `gpus`) from the command line. This also enables tensorboard to log hyperparameters for each experiment.