### PR TITLE
Fix info message when EarlyStopping 'mode' not provided [ci skip]

### DIFF
--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -88,7 +88,7 @@ class EarlyStopping(Callback):
 
         if mode not in self.mode_dict:
             if self.verbose > 0:
-                log.info('EarlyStopping mode not provided, fallback to auto mode.')
+                log.info("EarlyStopping mode not provided or set to 'auto'. Continuing with auto mode.")
             self.mode = 'auto'
 
         if self.mode == 'auto':

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -88,7 +88,7 @@ class EarlyStopping(Callback):
 
         if mode not in self.mode_dict:
             if self.verbose > 0:
-                log.info(f'EarlyStopping mode {mode} is unknown, fallback to auto mode.')
+                log.info('EarlyStopping mode not provided, fallback to auto mode.')
             self.mode = 'auto'
 
         if self.mode == 'auto':

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -86,9 +86,9 @@ class EarlyStopping(Callback):
         # It is set to False initially and overwritten, if eval results have been validated
         self.based_on_eval_results = False
 
-        if mode not in self.mode_dict:
+        if mode not in self.mode_dict and mode != 'auto':
             if self.verbose > 0:
-                log.info("EarlyStopping mode not provided or set to 'auto'. Continuing with auto mode.")
+                log.info(f'EarlyStopping mode {mode} is unknown, fallback to auto mode.')
             self.mode = 'auto'
 
         if self.mode == 'auto':


### PR DESCRIPTION
## What does this PR do?

Fix info message when EarlyStopping 'mode' not provided

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.
-->

Fixes #4268 

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.    
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
