### PR TITLE
isolate PL debugger in tests

### DIFF
--- a/tests/callbacks/test_early_stopping.py
+++ b/tests/callbacks/test_early_stopping.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from copy import deepcopy
 import pickle
+from unittest import mock
 
 import cloudpickle
 import pytest
@@ -82,10 +82,9 @@ def test_resume_early_stopping_from_checkpoint(tmpdir):
         new_trainer.fit(model)
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_early_stopping_no_extraneous_invocations(tmpdir):
     """Test to ensure that callback methods aren't being invoked outside of the callback handler."""
-    os.environ['PL_DEV_DEBUG'] = '1'
-
     model = EvalModelTemplate()
     expected_count = 4
     trainer = Trainer(

--- a/tests/checkpointing/test_checkpoint_callback_frequency.py
+++ b/tests/checkpointing/test_checkpoint_callback_frequency.py
@@ -19,9 +19,9 @@ import pytest
 import torch
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_mc_called_on_fastdevrun(tmpdir):
     seed_everything(1234)
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     train_val_step_model = EvalModelTemplate()
 
@@ -53,9 +53,9 @@ def test_mc_called_on_fastdevrun(tmpdir):
     assert len(trainer.dev_debugger.checkpoint_callback_history) == 1
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_mc_called(tmpdir):
     seed_everything(1234)
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     # -----------------
     # TRAIN LOOP ONLY

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 import os
 import os.path as osp
+from unittest import mock
+
 import pytorch_lightning as pl
-from distutils.version import LooseVersion
-from unittest.mock import MagicMock, Mock
+from unittest.mock import Mock
 
 import yaml
 import pickle
@@ -36,10 +37,9 @@ from pytorch_lightning.utilities.cloud_io import load as pl_load
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @pytest.mark.parametrize('save_top_k', [-1])
 def test_model_checkpoint_correct_score(tmpdir, save_top_k):
-    os.environ['PL_DEV_DEBUG'] = '1'
-
     """Test that when a model checkpoint is saved, it saves with the correct score appended to ckpt_path"""
     tutils.reset_seed()
 
@@ -432,10 +432,10 @@ def test_ckpt_metric_names(tmpdir):
     assert len(val) > 3
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_default_checkpoint_behavior(tmpdir):
     seed_everything(1234)
 
-    os.environ['PL_DEV_DEBUG'] = '1'
     model = EvalModelTemplate()
     model.validation_step = model.validation_step_no_monitor
     model.validation_epoch_end = model.validation_epoch_end_no_monitor
@@ -546,9 +546,9 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
         assert w0.eq(w1).all()
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @pytest.mark.parametrize('mode', ['min', 'max'])
 def test_checkpointing_with_nan_as_first(tmpdir, mode):
-    os.environ['PL_DEV_DEBUG'] = '1'
     monitor = [float('nan')]
     monitor += [5, 7, 8] if mode == 'max' else [8, 7, 5]
 
@@ -571,12 +571,11 @@ def test_checkpointing_with_nan_as_first(tmpdir, mode):
     assert trainer.dev_debugger.checkpoint_callback_history[-1]['epoch'] == len(monitor) - 1
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_checkpoint_repeated_strategy(tmpdir):
     """
     This test validates that the checkpoint can be called when provided to callacks list
     """
-
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     checkpoint_callback = ModelCheckpoint(monitor='val_loss', dirpath=tmpdir, filename="{epoch:02d}")
 
@@ -622,12 +621,11 @@ def test_checkpoint_repeated_strategy(tmpdir):
         assert str(os.listdir(tmpdir)) == "['epoch=00.ckpt']"
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_checkpoint_repeated_strategy_tmpdir(tmpdir):
     """
     This test validates that the checkpoint can be called when provided to callacks list
     """
-
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     checkpoint_callback = ModelCheckpoint(monitor='val_loss', filepath=os.path.join(tmpdir, "{epoch:02d}"))
 
@@ -678,13 +676,12 @@ def test_checkpoint_repeated_strategy_tmpdir(tmpdir):
         assert sorted(os.listdir(path_to_lightning_logs)) == sorted([f'version_{i}' for i in range(idx + 1)])
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_checkpoint_repeated_strategy_extended(tmpdir):
     """
     This test validates checkpoint can be called several times without
     increasing internally its global step if nothing run.
     """
-
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class ExtendedBoringModel(BoringModel):
 

--- a/tests/loggers/test_all.py
+++ b/tests/loggers/test_all.py
@@ -71,7 +71,6 @@ def test_loggers_fit_test_all(tmpdir, monkeypatch):
 
 
 def _test_loggers_fit_test(tmpdir, logger_class):
-    os.environ['PL_DEV_DEBUG'] = '0'
     model = EvalModelTemplate()
 
     class StoreHistoryLogger(logger_class):

--- a/tests/models/test_amp.py
+++ b/tests/models/test_amp.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from unittest import mock
 
 import pytest
 import torch
@@ -161,9 +162,9 @@ def test_cpu_model_with_amp(tmpdir):
         tpipes.run_model_test(trainer_options, model, on_gpu=False)
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_amp_without_apex(tmpdir):
     """Check that even with apex amp type without requesting precision=16 the amp backend is void."""
-    os.environ['PL_DEV_DEBUG'] = '1'
     model = EvalModelTemplate()
 
     trainer = Trainer(
@@ -183,11 +184,11 @@ def test_amp_without_apex(tmpdir):
     assert trainer.dev_debugger.count_events('AMP') == 0
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires GPU machine")
 @pytest.mark.skipif(not APEX_AVAILABLE, reason="test requires apex")
 def test_amp_with_apex(tmpdir):
     """Check calling apex scaling in training."""
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     model = EvalModelTemplate()
 

--- a/tests/models/test_grad_norm.py
+++ b/tests/models/test_grad_norm.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from unittest import mock
 from unittest.mock import patch
 
 import numpy as np
@@ -57,10 +58,9 @@ class ModelWithManualGradTracker(EvalModelTemplate):
         self.stored_grad_norms.append(out)
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @pytest.mark.parametrize("norm_type", [1., 1.25, 2, 3, 5, 10, 'inf'])
 def test_grad_tracking(tmpdir, norm_type, rtol=5e-3):
-    os.environ['PL_DEV_DEBUG'] = '1'
-
     # rtol=5e-3 respects the 3 decimals rounding in `.grad_norms` and above
 
     reset_seed()

--- a/tests/models/test_tpu.py
+++ b/tests/models/test_tpu.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from multiprocessing import Process, Queue
+from unittest import mock
 
 import pytest
 from torch.utils.data import DataLoader
@@ -252,11 +252,11 @@ def test_distributed_backend_set_when_using_tpu(tmpdir, tpu_cores):
     assert Trainer(tpu_cores=tpu_cores).distributed_backend == "tpu"
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @pytest.mark.skipif(not TPU_AVAILABLE, reason="test requires TPU machine")
 @pl_multi_process_test
 def test_result_obj_on_tpu(tmpdir):
     seed_everything(1234)
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     batches = 5
     epochs = 2

--- a/tests/trainer/data_flow/test_eval_loop_flow_1_0.py
+++ b/tests/trainer/data_flow/test_eval_loop_flow_1_0.py
@@ -14,19 +14,21 @@
 """
 Tests to ensure that the training loop works with a dict (1.0)
 """
+import os
+from unittest import mock
+
+import torch
+import pytest
 from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning import Trainer
 from tests.base.deterministic_model import DeterministicModel
-import os
-import torch
-import pytest
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__eval_step__flow(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):
@@ -66,11 +68,11 @@ def test__eval_step__flow(tmpdir):
     assert not model.validation_epoch_end_called
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__eval_step__eval_step_end__flow(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):
@@ -115,11 +117,11 @@ def test__eval_step__eval_step_end__flow(tmpdir):
     assert not model.validation_epoch_end_called
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__eval_step__epoch_end__flow(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):
@@ -174,11 +176,11 @@ def test__eval_step__epoch_end__flow(tmpdir):
     assert model.validation_epoch_end_called
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__validation_step__step_end__epoch_end__flow(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):

--- a/tests/trainer/data_flow/test_train_loop_flow_dict_1_0.py
+++ b/tests/trainer/data_flow/test_train_loop_flow_dict_1_0.py
@@ -14,18 +14,20 @@
 """
 Tests to ensure that the training loop works with a dict (1.0)
 """
+import os
+from unittest import mock
+
 from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning import Trainer
 from tests.base.deterministic_model import DeterministicModel
-import os
 import torch
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__training_step__flow_dict(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):
@@ -56,11 +58,11 @@ def test__training_step__flow_dict(tmpdir):
     assert not model.training_epoch_end_called
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__training_step__tr_step_end__flow_dict(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):
@@ -98,11 +100,11 @@ def test__training_step__tr_step_end__flow_dict(tmpdir):
     assert not model.training_epoch_end_called
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__training_step__epoch_end__flow_dict(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):
@@ -146,11 +148,11 @@ def test__training_step__epoch_end__flow_dict(tmpdir):
     assert model.training_epoch_end_called
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__training_step__step_end__epoch_end__flow_dict(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):

--- a/tests/trainer/data_flow/test_train_loop_flow_scalar_1_0.py
+++ b/tests/trainer/data_flow/test_train_loop_flow_scalar_1_0.py
@@ -14,20 +14,22 @@
 """
 Tests to ensure that the training loop works with a dict (1.0)
 """
+import os
+from unittest import mock
+
 from pytorch_lightning.core.lightning import LightningModule
 import pytest
 from pytorch_lightning import Trainer
 from tests.base.deterministic_model import DeterministicModel
 from tests.base.boring_model import BoringModel
-import os
 import torch
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__training_step__flow_scalar(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):
@@ -58,11 +60,11 @@ def test__training_step__flow_scalar(tmpdir):
     assert not model.training_epoch_end_called
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__training_step__tr_step_end__flow_scalar(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):
@@ -100,11 +102,11 @@ def test__training_step__tr_step_end__flow_scalar(tmpdir):
     assert not model.training_epoch_end_called
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__training_step__epoch_end__flow_scalar(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):
@@ -148,11 +150,11 @@ def test__training_step__epoch_end__flow_scalar(tmpdir):
     assert model.training_epoch_end_called
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__training_step__step_end__epoch_end__flow_scalar(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):

--- a/tests/trainer/legacy_deprecate_flow_log_tests/test_eval_loop_dict_return.py
+++ b/tests/trainer/legacy_deprecate_flow_log_tests/test_eval_loop_dict_return.py
@@ -127,8 +127,6 @@ def test_validation_step_dict_return(tmpdir):
     in the correct place
     """
 
-    os.environ['PL_DEV_DEBUG'] = '0'
-
     model = DeterministicModel()
     model.training_step = model.training_step_dict_return
     model.validation_step = model.validation_step_dict_return
@@ -170,7 +168,6 @@ def test_val_step_step_end_no_return(tmpdir):
     """
     Test that val step + val step end work (with no return in val step end)
     """
-    os.environ['PL_DEV_DEBUG'] = '0'
 
     model = DeterministicModel()
     model.training_step = model.training_step_dict_return
@@ -203,8 +200,6 @@ def test_val_step_step_end(tmpdir):
     """
     Test that val step + val step end work
     """
-
-    os.environ['PL_DEV_DEBUG'] = '0'
 
     model = DeterministicModel()
     model.training_step = model.training_step_dict_return
@@ -251,8 +246,6 @@ def test_no_val_step_end(tmpdir):
     Test that val step + val epoch end
     """
 
-    os.environ['PL_DEV_DEBUG'] = '0'
-
     model = DeterministicModel()
     model.training_step = model.training_step_dict_return
     model.validation_step = model.validation_step_dict_return
@@ -296,8 +289,6 @@ def test_full_val_loop(tmpdir):
     """
     Test that val step + val step end + val epoch end
     """
-
-    os.environ['PL_DEV_DEBUG'] = '0'
 
     model = DeterministicModel()
     model.training_step = model.training_step_dict_return

--- a/tests/trainer/legacy_deprecate_flow_log_tests/test_trainer_steps_dict_return.py
+++ b/tests/trainer/legacy_deprecate_flow_log_tests/test_trainer_steps_dict_return.py
@@ -14,9 +14,11 @@
 """
 Tests to ensure that the training loop works with a dict
 """
+import os
+from unittest import mock
+
 from pytorch_lightning import Trainer
 from tests.base.deterministic_model import DeterministicModel
-import os
 
 
 def test_training_step_dict(tmpdir):
@@ -146,11 +148,11 @@ def test_full_training_loop_dict(tmpdir):
     assert pbar_metrics['pbar_acc2'] == 21.0
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_result_obj_lr_scheduler_epoch(tmpdir):
     """
     test that the LR scheduler was called at the correct time with the correct metrics
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
     model = DeterministicModel()
     model.training_step = model.training_step_for_step_end_dict
     model.training_step_end = model.training_step_end_dict
@@ -168,11 +170,11 @@ def test_result_obj_lr_scheduler_epoch(tmpdir):
     assert len(trainer.dev_debugger.saved_lr_scheduler_updates) == 3
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_result_obj_lr_scheduler_step(tmpdir):
     """
     test that the LR scheduler was called at the correct time with the correct metrics
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
     model = DeterministicModel()
     model.training_step = model.training_step_for_step_end_dict
     model.training_step_end = model.training_step_end_dict

--- a/tests/trainer/legacy_deprecate_flow_log_tests/test_trainer_steps_scalar_return.py
+++ b/tests/trainer/legacy_deprecate_flow_log_tests/test_trainer_steps_scalar_return.py
@@ -105,7 +105,6 @@ def test_full_training_loop_scalar(tmpdir):
     Checks train_step + training_step_end + training_epoch_end
     (all with scalar return from train_step)
     """
-    os.environ['PL_DEV_DEBUG'] = '0'
 
     model = DeterministicModel()
     model.training_step = model.training_step_scalar_return
@@ -154,7 +153,6 @@ def test_train_step_epoch_end_scalar(tmpdir):
     Checks train_step + training_epoch_end (NO training_step_end)
     (with scalar return)
     """
-    os.environ['PL_DEV_DEBUG'] = '0'
 
     model = DeterministicModel()
     model.training_step = model.training_step_scalar_return

--- a/tests/trainer/legacy_deprecate_flow_log_tests/test_trainer_steps_scalar_return.py
+++ b/tests/trainer/legacy_deprecate_flow_log_tests/test_trainer_steps_scalar_return.py
@@ -15,6 +15,8 @@
 Tests to ensure that the training loop works with a scalar
 """
 import os
+from unittest import mock
+
 import torch
 import pytest
 
@@ -204,9 +206,9 @@ class DPPReduceMeanPbarModel(BoringModel):
         return {"loss": loss, "progress_bar":{"loss_2": loss}}
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="test requires multi-GPU machine")
 def test_dpp_reduce_mean_pbar(tmpdir):
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     model = DPPReduceMeanPbarModel()
     model.training_step_end = None

--- a/tests/trainer/logging/test_logger_connector.py
+++ b/tests/trainer/logging/test_logger_connector.py
@@ -15,6 +15,8 @@
 Tests to ensure that the training loop works with a dict (1.0)
 """
 import os
+from unittest import mock
+
 import torch
 import pytest
 from copy import deepcopy
@@ -47,13 +49,12 @@ class Helper:
         return decorator
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__logger_connector__epoch_result_store__train(tmpdir):
     """
     Tests that LoggerConnector will properly capture logged information
     and reduce them
     """
-
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(BoringModel):
 
@@ -214,13 +215,12 @@ def test__logger_connector__epoch_result_store__train__ttbt(tmpdir):
     assert generated == torch.stack(model.train_losses).mean().item()
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @pytest.mark.parametrize('num_dataloaders', [1, 2])
 def test__logger_connector__epoch_result_store__test_multi_dataloaders(tmpdir, num_dataloaders):
     """
     Tests that LoggerConnector will properly capture logged information in multi_dataloaders scenario
     """
-
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(BoringModel):
 

--- a/tests/trainer/logging_tests/test_eval_loop_logging_1_0.py
+++ b/tests/trainer/logging_tests/test_eval_loop_logging_1_0.py
@@ -14,12 +14,14 @@
 """
 Tests to ensure that the training loop works with a dict (1.0)
 """
+import os
+from unittest import mock
+
 from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning import Trainer
 from pytorch_lightning import callbacks, seed_everything
 from tests.base.deterministic_model import DeterministicModel
 from tests.base import SimpleModule, BoringModel, RandomDataset
-import os
 import numpy as np
 import itertools
 import collections
@@ -27,11 +29,11 @@ import torch
 import pytest
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__validation_step__log(tmpdir):
     """
     Tests that validation_step can log
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):
@@ -87,11 +89,11 @@ def test__validation_step__log(tmpdir):
     assert expected_cb_metrics == callback_metrics
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__validation_step__step_end__epoch_end__log(tmpdir):
     """
     Tests that validation_step can log
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):
@@ -165,12 +167,12 @@ def test__validation_step__step_end__epoch_end__log(tmpdir):
     assert expected_cb_metrics == callback_metrics
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @pytest.mark.parametrize(['batches', 'log_interval', 'max_epochs'], [(1, 1, 1), (64, 32, 2)])
 def test_eval_epoch_logging(tmpdir, batches, log_interval, max_epochs):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(BoringModel):
         def validation_epoch_end(self, outputs):
@@ -214,11 +216,11 @@ def test_eval_epoch_logging(tmpdir, batches, log_interval, max_epochs):
     assert len(trainer.dev_debugger.logged_metrics) == max_epochs
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_eval_float_logging(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(BoringModel):
 
@@ -249,13 +251,12 @@ def test_eval_float_logging(tmpdir):
     assert logged_metrics == expected_logged_metrics
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_eval_logging_auto_reduce(tmpdir):
     """
     Tests that only training_step can be used
     """
     seed_everything(1234)
-
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(BoringModel):
         def on_pretrain_routine_end(self) -> None:
@@ -319,7 +320,6 @@ def test_eval_epoch_only_logging(tmpdir, batches, log_interval, max_epochs):
     """
     Tests that only test_epoch_end can be used to log, and we return them in the results.
     """
-    os.environ['PL_DEV_DEBUG'] = '0'
 
     class TestModel(BoringModel):
         def test_epoch_end(self, outputs):
@@ -419,11 +419,11 @@ def test_single_dataloader_no_suffix_added(tmpdir):
     assert results[0]['test_loss'] == results[0]['y']
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_log_works_in_val_callback(tmpdir):
     """
     Tests that log can be called within callback
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestCallback(callbacks.Callback):
 
@@ -592,11 +592,11 @@ def test_log_works_in_val_callback(tmpdir):
             assert func_name not in trainer.logger_connector.progress_bar_metrics
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_log_works_in_test_callback(tmpdir):
     """
     Tests that log can be called within callback
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestCallback(callbacks.Callback):
 

--- a/tests/trainer/logging_tests/test_train_loop_logging_1_0.py
+++ b/tests/trainer/logging_tests/test_train_loop_logging_1_0.py
@@ -17,6 +17,8 @@ Tests to ensure that the training loop works with a dict (1.0)
 
 import os
 import collections
+from unittest import mock
+
 import pytest
 import itertools
 import numpy as np
@@ -32,11 +34,11 @@ from tests.base.boring_model import BoringModel, RandomDictDataset, RandomDictSt
 from tests.base.deterministic_model import DeterministicModel
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__training_step__log(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):
@@ -128,11 +130,11 @@ def test__training_step__log(tmpdir):
     assert callback_metrics == expected_callback_metrics
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test__training_step__epoch_end__log(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(DeterministicModel):
         def training_step(self, batch, batch_idx):
@@ -190,12 +192,12 @@ def test__training_step__epoch_end__log(tmpdir):
     assert callback_metrics == expected_callback_metrics
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @pytest.mark.parametrize(['batches', 'log_interval', 'max_epochs'], [(1, 1, 1), (64, 32, 2)])
 def test__training_step__step_end__epoch_end__log(tmpdir, batches, log_interval, max_epochs):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestModel(BoringModel):
         def training_step(self, batch, batch_idx):
@@ -500,12 +502,11 @@ def test_nested_datasouce_batch(tmpdir):
     trainer.fit(model, train_data, val_data)
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_log_works_in_train_callback(tmpdir):
     """
     Tests that log can be called within callback
     """
-
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     class TestCallback(callbacks.Callback):
 

--- a/tests/trainer/optimization/test_manual_optimization.py
+++ b/tests/trainer/optimization/test_manual_optimization.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import collections
 import os
+from unittest import mock
 
 import pytest
 import torch
@@ -22,9 +23,8 @@ from pytorch_lightning.utilities import APEX_AVAILABLE
 from tests.base.boring_model import BoringModel
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_multiple_optimizers_manual(tmpdir):
-    os.environ['PL_DEV_DEBUG'] = '1'
-
     """
     Tests that only training_step can be used
     """
@@ -85,9 +85,8 @@ def test_multiple_optimizers_manual(tmpdir):
     assert trainer.dev_debugger.count_events('backward_call') == limit_train_batches * num_manual_backward_calls
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_multiple_optimizers_manual_return(tmpdir):
-    os.environ['PL_DEV_DEBUG'] = '1'
-
     """
     Tests that only training_step can be used
     """
@@ -150,9 +149,8 @@ def test_multiple_optimizers_manual_return(tmpdir):
     assert trainer.dev_debugger.count_events('backward_call') == limit_train_batches * num_manual_backward_calls
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_multiple_optimizers_manual_return_and_log(tmpdir):
-    os.environ['PL_DEV_DEBUG'] = '1'
-
     """
     Tests that only training_step can be used
     """
@@ -220,10 +218,9 @@ def test_multiple_optimizers_manual_return_and_log(tmpdir):
     assert expected == logged
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires GPU machine")
 def test_multiple_optimizers_manual_native_amp(tmpdir):
-    os.environ['PL_DEV_DEBUG'] = '1'
-
     """
     Tests that only training_step can be used
     """
@@ -286,11 +283,10 @@ def test_multiple_optimizers_manual_native_amp(tmpdir):
     assert trainer.dev_debugger.count_events('backward_call') == limit_train_batches * num_manual_backward_calls
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires GPU machine")
 @pytest.mark.skipif(not APEX_AVAILABLE, reason="test requires apex")
 def test_multiple_optimizers_manual_apex(tmpdir):
-    os.environ['PL_DEV_DEBUG'] = '1'
-
     """
     Tests that only training_step can be used
     """
@@ -556,10 +552,9 @@ def test_manual_optimization_and_accumulated_gradient(tmpdir):
     trainer.fit(model)
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires GPU machine")
 def test_multiple_optimizers_manual_optimizer_step(tmpdir):
-    os.environ['PL_DEV_DEBUG'] = '1'
-
     """
     Tests that `manual_optimizer_step` works with several optimizers
     """

--- a/tests/trainer/test_correct_freq_accumulation.py
+++ b/tests/trainer/test_correct_freq_accumulation.py
@@ -14,16 +14,18 @@
 """
 Tests to ensure that the training loop works with a dict
 """
+import os
+from unittest import mock
+
 from pytorch_lightning import Trainer
 from tests.base.model_template import EvalModelTemplate
-import os
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_training_step_scalar(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     model = EvalModelTemplate()
     model.validation_step = None

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -14,6 +14,7 @@
 import os
 import platform
 from distutils.version import LooseVersion
+from unittest import mock
 from unittest.mock import patch
 
 import pytest
@@ -375,9 +376,9 @@ def test_dataloaders_with_limit_percent_batches(tmpdir, limit_train_batches, lim
         pytest.param(1, 2, 1e50),
     ]
 )
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_dataloaders_with_limit_num_batches(tmpdir, limit_train_batches, limit_val_batches, limit_test_batches):
     """Verify num_batches for train, val & test dataloaders passed with batch limit as number"""
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     model = EvalModelTemplate()
     model.val_dataloader = model.val_dataloader__multiple_mixed_length
@@ -432,9 +433,9 @@ def test_dataloaders_with_limit_num_batches(tmpdir, limit_train_batches, limit_v
                 assert num_batches == limit_test_batches
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_dataloaders_with_fast_dev_run(tmpdir):
     """Verify num_batches for train, val & test dataloaders passed with fast_dev_run = True"""
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     model = EvalModelTemplate()
     model.val_dataloader = model.val_dataloader__multiple_mixed_length
@@ -902,8 +903,8 @@ def test_test_dataloader_not_implemented_error_failed(tmpdir):
         trainer.test(model)
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_dataloaders_load_only_once(tmpdir):
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     model = EvalModelTemplate()
 
@@ -930,8 +931,8 @@ def test_dataloaders_load_only_once(tmpdir):
         assert call['name'] == expected
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_dataloaders_load_only_once_val_interval(tmpdir):
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     model = EvalModelTemplate()
 
@@ -974,8 +975,8 @@ def test_dataloaders_load_only_once_val_interval(tmpdir):
         assert call['name'] == expected
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_dataloaders_load_only_once_no_sanity_check(tmpdir):
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     model = EvalModelTemplate()
 
@@ -1003,8 +1004,8 @@ def test_dataloaders_load_only_once_no_sanity_check(tmpdir):
         assert call['name'] == expected
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_dataloaders_load_every_epoch(tmpdir):
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     model = EvalModelTemplate()
 
@@ -1040,8 +1041,8 @@ def test_dataloaders_load_every_epoch(tmpdir):
         assert call['name'] == expected
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_dataloaders_load_every_epoch_no_sanity_check(tmpdir):
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     model = EvalModelTemplate()
 
@@ -1077,8 +1078,8 @@ def test_dataloaders_load_every_epoch_no_sanity_check(tmpdir):
         assert call['name'] == expected
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_dataloaders_load_only_once_passed_loaders(tmpdir):
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     model = EvalModelTemplate()
     train_loader = model.train_dataloader()

--- a/tests/trainer/warnings_tests/test_flow_warnings.py
+++ b/tests/trainer/warnings_tests/test_flow_warnings.py
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from tests.base.boring_model import BoringModel
 import os
+from unittest import mock
+
+from tests.base.boring_model import BoringModel
 from pytorch_lightning import Trainer
 import warnings
 
@@ -23,11 +25,11 @@ class TestModel(BoringModel):
         return acc
 
 
+@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_no_depre_without_epoch_end(tmpdir):
     """
     Tests that only training_step can be used
     """
-    os.environ['PL_DEV_DEBUG'] = '1'
 
     model = TestModel()
     model.validation_epoch_end = None


### PR DESCRIPTION
## What does this PR do?

the actual state with `os.environ['PL_DEV_DEBUG'] = '1'` set the os env until it changed so, in fact, all tests run in debug mode, this sets the os env just for particular tests when it is needed

Closes #3962

## Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In in short, see following bullet-list:  

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified; _Bugfixes should be including in bug-fix release milestones (m.f.X) and features should be included in (m.X.b) releases._
 

## Did you have fun?
Make sure you had fun coding 🙃
