### PR TITLE
Added the function for downloading the badges locally and replace the url with downlaod path

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -42,6 +42,7 @@ exclude tests
 recursive-exclude docs *
 exclude docs
 recursive-include docs/source/_images/logos/ *
+recursive-include docs/source/_images/badges/ *
 recursive-include docs/source/_images/general/ pl_overview* tf_* tutorial_* PTL101_*
 
 # Include the Requirements

--- a/pytorch_lightning/__init__.py
+++ b/pytorch_lightning/__init__.py
@@ -34,10 +34,14 @@ Documentation
 """
 
 import logging as python_logging
+import os
 
 _logger = python_logging.getLogger("lightning")
 _logger.addHandler(python_logging.StreamHandler())
 _logger.setLevel(python_logging.INFO)
+
+PACKAGE_ROOT = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.dirname(PACKAGE_ROOT)
 
 try:
     # This variable is injected in the __builtins__ by the build

--- a/pytorch_lightning/__init__.py
+++ b/pytorch_lightning/__init__.py
@@ -72,12 +72,5 @@ else:
         'metrics',
     ]
 
-    # necessary for regular bolts imports. Skip exception since bolts is not always installed
-    try:
-        from pytorch_lightning import bolts
-    except ImportError:
-        pass
-    # __call__ = __all__
-
 # for compatibility with namespace packages
 __import__('pkg_resources').declare_namespace(__name__)

--- a/pytorch_lightning/setup_tools.py
+++ b/pytorch_lightning/setup_tools.py
@@ -41,7 +41,7 @@ def _load_requirements(path_dir, file_name='requirements.txt', comment_char='#')
     """Load requirements from a file
 
     >>> _load_requirements(PROJECT_ROOT)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-    ['numpy>=...', 'torch>=...', ...]
+    ['numpy...', 'torch...', ...]
     """
     with open(os.path.join(path_dir, file_name), 'r') as file:
         lines = [ln.strip() for ln in file.readlines()]

--- a/pytorch_lightning/setup_tools.py
+++ b/pytorch_lightning/setup_tools.py
@@ -15,8 +15,7 @@
 import os
 import re
 import warnings
-from urllib.error import HTTPError
-from urllib.error import URLError
+from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 from pytorch_lightning import __homepage__, __version__, PROJECT_ROOT

--- a/pytorch_lightning/setup_tools.py
+++ b/pytorch_lightning/setup_tools.py
@@ -22,7 +22,7 @@ import warnings
 
 from pytorch_lightning import __homepage__, __version__, PROJECT_ROOT
 
-_PATH_BADGES = os.path.join('.', 'docs', 'source', '_images', 'badges')
+_PATH_BADGES = os.path.join('utilities', 'docs', 'source', '_images', 'badges')
 # badge to download
 _DEFAULT_BADGES = [
     'PyPI - Python Version',
@@ -70,7 +70,7 @@ def _parse_for_badge(text: str, path_badges: str = _PATH_BADGES, badge_names: li
      [![PyPI - Python Version](./docs/source/_images/badges/PyPI_Python_Version_badge.png)](https://pypi.org/project/pytorch-lightning/)
      and another text later'
     >>> import shutil
-    >>> shutil.rmtree('./docs')
+    >>> shutil.rmtree(_PATH_BADGES)
     """
     for line in text.split(os.linesep):
         badge_name = re.search(r'\[!\[(.*?)]', line)
@@ -103,7 +103,7 @@ def _download_badge(url_badge, badge_name, target_dir):
     """Download badge from url
 
     >>> path_img = _download_badge('https://img.shields.io/pypi/pyversions/pytorch-lightning',
-    ...                            'PyPI - Python Version', '.')
+    ...                            'PyPI - Python Version', 'utilities')
     >>> os.path.isfile(path_img)
     True
     >>> path_img
@@ -159,7 +159,7 @@ def _load_long_description(path_dir):
     >>> _load_long_description(PROJECT_ROOT)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     '<div align="center">...'
     >>> import shutil
-    >>> shutil.rmtree('./docs')
+    >>> shutil.rmtree(_PATH_BADGES)
     """
     # https://github.com/PyTorchLightning/pytorch-lightning/raw/master/docs/source/_images/lightning_module/pt_to_pl.png
     url = os.path.join(__homepage__, 'raw', __version__, 'docs')

--- a/pytorch_lightning/setup_tools.py
+++ b/pytorch_lightning/setup_tools.py
@@ -18,7 +18,7 @@ import warnings
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-from pytorch_lightning import __homepage__, __version__, PROJECT_ROOT
+from pytorch_lightning import PROJECT_ROOT, __homepage__, __version__
 
 _PATH_BADGES = os.path.join('.', 'docs', 'source', '_images', 'badges')
 # badge to download

--- a/pytorch_lightning/setup_tools.py
+++ b/pytorch_lightning/setup_tools.py
@@ -65,7 +65,7 @@ def _parse_for_badge(text: str, path_badges: str = _PATH_BADGES, badge_names: li
     ...     '[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytorch-lightning)]'
     ...     '(https://pypi.org/project/pytorch-lightning/) and another text later')
     'Some text here...
-     [![PyPI - Python Version](./docs/source/_images/badges/PyPI_Python_Version_badge.png)](https://pypi.org/project/pytorch-lightning/)
+     [![PyPI - Python Version](...docs...source..._images...badges...PyPI_Python_Version_badge.png)](https://pypi.org/project/pytorch-lightning/)
      and another text later'
     >>> import shutil
     >>> shutil.rmtree(_PATH_BADGES)

--- a/pytorch_lightning/setup_tools.py
+++ b/pytorch_lightning/setup_tools.py
@@ -73,7 +73,7 @@ def _parse_for_badge(text: str, path_badges: str = _PATH_BADGES, badge_names: li
     >>> shutil.rmtree(_PATH_BADGES)
     """
     for line in text.split(os.linesep):
-        search_string = fr'\[\!\[(.*?)]\((.*?)\)]'
+        search_string = r'\[\!\[(.*?)]\((.*?)\)]'
         match = re.search(search_string, line)
         if match is None:
             continue

--- a/pytorch_lightning/setup_tools.py
+++ b/pytorch_lightning/setup_tools.py
@@ -14,11 +14,10 @@
 # limitations under the License.
 import os
 import re
-
-from urllib.error import URLError
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
 import warnings
+from urllib.error import HTTPError
+from urllib.error import URLError
+from urllib.request import Request, urlopen
 
 from pytorch_lightning import __homepage__, __version__, PROJECT_ROOT
 
@@ -73,7 +72,7 @@ def _parse_for_badge(text: str, path_badges: str = _PATH_BADGES, badge_names: li
     >>> shutil.rmtree(_PATH_BADGES)
     """
     for line in text.split(os.linesep):
-        search_string = r'\[\!\[(.*?)]\((.*?)\)]'
+        search_string = r'\[\!\[(.*)]\((.*)\)]'
         match = re.search(search_string, line)
         if match is None:
             continue
@@ -97,7 +96,7 @@ def _download_badge(url_badge, badge_name, target_dir):
     """Download badge from url
 
     >>> path_img = _download_badge('https://img.shields.io/pypi/pyversions/pytorch-lightning',
-    ...                            'PyPI - Python Version', 'utilities')
+    ...                            'PyPI - Python Version', '.')
     >>> os.path.isfile(path_img)
     True
     >>> path_img

--- a/pytorch_lightning/setup_tools.py
+++ b/pytorch_lightning/setup_tools.py
@@ -22,7 +22,7 @@ import warnings
 
 from pytorch_lightning import __homepage__, __version__, PROJECT_ROOT
 
-_PATH_BADGES = os.path.join('utilities', 'docs', 'source', '_images', 'badges')
+_PATH_BADGES = os.path.join('.', 'docs', 'source', '_images', 'badges')
 # badge to download
 _DEFAULT_BADGES = [
     'PyPI - Python Version',
@@ -73,28 +73,22 @@ def _parse_for_badge(text: str, path_badges: str = _PATH_BADGES, badge_names: li
     >>> shutil.rmtree(_PATH_BADGES)
     """
     for line in text.split(os.linesep):
-        badge_name = re.search(r'\[!\[(.*?)]', line)
+        search_string = fr'\[\!\[(.*?)]\((.*?)\)]'
+        match = re.search(search_string, line)
+        if match is None:
+            continue
 
-        # check for the badge name
-        if badge_name is not None:
-            badge_name = badge_name.group(1)
+        badge_name, badge_url = match.groups()
+        # check if valid name
+        if badge_name not in badge_names:
+            continue
 
-            # check if valid name
-            if badge_name not in badge_names:
-                continue
+        # download badge
+        saved_badge_name = _download_badge(badge_url, badge_name, path_badges)
 
-            search_string = fr'\[\!\[{badge_name}]\((.*?)\)]'
-            badge_url = re.search(search_string, line)
-            # check for badge url
-            if badge_url is not None:
-                badge_url = badge_url.group(1)
-
-            # download badge
-            saved_badge_name = _download_badge(badge_url, badge_name, path_badges)
-
-            # replace url with local file path
-            replace_string = f'[![{badge_name}]({saved_badge_name})]'
-            text = re.sub(search_string, replace_string, text)
+        # replace url with local file path
+        replace_string = f'[![{badge_name}]({saved_badge_name})]'
+        text = re.sub(search_string, replace_string, text)
 
     return text
 

--- a/pytorch_lightning/utilities/setup_tools.py
+++ b/pytorch_lightning/utilities/setup_tools.py
@@ -63,8 +63,12 @@ def _parse_for_badge(text, badge_names: list = _DEFAULT_BADGES):
     """
     Returns the new parsed text with url change with local downloaded files
 
-    >>> _parse_for_badge('[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytorch-lightning)](https://pypi.org/project/pytorch-lightning/)')
-    '[![PyPI - Python Version](docs/source/_images/badges/PyPI_Python_Version_badge.png)](https://pypi.org/project/pytorch-lightning/)'
+    >>> _parse_for_badge('Some text here... '  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    ... '[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytorch-lightning)]'
+    ... '(https://pypi.org/project/pytorch-lightning/)')
+    'Some text here...
+     [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytorch-lightning)]
+       (https://pypi.org/project/pytorch-lightning/)'
     """
     for line in text.split('\n'):
         badge_name = re.search(r'^\[!\[(.*?)]', line)
@@ -74,20 +78,21 @@ def _parse_for_badge(text, badge_names: list = _DEFAULT_BADGES):
             badge_name = badge_name.group(1)
 
             # check if valid name
-            if badge_name in badge_names:
+            if badge_name not in badge_names:
+                continue
 
-                search_string = fr'\[\!\[{badge_name}]\((.*?)\)]'
-                badge_url = re.search(search_string, line)
-                # check for badge url
-                if badge_url is not None:
-                    badge_url = badge_url.group(1)
+            search_string = fr'\[\!\[{badge_name}]\((.*?)\)]'
+            badge_url = re.search(search_string, line)
+            # check for badge url
+            if badge_url is not None:
+                badge_url = badge_url.group(1)
 
-                # download badge
-                saved_badge_name = _download_badges(badge_url, badge_name)
+            # download badge
+            saved_badge_name = _download_badges(badge_url, badge_name)
 
-                # replace url with local file path
-                replace_string = f'[![{badge_name}]({saved_badge_name})]'
-                text = re.sub(search_string, replace_string, text)
+            # replace url with local file path
+            replace_string = f'[![{badge_name}]({saved_badge_name})]'
+            text = re.sub(search_string, replace_string, text)
 
     return text
 
@@ -139,6 +144,11 @@ def _download_badges(url_badge, badge_name):
 
 
 def _load_long_description(path_dir):
+    """Load readme as decribtion
+
+    >>> _load_long_description(PROJECT_ROOT)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    '<div align="center">...'
+    """
     # https://github.com/PyTorchLightning/pytorch-lightning/raw/master/docs/source/_images/lightning_module/pt_to_pl.png
     url = os.path.join(__homepage__, 'raw', __version__, 'docs')
     path_readme = os.path.join(path_dir, 'README.md')

--- a/pytorch_lightning/utilities/setup_tools.py
+++ b/pytorch_lightning/utilities/setup_tools.py
@@ -60,6 +60,12 @@ def _load_requirements(path_dir, file_name='requirements.txt', comment_char='#')
 
 
 def _parse_for_badge(text, badge_names: list = _DEFAULT_BADGES):
+    """
+    Returns the new parsed text with url change with local downloaded files
+
+    >>> _parse_for_badge('[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytorch-lightning)](https://pypi.org/project/pytorch-lightning/)')
+    '[![PyPI - Python Version](docs/source/_images/badges/PyPI_Python_Version_badge.png)](https://pypi.org/project/pytorch-lightning/)'
+    """
     for line in text.split('\n'):
         badge_name = re.search(r'^\[!\[(.*?)]', line)
 
@@ -87,6 +93,10 @@ def _parse_for_badge(text, badge_names: list = _DEFAULT_BADGES):
 
 
 def _download_badges(url_badge, badge_name):
+    """
+    >>> _download_badges('https://img.shields.io/pypi/pyversions/pytorch-lightning', 'PyPI - Python Version')
+    'docs/source/_images/badges/PyPI_Python_Version_badge.png'
+    """
 
     base_path = 'docs/source/_images/badges'
     os.makedirs(base_path, exist_ok=True)
@@ -135,7 +145,7 @@ def _load_long_description(path_dir):
     text = open(path_readme, encoding='utf-8').read()
     # replace relative repository path to absolute link to the release
     text = text.replace('](docs', f']({url}')
-    # SVG images are not readable on PyPI, so replace them  with PNG
+    # SVG images are not readable on PyPI, so replace them with PNG
     text = text.replace('.svg', '.png')
     # download badge and replace url with local file
     text = _parse_for_badge(text)

--- a/pytorch_lightning/utilities/setup_tools.py
+++ b/pytorch_lightning/utilities/setup_tools.py
@@ -64,8 +64,8 @@ def _parse_for_badge(text: str, path_badges: str = _PATH_BADGES, badge_names: li
     """ Returns the new parsed text with url change with local downloaded files
 
     >>> _parse_for_badge('Some text here... '  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-    ... '[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytorch-lightning)]'
-    ... '(https://pypi.org/project/pytorch-lightning/) and another text later')
+    ...     '[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytorch-lightning)]'
+    ...     '(https://pypi.org/project/pytorch-lightning/) and another text later')
     'Some text here...
      [![PyPI - Python Version](.../docs/source/_images/badges/PyPI_Python_Version_badge.png)](https://pypi.org/project/pytorch-lightning/)
      and another text later'
@@ -101,7 +101,7 @@ def _download_badge(url_badge, badge_name, target_dir):
     """Download badge from url
 
     >>> path_img = _download_badge('https://img.shields.io/pypi/pyversions/pytorch-lightning',
-    ...                             'PyPI - Python Version', '.')
+    ...                            'PyPI - Python Version', '.')
     >>> os.path.isfile(path_img)
     True
     >>> path_img

--- a/pytorch_lightning/utilities/setup_tools.py
+++ b/pytorch_lightning/utilities/setup_tools.py
@@ -61,18 +61,17 @@ def _load_requirements(path_dir, file_name='requirements.txt', comment_char='#')
 
 
 def _parse_for_badge(text: str, path_badges: str = _PATH_BADGES, badge_names: list = _DEFAULT_BADGES):
-    """
-    Returns the new parsed text with url change with local downloaded files
+    """ Returns the new parsed text with url change with local downloaded files
 
     >>> _parse_for_badge('Some text here... '  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     ... '[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytorch-lightning)]'
     ... '(https://pypi.org/project/pytorch-lightning/) and another text later')
     'Some text here...
-     [![PyPI - Python Version](here relative path)](https://pypi.org/project/pytorch-lightning/)
+     [![PyPI - Python Version](.../docs/source/_images/badges/PyPI_Python_Version_badge.png)](https://pypi.org/project/pytorch-lightning/)
      and another text later'
     """
     for line in text.split(os.linesep):
-        badge_name = re.search(r'^\[!\[(.*?)]', line)
+        badge_name = re.search(r'\[!\[(.*?)]', line)
 
         # check for the badge name
         if badge_name is not None:

--- a/pytorch_lightning/utilities/setup_tools.py
+++ b/pytorch_lightning/utilities/setup_tools.py
@@ -20,7 +20,7 @@ from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 import warnings
 
-from pytorch_lightning import __homepage__, __version__
+from pytorch_lightning import __homepage__, __version__, PROJECT_ROOT
 
 # badge to download
 _DEFAULT_BADGES = [
@@ -39,6 +39,11 @@ _DEFAULT_BADGES = [
 
 
 def _load_requirements(path_dir, file_name='requirements.txt', comment_char='#'):
+    """Load requirements from a file
+
+    >>> _load_requirements(PROJECT_ROOT)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    ['numpy>=...', 'torch>=...', ...]
+    """
     with open(os.path.join(path_dir, file_name), 'r') as file:
         lines = [ln.strip() for ln in file.readlines()]
     reqs = []

--- a/pytorch_lightning/utilities/setup_tools.py
+++ b/pytorch_lightning/utilities/setup_tools.py
@@ -69,6 +69,8 @@ def _parse_for_badge(text: str, path_badges: str = _PATH_BADGES, badge_names: li
     'Some text here...
      [![PyPI - Python Version](./docs/source/_images/badges/PyPI_Python_Version_badge.png)](https://pypi.org/project/pytorch-lightning/)
      and another text later'
+    >>> import shutil
+    >>> shutil.rmtree('./docs')
     """
     for line in text.split(os.linesep):
         badge_name = re.search(r'\[!\[(.*?)]', line)
@@ -157,7 +159,7 @@ def _load_long_description(path_dir):
     >>> _load_long_description(PROJECT_ROOT)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     '<div align="center">...'
     >>> import shutil
-    >>> shutil.rmtree(_PATH_BADGES)
+    >>> shutil.rmtree('./docs')
     """
     # https://github.com/PyTorchLightning/pytorch-lightning/raw/master/docs/source/_images/lightning_module/pt_to_pl.png
     url = os.path.join(__homepage__, 'raw', __version__, 'docs')

--- a/pytorch_lightning/utilities/setup_tools.py
+++ b/pytorch_lightning/utilities/setup_tools.py
@@ -22,7 +22,7 @@ import warnings
 
 from pytorch_lightning import __homepage__, __version__, PROJECT_ROOT
 
-_PATH_BADGES = os.path.join(PROJECT_ROOT, 'docs', 'source', '_images', 'badges')
+_PATH_BADGES = os.path.join('.', 'docs', 'source', '_images', 'badges')
 # badge to download
 _DEFAULT_BADGES = [
     'PyPI - Python Version',
@@ -67,7 +67,7 @@ def _parse_for_badge(text: str, path_badges: str = _PATH_BADGES, badge_names: li
     ...     '[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pytorch-lightning)]'
     ...     '(https://pypi.org/project/pytorch-lightning/) and another text later')
     'Some text here...
-     [![PyPI - Python Version](.../docs/source/_images/badges/PyPI_Python_Version_badge.png)](https://pypi.org/project/pytorch-lightning/)
+     [![PyPI - Python Version](./docs/source/_images/badges/PyPI_Python_Version_badge.png)](https://pypi.org/project/pytorch-lightning/)
      and another text later'
     """
     for line in text.split(os.linesep):
@@ -152,6 +152,8 @@ def _load_long_description(path_dir):
 
     >>> _load_long_description(PROJECT_ROOT)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     '<div align="center">...'
+    >>> import shutil
+    >>> shutil.rmtree(_PATH_BADGES)
     """
     # https://github.com/PyTorchLightning/pytorch-lightning/raw/master/docs/source/_images/lightning_module/pt_to_pl.png
     url = os.path.join(__homepage__, 'raw', __version__, 'docs')

--- a/pytorch_lightning/utilities/setup_tools.py
+++ b/pytorch_lightning/utilities/setup_tools.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import re
+
+from urllib.error import URLError
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+import warnings
+
+from pytorch_lightning import __homepage__, __version__
+
+# badge to download
+_DEFAULT_BADGES = [
+    'PyPI - Python Version',
+    'PyPI Status',
+    'PyPI Status',
+    'Conda',
+    'DockerHub',
+    'codecov',
+    'ReadTheDocs',
+    'Slack',
+    'Discourse status',
+    'license',
+    'Next Release'
+]
+
+
+def _load_requirements(path_dir, file_name='requirements.txt', comment_char='#'):
+    with open(os.path.join(path_dir, file_name), 'r') as file:
+        lines = [ln.strip() for ln in file.readlines()]
+    reqs = []
+    for ln in lines:
+        # filer all comments
+        if comment_char in ln:
+            ln = ln[:ln.index(comment_char)].strip()
+        # skip directly installed dependencies
+        if ln.startswith('http'):
+            continue
+        if ln:  # if requirement is not empty
+            reqs.append(ln)
+    return reqs
+
+
+def _parse_for_badge(text, badge_names: list = _DEFAULT_BADGES):
+    for line in text.split('\n'):
+        badge_name = re.search(r'^\[!\[(.*?)]', line)
+
+        # check for the badge name
+        if badge_name is not None:
+            badge_name = badge_name.group(1)
+
+            # check if valid name
+            if badge_name in badge_names:
+
+                search_string = fr'\[\!\[{badge_name}]\((.*?)\)]'
+                badge_url = re.search(search_string, line)
+                # check for badge url
+                if badge_url is not None:
+                    badge_url = badge_url.group(1)
+
+                # download badge
+                saved_badge_name = _download_badges(badge_url, badge_name)
+
+                # replace url with local file path
+                replace_string = f'[![{badge_name}]({saved_badge_name})]'
+                text = re.sub(search_string, replace_string, text)
+
+    return text
+
+
+def _download_badges(url_badge, badge_name):
+
+    base_path = 'docs/source/_images/badges'
+    os.makedirs(base_path, exist_ok=True)
+
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/svg,*/*;q=0.8',
+    }
+
+    # function for saving the badge either in `.png` or `.svg`
+    def _save_file(url, save, extension):
+
+        # because there are two badge with name `PyPI Status` the second one is download
+        if 'https://pepy.tech/badge/pytorch-lightning' in url_badge:
+            save += '_downloads'
+
+        try:
+            req = Request(url=url, headers=headers)
+            resp = urlopen(req)
+        except URLError as err:
+            warnings.warn("Error while downloading the badge", UserWarning)
+        else:
+            save += extension
+            with open(save, 'wb') as download_file:
+                download_file.write(resp.read())
+
+    save_path = badge_name.replace(' - ', ' ')
+    save_path = f"{base_path}/{save_path.replace(' ', '_')}_badge"
+
+    try:
+        # always try to download the png versions (some url have an already png version available)
+        _save_file(url_badge, save_path, extension='.png')
+        return save_path + '.png'
+    except HTTPError as err:
+        if err.code == 404:
+            # save the `.svg`
+            url_badge = url_badge.replace('.png', '.svg')
+            _save_file(url_badge, save_path, extension='.svg')
+            return save_path + '.svg'
+
+
+def _load_long_description(path_dir):
+    # https://github.com/PyTorchLightning/pytorch-lightning/raw/master/docs/source/_images/lightning_module/pt_to_pl.png
+    url = os.path.join(__homepage__, 'raw', __version__, 'docs')
+    path_readme = os.path.join(path_dir, 'README.md')
+    text = open(path_readme, encoding='utf-8').read()
+    # replace relative repository path to absolute link to the release
+    text = text.replace('](docs', f']({url}')
+    # SVG images are not readable on PyPI, so replace them  with PNG
+    text = text.replace('.svg', '.png')
+    # download badge and replace url with local file
+    text = _parse_for_badge(text)
+    return text

--- a/pytorch_lightning/utilities/setup_tools.py
+++ b/pytorch_lightning/utilities/setup_tools.py
@@ -135,16 +135,20 @@ def _download_badge(url_badge, badge_name, target_dir):
     save_path = badge_name.replace(' - ', ' ')
     save_path = os.path.join(target_dir, f"{save_path.replace(' ', '_')}_badge")
 
-    try:
-        # always try to download the png versions (some url have an already png version available)
-        _save_file(url_badge, save_path, extension='.png')
-        return save_path + '.png'
-    except HTTPError as err:
-        if err.code == 404:
-            # save the `.svg`
-            url_badge = url_badge.replace('.png', '.svg')
-            _save_file(url_badge, save_path, extension='.svg')
-            return save_path + '.svg'
+    if "?" in url_badge and ".png" not in url_badge:
+        _save_file(url_badge, save_path, extension='.svg')
+        return save_path + '.svg'
+    else:
+        try:
+            # always try to download the png versions (some url have an already png version available)
+            _save_file(url_badge, save_path, extension='.png')
+            return save_path + '.png'
+        except HTTPError as err:
+            if err.code == 404:
+                # save the `.svg`
+                url_badge = url_badge.replace('.png', '.svg')
+                _save_file(url_badge, save_path, extension='.svg')
+                return save_path + '.svg'
 
 
 def _load_long_description(path_dir):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import os
-from io import open
 
 # Always prefer setuptools over distutils
 from setuptools import find_packages, setup
@@ -30,7 +29,7 @@ PATH_ROOT = os.path.dirname(__file__)
 builtins.__LIGHTNING_SETUP__ = True
 
 import pytorch_lightning  # noqa: E402
-from pytorch_lightning.utilities.setup_tools import _load_requirements, _load_long_description  # noqa: E402
+from pytorch_lightning.setup_tools import _load_requirements, _load_long_description  # noqa: E402
 
 
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ PATH_ROOT = os.path.dirname(__file__)
 builtins.__LIGHTNING_SETUP__ = True
 
 import pytorch_lightning  # noqa: E402
-from pytorch_lightning.utilities.setup_tools import _load_requirements, _load_long_description
+from pytorch_lightning.utilities.setup_tools import _load_requirements, _load_long_description  # noqa: E402
 
 
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,89 @@ def load_requirements(path_dir=PATH_ROOT, file_name='requirements.txt', comment_
     return reqs
 
 
+def _parse_README_for_badge(text):
+
+    # badge to download
+    valid_badge_names = [
+        'PyPI - Python Version',
+        'PyPI Status',
+        'PyPI Status',
+        'Conda',
+        'DockerHub',
+        'codecov',
+        'ReadTheDocs',
+        'Slack',
+        'Discourse status',
+        'license',
+        'Next Release'
+    ]
+
+    for line in text.split('\n'):
+        badge_name = re.search(r'^\[!\[(.*?)]', line)
+
+        # check for the badge name
+        if badge_name is not None:
+            badge_name = badge_name.group(1)
+
+            # check if valid name
+            if badge_name in valid_badge_names:
+
+                search_string = fr'\[\!\[{badge_name}]\((.*?)\)]'
+                badge_url = re.search(search_string, line)
+                # check for badge url
+                if badge_url is not None:
+                    badge_url = badge_url.group(1)
+
+                # download badge
+                saved_badge_name = _download_badges(badge_url, badge_name)
+
+                # replace url with local file path
+                replace_string =  f'[![{badge_name}]({saved_badge_name})]'
+                text = re.sub(search_string, replace_string, text)
+
+    return text
+
+
+def _download_badges(url_badge, badge_name):
+
+    base_path = f'docs/source/_images/badges'
+    os.makedirs(base_path, exist_ok=True)
+
+    headers = {'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0',
+               'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/svg,*/*;q=0.8', }
+
+    # function for saving the badge either in `.png` or `.svg`
+    def _save_file(url, save, extension):
+
+        # because there are two badge with name `PyPI Status` the second one is download
+        if 'https://pepy.tech/badge/pytorch-lightning' in url_badge:
+            save += '_downloads'
+
+        try:
+            req = Request(url=url, headers=headers)
+            resp = urlopen(req)
+        except URLError as err:
+            warnings.warn("Error while downloading the badge", UserWarning)
+        else:
+            save += extension
+            with open(save, 'wb') as download_file:
+                download_file.write(resp.read())
+
+    save_path = badge_name.replace(' - ', ' ')
+    save_path = f"{base_path}/{save_path.replace(' ', '_')}_badge"
+
+    try:
+        # always try to download the png versions (some url have an already png version available)
+        _save_file(url_badge, save_path, extension='.png')
+        return save_path + '.png'
+    except HTTPError as err:
+        if err.code == 404:
+            # save the `.svg`
+            url_badge = url_badge.replace('.png', '.svg')
+            _save_file(url_badge, save_path, extension='.svg')
+            return save_path +'.svg'
+
+
 def load_long_description():
     # https://github.com/PyTorchLightning/pytorch-lightning/raw/master/docs/source/_images/lightning_module/pt_to_pl.png
     url = os.path.join(pytorch_lightning.__homepage__, 'raw', pytorch_lightning.__version__, 'docs')
@@ -56,6 +139,8 @@ def load_long_description():
     text = text.replace('](docs', f']({url}')
     # SVG images are not readable on PyPI, so replace them  with PNG
     text = text.replace('.svg', '.png')
+    # download badge and replace url with local file
+    text = _parse_README_for_badge(text)
     return text
 
 
@@ -89,7 +174,7 @@ for ex in ('cpu', 'cpu-extra'):
 # the goal of the project is simplicity for researchers, don't want to add too much
 # engineer specific practices
 setup(
-    name='pytorch-lightning',
+    name="pytorch-lightning-nightly",
     version=pytorch_lightning.__version__,
     description=pytorch_lightning.__docs__,
     author=pytorch_lightning.__author__,

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ for ex in ('cpu', 'cpu-extra'):
 # the goal of the project is simplicity for researchers, don't want to add too much
 # engineer specific practices
 setup(
-    name="pytorch-lightning-nightly",
+    name="pytorch-lightning",
     version=pytorch_lightning.__version__,
     description=pytorch_lightning.__docs__,
     author=pytorch_lightning.__author__,

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,12 @@
 
 import os
 from io import open
+import re
+
+from urllib.error import URLError
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+import warnings
 
 # Always prefer setuptools over distutils
 from setuptools import find_packages, setup
@@ -85,7 +91,7 @@ def _parse_README_for_badge(text):
                 saved_badge_name = _download_badges(badge_url, badge_name)
 
                 # replace url with local file path
-                replace_string =  f'[![{badge_name}]({saved_badge_name})]'
+                replace_string = f'[![{badge_name}]({saved_badge_name})]'
                 text = re.sub(search_string, replace_string, text)
 
     return text
@@ -93,7 +99,7 @@ def _parse_README_for_badge(text):
 
 def _download_badges(url_badge, badge_name):
 
-    base_path = f'docs/source/_images/badges'
+    base_path = 'docs/source/_images/badges'
     os.makedirs(base_path, exist_ok=True)
 
     headers = {'User-Agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:81.0) Gecko/20100101 Firefox/81.0',
@@ -128,7 +134,7 @@ def _download_badges(url_badge, badge_name):
             # save the `.svg`
             url_badge = url_badge.replace('.png', '.svg')
             _save_file(url_badge, save_path, extension='.svg')
-            return save_path +'.svg'
+            return save_path + '.svg'
 
 
 def load_long_description():

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ PATH_ROOT = os.path.dirname(__file__)
 builtins.__LIGHTNING_SETUP__ = True
 
 import pytorch_lightning  # noqa: E402
-from pytorch_lightning.setup_tools import _load_requirements, _load_long_description  # noqa: E402
+from pytorch_lightning.setup_tools import _load_long_description, _load_requirements  # noqa: E402
 
 
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ builtins.__LIGHTNING_SETUP__ = True
 import pytorch_lightning  # noqa: E402
 from pytorch_lightning.setup_tools import _load_long_description, _load_requirements  # noqa: E402
 
-
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras
 # Define package extras. These are only installed if you specify them.
 # From remote, use like `pip install pytorch-lightning[dev, docs]`


### PR DESCRIPTION
Issue ref: #3905 

Added a function to `setup.py` for downloading the badge locally and replacing the url with the local path.

Fixes #3914 
Fixes #3905 

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
SURE!
