### PR TITLE
top k accuracy

### DIFF
--- a/pytorch_lightning/metrics/classification/accuracy.py
+++ b/pytorch_lightning/metrics/classification/accuracy.py
@@ -104,6 +104,7 @@ class Accuracy(Metric):
         """
         return self.correct.float() / self.total
 
+
 class TopKAccuracy(Metric):
     r"""
     Computes Top - K accuracy:
@@ -111,7 +112,7 @@ class TopKAccuracy(Metric):
     .. math:: \text{Accuracy} = \frac{1}{N}\sum_i^N 1(y_i \in \text{topk}(\hat{\mathbf{p}_i}))
 
     Where :math:`y` is a tensor of target values, :math:`\hat{\mathbf{p}_i}` is a
-    tensor of predictions (logits or probabilities) :math:`\text{topk}` is a function that gives back the top k indices.  
+    tensor of predictions (logits or probabilities) :math:`\text{topk}` is a function that gives back the top k indices.
     Works with multiclass and multilabel data.  Accepts logits from a model output or integer class values in
     prediction.  Works with multi-dimensional preds and target.
 
@@ -139,10 +140,10 @@ class TopKAccuracy(Metric):
         >>> from pytorch_lightning.metrics import TopKAccuracy
         >>> target = torch.tensor([0, 1, 2, 3])
         >>> preds = torch.tensor([
-            [0.0, 0.9, 0.1, 0.0], 
-            [0.0, 0.9, 0.1, 0.0], 
-            [0.0, 0.9, 0.1, 0.0], 
-            [0.0, 0.9, 0.1, 0.0], 
+            [0.0, 0.9, 0.1, 0.0],
+            [0.0, 0.9, 0.1, 0.0],
+            [0.0, 0.9, 0.1, 0.0],
+            [0.0, 0.9, 0.1, 0.0],
             ])
         >>> accuracy = TopKAccuracy(k=2)
         >>> accuracy(preds, target)
@@ -150,7 +151,7 @@ class TopKAccuracy(Metric):
 
     """
     def __init__(
-        self, 
+        self,
         k: int = 5,
         compute_on_step: bool = True,
         dist_sync_on_step: bool = False,
@@ -174,7 +175,7 @@ class TopKAccuracy(Metric):
             target = target[:, None]
 
         self.correct += torch.sum((preds == target).any(dim=-1))
-        self.total += target.numel() 
+        self.total += target.numel()
 
     def compute(self):
         """

--- a/tests/metrics/classification/test_accuracy.py
+++ b/tests/metrics/classification/test_accuracy.py
@@ -112,14 +112,15 @@ class TestAccuracy(MetricTester):
             metric_args={"threshold": THRESHOLD},
         )
 
+
 def test_topk_accuracy():
     target = torch.tensor([0, 1, 2, 3])
     preds = torch.tensor(
         [
-            [0.0, 0.9, 0.1, 0.0], 
-            [0.0, 0.9, 0.1, 0.0], 
-            [0.0, 0.9, 0.1, 0.0], 
-            [0.0, 0.9, 0.1, 0.0], 
+            [0.0, 0.9, 0.1, 0.0],
+            [0.0, 0.9, 0.1, 0.0],
+            [0.0, 0.9, 0.1, 0.0],
+            [0.0, 0.9, 0.1, 0.0],
         ]
     )
 

--- a/tests/metrics/classification/test_accuracy.py
+++ b/tests/metrics/classification/test_accuracy.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 from sklearn.metrics import accuracy_score
 
-from pytorch_lightning.metrics.classification.accuracy import Accuracy
+from pytorch_lightning.metrics.classification.accuracy import Accuracy, TopKAccuracy
 from tests.metrics.classification.inputs import (
     _binary_inputs,
     _binary_prob_inputs,
@@ -111,3 +111,17 @@ class TestAccuracy(MetricTester):
             dist_sync_on_step=dist_sync_on_step,
             metric_args={"threshold": THRESHOLD},
         )
+
+def test_topk_accuracy():
+    target = torch.tensor([0, 1, 2, 3])
+    preds = torch.tensor(
+        [
+            [0.0, 0.9, 0.1, 0.0], 
+            [0.0, 0.9, 0.1, 0.0], 
+            [0.0, 0.9, 0.1, 0.0], 
+            [0.0, 0.9, 0.1, 0.0], 
+        ]
+    )
+
+    topk_accuracy = TopKAccuracy(k=2)
+    assert (topk_accuracy(preds, target) == 0.5).item()


### PR DESCRIPTION
In early stages of training it's important to see the top-k accuracy to see that your model is indeed training and heading in the right direction. Therefore I've added this as a metric.

```python
import torch
from pytorch_lightning.metrics import TopKAccuracy

target = torch.tensor([0, 1, 2, 3])
preds = torch.tensor([
            [0.0, 0.9, 0.1, 0.0], 
            [0.0, 0.9, 0.1, 0.0], 
            [0.0, 0.9, 0.1, 0.0], 
            [0.0, 0.9, 0.1, 0.0], 
            ])
accuracy = TopKAccuracy(k=2)
accuracy(preds, target) # shows 0.5
```