### PR TITLE
Change behavior of metric state "cat" reduction

### DIFF
--- a/pytorch_lightning/metrics/metric.py
+++ b/pytorch_lightning/metrics/metric.py
@@ -20,7 +20,7 @@ from typing import Any, Callable, Optional, Union
 import torch
 from torch import nn
 
-from pytorch_lightning.metrics.utils import _flatten, dim_zero_cat, dim_zero_mean, dim_zero_sum
+from pytorch_lightning.metrics.utils import _flatten, dim_zero_unroll, dim_zero_mean, dim_zero_sum
 from pytorch_lightning.utilities.apply_func import apply_to_collection
 from pytorch_lightning.utilities.distributed import gather_all_tensors
 
@@ -131,7 +131,7 @@ class Metric(nn.Module, ABC):
         elif dist_reduce_fx == "mean":
             dist_reduce_fx = dim_zero_mean
         elif dist_reduce_fx == "cat":
-            dist_reduce_fx = dim_zero_cat
+            dist_reduce_fx = dim_zero_unroll
         elif dist_reduce_fx is not None and not isinstance(dist_reduce_fx, Callable):
             raise ValueError(
                 "`dist_reduce_fx` must be callable or one of ['mean', 'sum', 'cat', None]"

--- a/pytorch_lightning/metrics/metric.py
+++ b/pytorch_lightning/metrics/metric.py
@@ -93,8 +93,9 @@ class Metric(nn.Module, ABC):
             default: Default value of the state; can either be a ``torch.Tensor`` or an empty list. The state will be
                 reset to this value when ``self.reset()`` is called.
             dist_reduce_fx (Optional): Function to reduce state accross mutliple processes in distributed mode.
-                If value is ``"sum"``, ``"mean"``, or ``"cat"``, we will use ``torch.sum``, ``torch.mean``,
-                and ``torch.cat`` respectively, each with argument ``dim=0``. The user can also pass a custom
+                If value is ``"sum"`` or ``"mean"``, we will use ``torch.sum`` and ``torch.mean``,
+                respectively, each with argument ``dim=0``. If the value if ``"cat"``, the returned state will be
+                a concatenation of the states from each process along ``dim=0``. The user can also pass a custom
                 function in this parameter.
             persistent (Optional): whether the state will be saved as part of the modules ``state_dict``.
                 Default is ``False``.

--- a/pytorch_lightning/metrics/utils.py
+++ b/pytorch_lightning/metrics/utils.py
@@ -20,9 +20,8 @@ from pytorch_lightning.utilities import rank_zero_warn
 METRIC_EPS = 1e-6
 
 
-def dim_zero_cat(x):
-    x = x if isinstance(x, (list, tuple)) else [x]
-    return torch.cat(x, dim=0)
+def dim_zero_unroll(x):
+    return x.reshape(-1, *x.shape[2:])
 
 
 def dim_zero_sum(x):

--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -32,15 +32,16 @@ def test_inherit():
 
 def test_add_state():
     a = Dummy()
+    stacked_inputs = torch.stack([torch.tensor(1), torch.tensor(2)]).float()
 
     a.add_state("a", torch.tensor(0), "sum")
-    assert a._reductions["a"](torch.tensor([1, 1])) == 2
+    assert a._reductions["a"](stacked_inputs) == 3
 
     a.add_state("b", torch.tensor(0), "mean")
-    assert np.allclose(a._reductions["b"](torch.tensor([1.0, 2.0])).numpy(), 1.5)
+    assert np.allclose(a._reductions["b"](stacked_inputs).numpy(), 1.5)
 
     a.add_state("c", torch.tensor(0), "cat")
-    assert a._reductions["c"]([torch.tensor([1]), torch.tensor([1])]).shape == (2,)
+    assert a._reductions["c"](stacked_inputs).shape == (2,)
 
     with pytest.raises(ValueError):
         a.add_state("d1", torch.tensor(0), 'xyz')


### PR DESCRIPTION
This changes the behavior of `"cat"` metrics state sync reduction method.

Right now, before any reduction methods are applied, the metric states from different processes are first stacked together - returning a tensor of dimension `(n_proc, dim_1, ...)` - here `dim_1` is whatever the first dimension of the state is. This tensor is then passed on the the reduction method.

For cat reduction method this means that `torch.cat` is applied on a single tensor (well, a list with only that tensor). This returns back the same tensor - not the desired behavior (otherwise `None` can be passed as the reduction method). The desired behavior would be to to concatenate the metric states on the zero dimension, so that the dimension of the output would be `(n_proc * dim_1, ...)`.

I realize that using `torch.cat` can be useful if the metric returns a list instead of a tensor- but this seems like a very rare scenario (none of the current metrics do it). The current behavior of ``cat`` is also misleading, as users will probably miss that if tensors are returned, than `torch.cat` is applied on a single stacked tensor, rendering it moot.