### PR TITLE
GAN Domain Template: Typo in the description of Adam's beta 2

### DIFF
--- a/pl_examples/domain_templates/generative_adversarial_net.py
+++ b/pl_examples/domain_templates/generative_adversarial_net.py
@@ -76,7 +76,7 @@ class GAN(LightningModule):
         parser.add_argument("--b1", type=float, default=0.5,
                             help="adam: decay of first order momentum of gradient")
         parser.add_argument("--b2", type=float, default=0.999,
-                            help="adam: decay of first order momentum of gradient")
+                            help="adam: decay of second order momentum of gradient")
         parser.add_argument("--latent_dim", type=int, default=100,
                             help="dimensionality of the latent space")
 


### PR DESCRIPTION
Adam's beta 2 parameter was mistakenly referred to as the first order momentum of the gradient, whereas it should be the second order momentum. This has no effect on the correct working of the example.