### PR TITLE
[Docs] Fix typo in Trainer.test()

### DIFF
--- a/docs/source/trainer.rst
+++ b/docs/source/trainer.rst
@@ -155,7 +155,7 @@ Once you're done training, feel free to run the test set!
 
 .. code-block:: python
 
-    trainer.test(test_dataloader=test_dataloader)
+    trainer.test(test_dataloaders=test_dataloader)
 
 ------------
 


### PR DESCRIPTION
## What does this PR do?

This is an extremely small PR fixing a typo in the [Trainer.test() docs](https://pytorch-lightning.readthedocs.io/en/stable/trainer.html#testing) example.

Currently, it reads:

`Trainer.test(test_dataloader=test_dataloader)`

It's currently missing the 's', it should read:

`Trainer.test(test_dataloaders=test_dataloader)`

Fixes: No issue found/small typo.

## Before submitting
- [X] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together? Otherwise, we ask you to create a separate PR for every change.
- [X] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
- [X] Did you verify new and existing tests pass locally with your changes?
- [X] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:  

 - [X] Is this pull request ready for review? (if not, please submit in draft mode)
 - [X] Check that all items from **Before submitting** are resolved
 - [X] Make sure the title is self-explanatory and the description concisely explains the PR
 - [X] Add labels and milestones (and optionally projects) to the PR so it can be classified; _Bugfixes should be including in bug-fix release milestones (m.f.X) and features should be included in (m.X.b) releases._
