### PR TITLE
[Fix] type checker issue with explicit cast of ref_model object

### DIFF
--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -15,7 +15,7 @@ import inspect
 import os
 from abc import ABC
 from argparse import ArgumentParser, Namespace
-from typing import List, Optional, Union, Type, TypeVar
+from typing import List, Optional, Union, Type, TypeVar, cast
 
 from pytorch_lightning.callbacks import Callback, ProgressBarBase, ModelCheckpoint
 from pytorch_lightning.core.lightning import LightningModule
@@ -154,6 +154,7 @@ class TrainerProperties(ABC):
     def progress_bar_dict(self) -> dict:
         """ Read-only for progress bar metrics. """
         ref_model = self.model if not self.data_parallel else self.model.module
+        ref_model = cast(LightningModule, ref_model)
         return dict(**ref_model.get_progress_bar_dict(), **self.logger_connector.progress_bar_metrics)
 
     @property


### PR DESCRIPTION
## What does this PR do?

Type checking is broken on master due to a properties type not being inferred properly:

https://github.com/PyTorchLightning/pytorch-lightning/pull/4453/checks?check_run_id=1335530408

Adds explicit cast in the properties file for type checker to work correctly.

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)

Anyone in the community is free to review the PR once the tests have passed.    
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
