### PR TITLE
Min version req for skimage in tests

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -7,7 +7,7 @@ flake8>=3.6
 flake8-black
 check-manifest
 twine==1.13.0
-scikit-image
+scikit-image>=0.17.2
 black>=20.8b1
 pre-commit>=1.0
 


### PR DESCRIPTION
## What does this PR do?
Adds a minimum version for skimage in tests since old versions do not contain the needed metrics package

<details>
  <summary>Trace (skimage 0.15.x)</summary>

```
================================================== ERRORS ==================================================
__________________________ ERROR collecting tests/metrics/regression/test_psnr.py __________________________
tests/metrics/regression/test_psnr.py:6: in <module>
    from skimage.metrics import peak_signal_noise_ratio
E   ModuleNotFoundError: No module named 'skimage.metrics'
__________________________ ERROR collecting tests/metrics/regression/test_psnr.py __________________________
ImportError while importing test module '/home/roger/pytorch-lightning-dev/tests/metrics/regression/test_psnr.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/conda/lib/python3.6/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/metrics/regression/test_psnr.py:6: in <module>
    from skimage.metrics import peak_signal_noise_ratio
E   ModuleNotFoundError: No module named 'skimage.metrics'
__________________________ ERROR collecting tests/metrics/regression/test_ssim.py __________________________
tests/metrics/regression/test_ssim.py:6: in <module>
    from skimage.metrics import structural_similarity
E   ModuleNotFoundError: No module named 'skimage.metrics'
__________________________ ERROR collecting tests/metrics/regression/test_ssim.py __________________________
ImportError while importing test module '/home/roger/pytorch-lightning-dev/tests/metrics/regression/test_ssim.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/conda/lib/python3.6/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/metrics/regression/test_ssim.py:6: in <module>
    from skimage.metrics import structural_similarity
E   ModuleNotFoundError: No module named 'skimage.metrics'
```

</details>
