### PR TITLE
Fix DDP hanging metric tests

### DIFF
--- a/tests/metrics/utils.py
+++ b/tests/metrics/utils.py
@@ -15,10 +15,11 @@ if LooseVersion(torch.__version__) >= LooseVersion("1.5.0"):
     from torch.multiprocessing import start_processes
 else:
     # Adapted from torch/multiprocessing/spawn
-    from torch.multiprocessing import SpawnContext
+    from torch import multiprocessing as mp
+    from torch.multiprocessing import SpawnContext, get_context
 
     def start_processes(fn, args=(), nprocs=1, join=True, daemon=False, start_method="spawn"):
-        mp = multiprocessing.get_context(start_method)
+        mp = get_context(start_method)
         error_queues = []
         processes = []
         for i in range(nprocs):
@@ -46,10 +47,11 @@ THRESHOLD = 0.5
 
 
 def setup_ddp(rank, world_size):
+    """ Setup ddp enviroment """
+
     if world_size == 1:
         return
 
-    """ Setup ddp enviroment """
     os.environ["MASTER_ADDR"] = "localhost"
     os.environ["MASTER_PORT"] = "8088"
 

--- a/tests/metrics/utils.py
+++ b/tests/metrics/utils.py
@@ -16,9 +16,9 @@ if LooseVersion(torch.__version__) >= LooseVersion("1.5.0"):
 else:
     # Adapted from torch/multiprocessing/spawn
     from torch import multiprocessing
-    from torch.multiprocessing.spawn import _wrap
+    from torch.multiprocessing.spawn import _wrap, SpawnContext
 
-    def start_processes(fn, args=(), nprocs=1, join=True, daemon=False, start_method="spawn"):
+    def start_processes(fn, args=(), nprocs=1, daemon=False, start_method="spawn"):
         mp = multiprocessing.get_context(start_method)
         error_queues = []
         processes = []
@@ -33,7 +33,7 @@ else:
             error_queues.append(error_queue)
             processes.append(process)
 
-        context = multiprocessing.spawn.SpawnContext(processes, error_queues)
+        context = SpawnContext(processes, error_queues)
         while not context.join():
             pass
 

--- a/tests/metrics/utils.py
+++ b/tests/metrics/utils.py
@@ -15,17 +15,16 @@ if LooseVersion(torch.__version__) >= LooseVersion("1.5.0"):
     from torch.multiprocessing import start_processes
 else:
     # Adapted from torch/multiprocessing/spawn
-    from torch import multiprocessing as mp
-    from torch.multiprocessing import SpawnContext, get_context
+    from torch import multiprocessing
 
     def start_processes(fn, args=(), nprocs=1, join=True, daemon=False, start_method="spawn"):
-        mp = get_context(start_method)
+        mp = multiprocessing.get_context(start_method)
         error_queues = []
         processes = []
         for i in range(nprocs):
             error_queue = mp.SimpleQueue()
             process = mp.Process(
-                target=_wrap,
+                target=multiprocessing.spawn._wrap,
                 args=(fn, i, args, error_queue),
                 daemon=daemon,
             )
@@ -33,7 +32,7 @@ else:
             error_queues.append(error_queue)
             processes.append(process)
 
-        context = SpawnContext(processes, error_queues)
+        context = multiprocessing.spawn.SpawnContext(processes, error_queues)
         while not context.join():
             pass
 

--- a/tests/metrics/utils.py
+++ b/tests/metrics/utils.py
@@ -16,6 +16,7 @@ if LooseVersion(torch.__version__) >= LooseVersion("1.5.0"):
 else:
     # Adapted from torch/multiprocessing/spawn
     from torch import multiprocessing
+    from torch.multiprocessing.spawn import _wrap
 
     def start_processes(fn, args=(), nprocs=1, join=True, daemon=False, start_method="spawn"):
         mp = multiprocessing.get_context(start_method)
@@ -24,7 +25,7 @@ else:
         for i in range(nprocs):
             error_queue = mp.SimpleQueue()
             process = mp.Process(
-                target=multiprocessing.spawn._wrap,
+                target=_wrap,
                 args=(fn, i, args, error_queue),
                 daemon=daemon,
             )


### PR DESCRIPTION
This fixes the hanging DDP metric tests that occur in #4839.

This solution is taken from a comment [this pytorch issue](https://github.com/pytorch/pytorch/issues/17199) - I believe this (OpenMP global state mismanagement) is the root issue of all the current and previous hanging metric test problems.

This solution does not add a significant overhead for tests - total test time increase only about ~20 seconds for me locally.