### PR TITLE
Add `batch_arg_name` to all calls to `_adjust_batch_size`

### DIFF
--- a/pytorch_lightning/tuner/batch_size_scaling.py
+++ b/pytorch_lightning/tuner/batch_size_scaling.py
@@ -102,7 +102,7 @@ def scale_batch_size(trainer,
         trainer.progress_bar_callback.disable()
 
     # Initially we just double in size until an OOM is encountered
-    new_size = _adjust_batch_size(trainer, value=init_val)  # initially set to init_val
+    new_size = _adjust_batch_size(trainer, batch_arg_name, value=init_val)  # initially set to init_val
     if mode == 'power':
         new_size = _run_power_scaling(trainer, model, new_size, batch_arg_name, max_trials, **fit_kwargs)
     elif mode == 'binsearch':
@@ -231,7 +231,7 @@ def _run_binsearch_scaling(trainer, model, new_size, batch_arg_name, max_trials,
                 garbage_collection_cuda()
                 high = new_size
                 midval = (high + low) // 2
-                new_size, _ = _adjust_batch_size(trainer, value=midval, desc='failed')
+                new_size, _ = _adjust_batch_size(trainer, batch_arg_name, value=midval, desc='failed')
                 if high - low <= 1:
                     break
             else:


### PR DESCRIPTION
This PR fixes a bug in `scale_batch_size` when using a `batch_arg_name` other than the default `'batch_size'`; not all the calls to `_adjust_batch_size` are passing `batch_arg_name` causing an exception when using `batch_arg_name='bs'` for example.

Here are two Colabs showing the bug and the fix:
1- (Bug) Install PL from the master branch: https://colab.research.google.com/drive/1VgLVfBl2xB0TJz4Js_xDSgz-Ae_fi_Jt
2- (Fix) Install PL from _my_ master branch: https://colab.research.google.com/drive/1yierw80jgJb0qukBiCw54iNSelK8qJYB
The only difference is in the first cell (installation source).

