### PR TITLE
Fix metric state reset

### DIFF
--- a/pytorch_lightning/metrics/metric.py
+++ b/pytorch_lightning/metrics/metric.py
@@ -94,7 +94,8 @@ class Metric(nn.Module, ABC):
                 reset to this value when ``self.reset()`` is called.
             dist_reduce_fx (Optional): Function to reduce state accross mutliple processes in distributed mode.
                 If value is ``"sum"``, ``"mean"``, or ``"cat"``, we will use ``torch.sum``, ``torch.mean``,
-                and ``torch.cat`` respectively, each with argument ``dim=0``. The user can also pass a custom
+                and ``torch.cat`` respectively, each with argument ``dim=0``. Note that the ``"cat"`` reduction
+                only makes sense if the state is a list, and not a tensor. The user can also pass a custom
                 function in this parameter.
             persistent (Optional): whether the state will be saved as part of the modules ``state_dict``.
                 Default is ``False``.
@@ -244,7 +245,7 @@ class Metric(nn.Module, ABC):
         """
         for attr, default in self._defaults.items():
             current_val = getattr(self, attr)
-            if isinstance(current_val, torch.Tensor):
+            if isinstance(default, torch.Tensor):
                 setattr(self, attr, deepcopy(default).to(current_val.device))
             else:
                 setattr(self, attr, deepcopy(default))

--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -25,6 +25,18 @@ class Dummy(Metric):
     def compute(self):
         pass
 
+class DummyList(Metric):
+    name = "DummyList"
+
+    def __init__(self):
+        super().__init__()
+        self.add_state("x", list(), dist_reduce_fx=None)
+
+    def update(self):
+        pass
+
+    def compute(self):
+        pass
 
 def test_inherit():
     a = Dummy()
@@ -77,12 +89,20 @@ def test_reset():
     class A(Dummy):
         pass
 
+    class B(DummyList):
+        pass
+        
     a = A()
     assert a.x == 0
     a.x = torch.tensor(5)
     a.reset()
     assert a.x == 0
 
+    b = B()
+    assert isinstance(b.x, list) and len(b.x) == 0
+    b.x.append(torch.tensor(5))
+    b.reset()
+    assert isinstance(b.x, list) and len(b.x) == 0
 
 def test_update():
     class A(Dummy):

--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -25,6 +25,7 @@ class Dummy(Metric):
     def compute(self):
         pass
 
+
 class DummyList(Metric):
     name = "DummyList"
 
@@ -37,6 +38,7 @@ class DummyList(Metric):
 
     def compute(self):
         pass
+
 
 def test_inherit():
     a = Dummy()
@@ -91,7 +93,7 @@ def test_reset():
 
     class B(DummyList):
         pass
-        
+
     a = A()
     assert a.x == 0
     a.x = torch.tensor(5)
@@ -103,6 +105,7 @@ def test_reset():
     b.x = torch.tensor(5)
     b.reset()
     assert isinstance(b.x, list) and len(b.x) == 0
+
 
 def test_update():
     class A(Dummy):

--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -100,7 +100,7 @@ def test_reset():
 
     b = B()
     assert isinstance(b.x, list) and len(b.x) == 0
-    b.x.append(torch.tensor(5))
+    b.x = torch.tensor(5)
     b.reset()
     assert isinstance(b.x, list) and len(b.x) == 0
 


### PR DESCRIPTION
This fixes an issue that occurs when the default value of a metric state was `list()`, but the current value of the state was a tensor (this happens, for example, after syncing the state in ddp with reduction method `"cat"`). On `reset` this would attempt to move the empty list to `self.device` using `.to()` - which would throw an error.

I've also updated the docstring so that it is clear that `"cat"` is to be used with list states.