### PR TITLE
Throw MisconfigurationError on unknown mode

### DIFF
--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -98,7 +98,9 @@ class EarlyStopping(Callback):
 
     def __init_monitor_mode(self):
         if self.mode not in self.mode_dict and self.mode != 'auto':
-            raise MisconfigurationException(f'EarlyStopping mode={self.mode} is unknown.')
+            raise MisconfigurationException(
+                f"`mode` can be auto, {', '.join(self.mode_dict.keys())}, got {self.mode}"
+            )
 
         # TODO: Update with MisconfigurationException when auto mode is removed in v1.3
         if self.mode == 'auto':

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -25,6 +25,7 @@ import torch
 
 from pytorch_lightning.callbacks.base import Callback
 from pytorch_lightning.utilities import rank_zero_info, rank_zero_warn
+from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 
 class EarlyStopping(Callback):
@@ -96,15 +97,10 @@ class EarlyStopping(Callback):
         self.best_score = torch_inf if self.monitor_op == torch.lt else -torch_inf
 
     def __init_monitor_mode(self):
-        # TODO: Update with MisconfigurationException when auto mode is removed in v1.3
         if self.mode not in self.mode_dict and self.mode != 'auto':
-            if self.verbose > 0:
-                rank_zero_warn(
-                    f'EarlyStopping mode={self.mode} is unknown, fallback to auto mode.',
-                    RuntimeWarning,
-                )
-            self.mode = 'auto'
+            raise MisconfigurationException(f'EarlyStopping mode={self.mode} is unknown.')
 
+        # TODO: Update with MisconfigurationException when auto mode is removed in v1.3
         if self.mode == 'auto':
             rank_zero_warn(
                 "mode='auto' is deprecated in v1.1 and will be removed in v1.3."

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -287,14 +287,10 @@ class ModelCheckpoint(Callback):
             "max": (-torch_inf, "max"),
         }
 
-        # TODO: Update with MisconfigurationException when auto mode is removed in v1.3
         if mode not in mode_dict and mode != 'auto':
-            rank_zero_warn(
-                f"ModelCheckpoint mode {mode} is unknown, fallback to auto mode",
-                RuntimeWarning,
-            )
-            mode = "auto"
+            raise MisconfigurationException(f'ModelCheckpoint mode={mode} is unknown.')
 
+        # TODO: Update with MisconfigurationException when auto mode is removed in v1.3
         if mode == 'auto':
             rank_zero_warn(
                 "mode='auto' is deprecated in v1.1 and will be removed in v1.3."

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -288,7 +288,9 @@ class ModelCheckpoint(Callback):
         }
 
         if mode not in mode_dict and mode != 'auto':
-            raise MisconfigurationException(f'ModelCheckpoint mode={mode} is unknown.')
+            raise MisconfigurationException(
+                f"`mode` can be auto, {', '.join(mode_dict.keys())}, got {mode}"
+            )
 
         # TODO: Update with MisconfigurationException when auto mode is removed in v1.3
         if mode == 'auto':

--- a/tests/callbacks/test_early_stopping.py
+++ b/tests/callbacks/test_early_stopping.py
@@ -299,3 +299,13 @@ def test_min_steps_override_early_stopping_functionality(tmpdir, step_freeze, mi
         (trainer.global_step, max(min_steps, by_early_stopping, by_min_epochs), step_freeze, min_steps, min_epochs)
 
     _logger.disabled = False
+
+
+def test_early_stopping_mode_options():
+    with pytest.raises(MisconfigurationException, match="unknown_option"):
+        EarlyStopping(mode="unknown_option")
+
+
+def test_model_checkpoint_mode_options():
+    with pytest.raises(MisconfigurationException, match="unknown_option"):
+        ModelCheckpoint(mode="unknown_option")

--- a/tests/callbacks/test_early_stopping.py
+++ b/tests/callbacks/test_early_stopping.py
@@ -304,8 +304,3 @@ def test_min_steps_override_early_stopping_functionality(tmpdir, step_freeze, mi
 def test_early_stopping_mode_options():
     with pytest.raises(MisconfigurationException, match="`mode` can be auto, .* got unknown_option"):
         EarlyStopping(mode="unknown_option")
-
-
-def test_model_checkpoint_mode_options():
-    with pytest.raises(MisconfigurationException, match="`mode` can be auto, .* got unknown_option"):
-        ModelCheckpoint(mode="unknown_option")

--- a/tests/callbacks/test_early_stopping.py
+++ b/tests/callbacks/test_early_stopping.py
@@ -302,10 +302,10 @@ def test_min_steps_override_early_stopping_functionality(tmpdir, step_freeze, mi
 
 
 def test_early_stopping_mode_options():
-    with pytest.raises(MisconfigurationException, match="unknown_option"):
+    with pytest.raises(MisconfigurationException, match="`mode` can be auto, .* got unknown_option"):
         EarlyStopping(mode="unknown_option")
 
 
 def test_model_checkpoint_mode_options():
-    with pytest.raises(MisconfigurationException, match="unknown_option"):
+    with pytest.raises(MisconfigurationException, match="`mode` can be auto, .* got unknown_option"):
         ModelCheckpoint(mode="unknown_option")

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -946,3 +946,8 @@ def test_model_checkpoint_file_already_exists(tmpdir, max_epochs, save_top_k, ex
 
     epochs_in_ckpt_files = [pl_load(os.path.join(tmpdir, f))['epoch'] - 1 for f in ckpt_files]
     assert sorted(epochs_in_ckpt_files) == list(range(max_epochs - save_top_k, max_epochs))
+
+
+def test_model_checkpoint_mode_options():
+    with pytest.raises(MisconfigurationException, match="`mode` can be auto, .* got unknown_option"):
+        ModelCheckpoint(mode="unknown_option")


### PR DESCRIPTION
Potential closes  https://github.com/PyTorchLightning/pytorch-lightning/issues/5252

When an unknown `mode` is passed to `EarlyStopping` or `ModelCheckpoitn`, raise a misconfiguration error instead of just a runtime warning.