### PR TITLE
skip multi-gpu test when running on single-gpu machine

### DIFF
--- a/tests/models/test_gpu.py
+++ b/tests/models/test_gpu.py
@@ -49,7 +49,7 @@ def test_multi_gpu_none_backend(tmpdir):
     tpipes.run_model_test(trainer_options, model)
 
 
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires GPU machine")
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="test requires 2 GPUs")
 @pytest.mark.parametrize('gpus', [1, [0], [1]])
 def test_single_gpu_model(tmpdir, gpus):
     """Make sure single GPU works (DP mode)."""

--- a/tests/models/test_gpu.py
+++ b/tests/models/test_gpu.py
@@ -49,7 +49,7 @@ def test_multi_gpu_none_backend(tmpdir):
     tpipes.run_model_test(trainer_options, model)
 
 
-@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="test requires 2 GPUs")
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="test requires multi-GPU machine")
 @pytest.mark.parametrize('gpus', [1, [0], [1]])
 def test_single_gpu_model(tmpdir, gpus):
     """Make sure single GPU works (DP mode)."""


### PR DESCRIPTION
a test that requires 2 gpus should be skipped when running on single-gpu system.
