### PR TITLE
LR Monitor docfix

### DIFF
--- a/pytorch_lightning/callbacks/lr_monitor.py
+++ b/pytorch_lightning/callbacks/lr_monitor.py
@@ -56,7 +56,7 @@ class LearningRateMonitor(Callback):
 
         def configure_optimizer(self):
             optimizer = torch.optim.Adam(...)
-            lr_scheduler = {'scheduler': torch.optim.lr_schedulers.LambdaLR(optimizer, ...)
+            lr_scheduler = {'scheduler': torch.optim.lr_scheduler.LambdaLR(optimizer, ...)
                             'name': 'my_logging_name'}
             return [optimizer], [lr_scheduler]
 


### PR DESCRIPTION
`torch.optim.lr_scheduler` not `torch.optim.lr_schedulers`, https://pytorch.org/docs/stable/optim.html