### PR TITLE
Adding class weights to accuracy

### DIFF
--- a/pytorch_lightning/metrics/classification/accuracy.py
+++ b/pytorch_lightning/metrics/classification/accuracy.py
@@ -45,8 +45,8 @@ class Accuracy(Metric):
             Threshold probability value for transforming probability predictions to binary
             (0,1) predictions, in the case of binary or multi-label inputs.
         class_weights:
-            Weight of each target class. Does not need to sum to one. 
-            Default value (``None``) would indicate that the classes are equally important 
+            Weight of each target class. Does not need to sum to one.
+            Default value (``None``) would indicate that the classes are equally important
             (i.e. equal to one). **Note that this is class weights and not sample weights**.
         top_k:
             Number of highest probability predictions considered to find the correct label, relevant
@@ -142,7 +142,12 @@ class Accuracy(Metric):
         """
 
         correct, total = _accuracy_update(
-            preds, target, threshold=self.threshold, class_weights=self.class_weights, top_k=self.top_k, subset_accuracy=self.subset_accuracy
+            preds,
+            target,
+            threshold=self.threshold,
+            class_weights=self.class_weights,
+            top_k=self.top_k,
+            subset_accuracy=self.subset_accuracy
         )
 
         self.correct += correct

--- a/pytorch_lightning/metrics/classification/accuracy.py
+++ b/pytorch_lightning/metrics/classification/accuracy.py
@@ -44,6 +44,10 @@ class Accuracy(Metric):
         threshold:
             Threshold probability value for transforming probability predictions to binary
             (0,1) predictions, in the case of binary or multi-label inputs.
+        class_weights:
+            Weight of each target class. Does not need to sum to one. 
+            Default value (``None``) would indicate that the classes are equally important 
+            (i.e. equal to one). **Note that this is class weights and not sample weights**.
         top_k:
             Number of highest probability predictions considered to find the correct label, relevant
             only for (multi-dimensional) multi-class inputs with probability predictions. The
@@ -98,6 +102,7 @@ class Accuracy(Metric):
     def __init__(
         self,
         threshold: float = 0.5,
+        class_weights: Optional[torch.Tensor] = None,
         top_k: Optional[int] = None,
         subset_accuracy: bool = False,
         compute_on_step: bool = True,
@@ -122,6 +127,7 @@ class Accuracy(Metric):
             raise ValueError(f"The `top_k` should be an integer larger than 0, got {top_k}")
 
         self.threshold = threshold
+        self.class_weights = class_weights
         self.top_k = top_k
         self.subset_accuracy = subset_accuracy
 
@@ -136,7 +142,7 @@ class Accuracy(Metric):
         """
 
         correct, total = _accuracy_update(
-            preds, target, threshold=self.threshold, top_k=self.top_k, subset_accuracy=self.subset_accuracy
+            preds, target, threshold=self.threshold, class_weights=self.class_weights, top_k=self.top_k, subset_accuracy=self.subset_accuracy
         )
 
         self.correct += correct

--- a/pytorch_lightning/metrics/functional/accuracy.py
+++ b/pytorch_lightning/metrics/functional/accuracy.py
@@ -18,11 +18,11 @@ from pytorch_lightning.metrics.classification.helpers import _input_format_class
 
 
 def _accuracy_update(
-    preds: torch.Tensor, 
-    target: torch.Tensor, 
-    threshold: float, 
-    class_weights: Optional[torch.Tensor], 
-    top_k: Optional[int], 
+    preds: torch.Tensor,
+    target: torch.Tensor,
+    threshold: float,
+    class_weights: Optional[torch.Tensor],
+    top_k: Optional[int],
     subset_accuracy: bool
 ) -> Tuple[torch.Tensor, torch.Tensor]:
 
@@ -92,6 +92,10 @@ def accuracy(
         threshold:
             Threshold probability value for transforming probability predictions to binary
             (0,1) predictions, in the case of binary or multi-label inputs.
+        class_weights:
+            Weight of each target class. Does not need to sum to one. 
+            Default value (``None``) would indicate that the classes are equally important 
+            (i.e. equal to one).
         top_k:
             Number of highest probability predictions considered to find the correct label, relevant
             only for (multi-dimensional) multi-class inputs with probability predictions. The

--- a/pytorch_lightning/metrics/functional/accuracy.py
+++ b/pytorch_lightning/metrics/functional/accuracy.py
@@ -18,7 +18,12 @@ from pytorch_lightning.metrics.classification.helpers import _input_format_class
 
 
 def _accuracy_update(
-    preds: torch.Tensor, target: torch.Tensor, threshold: float, class_weights: Optional[torch.Tensor], top_k: Optional[int], subset_accuracy: bool
+    preds: torch.Tensor, 
+    target: torch.Tensor, 
+    threshold: float, 
+    class_weights: Optional[torch.Tensor], 
+    top_k: Optional[int], 
+    subset_accuracy: bool
 ) -> Tuple[torch.Tensor, torch.Tensor]:
 
     preds, target, mode = _input_format_classification(preds, target, threshold=threshold, top_k=top_k)

--- a/pytorch_lightning/metrics/functional/accuracy.py
+++ b/pytorch_lightning/metrics/functional/accuracy.py
@@ -95,7 +95,7 @@ def accuracy(
         class_weights:
             Weight of each target class. Does not need to sum to one. 
             Default value (``None``) would indicate that the classes are equally important 
-            (i.e. equal to one).
+            (i.e. equal to one). **Note that this is class weights and not sample weights**.
         top_k:
             Number of highest probability predictions considered to find the correct label, relevant
             only for (multi-dimensional) multi-class inputs with probability predictions. The

--- a/pytorch_lightning/metrics/functional/accuracy.py
+++ b/pytorch_lightning/metrics/functional/accuracy.py
@@ -93,8 +93,8 @@ def accuracy(
             Threshold probability value for transforming probability predictions to binary
             (0,1) predictions, in the case of binary or multi-label inputs.
         class_weights:
-            Weight of each target class. Does not need to sum to one. 
-            Default value (``None``) would indicate that the classes are equally important 
+            Weight of each target class. Does not need to sum to one.
+            Default value (``None``) would indicate that the classes are equally important
             (i.e. equal to one). **Note that this is class weights and not sample weights**.
         top_k:
             Number of highest probability predictions considered to find the correct label, relevant


### PR DESCRIPTION
For imbalanced classes it is important to look at accuracy after reweighting each instance. This achieves that. Note that it is not sample weights.

Apologies for not completing the classes with accuracy. Wanted to do only a few changes before I do something fullblown.

## Notes
- I'm not sure what `"multi-dim multi-class"` is, so I have not included weights there.
- I do `weights = class_weights.to(target.device)[target]` incase this is happening in different GPUs. This way we know that weights and targets are always on the same device no matter what.