### PR TITLE
reduce verbosity level in drone ci

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,7 @@ steps:
     - pip --version
     - nvidia-smi
     - pip install -r ./requirements/devel.txt --upgrade-strategy only-if-needed --no-cache-dir
-    - pip install git+https://${AUTH_TOKEN}@github.com/PyTorchLightning/lightning-dtrun.git@v0.0.2 -v --no-cache-dir
+    - pip install git+https://${AUTH_TOKEN}@github.com/PyTorchLightning/lightning-dtrun.git@v0.0.2 --no-cache-dir
     # when Image has defined CUDa version we can switch to this package spec "nvidia-dali-cuda${CUDA_VERSION%%.*}0"
     - pip install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-cuda100 --upgrade-strategy only-if-needed
     - pip list

--- a/.drone.yml
+++ b/.drone.yml
@@ -33,7 +33,7 @@ steps:
     - python --version
     - pip --version
     - nvidia-smi
-    - pip install -r ./requirements/devel.txt --upgrade-strategy only-if-needed -v --no-cache-dir
+    - pip install -r ./requirements/devel.txt --upgrade-strategy only-if-needed --no-cache-dir
     - pip install git+https://${AUTH_TOKEN}@github.com/PyTorchLightning/lightning-dtrun.git@v0.0.2 -v --no-cache-dir
     # when Image has defined CUDa version we can switch to this package spec "nvidia-dali-cuda${CUDA_VERSION%%.*}0"
     - pip install --extra-index-url https://developer.download.nvidia.com/compute/redist nvidia-dali-cuda100 --upgrade-strategy only-if-needed


### PR DESCRIPTION
There are thousands of messages like this in drone:

```
Skipping link: unsupported archive format: .egg:
https://files.pythonhosted.org/packages/64/c4/cb2718f8851517aba754c4f25d79f2a65430d4a4979375d78ea51f217123/
setuptools-0.6c2-py2.4.egg#sha256=ae8d7538033fb893d1e14d385f08adb303cd4c0dc1ae75fbb0390d96d384fb40 
(from https://pypi.org/simple/setuptools/)
```

It makes it very  hard to scroll past these messages to the actual test logs.

