### PR TITLE
Sharded Plugin 3/n: Unify distributed accelerators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Tuner algorithms will be skipped if `fast_dev_run=True` ([#3903](https://github.com/PyTorchLightning/pytorch-lightning/pull/3903))
 
 
+- Unified DDP accelerators using distributed accelerator class ([#4683](https://github.com/PyTorchLightning/pytorch-lightning/pull/4683))
+
+
 ### Deprecated
 
 

--- a/pytorch_lightning/accelerators/ddp2_accelerator.py
+++ b/pytorch_lightning/accelerators/ddp2_accelerator.py
@@ -11,20 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-import os
 
 import torch
-import torch.distributed as torch_distrib
 
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.accelerators.distributed_accelerator import DistributedAccelerator
 from pytorch_lightning.core.step_result import Result
 from pytorch_lightning.distributed.dist import LightningDistributed
-from pytorch_lightning import _logger as log
-from pytorch_lightning.accelerators.accelerator import Accelerator, ReduceOp
-from pytorch_lightning.utilities import AMPType
-from pytorch_lightning.utilities.distributed import rank_zero_only, sync_ddp_if_available
-from torch.nn.parallel import DistributedDataParallel
-from typing import List, Optional, Union, Any
 
 try:
     from hydra.utils import to_absolute_path, get_original_cwd
@@ -35,7 +27,7 @@ else:
     HYDRA_AVAILABLE = True
 
 
-class DDP2Accelerator(Accelerator):
+class DDP2Accelerator(DistributedAccelerator):
 
     def __init__(self, trainer, cluster_environment=None, ddp_plugin=None):
         """
@@ -58,27 +50,7 @@ class DDP2Accelerator(Accelerator):
 
     def train(self):
         model = self.trainer.model
-        return self.ddp_train(process_idx=self.task_idx, mp_queue=None, model=model)
-
-    def training_step(self, args):
-        if self.trainer.amp_backend == AMPType.NATIVE:
-            with torch.cuda.amp.autocast():
-                output = self.trainer.model(*args)
-        else:
-            output = self.trainer.model(*args)
-        return output
-
-    def validation_step(self, args):
-        output = self.training_step(args)
-        return output
-
-    def test_step(self, args):
-        output = self.training_step(args)
-        return output
-
-    def barrier(self, name: Optional[str] = None):
-        if torch_distrib.is_initialized():
-            torch_distrib.barrier()
+        return self.ddp_train(process_idx=self.task_idx, model=model)
 
     def training_step_end(self, output):
         if isinstance(output, Result):
@@ -100,9 +72,6 @@ class DDP2Accelerator(Accelerator):
         self.trainer.global_rank = self.trainer.node_rank
         self.trainer.world_size = self.trainer.num_nodes
 
-    def broadcast(self, obj, src=0):
-        return self.dist.broadcast(obj)
-
     def model_to_device(self, model, process_idx):
         self.trainer.root_gpu = process_idx
         torch.cuda.set_device(self.trainer.root_gpu)
@@ -111,108 +80,3 @@ class DDP2Accelerator(Accelerator):
     def get_device_ids(self):
         device_ids = self.trainer.data_parallel_device_ids
         return device_ids
-
-    def ddp_train(self, process_idx, mp_queue, model):
-        """
-        Entry point for ddp
-
-        Args:
-            process_idx: current process rank
-            mp_queue: multiprocessing queue
-            model: pointer to current :class:`LightningModule`
-
-        Returns:
-            Dict with evaluation results
-
-        """
-        # show progressbar only on progress_rank 0
-        if (self.trainer.node_rank != 0 or process_idx != 0) and self.trainer.progress_bar_callback is not None:
-            self.trainer.progress_bar_callback.disable()
-
-        # determine which process we are and world size
-        self.set_world_ranks(process_idx)
-
-        # set warning rank
-        rank_zero_only.rank = self.trainer.global_rank
-
-        # set up server using proc 0's ip address
-        # try to init for 20 times at max in case ports are taken
-        # where to store ip_table
-        model.trainer = self.trainer
-        self.init_ddp_connection(
-            self.trainer.global_rank,
-            self.trainer.world_size,
-            self.trainer.is_slurm_managing_tasks
-        )
-
-        # call setup after the ddp process has connected
-        self.trainer.call_setup_hook(model)
-
-        # on world_size=0 let everyone know training is starting
-        if self.trainer.is_global_zero and not torch.distributed.is_initialized():
-            log.info('-' * 100)
-            log.info(f'distributed_backend={self.trainer.distributed_backend}')
-            log.info(f'All DDP processes registered. Starting ddp with {self.trainer.world_size} processes')
-            log.info('-' * 100)
-
-        # call sync_bn before .cuda(), configure_apex and configure_ddp
-        if self.trainer.sync_batchnorm:
-            model = self.configure_sync_batchnorm(model)
-
-        # move the model to the correct device
-        self.model_to_device(model, process_idx)
-
-        # CHOOSE OPTIMIZER
-        # allow for lr schedulers as well
-        self.setup_optimizers(model)
-
-        # set model properties before going into wrapper
-        self.trainer.model_connector.copy_trainer_model_properties(model)
-
-        # 16-bit
-        model = self.trainer.precision_connector.connect(model)
-
-        # device ids change depending on the DDP setup
-        device_ids = self.get_device_ids()
-
-        # allow user to configure ddp
-        model = self.configure_ddp(model, device_ids)
-
-        # set up training routine
-        self.trainer.train_loop.setup_training(model)
-
-        # train or test
-        results = self.train_or_test()
-
-        # clean up memory
-        torch.cuda.empty_cache()
-        return results
-
-    def configure_ddp(
-        self, model: LightningModule, device_ids: List[int]
-    ) -> DistributedDataParallel:
-        model = self.ddp_plugin.configure_ddp(model, device_ids)
-        return model
-
-    def configure_sync_batchnorm(self, model: LightningModule) -> LightningModule:
-        """
-        Add global batchnorm for a model spread across multiple GPUs and nodes.
-
-        Override to synchronize batchnorm between specific process groups instead
-        of the whole world or use a different sync_bn like `apex`'s version.
-
-        Args:
-            model: pointer to current :class:`LightningModule`.
-
-        Return:
-            LightningModule with batchnorm layers synchronized between process groups
-        """
-        model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model, process_group=None)
-
-        return model
-
-    def sync_tensor(self,
-                    tensor: Union[torch.Tensor],
-                    group: Optional[Any] = None,
-                    reduce_op: Optional[Union[ReduceOp, str]] = None) -> torch.Tensor:
-        return sync_ddp_if_available(tensor, group, reduce_op)

--- a/pytorch_lightning/accelerators/ddp_accelerator.py
+++ b/pytorch_lightning/accelerators/ddp_accelerator.py
@@ -20,9 +20,9 @@ from typing import Optional
 
 import numpy as np
 
-from pytorch_lightning import seed_everything
 from pytorch_lightning.accelerators.distributed_accelerator import DistributedAccelerator
 from pytorch_lightning.distributed.dist import LightningDistributed
+from pytorch_lightning.utilities.seed import seed_everything
 from pytorch_lightning.utilities.distributed import find_free_network_port
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 

--- a/pytorch_lightning/accelerators/ddp_accelerator.py
+++ b/pytorch_lightning/accelerators/ddp_accelerator.py
@@ -12,28 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License
 import os
-import torch
-import torch.distributed as torch_distrib
 import subprocess
 import sys
 from os.path import abspath
 from time import sleep
-from typing import Any, Optional, List, Union
+from typing import Optional
 
 import numpy as np
 
-from pytorch_lightning import _logger as log
-from pytorch_lightning.accelerators.accelerator import Accelerator, ReduceOp
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning import seed_everything
+from pytorch_lightning.accelerators.distributed_accelerator import DistributedAccelerator
 from pytorch_lightning.distributed.dist import LightningDistributed
-from pytorch_lightning.utilities import AMPType
 from pytorch_lightning.utilities.distributed import find_free_network_port
-from pytorch_lightning.utilities.distributed import rank_zero_only
-from pytorch_lightning.utilities.distributed import sync_ddp_if_available
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities.seed import seed_everything
-from torch.nn.parallel import DistributedDataParallel
-
 
 try:
     from hydra.utils import to_absolute_path, get_original_cwd
@@ -44,7 +35,7 @@ else:
     HYDRA_AVAILABLE = True
 
 
-class DDPAccelerator(Accelerator):
+class DDPAccelerator(DistributedAccelerator):
 
     def __init__(self, trainer, cluster_environment=None, ddp_plugin=None):
         """
@@ -150,26 +141,6 @@ class DDPAccelerator(Accelerator):
             del os.environ['WORLD_SIZE']
         return results
 
-    def training_step(self, args):
-        if self.trainer.amp_backend == AMPType.NATIVE:
-            with torch.cuda.amp.autocast():
-                output = self.trainer.model(*args)
-        else:
-            output = self.trainer.model(*args)
-        return output
-
-    def validation_step(self, args):
-        output = self.training_step(args)
-        return output
-
-    def test_step(self, args):
-        output = self.training_step(args)
-        return output
-
-    def barrier(self, name: Optional[str] = None):
-        if torch_distrib.is_initialized():
-            torch_distrib.barrier()
-
     def _check_can_spawn_children(self):
         if self._has_spawned_children:
             raise RuntimeError(
@@ -177,143 +148,8 @@ class DDPAccelerator(Accelerator):
                 " This is not supported in DDP mode, switch to `distributed_backend='ddp_spawn'` instead."
             )
 
-    def set_world_ranks(self, process_idx):
-        self.trainer.local_rank = process_idx
-        self.trainer.global_rank = self.trainer.node_rank * self.trainer.num_processes + process_idx
-        self.trainer.world_size = self.trainer.num_nodes * self.trainer.num_processes
-
-    def model_to_device(self, model, process_idx):
-        self.trainer.root_gpu = self.trainer.data_parallel_device_ids[self.trainer.local_rank]
-        torch.cuda.set_device(self.trainer.root_gpu)
-        model.cuda(self.trainer.root_gpu)
-
-    def get_device_ids(self):
-        device_ids = [self.trainer.root_gpu]
-        return device_ids
-
-    def on_train_end(self):
-        pass
-
-    def early_stopping_should_stop(self, pl_module):
-        stop = torch.tensor(int(self.trainer.should_stop), device=pl_module.device)
-        torch_distrib.all_reduce(stop, op=torch_distrib.reduce_op.SUM)
-        torch_distrib.barrier()
-        should_stop = stop == self.trainer.world_size
-        return should_stop
-
-    def broadcast(self, obj, src=0):
-        return self.dist.broadcast(obj)
-
     def ddp_train(self, process_idx, model):
-        """
-        Entry point for ddp
-
-        Args:
-            process_idx:
-            mp_queue: multiprocessing queue
-            model:
-
-        Returns:
-            Dict with evaluation results
-
-        """
         seed = os.environ.get("PL_GLOBAL_SEED")
         if seed is not None:
             seed_everything(int(seed))
-
-        # show progressbar only on progress_rank 0
-        if (self.trainer.node_rank != 0 or process_idx != 0) and self.trainer.progress_bar_callback is not None:
-            self.trainer.progress_bar_callback.disable()
-
-        # determine which process we are and world size
-        self.set_world_ranks(process_idx)
-
-        # set warning rank
-        rank_zero_only.rank = self.trainer.global_rank
-
-        # set up server using proc 0's ip address
-        # try to init for 20 times at max in case ports are taken
-        # where to store ip_table
-        model.trainer = self.trainer
-        self.init_ddp_connection(
-            self.trainer.global_rank,
-            self.trainer.world_size,
-            self.trainer.is_slurm_managing_tasks
-        )
-
-        # call setup after the ddp process has connected
-        self.trainer.call_setup_hook(model)
-
-        # on world_size=0 let everyone know training is starting
-        if self.trainer.is_global_zero and not torch.distributed.is_initialized():
-            log.info('-' * 100)
-            log.info(f'distributed_backend={self.trainer.distributed_backend}')
-            log.info(f'All DDP processes registered. Starting ddp with {self.trainer.world_size} processes')
-            log.info('-' * 100)
-
-        # call sync_bn before .cuda(), configure_apex and configure_ddp
-        if self.trainer.sync_batchnorm:
-            model = self.configure_sync_batchnorm(model)
-
-        # move the model to the correct device
-        self.model_to_device(model, process_idx)
-
-        # CHOOSE OPTIMIZER
-        # allow for lr schedulers as well
-        self.setup_optimizers(model)
-
-        # set model properties before going into wrapper
-        self.trainer.model_connector.copy_trainer_model_properties(model)
-
-        # 16-bit
-        model = self.trainer.precision_connector.connect(model)
-
-        # device ids change depending on the DDP setup
-        device_ids = self.get_device_ids()
-
-        # allow user to configure ddp
-        model = self.configure_ddp(model, device_ids)
-
-        # set up training routine
-        self.barrier('ddp_setup')
-        self.trainer.train_loop.setup_training(model)
-
-        # train or test
-        results = self.train_or_test()
-
-        # clean up memory
-        torch.cuda.empty_cache()
-
-        return results
-
-    def configure_ddp(
-        self, model: LightningModule, device_ids: List[int]
-    ) -> DistributedDataParallel:
-        model = self.ddp_plugin.configure_ddp(model, device_ids)
-        return model
-
-    def configure_sync_batchnorm(self, model: LightningModule) -> LightningModule:
-        """
-        Add global batchnorm for a model spread across multiple GPUs and nodes.
-
-        Override to synchronize batchnorm between specific process groups instead
-        of the whole world or use a different sync_bn like `apex`'s version.
-
-        Args:
-            model: pointer to current :class:`LightningModule`.
-
-        Return:
-            LightningModule with batchnorm layers synchronized between process groups
-        """
-        model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model, process_group=None)
-
-        return model
-
-    def sync_tensor(self,
-                    tensor: Union[torch.Tensor],
-                    group: Optional[Any] = None,
-                    reduce_op: Optional[Union[ReduceOp, str]] = None) -> torch.Tensor:
-        """
-
-        """
-        return sync_ddp_if_available(tensor, group, reduce_op)
+        return super().ddp_train(process_idx, model)

--- a/pytorch_lightning/accelerators/ddp_hpc_accelerator.py
+++ b/pytorch_lightning/accelerators/ddp_hpc_accelerator.py
@@ -11,21 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License
-import os
-from typing import Any, List, Optional, Union
 
-import torch
-import torch.distributed as torch_distrib
-import torch.distributed as dist
-from torch.nn.parallel import DistributedDataParallel
-
-from pytorch_lightning import _logger as log
-from pytorch_lightning.accelerators.accelerator import Accelerator, ReduceOp
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.accelerators.distributed_accelerator import DistributedAccelerator
 from pytorch_lightning.distributed.dist import LightningDistributed
-from pytorch_lightning.utilities import AMPType
-from pytorch_lightning.utilities.distributed import rank_zero_only, sync_ddp_if_available
-
 
 try:
     from hydra.utils import to_absolute_path, get_original_cwd
@@ -36,7 +24,7 @@ else:
     HYDRA_AVAILABLE = True
 
 
-class DDPHPCAccelerator(Accelerator):
+class DDPHPCAccelerator(DistributedAccelerator):
 
     def __init__(self, trainer, cluster_environment=None, ddp_plugin=None):
         """
@@ -61,153 +49,3 @@ class DDPHPCAccelerator(Accelerator):
     def train(self):
         model = self.trainer.model
         self.ddp_train(process_idx=self.task_idx, model=model)
-
-    def set_world_ranks(self, process_idx):
-        self.trainer.local_rank = process_idx
-        self.trainer.global_rank = self.trainer.node_rank * self.trainer.num_processes + process_idx
-        self.trainer.world_size = self.trainer.num_nodes * self.trainer.num_processes
-
-    def model_to_device(self, model, process_idx):
-        self.trainer.root_gpu = process_idx
-        torch.cuda.set_device(self.trainer.root_gpu)
-        model.cuda(self.trainer.root_gpu)
-
-    def get_device_ids(self):
-        device_ids = [self.trainer.root_gpu]
-        return device_ids
-
-    def training_step(self, args):
-        if self.trainer.amp_backend == AMPType.NATIVE:
-            with torch.cuda.amp.autocast():
-                output = self.trainer.model(*args)
-        else:
-            output = self.trainer.model(*args)
-        return output
-
-    def validation_step(self, args):
-        output = self.training_step(args)
-        return output
-
-    def test_step(self, args):
-        output = self.training_step(args)
-        return output
-
-    def barrier(self, name: Optional[str] = None):
-        if torch_distrib.is_initialized():
-            torch_distrib.barrier()
-
-    def early_stopping_should_stop(self, pl_module):
-        stop = torch.tensor(int(self.trainer.should_stop), device=pl_module.device)
-        dist.all_reduce(stop, op=dist.reduce_op.SUM)
-        dist.barrier()
-        should_stop = stop == self.trainer.world_size
-        return should_stop
-
-    def broadcast(self, obj, src=0):
-        return self.dist.broadcast(obj)
-
-    def ddp_train(self, process_idx, model):
-        """
-        Entry point for ddp
-
-        Args:
-            process_idx:
-            mp_queue: multiprocessing queue
-            model:
-
-        Returns:
-            Dict with evaluation results
-
-        """
-        # determine which process we are and world size
-        self.set_world_ranks(process_idx)
-
-        # toggle prog bar
-        if (self.trainer.node_rank != 0 or process_idx != 0) and self.trainer.progress_bar_callback is not None:
-            self.trainer.progress_bar_callback.disable()
-
-        # set warning rank
-        rank_zero_only.rank = self.trainer.global_rank
-
-        # set up server using proc 0's ip address
-        # try to init for 20 times at max in case ports are taken
-        # where to store ip_table
-        model.trainer = self.trainer
-        self.init_ddp_connection(
-            self.trainer.global_rank,
-            self.trainer.world_size,
-            self.trainer.is_slurm_managing_tasks
-        )
-
-        # call setup after the ddp process has connected
-        self.trainer.call_setup_hook(model)
-
-        # on world_size=0 let everyone know training is starting
-        if self.trainer.is_global_zero and not torch.distributed.is_initialized():
-            log.info('-' * 100)
-            log.info(f'distributed_backend={self.trainer.distributed_backend}')
-            log.info(f'All DDP processes registered. Starting ddp with {self.trainer.world_size} processes')
-            log.info('-' * 100)
-
-        # call sync_bn before .cuda(), configure_apex and configure_ddp
-        if self.trainer.sync_batchnorm:
-            model = self.configure_sync_batchnorm(model)
-
-        # move the model to the correct device
-        self.model_to_device(model, process_idx)
-
-        # CHOOSE OPTIMIZER
-        # allow for lr schedulers as well
-        self.setup_optimizers(model)
-
-        # set model properties before going into wrapper
-        self.trainer.model_connector.copy_trainer_model_properties(model)
-
-        # 16-bit
-        model = self.trainer.precision_connector.connect(model)
-
-        # device ids change depending on the DDP setup
-        device_ids = self.get_device_ids()
-
-        # allow user to configure ddp
-        model = self.configure_ddp(model, device_ids)
-
-        # set up training routine
-        self.trainer.train_loop.setup_training(model)
-
-        # train or test
-        results = self.train_or_test()
-
-        # clean up memory
-        torch.cuda.empty_cache()
-
-        return results
-
-    def configure_ddp(
-        self, model: LightningModule, device_ids: List[int]
-    ) -> DistributedDataParallel:
-        model = self.ddp_plugin.configure_ddp(model, device_ids)
-        return model
-
-    def configure_sync_batchnorm(self, model: LightningModule) -> LightningModule:
-        """
-        Add global batchnorm for a model spread across multiple GPUs and nodes.
-
-        Override to synchronize batchnorm between specific process groups instead
-        of the whole world or use a different sync_bn like `apex`'s version.
-
-        Args:
-            model: pointer to current :class:`LightningModule`.
-
-        Return:
-            LightningModule with batchnorm layers synchronized between process groups
-        """
-        model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model, process_group=None)
-
-        return model
-
-    def sync_tensor(self,
-                    tensor: Union[torch.Tensor],
-                    group: Optional[Any] = None,
-                    reduce_op: Optional[Union[ReduceOp, str]] = None) -> torch.Tensor:
-        return sync_ddp_if_available(tensor, group, reduce_op)

--- a/pytorch_lightning/accelerators/distributed_accelerator.py
+++ b/pytorch_lightning/accelerators/distributed_accelerator.py
@@ -17,7 +17,7 @@ import torch
 import torch.distributed as torch_distrib
 from torch.nn.parallel import DistributedDataParallel
 
-from pytorch_lightning import LightningModule
+from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning import _logger as log
 from pytorch_lightning.accelerators.accelerator import Accelerator, ReduceOp
 from pytorch_lightning.utilities import AMPType

--- a/pytorch_lightning/accelerators/distributed_accelerator.py
+++ b/pytorch_lightning/accelerators/distributed_accelerator.py
@@ -1,0 +1,184 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+from typing import Optional, List, Union, Any
+
+import torch
+import torch.distributed as torch_distrib
+from torch.nn.parallel import DistributedDataParallel
+
+from pytorch_lightning import LightningModule
+from pytorch_lightning import _logger as log
+from pytorch_lightning.accelerators.accelerator import Accelerator, ReduceOp
+from pytorch_lightning.utilities import AMPType
+from pytorch_lightning.utilities.distributed import rank_zero_only
+from pytorch_lightning.utilities.distributed import sync_ddp_if_available
+
+
+class DistributedAccelerator(Accelerator):
+    """
+        Base class to extend for distributed Accelerators.
+        Contains base function implementations for all distributed accelerators.
+    """
+
+    def training_step(self, args):
+        return self._step(args)
+
+    def validation_step(self, args):
+        return self._step(args)
+
+    def test_step(self, args):
+        return self._step(args)
+
+    def _step(self, args):
+        args = self.ddp_plugin.input_to_device(args, self.trainer.get_model())
+        if self.trainer.amp_backend == AMPType.NATIVE:
+            with torch.cuda.amp.autocast():
+                output = self.trainer.model(*args)
+        else:
+            output = self.trainer.model(*args)
+        return output
+
+    def barrier(self, name: Optional[str] = None):
+        if torch_distrib.is_initialized():
+            torch_distrib.barrier()
+
+    def broadcast(self, obj, src=0):
+        return self.dist.broadcast(obj)
+
+    def configure_ddp(
+            self, model: LightningModule, device_ids: List[int]
+    ) -> DistributedDataParallel:
+        model = self.ddp_plugin.configure_ddp(model, device_ids)
+        return model
+
+    def configure_sync_batchnorm(self, model: LightningModule) -> LightningModule:
+        """
+        Add global batchnorm for a model spread across multiple GPUs and nodes.
+
+        Override to synchronize batchnorm between specific process groups instead
+        of the whole world or use a different sync_bn like `apex`'s version.
+
+        Args:
+            model: pointer to current :class:`LightningModule`.
+
+        Return:
+            LightningModule with batchnorm layers synchronized between process groups
+        """
+        model = torch.nn.SyncBatchNorm.convert_sync_batchnorm(model, process_group=None)
+
+        return model
+
+    def sync_tensor(self,
+                    tensor: Union[torch.Tensor],
+                    group: Optional[Any] = None,
+                    reduce_op: Optional[Union[ReduceOp, str]] = None) -> torch.Tensor:
+        return sync_ddp_if_available(tensor, group, reduce_op)
+
+    def get_device_ids(self):
+        device_ids = [self.trainer.root_gpu]
+        return device_ids
+
+    def set_world_ranks(self, process_idx):
+        self.trainer.local_rank = process_idx
+        self.trainer.global_rank = self.trainer.node_rank * self.trainer.num_processes + process_idx
+        self.trainer.world_size = self.trainer.num_nodes * self.trainer.num_processes
+
+    def model_to_device(self, model, process_idx):
+        self.trainer.root_gpu = process_idx
+        torch.cuda.set_device(self.trainer.root_gpu)
+        model.cuda(self.trainer.root_gpu)
+
+    def early_stopping_should_stop(self, pl_module):
+        stop = torch.tensor(int(self.trainer.should_stop), device=pl_module.device)
+        torch_distrib.all_reduce(stop, op=torch_distrib.reduce_op.SUM)
+        torch_distrib.barrier()
+        should_stop = stop == self.trainer.world_size
+        return should_stop
+
+    def ddp_train(self, process_idx, model):
+        """
+        Entry point for ddp train. Contains logic to initialize/train or test the model using distributed.
+
+        Args:
+            process_idx: Rank of the process.
+            model: Model to be trained distributed.
+
+        Returns:
+            Dict with evaluation results
+        """
+
+        # show progressbar only on progress_rank 0
+        if (self.trainer.node_rank != 0 or process_idx != 0) and self.trainer.progress_bar_callback is not None:
+            self.trainer.progress_bar_callback.disable()
+
+        # determine which process we are and world size
+        self.set_world_ranks(process_idx)
+
+        # set warning rank
+        rank_zero_only.rank = self.trainer.global_rank
+
+        # set up server using proc 0's ip address
+        # try to init for 20 times at max in case ports are taken
+        # where to store ip_table
+        model.trainer = self.trainer
+        self.init_ddp_connection(
+            self.trainer.global_rank,
+            self.trainer.world_size,
+            self.trainer.is_slurm_managing_tasks
+        )
+
+        # call setup after the ddp process has connected
+        self.trainer.call_setup_hook(model)
+
+        # on world_size=0 let everyone know training is starting
+        if self.trainer.is_global_zero and not torch.distributed.is_initialized():
+            log.info('-' * 100)
+            log.info(f'distributed_backend={self.trainer.distributed_backend}')
+            log.info(f'All DDP processes registered. Starting ddp with {self.trainer.world_size} processes')
+            log.info('-' * 100)
+
+        # call sync_bn before .cuda(), configure_apex and configure_ddp
+        if self.trainer.sync_batchnorm:
+            model = self.configure_sync_batchnorm(model)
+
+        # move the model to the correct device
+        self.model_to_device(model, process_idx)
+
+        # CHOOSE OPTIMIZER
+        # allow for lr schedulers as well
+        self.setup_optimizers(model)
+
+        # set model properties before going into wrapper
+        self.trainer.model_connector.copy_trainer_model_properties(model)
+
+        # 16-bit
+        model = self.trainer.precision_connector.connect(model)
+
+        # device ids change depending on the DDP setup
+        device_ids = self.get_device_ids()
+
+        # allow user to configure ddp
+        model = self.configure_ddp(model, device_ids)
+
+        # set up training routine
+        self.barrier('ddp_setup')
+        self.trainer.train_loop.setup_training(model)
+
+        # train or test
+        results = self.train_or_test()
+
+        # clean up memory
+        torch.cuda.empty_cache()
+
+        return results

--- a/pytorch_lightning/plugins/ddp_plugin.py
+++ b/pytorch_lightning/plugins/ddp_plugin.py
@@ -27,7 +27,7 @@ class DDPPlugin(object):
         self._ddp_kwargs: Dict[str, Any] = kwargs
 
     def configure_ddp(
-        self, model: LightningModule, device_ids: List[int]
+            self, model: LightningModule, device_ids: List[int]
     ) -> LightningDistributedDataParallel:
         """
         Pass through all customizations from constructor to `LightningDistributedDataParallel`.
@@ -62,3 +62,14 @@ class DDPPlugin(object):
             **self._ddp_kwargs,
         )
         return model
+
+    def input_to_device(self, args: Any, model: LightningModule):
+        """
+        Override to handle custom input to device logic. For DDP, no move is required as this is handled internally
+        within the wrapper.
+        Args:
+            args: Inputs to the model.
+            model: Model to train.
+        Returns: args moved to correct device if needed.
+        """
+        return args


### PR DESCRIPTION
## What does this PR do?

Relates to #4178

To integrated the sharded plugin I had to make a few API changes to the accelerator. This was very ugly as it involved modifying the logic in all DDP based accelerators.

This PR adds a unified distributed accelerator which all DDP accelerators inherit from. This has reduced the code duplication and allowed for API changes to happen for all DDP supported accelerators. Included is the addition of a plugin extension to move inputs to the appropriate device, required for custom DDP wrappers (like sharded DDP).

cc @ananthsub @williamFalcon @awaelchli @justusschock @Borda @tchaton 

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In in short, see following bullet-list:  

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified; _Bugfixes should be including in bug-fix release milestones (m.f.X) and features should be included in (m.X.b) releases._
 

## Did you have fun?
Make sure you had fun coding 🙃
