### PR TITLE
Separate CombinedLoaderIterator into two classes, and update related tests.

### DIFF
--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -189,7 +189,7 @@ class TrainerDataLoadingMixin(ABC):
         # check the workers recursively
         apply_to_collection(self.train_dataloader, DataLoader, self._worker_check, 'train dataloader')
 
-        # wrap the sequence of train loaders to a CombinedLoader object for computing the num_training_batches 
+        # wrap the sequence of train loaders to a CombinedLoader object for computing the num_training_batches
         self.train_dataloader = CombinedLoader(self.train_dataloader, self._multiple_trainloader_mode)
 
         self.num_training_batches = 0
@@ -348,10 +348,9 @@ class TrainerDataLoadingMixin(ABC):
         Returns:
             The dataloader
         """
-        # dataloader = MultiIterator(dataloader_fx())
         dataloader = dataloader_fx()
         dataloader = self._flatten_dl_only(dataloader)
-        
+
         if self.accelerator_backend is not None:
             self.accelerator_backend.barrier('get_dataloaders')
         return dataloader

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -184,7 +184,7 @@ class TrainerDataLoadingMixin(ABC):
 
         # automatically add samplers
         self.train_dataloader = apply_to_collection(
-            self.train_dataloader, DataLoader, self.auto_add_sampler, train=True)
+            self.train_dataloader, DataLoader, self.auto_add_sampler, shuffle=True)
 
         self.num_training_batches = len(self.train_dataloader) if has_len(self.train_dataloader) else float('inf')
         self._worker_check(self.train_dataloader, 'train dataloader')
@@ -341,7 +341,8 @@ class TrainerDataLoadingMixin(ABC):
         Returns:
             The dataloader
         """
-        dataloader = MultiIterator(dataloader_fx())
+        # dataloader = MultiIterator(dataloader_fx())
+        dataloader = dataloader_fx()
         dataloader = self._flatten_dl_only(dataloader)
         
         if self.accelerator_backend is not None:

--- a/pytorch_lightning/trainer/supporters.py
+++ b/pytorch_lightning/trainer/supporters.py
@@ -177,7 +177,6 @@ class PredictionCollection(object):
             # Write predictions for current file to disk
             with fs.open(filepath, "wb") as fp:
                 torch.save(outputs, fp)
-                return getattr(self.memory[:self.current_idx], how)()
 
 
 class CycleIterator(object):

--- a/pytorch_lightning/trainer/supporters.py
+++ b/pytorch_lightning/trainer/supporters.py
@@ -335,7 +335,7 @@ class CombinedLoader(object):
         """
         self.loaders = loaders
 
-        datasets = apply_to_collection(self.loaders, Iterable, self.extract_dataset,
+        datasets = apply_to_collection(self.loaders, Iterable, getattr, 'dataset', None,
                                        wrong_dtype=(Sequence, Mapping))
         # could be multiple datasets, but use self.dataset to follow the name convention in DataLoader
         self.dataset = CombinedDataset(datasets)
@@ -348,23 +348,10 @@ class CombinedLoader(object):
         if self.mode == 'max_size_cycle':
             self._wrap_loaders_max_size_cycle()
 
-    @staticmethod
-    def extract_dataset(loader: Any) -> Any:
-        """
-        Extract the variable `dataset` from loader. `dataset` can be torch.utils.data.Dataset or Iterable.
-
-        Args:
-            loader: a loader which can be all kinds of iterable object
-        Returns:
-            Return `dataset` if it exists. Otherwise, return None.
-
-        """
-        return getattr(loader, 'dataset', None)
-
     @property
     def sampler(self) -> Union[Iterable, Sequence, Mapping]:
         """Return a collections of samplers extracting from loaders."""
-        return apply_to_collection(self.loaders, Iterable, getattr, "sampler", None,
+        return apply_to_collection(self.loaders, Iterable, getattr, 'sampler', None,
                                    wrong_dtype=(Sequence, Mapping))
 
     def _wrap_loaders_max_size_cycle(self) -> Any:

--- a/pytorch_lightning/trainer/supporters.py
+++ b/pytorch_lightning/trainer/supporters.py
@@ -361,6 +361,12 @@ class CombinedLoader(object):
         """
         return getattr(loader, 'dataset', None)
 
+    @property
+    def sampler(self) -> Union[Iterable, Sequence, Mapping]:
+        """Return a collections of samplers extracting from loaders."""
+        return apply_to_collection(self.loaders, Iterable, getattr, "sampler", None,
+                                   wrong_dtype=(Sequence, Mapping))
+
     def _wrap_loaders_max_size_cycle(self) -> Any:
         """
         Wraps all loaders to make sure they are cycled until the longest loader is exhausted

--- a/pytorch_lightning/trainer/supporters.py
+++ b/pytorch_lightning/trainer/supporters.py
@@ -226,7 +226,7 @@ class CycleIterator(object):
         """
         if self.counter >= self.__len__():
             raise StopIteration
-        
+
         try:
             return next(self._loader_iter)
 
@@ -291,9 +291,9 @@ class CombinedLoader(object):
                 'max_size_cycle' which stops if the longest loader is exhausted and cycles through the smaller ones.
         """
         self.loaders = loaders
-        # could be multiple datasets, but use self.dataset to follow 
+        # could be multiple datasets, but use self.dataset to follow the name convention in DataLoader
         datasets = apply_to_collection(self.loaders, Iterable, self.extract_dataset,
-                                      wrong_dtype=(Sequence, Mapping))
+                                       wrong_dtype=(Sequence, Mapping))
 
         self.dataset = CombinedDataset(datasets)
 
@@ -396,7 +396,7 @@ class CombinedLoaderIterator(object):
         if self._loader_iters is None:
             self._loader_iters = self.create_loader_iters(self.loaders)
         return self.request_next_batch(self._loader_iters)
-        
+
     @staticmethod
     def request_next_batch(loader_iters: Union[Iterator, Sequence, Mapping]) -> Any:
         return apply_to_collection(loader_iters, Iterator, next)

--- a/pytorch_lightning/trainer/supporters.py
+++ b/pytorch_lightning/trainer/supporters.py
@@ -297,9 +297,6 @@ class CombinedLoader(object):
 
         self.dataset = CombinedDataset(datasets)
 
-        self._loader_iters = None
-        self.counter = 0
-
         if mode not in self.SUPPORTED_MODES:
             raise ValueError(f"Invalid Mode: {mode}")
 

--- a/pytorch_lightning/trainer/supporters.py
+++ b/pytorch_lightning/trainer/supporters.py
@@ -295,7 +295,9 @@ class CombinedLoaderIterator(object):
 
         # dataloaders are iterable but not sequence
         elif isinstance(self.loaders, Iterable):
-            self.loaders = CycleIterator(self.loaders, length=length)
+            # only one dataloader, just remain the same
+            pass
+            # self.loaders = CycleIterator(self.loaders, length=length)
         else:
             raise ValueError(f'Invalid Datatype for loaders: {type(self.loaders).__name__}')
 

--- a/pytorch_lightning/trainer/supporters.py
+++ b/pytorch_lightning/trainer/supporters.py
@@ -467,8 +467,6 @@ class CombinedLoaderIterator(object):
             Any: a collections of batch data
 
         """
-        # if self._loader_iters is None:
-        #     self._loader_iters = self.create_loader_iters(self.loaders)
         return self.request_next_batch(self.loader_iters)
 
     @staticmethod

--- a/pytorch_lightning/trainer/supporters.py
+++ b/pytorch_lightning/trainer/supporters.py
@@ -263,7 +263,7 @@ class CombinedDataset(object):
         self.min_len = self._calc_num_data(self.datasets, 'min')
 
     @staticmethod
-    def _calc_num_data(datasets: Union[Sequence, Mapping], mode: str = 'min'):
+    def _calc_num_data(datasets: Union[Sequence, Mapping], mode: str = 'min') -> Union[int, float]:
         """
         Compute the length of `CombinedDataset` according to the `mode`.
 
@@ -396,7 +396,7 @@ class CombinedLoader(object):
         return CombinedLoaderIterator(self.loaders)
 
     @staticmethod
-    def _calc_num_batches(loaders: Any) -> int:
+    def _calc_num_batches(loaders: Any) -> Union[int, float]:
         """
         Compute the length (aka the number of batches) of `CombinedLoader`.
 

--- a/pytorch_lightning/trainer/train_loader_patch.py
+++ b/pytorch_lightning/trainer/train_loader_patch.py
@@ -1,11 +1,11 @@
 '''
-    This patch solves two problems discussed in 
+    This patch solves two problems discussed in
     https://github.com/PyTorchLightning/pytorch-lightning/pull/1959
 
-    The function  train_dataloader can either return a single instance of 
+    The function  train_dataloader can either return a single instance of
     torch.utils.data.DataLoader or a dictionary of dataloaders.
 
-    This patch fixes the length and iteration issus 
+    This patch fixes the length and iteration issus
     and make the rest of the code oblivious of the underlying data structure.
 
     I will keep the name of the class but a better name is probable advisable
@@ -22,7 +22,7 @@ from torch.utils.data import DataLoader
 
 from pytorch_lightning.utilities.data import get_len
 from pytorch_lightning.utilities.apply_func import apply_to_collection
-  
+
 
 # def get_len(d):
 #     if isinstance(d, dict):
@@ -35,7 +35,7 @@ class MultiIterator(object):
     SUPPORTED_MODES = ('min_size', 'max_size_cycle')
 
     def __init__(self, loaders: Any, mode: str = 'min_size') -> None:
-        self.loaders = loaders 
+        self.loaders = loaders
         self.num_batches = self._calc_num_batches(loaders, mode)
 
     def _calc_num_batches(self, loaders, mode: str) -> Union[int, float]:
@@ -57,7 +57,7 @@ class MultiIterator(object):
             return compare_func(all_lengths)
 
         raise TypeError(f'Got Type {type(all_lengths).__name__}, but expected one of Sequence, Mapping, int or float')
- 
+
     def __len__(self) -> Union[int, float]:
         # Return type might be int or inf. Inf will cause type error when calling len()
         return self.num_batches
@@ -70,7 +70,7 @@ class MultiIterator(object):
                 for loader_name, loader in self.loaders.items():
                     # If reaching the end of the iterator, recreate one
                     # because shuffle=True in dataloader, the iterator will have a different order
-                    if batch_idx % len(loader) == 0: 
+                    if batch_idx % len(loader) == 0:
                         gens[loader_name] = iter(loader)
                     rv[loader_name] = next(gens[loader_name])
                 yield rv
@@ -87,4 +87,3 @@ class MultiIterator(object):
                 yield rv
 
         return iter(self.loaders)
-        

--- a/pytorch_lightning/trainer/train_loader_patch.py
+++ b/pytorch_lightning/trainer/train_loader_patch.py
@@ -14,35 +14,77 @@
 '''
 
 import itertools
+
+from typing import Any, Union
+from collections.abc import Iterable, Iterator, Mapping, Sequence
+
+from torch.utils.data import DataLoader
+
+from pytorch_lightning.utilities.data import get_len
+from pytorch_lightning.utilities.apply_func import apply_to_collection
   
-def get_len(d):
-    if isinstance(d, dict):
-        v = max(d.items(), key=lambda x: len(x[1]))
-        return len(v[1])
-    else:
-        return len(d)
+
+# def get_len(d):
+#     if isinstance(d, dict):
+#         v = max(d.items(), key=lambda x: len(x[1]))
+#         return len(v[1])
+#     else:
+#         return len(d)
 
 class MultiIterator(object):
-    def __init__(self, data) -> None:
-        super(object, self).__init__()
-        self.d = data
-        self.l = get_len(data)
+    SUPPORTED_MODES = ('min_size', 'max_size_cycle')
+
+    def __init__(self, loaders: Any, mode: str = 'min_size') -> None:
+        self.loaders = loaders 
+        self.num_batches = self._calc_num_batches(loaders, mode)
+
+    def _calc_num_batches(self, loaders, mode: str) -> Union[int, float]:
+        all_lengths = apply_to_collection(loaders, Iterable, get_len,
+                                          wrong_dtype=(Sequence, Mapping))
+
+        if mode == 'min_size':
+            compare_func = min
+        elif mode == 'max_size_cycle':
+            compare_func = max
+        else:
+            raise ValueError(f"Invalid Mode: {mode}")
+
+        if isinstance(all_lengths, (int, float)):
+            return all_lengths
+        if isinstance(all_lengths, Mapping):
+            return compare_func(all_lengths.values())
+        elif isinstance(all_lengths, Sequence):
+            return compare_func(all_lengths)
+
+        raise TypeError(f'Got Type {type(all_lengths).__name__}, but expected one of Sequence, Mapping, int or float')
  
-    def __len__(self) -> int:
-        return get_len(self.d)
+    def __len__(self) -> Union[int, float]:
+        # Return type might be int or inf. Inf will cause type error when calling len()
+        return self.num_batches
 
     def __iter__(self):
-        if isinstance(self.d, dict):
-            gen = {}
-            for k,v in self.d.items():
-                gen[k] = itertools.cycle(v)
-            for i in range(self.l):
+        if isinstance(self.loaders, Mapping):
+            gens = {}
+            for batch_idx in range(self.num_batches):
                 rv = {}
-                for k,v in self.d.items():
-                    rv[k] = next(gen[k])
+                for loader_name, loader in self.loaders.items():
+                    # If reaching the end of the iterator, recreate one
+                    # because shuffle=True in dataloader, the iterator will have a different order
+                    if batch_idx % len(loader) == 0: 
+                        gens[loader_name] = iter(loader)
+                    rv[loader_name] = next(gens[loader_name])
                 yield rv
-        else:
-            gen = itertools.cycle(self.d)
-            for i in range(self.l):
-                batch = next(gen)
-                yield batch
+        elif isinstance(self.loaders, Sequence):
+            gens = [None] * self.num_batches
+            for batch_idx in range(self.num_batches):
+                rv = []
+                for idx, loader in enumerate(self.loaders):
+                    # If reaching the end of the iterator, recreate one
+                    # because shuffle=True in dataloader, the iterator will have a different order
+                    if batch_idx % len(loader) == 0:
+                        gens[idx] = iter(loader)
+                    rv.append(next(gens[idx]))
+                yield rv
+
+        return iter(self.loaders)
+        

--- a/pytorch_lightning/trainer/train_loader_patch.py
+++ b/pytorch_lightning/trainer/train_loader_patch.py
@@ -24,13 +24,6 @@ from pytorch_lightning.utilities.data import get_len
 from pytorch_lightning.utilities.apply_func import apply_to_collection
 
 
-# def get_len(d):
-#     if isinstance(d, dict):
-#         v = max(d.items(), key=lambda x: len(x[1]))
-#         return len(v[1])
-#     else:
-#         return len(d)
-
 class MultiIterator(object):
     SUPPORTED_MODES = ('min_size', 'max_size_cycle')
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -269,8 +269,8 @@ class Trainer(
                     Defaults to `default_root_dir`.
 
             multiple_trainloader_mode: How to loop over the datasets when there are multiple train loaders.
-                In "max_size_cycle" mode, the trainer ends one epoch when the largest dataset is traversed,
-                and smaller datasets reload when running out of their data. In "min_size" mode, all the datasets
+                In 'max_size_cycle' mode, the trainer ends one epoch when the largest dataset is traversed,
+                and smaller datasets reload when running out of their data. In 'min_size' mode, all the datasets
                 reload when reaching the minimum length of datasets.
         """
         super().__init__()

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -267,6 +267,11 @@ class Trainer(
                     stored in a different place than the logs written in `default_root_dir`.
                     Can be remote file paths such as `s3://mybucket/path` or 'hdfs://path/'
                     Defaults to `default_root_dir`.
+
+            multiple_trainloader_mode: How to loop over the datasets when there are multiple train loaders.
+                In "max_size_cycle" mode, the trainer ends one epoch when the largest dataset is traversed,
+                and smaller datasets reload when running out of their data. In "min_size" mode, all the datasets
+                reload when reaching the minimum length of datasets.
         """
         super().__init__()
 

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -46,7 +46,7 @@ class TrainLoop:
         self.automatic_optimization = True
         self._curr_step_result = None
         self._cur_grad_norm_dict = None
-        self._multiple_trainloader_mode
+        self._multiple_trainloader_mode = multiple_trainloader_mode
 
     def on_trainer_init(
         self, max_epochs, min_epochs, max_steps, min_steps, num_sanity_val_steps, automatic_optimization
@@ -526,12 +526,13 @@ class TrainLoop:
         model = self.trainer.get_model()
 
         # modify dataloader if needed (ddp, etc...)
-        train_dataloader = self.trainer.accelerator_backend.process_dataloader(CombinedLoaderIterator(self.trainer.train_dataloader, mode=self._multiple_trainloader_mode))
+        train_dataloader = self.trainer.accelerator_backend.process_dataloader(
+            CombinedLoaderIterator(self.trainer.train_dataloader, mode=self._multiple_trainloader_mode))
 
         # track epoch output
         epoch_output = [[] for _ in range(self.num_optimizers)]
 
-        self.trainer.data_connector.get_profiled_train_dataloader(train_dataloader)
+        train_dataloader = self.trainer.data_connector.get_profiled_train_dataloader(train_dataloader)
         dataloader_idx = 0
         should_check_val = False
 

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -47,6 +47,7 @@ class TrainLoop:
         self._curr_step_result = None
         self._cur_grad_norm_dict = None
         self._multiple_trainloader_mode = multiple_trainloader_mode
+        self.trainer._multiple_trainloader_mode = multiple_trainloader_mode
 
     def on_trainer_init(
         self, max_epochs, min_epochs, max_steps, min_steps, num_sanity_val_steps, automatic_optimization
@@ -526,8 +527,9 @@ class TrainLoop:
         model = self.trainer.get_model()
 
         # modify dataloader if needed (ddp, etc...)
-        train_dataloader = self.trainer.accelerator_backend.process_dataloader(
-            CombinedLoaderIterator(self.trainer.train_dataloader, mode=self._multiple_trainloader_mode))
+        # train_dataloader = self.trainer.accelerator_backend.process_dataloader(
+        #     CombinedLoaderIterator(self.trainer.train_dataloader, mode=self._multiple_trainloader_mode))
+        train_dataloader = self.trainer.accelerator_backend.process_dataloader(self.trainer.train_dataloader)
 
         # track epoch output
         epoch_output = [[] for _ in range(self.num_optimizers)]

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -527,8 +527,6 @@ class TrainLoop:
         model = self.trainer.get_model()
 
         # modify dataloader if needed (ddp, etc...)
-        # train_dataloader = self.trainer.accelerator_backend.process_dataloader(
-        #     CombinedLoaderIterator(self.trainer.train_dataloader, mode=self._multiple_trainloader_mode))
         train_dataloader = self.trainer.accelerator_backend.process_dataloader(self.trainer.train_dataloader)
 
         # track epoch output

--- a/pytorch_lightning/utilities/data.py
+++ b/pytorch_lightning/utilities/data.py
@@ -49,9 +49,9 @@ def has_len(dataloader: DataLoader) -> bool:
 
 
 def get_len(dataloader: DataLoader) -> Union[int, float]:
-    """ Return the length of the given DataLoader. If __len__ method is not implemented, 
+    """ Return the length of the given DataLoader. If __len__ method is not implemented,
         return float('inf'). """
-        
+
     if has_len(dataloader):
         return len(dataloader)
 

--- a/pytorch_lightning/utilities/data.py
+++ b/pytorch_lightning/utilities/data.py
@@ -17,6 +17,7 @@ import torch
 from torch.utils.data import DataLoader, IterableDataset
 
 from pytorch_lightning.utilities import rank_zero_warn
+from typing import Union
 
 
 def has_iterable_dataset(dataloader: DataLoader):
@@ -45,3 +46,13 @@ def has_len(dataloader: DataLoader) -> bool:
             ' this can lead to unintended side effects since the samples will be duplicated.'
         )
     return has_len
+
+
+def get_len(dataloader: DataLoader) -> Union[int, float]:
+    """ Return the length of the given DataLoader. If __len__ method is not implemented, 
+        return float('inf'). """
+        
+    if has_len(dataloader):
+        return len(dataloader)
+
+    return float('inf')

--- a/tests/base/model_train_dataloaders.py
+++ b/tests/base/model_train_dataloaders.py
@@ -39,5 +39,6 @@ class TrainDataloaderVariations(ABC):
         return dataloader
 
     def train_dataloader__multiple(self):
+        """Return a mapping loaders with different lengths"""
         return {'a': self.dataloader(train=True, num_samples=100),
                 'b': self.dataloader(train=True, num_samples=50)}

--- a/tests/base/model_train_dataloaders.py
+++ b/tests/base/model_train_dataloaders.py
@@ -20,7 +20,7 @@ from tests.base.dataloaders import CustomNotImplementedErrorDataloader
 class TrainDataloaderVariations(ABC):
 
     @abstractmethod
-    def dataloader(self, train: bool):
+    def dataloader(self, train: bool, *args, **kwargs):
         """placeholder"""
 
     def train_dataloader(self):
@@ -37,3 +37,7 @@ class TrainDataloaderVariations(ABC):
         dataloader.dataset.data = dataloader.dataset.data[:0]
         dataloader.dataset.targets = dataloader.dataset.targets[:0]
         return dataloader
+
+    def train_dataloader__multiple(self):
+        return {'a': self.dataloader(train=True, num_samples=100),
+                'b': self.dataloader(train=True, num_samples=50)}

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -218,7 +218,7 @@ class TrainingStepVariations(ABC):
 
     def training_step__multiple_dataloaders(self, batch, batch_idx, optimizer_idx=None):
         """Lightning calls this inside the training loop"""
-        
+
         assert isinstance(batch, dict)
         assert len(batch) == 2
         assert 'a' in batch and 'b' in batch

--- a/tests/base/model_train_steps.py
+++ b/tests/base/model_train_steps.py
@@ -217,7 +217,7 @@ class TrainingStepVariations(ABC):
         return result
 
     def training_step__multiple_dataloaders(self, batch, batch_idx, optimizer_idx=None):
-        """Lightning calls this inside the training loop"""
+        """Training step for multiple train loaders"""
 
         assert isinstance(batch, dict)
         assert len(batch) == 2

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -630,6 +630,62 @@ def test_warning_with_few_workers(mock, tmpdir, ckpt_path):
         trainer.test(**test_options)
 
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Does not apply to Windows platform.')
+@pytest.mark.parametrize('ckpt_path', [None, 'best', 'specific'])
+@patch('pytorch_lightning.trainer.data_loading.multiprocessing.cpu_count', return_value=4)
+def test_warning_with_few_workers_multi_loader(mock, tmpdir, ckpt_path):
+    """ Test that error is raised if dataloader with only a few workers is used """
+
+    model = EvalModelTemplate()
+    model.training_step = model.training_step__multiple_dataloaders
+    model.validation_step = model.validation_step__multiple_dataloaders
+    model.validation_epoch_end = model.validation_epoch_end__multiple_dataloaders
+    model.test_step = model.test_step__multiple_dataloaders
+    model.test_epoch_end = model.test_epoch_end__multiple_dataloaders
+
+    # logger file to get meta
+    train_dl = model.dataloader(train=True)
+    train_dl.num_workers = 0
+
+    val_dl = model.dataloader(train=False)
+    val_dl.num_workers = 0
+
+    train_dl = model.dataloader(train=False)
+    train_dl.num_workers = 0
+
+    train_multi_dl = {'a': train_dl, 'b': train_dl}
+    val_multi_dl = [val_dl, val_dl]
+    test_multi_dl = [train_dl, train_dl]
+
+    fit_options = dict(train_dataloader=train_multi_dl,
+                       val_dataloaders=val_multi_dl)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_val_batches=0.1,
+        limit_train_batches=0.2,
+    )
+
+    # fit model
+    with pytest.warns(
+        UserWarning, match='The dataloader, train dataloader, does not have many workers which may be a bottleneck.'
+    ):
+        trainer.fit(model, **fit_options)
+
+    with pytest.warns(
+        UserWarning, match='The dataloader, val dataloader 0, does not have many workers which may be a bottleneck.'
+    ):
+        trainer.fit(model, **fit_options)
+
+    if ckpt_path == 'specific':
+        ckpt_path = trainer.checkpoint_callback.best_model_path
+    test_options = dict(test_dataloaders=test_multi_dl, ckpt_path=ckpt_path)
+    with pytest.warns(
+        UserWarning, match='The dataloader, test dataloader 0, does not have many workers which may be a bottleneck.'
+    ):
+        trainer.test(**test_options)
+
+
 @pytest.mark.xfail(
     LooseVersion(torch.__version__) < LooseVersion("1.4.0"),
     reason="IterableDataset with __len__ before 1.4 raises",
@@ -834,21 +890,10 @@ def test_batch_size_smaller_than_num_gpus(tmpdir):
     pytest.param("max_size_cycle", 10),
 ])
 def test_fit_multiple_train_loaders(tmpdir, multiple_trainloader_mode, num_training_batches):
-    class MutipleLoaderModel(EvalModelTemplate):
-        def train_dataloader(self):
-            return {'a': self.dataloader(train=True, num_samples=100),
-                    'b': self.dataloader(train=True, num_samples=50)}
+    model = EvalModelTemplate()
 
-        def training_step(self, batch, batch_idx, optimizer_idx=None):
-            assert isinstance(batch, dict)
-            assert len(batch) == 2
-            assert 'a' in batch and 'b' in batch
-            return super().training_step(batch=batch['a'], batch_idx=batch_idx,
-                                         optimizer_idx=optimizer_idx)
-
-    hparams = EvalModelTemplate.get_default_hparams()
-
-    model = MutipleLoaderModel(**hparams)
+    model.train_dataloader = model.train_dataloader__multiple
+    model.training_step = model.training_step__multiple_dataloaders
 
     trainer = Trainer(
         max_epochs=1, default_root_dir=tmpdir, multiple_trainloader_mode=multiple_trainloader_mode

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -890,6 +890,7 @@ def test_batch_size_smaller_than_num_gpus(tmpdir):
     pytest.param("max_size_cycle", 10),
 ])
 def test_fit_multiple_train_loaders(tmpdir, multiple_trainloader_mode, num_training_batches):
+    """Integration test for multple train loaders"""
     model = EvalModelTemplate()
 
     model.train_dataloader = model.train_dataloader__multiple

--- a/tests/trainer/test_supporters.py
+++ b/tests/trainer/test_supporters.py
@@ -1,8 +1,10 @@
 from collections import Sequence
 
+import pytest
 import torch
 
-from pytorch_lightning.trainer.supporters import CycleIterator, CombinedLoaderIterator
+from torch.utils.data import TensorDataset
+from pytorch_lightning.trainer.supporters import CycleIterator, CombinedLoader, CombinedDataset, CombinedLoaderIterator
 
 
 def test_cycle_iterator():
@@ -14,11 +16,39 @@ def test_cycle_iterator():
     assert idx == len(iterator) - 1
 
 
+@pytest.mark.parametrize(['dataset_1', 'dataset_2'], [
+    ([list(range(10)), list(range(20))]),
+    ([range(10), range(20)]),
+    ([torch.randn(10, 3, 2), torch.randn(20, 5, 6)]),
+    ([TensorDataset(torch.randn(10, 3, 2)), TensorDataset(torch.randn(20, 5, 6))])
+])
+def test_combined_dataset(dataset_1, dataset_2):
+    datasets = [dataset_1, dataset_2]
+    combined_dataset = CombinedDataset(datasets)
+
+    assert combined_dataset.max_len == 20
+    assert combined_dataset.min_len == len(combined_dataset) == 10
+
+
 def test_combined_loader_iterator_dict_min_size():
     loaders = {'a': torch.utils.data.DataLoader(range(10), batch_size=4),
                'b': torch.utils.data.DataLoader(range(20), batch_size=5)}
 
-    combined_loader = CombinedLoaderIterator(loaders, 'min_size')
+    combined_iter = CombinedLoaderIterator(loaders)
+
+    for idx, item in enumerate(combined_iter):
+        assert isinstance(item, dict)
+        assert len(item) == 2
+        assert 'a' in item and 'b' in item
+
+    assert idx == min(len(loaders['a']), len(loaders['b'])) - 1
+
+
+def test_combined_loader_dict_min_size():
+    loaders = {'a': torch.utils.data.DataLoader(range(10), batch_size=4),
+               'b': torch.utils.data.DataLoader(range(20), batch_size=5)}
+
+    combined_loader = CombinedLoader(loaders, 'min_size')
 
     assert len(combined_loader) == min([len(v) for v in loaders.values()])
 
@@ -30,11 +60,11 @@ def test_combined_loader_iterator_dict_min_size():
     assert idx == len(combined_loader) - 1
 
 
-def test_combined_loader_iterator_dict_max_size_cycle():
+def test_combined_loader_dict_max_size_cycle():
     loaders = {'a': torch.utils.data.DataLoader(range(10), batch_size=4),
                'b': torch.utils.data.DataLoader(range(20), batch_size=5)}
 
-    combined_loader = CombinedLoaderIterator(loaders, 'max_size_cycle')
+    combined_loader = CombinedLoader(loaders, 'max_size_cycle')
 
     assert len(combined_loader) == max([len(v) for v in loaders.values()])
 
@@ -46,11 +76,11 @@ def test_combined_loader_iterator_dict_max_size_cycle():
     assert idx == len(combined_loader) - 1
 
 
-def test_combined_loader_iterator_sequence_min_size():
+def test_combined_loader_sequence_min_size():
     loaders = [torch.utils.data.DataLoader(range(10), batch_size=4),
                torch.utils.data.DataLoader(range(20), batch_size=5)]
 
-    combined_loader = CombinedLoaderIterator(loaders, 'min_size')
+    combined_loader = CombinedLoader(loaders, 'min_size')
 
     assert len(combined_loader) == min([len(v) for v in loaders])
 
@@ -61,11 +91,11 @@ def test_combined_loader_iterator_sequence_min_size():
     assert idx == len(combined_loader) - 1
 
 
-def test_combined_loader_iterator_sequence_max_size_cycle():
+def test_combined_loader_sequence_max_size_cycle():
     loaders = [torch.utils.data.DataLoader(range(10), batch_size=4),
                torch.utils.data.DataLoader(range(20), batch_size=5)]
 
-    combined_loader = CombinedLoaderIterator(loaders, 'max_size_cycle')
+    combined_loader = CombinedLoader(loaders, 'max_size_cycle')
 
     assert len(combined_loader) == max([len(v) for v in loaders])
 

--- a/tests/trainer/test_supporters.py
+++ b/tests/trainer/test_supporters.py
@@ -8,6 +8,7 @@ from pytorch_lightning.trainer.supporters import CycleIterator, CombinedLoader, 
 
 
 def test_cycle_iterator():
+    """Test the cycling function of `CycleIterator`"""
     iterator = CycleIterator(range(100), 1000)
     assert len(iterator) == 1000
     for idx, item in enumerate(iterator):
@@ -23,6 +24,7 @@ def test_cycle_iterator():
     ([TensorDataset(torch.randn(10, 3, 2)), TensorDataset(torch.randn(20, 5, 6))])
 ])
 def test_combined_dataset(dataset_1, dataset_2):
+    """Verify the length of the CombinedDataset"""
     datasets = [dataset_1, dataset_2]
     combined_dataset = CombinedDataset(datasets)
 
@@ -31,6 +33,7 @@ def test_combined_dataset(dataset_1, dataset_2):
 
 
 def test_combined_loader_iterator_dict_min_size():
+    """Test `CombinedLoaderIterator` given mapping loaders"""
     loaders = {'a': torch.utils.data.DataLoader(range(10), batch_size=4),
                'b': torch.utils.data.DataLoader(range(20), batch_size=5)}
 
@@ -45,6 +48,7 @@ def test_combined_loader_iterator_dict_min_size():
 
 
 def test_combined_loader_dict_min_size():
+    """Test `CombinedLoader` of mode 'min_size' given mapping loaders"""
     loaders = {'a': torch.utils.data.DataLoader(range(10), batch_size=4),
                'b': torch.utils.data.DataLoader(range(20), batch_size=5)}
 
@@ -61,6 +65,7 @@ def test_combined_loader_dict_min_size():
 
 
 def test_combined_loader_dict_max_size_cycle():
+    """Test `CombinedLoader` of mode 'max_size_cycle' given mapping loaders"""
     loaders = {'a': torch.utils.data.DataLoader(range(10), batch_size=4),
                'b': torch.utils.data.DataLoader(range(20), batch_size=5)}
 
@@ -77,6 +82,7 @@ def test_combined_loader_dict_max_size_cycle():
 
 
 def test_combined_loader_sequence_min_size():
+    """Test `CombinedLoader` of mode 'min_size' given sequence loaders"""
     loaders = [torch.utils.data.DataLoader(range(10), batch_size=4),
                torch.utils.data.DataLoader(range(20), batch_size=5)]
 
@@ -92,6 +98,7 @@ def test_combined_loader_sequence_min_size():
 
 
 def test_combined_loader_sequence_max_size_cycle():
+    """Test `CombinedLoader` of mode 'max_size_cycle' given sequence loaders"""
     loaders = [torch.utils.data.DataLoader(range(10), batch_size=4),
                torch.utils.data.DataLoader(range(20), batch_size=5)]
 

--- a/tests/trainer/test_supporters.py
+++ b/tests/trainer/test_supporters.py
@@ -17,6 +17,18 @@ def test_cycle_iterator():
     assert idx == len(iterator) - 1
 
 
+def test_none_length_cycle_iterator():
+    """Test the infinite cycling function of `CycleIterator`"""
+    iterator = CycleIterator(range(100))
+    assert iterator.__len__() == float('inf')
+
+    # test infinite loop
+    for idx, item in enumerate(iterator):
+        if idx == 1000:
+            break
+    assert item == 0
+
+
 @pytest.mark.parametrize(['dataset_1', 'dataset_2'], [
     ([list(range(10)), list(range(20))]),
     ([range(10), range(20)]),
@@ -32,6 +44,11 @@ def test_combined_dataset(dataset_1, dataset_2):
     assert combined_dataset.min_len == len(combined_dataset) == 10
 
 
+def test_combined_dataset_length_mode_error():
+    with pytest.raises(ValueError):
+        CombinedDataset._calc_num_data([range(10)], 'test')
+
+
 def test_combined_loader_iterator_dict_min_size():
     """Test `CombinedLoaderIterator` given mapping loaders"""
     loaders = {'a': torch.utils.data.DataLoader(range(10), batch_size=4),
@@ -45,6 +62,24 @@ def test_combined_loader_iterator_dict_min_size():
         assert 'a' in item and 'b' in item
 
     assert idx == min(len(loaders['a']), len(loaders['b'])) - 1
+
+
+def test_combined_loader_init_mode_error():
+    """Test the ValueError when constructing `CombinedLoader`"""
+    with pytest.raises(ValueError):
+        CombinedLoader([range(10)], 'test')
+
+
+def test_combined_loader_loader_type_error():
+    """Test the ValueError when wrapping the loaders"""
+    with pytest.raises(ValueError):
+        CombinedLoader(None, 'max_size_cycle')
+
+
+def test_combined_loader_calc_length_mode_error():
+    """Test the ValueError when calculating the number of batches"""
+    with pytest.raises(TypeError):
+        CombinedLoader._calc_num_batches(None)
 
 
 def test_combined_loader_dict_min_size():

--- a/tests/trainer/test_train_loader_patch.py
+++ b/tests/trainer/test_train_loader_patch.py
@@ -1,0 +1,69 @@
+from collections import Sequence
+
+import pytest
+import torch
+
+from torch.utils.data import TensorDataset
+from pytorch_lightning.trainer.train_loader_patch import MultiIterator
+
+
+def test_multi_iterator_dict_min_size():
+    loaders = {'a': torch.utils.data.DataLoader(range(10), batch_size=4),
+               'b': torch.utils.data.DataLoader(range(20), batch_size=5)}
+
+    combined_loader = MultiIterator(loaders, 'min_size')
+
+    assert len(combined_loader) == min([len(v) for v in loaders.values()])
+
+    for idx, item in enumerate(combined_loader):
+        assert isinstance(item, dict)
+        assert len(item) == 2
+        assert 'a' in item and 'b' in item
+
+    assert idx == len(combined_loader) - 1
+
+
+def test_multi_iterator_dict_max_size_cycle():
+    loaders = {'a': torch.utils.data.DataLoader(range(10), batch_size=4),
+               'b': torch.utils.data.DataLoader(range(20), batch_size=5)}
+
+    combined_loader = MultiIterator(loaders, 'max_size_cycle')
+
+    assert len(combined_loader) == max([len(v) for v in loaders.values()])
+
+    for idx, item in enumerate(combined_loader):
+        assert isinstance(item, dict)
+        assert len(item) == 2
+        assert 'a' in item and 'b' in item
+
+    assert idx == len(combined_loader) - 1
+
+
+def test_multi_iterator_sequence_min_size():
+    loaders = [torch.utils.data.DataLoader(range(10), batch_size=4),
+               torch.utils.data.DataLoader(range(20), batch_size=5)]
+
+    combined_loader = MultiIterator(loaders, 'min_size')
+
+    assert len(combined_loader) == min([len(v) for v in loaders])
+
+    for idx, item in enumerate(combined_loader):
+        assert isinstance(item, Sequence)
+        assert len(item) == 2
+
+    assert idx == len(combined_loader) - 1
+
+
+def test_multi_iterator_sequence_max_size_cycle():
+    loaders = [torch.utils.data.DataLoader(range(10), batch_size=4),
+               torch.utils.data.DataLoader(range(20), batch_size=5)]
+
+    combined_loader = MultiIterator(loaders, 'max_size_cycle')
+
+    assert len(combined_loader) == max([len(v) for v in loaders])
+
+    for idx, item in enumerate(combined_loader):
+        assert isinstance(item, Sequence)
+        assert len(item) == 2
+
+    assert idx == len(combined_loader) - 1


### PR DESCRIPTION
## What does this PR do?

1. To make the `CombinedLoaderIterator` able to fit with the single `DataLoader` and fix some bugs, I separate the `CombinedLoaderIterator` into two classes: `CombinedLoaderIterator` and `CombinedLoader`, where their roles are similar to `_BaseDataLoaderIter ` and `DataLoader` in PyTorch. This change can fix the bugs about calculating `num_training_batches` and other tests.
https://github.com/PyTorchLightning/pytorch-lightning/blob/6e5f232f5cec2b5e635ae34fa365c6b969d0902e/pytorch_lightning/trainer/data_loading.py#L186-L198
2. Add `CombinedDataset`. Because in https://github.com/PyTorchLightning/pytorch-lightning/blob/6e5f232f5cec2b5e635ae34fa365c6b969d0902e/pytorch_lightning/tuner/batch_size_scaling.py#L269-L270
there should be `dataset` attribute in `train_dataloader`, so `CombinedDataset` used in `CombinedDataLoader` is for fitting the unified format of `DataLoader`.
3. Update and add related tests for changes. 

***Something need to be improved***
1. Maybe need some warnings about inf loader with no valid end condition (`max_steps`, `limited_training_batches`).
2. Documents about multiple training loaders.
3. Where to initialize `_multiple_trainloader_mode`? Currently, it's in the `training_loop.py`, but it's weird after I moving `CombinedLoader` into `data_loading.py`.
4. What's the behavior should be when calling `len(trainer.train_dataloader.dataset)` when there are multiple loaders? For now, it will return the minimum length of the datasets, but maybe it should depend on situations. 

-->

Fixes #1959 

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## Did you have fun?
Make sure you had fun coding 🙃
