### PR TITLE
Remove extra param in Docs from metric Precision

### DIFF
--- a/pytorch_lightning/metrics/classification/precision_recall.py
+++ b/pytorch_lightning/metrics/classification/precision_recall.py
@@ -42,7 +42,6 @@ class Precision(Metric):
 
     Args:
         num_classes: Number of classes in the dataset.
-        beta: Beta coefficient in the F measure.
         threshold:
             Threshold value for binary or multi-label logits. default: 0.5
 


### PR DESCRIPTION
In the docs there is `beta` param, which does not correspond to any param of `Precision`.