### PR TITLE
encourage draft PR submission [ci skip]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,8 +8,7 @@ Please include a summary of the change and which issue is fixed.
 
 Fixes # (issue)
 
-# Before submitting
-
+## Before submitting
 - [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
 - [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
 - [ ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
@@ -20,8 +19,10 @@ Fixes # (issue)
 
 <!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->
 
-## PR review    
-Anyone in the community is free to review the PR once the tests have passed.     
+## PR review
+ - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
+
+Anyone in the community is free to review the PR once the tests have passed.    
 If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
 
 ## Did you have fun?


### PR DESCRIPTION
## What does this PR do?
add a reminder to the PR template to encourage draft PR submissions

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review    
Anyone in the community is free to review the PR once the tests have passed.     
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
