### PR TITLE
Add individuals to Metrics in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,11 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @williamfalcon @borda @teddykoker @awaelchli @nateraw @justusschock @tchaton @SeanNaren @ananyahjha93
+* @williamfalcon @borda @teddykoker @awaelchli @nateraw @justusschock @tchaton @SeanNaren @ananyahjha93
+
+# Metrics
+/pytorch_lightning/metrics/*  @teddykoker @ananyahjha93
+/tests/metrics/*              @teddykoker @ananyahjha93
+/docs/source/metrics.rst      @teddykoker @ananyahjha93
+
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,8 +8,8 @@
 * @williamfalcon @borda @teddykoker @awaelchli @nateraw @justusschock @tchaton @SeanNaren @ananyahjha93
 
 # Metrics
-/pytorch_lightning/metrics/*  @teddykoker @ananyahjha93
-/tests/metrics/*              @teddykoker @ananyahjha93
-/docs/source/metrics.rst      @teddykoker @ananyahjha93
+/pytorch_lightning/metrics/*  @teddykoker @ananyahjha93 @justusschock
+/tests/metrics/*              @teddykoker @ananyahjha93 @justusschock
+/docs/source/metrics.rst      @teddykoker @ananyahjha93 @justusschock
 
 


### PR DESCRIPTION
## What does this PR do?
Add myself and @ananyahjha93 to `CODEOWNERS` for metrics. I recommend others do the same for other portions of the library.