### PR TITLE
Use get_last_lr() method on schedulers

### DIFF
--- a/pytorch_lightning/trainer/connectors/optimizer_connector.py
+++ b/pytorch_lightning/trainer/connectors/optimizer_connector.py
@@ -65,15 +65,20 @@ class OptimizerConnector:
                             RuntimeWarning,
                         )
                         continue
+
                 # update LR
                 if lr_scheduler['reduce_on_plateau']:
                     old_lr = lr_scheduler['scheduler'].optimizer.param_groups[0]['lr']
                     lr_scheduler['scheduler'].step(monitor_val)
                     new_lr = lr_scheduler['scheduler'].optimizer.param_groups[0]['lr']
-                else:
+                elif hasattr(lr_scheduler['scheduler'], 'get_last_lr'):
                     old_lr = lr_scheduler['scheduler'].get_last_lr()[0]
                     lr_scheduler['scheduler'].step()
                     new_lr = lr_scheduler['scheduler'].get_last_lr()[0]
+                else:
+                    old_lr = lr_scheduler['scheduler'].optimizer.param_groups[0]['lr']
+                    lr_scheduler['scheduler'].step()
+                    new_lr = lr_scheduler['scheduler'].optimizer.param_groups[0]['lr']
 
                 if self.trainer.dev_debugger.enabled:
                     self.trainer.dev_debugger.track_lr_schedulers_update(

--- a/pytorch_lightning/trainer/connectors/optimizer_connector.py
+++ b/pytorch_lightning/trainer/connectors/optimizer_connector.py
@@ -66,12 +66,14 @@ class OptimizerConnector:
                         )
                         continue
                 # update LR
-                old_lr = lr_scheduler['scheduler'].optimizer.param_groups[0]['lr']
                 if lr_scheduler['reduce_on_plateau']:
+                    old_lr = lr_scheduler['scheduler'].optimizer.param_groups[0]['lr']
                     lr_scheduler['scheduler'].step(monitor_val)
+                    new_lr = lr_scheduler['scheduler'].optimizer.param_groups[0]['lr']
                 else:
+                    old_lr = lr_scheduler['scheduler'].get_last_lr()[0]
                     lr_scheduler['scheduler'].step()
-                new_lr = lr_scheduler['scheduler'].optimizer.param_groups[0]['lr']
+                    new_lr = lr_scheduler['scheduler'].get_last_lr()[0]
 
                 if self.trainer.dev_debugger.enabled:
                     self.trainer.dev_debugger.track_lr_schedulers_update(


### PR DESCRIPTION
## What does this PR do?
Instead of manually looking for the LR through ``scheduler.optimizer.param_groups[0]['lr']``, we can use the ``get_last_lr()`` method which is available on all Schedulers (except for ReduceLROnPlateau, which is handled separately).

Fixes #5363

## Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [X] Did you make sure to update the documentation with your changes [if needed]?
- [ ] Did you write any new necessary tests [no need for typos, docs]? 
- [ ] Did you verify new and existing tests pass locally with your changes?
- [X] If you made a notable change (that affects users), did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)?

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:  

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
 - [ ] **Check that target branch and milestone are aligned!**
 

## Did you have fun?
Make sure you had fun coding 🙃
:heavy_check_mark: 
