### PR TITLE
[docker] Lock cuda version

### DIFF
--- a/.github/workflows/ci_dockers.yml
+++ b/.github/workflows/ci_dockers.yml
@@ -108,8 +108,11 @@ jobs:
             pytorch_version: 1.6
           - python_version: 3.6
             pytorch_version: 1.4
-          #- python_version: 3.7
-          #  pytorch_version: 1.8  # todo
+          - python_version: 3.7
+            pytorch_version: 1.7
+          # TODO
+          # - python_version: 3.7
+          #   pytorch_version: 1.8
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python_version: [3.6, 3.7, 3.8]
-        pytorch_version: [1.3, 1.4, 1.5, 1.6]
+        pytorch_version: [1.3, 1.4, 1.5, 1.6, 1.7]
         exclude:
           # excludes PT 1.3 as it is missing on pypi
           - python_version: 3.8

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,39 +2,41 @@ name: Nightly events
 
 # https://jasonet.co/posts/scheduled-actions/
 on:
-  schedule:
-    # At the end of every day
-    - cron: "0 0 * * *"
+  push:
+    branches: [master]
+  # schedule:
+  #   # At the end of every day
+  #   - cron: "0 0 * * *"
 
 # based on https://github.com/pypa/gh-action-pypi-publish
 jobs:
 
-  pypi-release:
-    runs-on: ubuntu-20.04
+  # pypi-release:
+  #   runs-on: ubuntu-20.04
 
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: 3.7
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - uses: actions/setup-python@v2
+  #     with:
+  #       python-version: 3.7
 
-    - name: Install dependencies
-      run: >-
-        python -m pip install --user --upgrade setuptools wheel
-    - name: Build
-      run: |
-        python .github/prepare-nightly_version.py
-        python setup.py sdist bdist_wheel
-        ls -lh dist/
+  #   - name: Install dependencies
+  #     run: >-
+  #       python -m pip install --user --upgrade setuptools wheel
+  #   - name: Build
+  #     run: |
+  #       python .github/prepare-nightly_version.py
+  #       python setup.py sdist bdist_wheel
+  #       ls -lh dist/
 
-    # We do this, since failures on test.pypi aren't that bad
-    - name: Publish to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        user: __token__
-        password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
-        verbose: true
+  #   # We do this, since failures on test.pypi aren't that bad
+  #   - name: Publish to Test PyPI
+  #     uses: pypa/gh-action-pypi-publish@master
+  #     with:
+  #       user: __token__
+  #       password: ${{ secrets.test_pypi_password }}
+  #       repository_url: https://test.pypi.org/legacy/
+  #       verbose: true
 
   docker-XLA:
     runs-on: ubuntu-20.04

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,7 @@ name: Nightly events
 
 # https://jasonet.co/posts/scheduled-actions/
 on:
-  push:
+  pull_request:
     branches: [master]
   # schedule:
   #   # At the end of every day

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,41 +2,39 @@ name: Nightly events
 
 # https://jasonet.co/posts/scheduled-actions/
 on:
-  pull_request:
-    branches: [master]
-  # schedule:
-  #   # At the end of every day
-  #   - cron: "0 0 * * *"
+  schedule:
+    # At the end of every day
+    - cron: "0 0 * * *"
 
 # based on https://github.com/pypa/gh-action-pypi-publish
 jobs:
 
-  # pypi-release:
-  #   runs-on: ubuntu-20.04
+  pypi-release:
+    runs-on: ubuntu-20.04
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: actions/setup-python@v2
-  #     with:
-  #       python-version: 3.7
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
 
-  #   - name: Install dependencies
-  #     run: >-
-  #       python -m pip install --user --upgrade setuptools wheel
-  #   - name: Build
-  #     run: |
-  #       python .github/prepare-nightly_version.py
-  #       python setup.py sdist bdist_wheel
-  #       ls -lh dist/
+    - name: Install dependencies
+      run: >-
+        python -m pip install --user --upgrade setuptools wheel
+    - name: Build
+      run: |
+        python .github/prepare-nightly_version.py
+        python setup.py sdist bdist_wheel
+        ls -lh dist/
 
-  #   # We do this, since failures on test.pypi aren't that bad
-  #   - name: Publish to Test PyPI
-  #     uses: pypa/gh-action-pypi-publish@master
-  #     with:
-  #       user: __token__
-  #       password: ${{ secrets.test_pypi_password }}
-  #       repository_url: https://test.pypi.org/legacy/
-  #       verbose: true
+    # We do this, since failures on test.pypi aren't that bad
+    - name: Publish to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        user: __token__
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+        verbose: true
 
   docker-XLA:
     runs-on: ubuntu-20.04

--- a/dockers/base-conda/Dockerfile
+++ b/dockers/base-conda/Dockerfile
@@ -74,7 +74,7 @@ ENV CONDA_ENV=lightning
 COPY environment.yml environment.yml
 
 # conda init
-RUN conda create -y --name $CONDA_ENV && \
+RUN conda create -y --name $CONDA_ENV cudatoolkit=${CUDA_VERSION} && \
     conda init bash && \
     # NOTE: this requires that the channel is presented in the yaml before packages
     # replace channel to nigtly if needed, fix PT version and remove Horovod as it will be installe later


### PR DESCRIPTION
## What does this PR do?

PyTorch 1.7 ships binaries with CUDA 11 by default, so apex is failed to install from source
Lock cuda=CUDA_VERSION in building dockers

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.    
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
