### PR TITLE
Support for uneven inputs in LightningDDP

### DIFF
--- a/pytorch_lightning/utilities/__init__.py
+++ b/pytorch_lightning/utilities/__init__.py
@@ -62,6 +62,8 @@ _GROUP_AVAILABLE = platform.system() != 'Windows' and _module_available('torch.d
 _FAIRSCALE_PIPE_AVAILABLE = _FAIRSCALE_AVAILABLE and LooseVersion(torch.__version__) >= LooseVersion("1.6.0")
 _BOLTS_AVAILABLE = _module_available('pl_bolts')
 
+DDP_JOIN_AND_REBUILD_BUCKETS_AVAILABLE = LooseVersion(torch.__version__) >= LooseVersion("1.7.0")
+
 FLOAT16_EPSILON = numpy.finfo(numpy.float16).eps
 FLOAT32_EPSILON = numpy.finfo(numpy.float32).eps
 FLOAT64_EPSILON = numpy.finfo(numpy.float64).eps


### PR DESCRIPTION
## What does this PR do?

Adds support for DDP `join()` API for uneven inputs support to PT lightning. See https://github.com/pytorch/pytorch/issues/38174 for the PyTorch RFC. Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/3325

It is implemented in a backwards-compatible way by gating the code with a version check requiring torch >= 1.7.0 where this API is available. Open to discussion on better ideas on how to ensure the BC. Since PT lightning overrides PT DDP implementation, we will likely have to change this code again for PT 1.8 where these APIs have somewhat changed.

We also introduce `rebuild_buckets` feature back to PyTorch lightning (the logic to enable it was moved to Python in PT 1.7, but not updated on the lightning side), this is necessary since the DDP `join()` API assumes that buckets are rebuilt (which is always true in PT DDP). It also provides potential for performance improvement by ensuring our allreduce order corresponds with gradient ready order. 

Tested using the script at https://gist.github.com/rohan-varma/3906e7f07669f0177801a9f753848550. The `join()` API is also extensively tested in the PyTorch codebase. 

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:  

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified; _Bugfixes should be including in bug-fix release milestones (m.f.X) and features should be included in (m.X.b) releases._
 

## Did you have fun?
Make sure you had fun coding 🙃
