### PR TITLE
[bugfix] Logging only on `not should_accumulate()` during training

### DIFF
--- a/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -590,14 +590,15 @@ class LoggerConnector:
         return gathered_epoch_outputs
 
     def log_train_step_metrics(self, batch_output):
-        if not self.trainer.train_loop.should_accumulate():
-            _, batch_log_metrics = self.cached_results.update_logger_connector()
-            # when metrics should be logged
-            if self.should_update_logs or self.trainer.fast_dev_run is True:
-                # logs user requested information to logger
-                grad_norm_dic = batch_output.grad_norm_dic
-                if grad_norm_dic is None:
-                    grad_norm_dic = {}
-                if len(batch_log_metrics) > 0 or len(grad_norm_dic) > 0:
-                    self.log_metrics(batch_log_metrics, grad_norm_dic)
-                    self.callback_metrics.update(batch_log_metrics)
+        if self.trainer.train_loop.should_accumulate() and self.trainer.train_loop.automatic_optimization:
+            return
+        _, batch_log_metrics = self.cached_results.update_logger_connector()
+        # when metrics should be logged
+        if self.should_update_logs or self.trainer.fast_dev_run is True:
+            # logs user requested information to logger
+            grad_norm_dic = batch_output.grad_norm_dic
+            if grad_norm_dic is None:
+                grad_norm_dic = {}
+            if len(batch_log_metrics) > 0 or len(grad_norm_dic) > 0:
+                self.log_metrics(batch_log_metrics, grad_norm_dic)
+                self.callback_metrics.update(batch_log_metrics)

--- a/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from copy import deepcopy
 import os
+from copy import deepcopy
 from pprint import pprint
 from typing import Iterable, Union
 
@@ -158,7 +158,7 @@ class LoggerConnector:
         self.logged_metrics.update(logged_metrics_tmp)
         self.cached_results.legacy_batch_log_metrics.update(logged_metrics_tmp)
 
-    def log_metrics(self, metrics, grad_norm_dic, step=None, log_train_step_metrics=False):
+    def log_metrics(self, metrics, grad_norm_dic, step=None):
         """Logs the metric dict passed in.
         If `step` parameter is None and `step` key is presented is metrics,
         uses metrics["step"] as a step
@@ -186,11 +186,8 @@ class LoggerConnector:
 
         elif step is None:
             # added metrics by Lightning for convenience
-            if log_train_step_metrics:
-                step = self.trainer.total_batch_idx
-            else:
-                scalar_metrics['epoch'] = self.trainer.current_epoch
-                step = self.trainer.global_step
+            scalar_metrics['epoch'] = self.trainer.current_epoch
+            step = self.trainer.global_step
 
         # log actual metrics
         if self.trainer.logger is not None:
@@ -593,13 +590,14 @@ class LoggerConnector:
         return gathered_epoch_outputs
 
     def log_train_step_metrics(self, batch_output):
-        _, batch_log_metrics = self.cached_results.update_logger_connector()
-        # when metrics should be logged
-        if self.should_update_logs or self.trainer.fast_dev_run is True:
-            # logs user requested information to logger
-            grad_norm_dic = batch_output.grad_norm_dic
-            if grad_norm_dic is None:
-                grad_norm_dic = {}
-            if len(batch_log_metrics) > 0 or len(grad_norm_dic) > 0:
-                self.log_metrics(batch_log_metrics, grad_norm_dic, log_train_step_metrics=True)
-                self.callback_metrics.update(batch_log_metrics)
+        if not self.trainer.train_loop.should_accumulate():
+            _, batch_log_metrics = self.cached_results.update_logger_connector()
+            # when metrics should be logged
+            if self.should_update_logs or self.trainer.fast_dev_run is True:
+                # logs user requested information to logger
+                grad_norm_dic = batch_output.grad_norm_dic
+                if grad_norm_dic is None:
+                    grad_norm_dic = {}
+                if len(batch_log_metrics) > 0 or len(grad_norm_dic) > 0:
+                    self.log_metrics(batch_log_metrics, grad_norm_dic)
+                    self.callback_metrics.update(batch_log_metrics)

--- a/tests/loggers/test_all.py
+++ b/tests/loggers/test_all.py
@@ -126,7 +126,7 @@ def _test_loggers_fit_test(tmpdir, logger_class):
     if logger_class == TensorBoardLogger:
         expected = [
             (0, ['hp_metric']),
-            (0, ['train_some_val']),
+            (0, ['epoch', 'train_some_val']),
             (0, ['early_stop_on', 'epoch', 'val_acc']),
             (0, ['hp_metric']),
             (1, ['epoch', 'test_acc', 'test_loss'])
@@ -134,7 +134,7 @@ def _test_loggers_fit_test(tmpdir, logger_class):
         assert log_metric_names == expected
     else:
         expected = [
-            (0, ['train_some_val']),
+            (0, ['epoch', 'train_some_val']),
             (0, ['early_stop_on', 'epoch', 'val_acc']),
             (1, ['epoch', 'test_acc', 'test_loss'])
         ]

--- a/tests/loggers/test_tensorboard.py
+++ b/tests/loggers/test_tensorboard.py
@@ -226,7 +226,7 @@ def test_tensorboard_with_accummulated_gradients(mock_log_metrics, expected, tmp
             self.log('loss', loss, on_step=True, on_epoch=True)
 
             if not self.trainer.train_loop.should_accumulate():
-                if self.trainer.logger_connector.should_update_logs or self.trainer.fast_dev_run is True:
+                if self.trainer.logger_connector.should_update_logs:
                     self._indexes.append(self.trainer.global_step)
 
             return loss

--- a/tests/loggers/test_tensorboard.py
+++ b/tests/loggers/test_tensorboard.py
@@ -220,7 +220,6 @@ def test_tensorboard_with_accummulated_gradients(mock_log_metrics, expected, tmp
             self._indexes = []
 
         def training_step(self, batch, batch_idx):
-            print(self._indexes)
             output = self.layer(batch)
             loss = self.loss(batch, output)
             self.log('count', self._count, on_step=True, on_epoch=True)

--- a/tests/trainer/logging_tests/test_train_loop_logging_1_0.py
+++ b/tests/trainer/logging_tests/test_train_loop_logging_1_0.py
@@ -24,12 +24,16 @@ from unittest import mock
 import numpy as np
 import pytest
 import torch
-from torch.utils.data import Dataset
+from torch.nn import functional as F
+from torch.utils.data import DataLoader, Dataset, random_split
+from torchvision import transforms
+from torchvision.datasets.mnist import MNIST
 
 import pytorch_lightning as pl
 from pytorch_lightning import callbacks, Trainer
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint
 from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.loggers import WandbLogger
 from tests.base.boring_model import BoringModel, RandomDictDataset, RandomDictStringDataset
 from tests.base.deterministic_model import DeterministicModel
 


### PR DESCRIPTION
## What does this PR do?

<!--
IMPORTANT:
 We separated bug-fix PRs and feature PRs and they shall land in master and release/1.X-dev accordingly.
 By default all PR are targeted to master which is correct for bug-fixes, but need to be change for features.
 If you miss it we can still fix it for you, just ping us... :]

Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
-->

This PR fixes visual logging with accumulated_grad_batches > 1.

Solution: We can't assume the metrics can be averaged, so we will log only when `optimizer_step` will be called.

Previously

<img width="1705" alt="Screenshot 2021-01-08 at 13 16 19" src="https://user-images.githubusercontent.com/12861981/104014938-2dd79b80-51b4-11eb-940d-170f365220a3.png">


Now.

<img width="1699" alt="Screenshot 2021-01-08 at 12 55 57" src="https://user-images.githubusercontent.com/12861981/104012872-ddab0a00-51b0-11eb-9e3a-b1872b590710.png">


Code used to generate the visualization

```
def test_logging_with_accumulate_grad_batches(tmpdir):
    class LitClassifier(pl.LightningModule):
        def __init__(self, hidden_dim=128, learning_rate=1e-3):
            super().__init__()
            self.save_hyperparameters()

            self.l1 = torch.nn.Linear(28 * 28, self.hparams.hidden_dim)
            self.l2 = torch.nn.Linear(self.hparams.hidden_dim, 10)

            self.train_acc = pl.metrics.Accuracy()

        def forward(self, x):
            x = x.view(x.size(0), -1)
            x = torch.relu(self.l1(x))
            return self.l2(x)

        def training_step(self, batch, batch_idx):
            x, y = batch
            y_hat = self(x)
            loss = F.cross_entropy(y_hat, y)
            self.log('train_acc', self.train_acc(y_hat, y), on_step=True, on_epoch=True, prog_bar=True)
            self.log("train_loss",loss)
            return loss

        def validation_step(self, batch, batch_idx):
            x, y = batch
            y_hat = self(x)
            loss = F.cross_entropy(y_hat, y)

        def configure_optimizers(self):
            return torch.optim.Adam(self.parameters(), lr=self.hparams.learning_rate)

    def run_test(model, max_epochs, accumulate_grad_batches, batch_size, num_workers=4):
        dataset = MNIST('', train=True, download=True, transform=transforms.ToTensor())
        mnist_train, mnist_val = random_split(dataset, [55000, 5000])
        train_loader = DataLoader(mnist_train,batch_size)
        val_loader = DataLoader(mnist_val,batch_size)

        trainer = pl.Trainer(
            logger=WandbLogger(name="bug", project='.....', save_dir=".", log_model=False),
            accumulate_grad_batches=accumulate_grad_batches,
            limit_train_batches=100,
            log_every_n_steps=5,
            max_epochs=max_epochs
            )
        trainer.fit(model, train_loader, val_loader)

    model = LitClassifier()

    run_test(model, 3, 1, 32)
    run_test(model, 3, 8, 32)
```

Fixes #5405 <- this [links related issue to this PR](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
 - [ ] **Check that target branch and milestone match!**


## Did you have fun?
Make sure you had fun coding 🙃
