### PR TITLE
Tighten up mypy config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -102,6 +102,10 @@ max-line-length = 120
 files = pytorch_lightning, pl_examples, benchmarks, tests
 disallow_untyped_defs = True
 ignore_missing_imports = True
+show_error_codes = True
+warn_redundant_casts = True
+warn_unused_configs = True
+warn_unused_ignores = True
 
 # todo: add proper typing to this module...
 [mypy-pytorch_lightning.callbacks.*]


### PR DESCRIPTION
This updates the mypy config with some helpful flags:

- `show_error_codes` -- this makes it easier to `# type: ignore[error-code]`, which limits the blast radius of any given ignore comment
- `warn_redundant_casts` and `warn_unused_ignores` notify you when type work-arounds are no longer needed
- `warn_unused_configs` -- this helps catch potential typos in the mypy configuration.