### PR TITLE
Increase TPU check timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 ### Changed
-
+- Increased TPU check timeout from 20s to 100s ([#5598](https://github.com/PyTorchLightning/pytorch-lightning/pull/5598))
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 ### Changed
+
 - Increased TPU check timeout from 20s to 100s ([#5598](https://github.com/PyTorchLightning/pytorch-lightning/pull/5598))
+
 
 ### Deprecated
 

--- a/pytorch_lightning/utilities/xla_device_utils.py
+++ b/pytorch_lightning/utilities/xla_device_utils.py
@@ -20,7 +20,8 @@ from multiprocessing import Process, Queue
 import torch
 
 XLA_AVAILABLE = importlib.util.find_spec("torch_xla") is not None
-TPU_TIMEOUT_CONSTANT = 100
+#: define waiting time got checking TPU available in sec
+TPU_CHECK_TIMEOUT = 100
 
 if XLA_AVAILABLE:
     import torch_xla.core.xla_model as xm
@@ -40,7 +41,7 @@ def pl_multi_process(func):
         queue = Queue()
         proc = Process(target=inner_f, args=(queue, func, *args), kwargs=kwargs)
         proc.start()
-        proc.join(TPU_TIMEOUT_CONSTANT)
+        proc.join(TPU_CHECK_TIMEOUT)
         try:
             return queue.get_nowait()
         except q.Empty:

--- a/pytorch_lightning/utilities/xla_device_utils.py
+++ b/pytorch_lightning/utilities/xla_device_utils.py
@@ -20,6 +20,7 @@ from multiprocessing import Process, Queue
 import torch
 
 XLA_AVAILABLE = importlib.util.find_spec("torch_xla") is not None
+TPU_TIMEOUT_CONSTANT = 100
 
 if XLA_AVAILABLE:
     import torch_xla.core.xla_model as xm
@@ -39,7 +40,7 @@ def pl_multi_process(func):
         queue = Queue()
         proc = Process(target=inner_f, args=(queue, func, *args), kwargs=kwargs)
         proc.start()
-        proc.join(100)
+        proc.join(TPU_TIMEOUT_CONSTANT)
         try:
             return queue.get_nowait()
         except q.Empty:

--- a/pytorch_lightning/utilities/xla_device_utils.py
+++ b/pytorch_lightning/utilities/xla_device_utils.py
@@ -39,7 +39,7 @@ def pl_multi_process(func):
         queue = Queue()
         proc = Process(target=inner_f, args=(queue, func, *args), kwargs=kwargs)
         proc.start()
-        proc.join(20)
+        proc.join(100)
         try:
             return queue.get_nowait()
         except q.Empty:

--- a/tests/utilities/test_xla_device_utils.py
+++ b/tests/utilities/test_xla_device_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import time
+from unittest.mock import patch
 
 import pytest
 
@@ -19,11 +20,7 @@ import pytorch_lightning.utilities.xla_device_utils as xla_utils
 from pytorch_lightning.utilities import XLA_AVAILABLE, TPU_AVAILABLE
 from tests.base.develop_utils import pl_multi_process_test
 
-if XLA_AVAILABLE:
-    import torch_xla.core.xla_model as xm
 
-
-# lets hope that in or env we have installed XLA only for TPU devices, otherwise, it is testing in the cycle "if I am true test that I am true :D"
 @pytest.mark.skipif(XLA_AVAILABLE, reason="test requires torch_xla to be absent")
 def test_tpu_device_absence():
     """Check tpu_device_exists returns None when torch_xla is not available"""
@@ -37,12 +34,9 @@ def test_tpu_device_presence():
     assert xla_utils.XLADeviceUtils.tpu_device_exists() is True
 
 
+@patch('pytorch_lightning.utilities.xla_device_utils.TPU_TIMEOUT_CONSTANT', 10)
 def test_result_returns_within_timeout_seconds():
     """Check that pl_multi_process returns within 10 seconds"""
-
-    # change timeout value during test
-    xla_utils.TPU_TIMEOUT_CONSTANT = 10
-
     start = time.time()
     result = xla_utils.pl_multi_process(time.sleep)(xla_utils.TPU_TIMEOUT_CONSTANT * 1.25)
     end = time.time()

--- a/tests/utilities/test_xla_device_utils.py
+++ b/tests/utilities/test_xla_device_utils.py
@@ -40,9 +40,12 @@ def test_tpu_device_presence():
 def test_result_returns_within_100_seconds():
     """Check that pl_multi_process returns within 10 seconds"""
 
+    # change timeout value during test
+    xla_utils.TPU_TIMEOUT_CONSTANT = 10
+
     start = time.time()
     result = xla_utils.pl_multi_process(time.sleep)(xla_utils.TPU_TIMEOUT_CONSTANT * 1.25)
     end = time.time()
     elapsed_time = int(end - start)
-    assert elapsed_time <= 100
+    assert elapsed_time <= xla_utils.TPU_TIMEOUT_CONSTANT
     assert result is False

--- a/tests/utilities/test_xla_device_utils.py
+++ b/tests/utilities/test_xla_device_utils.py
@@ -37,7 +37,7 @@ def test_tpu_device_presence():
     assert xla_utils.XLADeviceUtils.tpu_device_exists() is True
 
 
-def test_result_returns_within_100_seconds():
+def test_result_returns_within_timeout_seconds():
     """Check that pl_multi_process returns within 10 seconds"""
 
     # change timeout value during test

--- a/tests/utilities/test_xla_device_utils.py
+++ b/tests/utilities/test_xla_device_utils.py
@@ -37,12 +37,12 @@ def test_tpu_device_presence():
     assert xla_utils.XLADeviceUtils.tpu_device_exists() is True
 
 
-def test_result_returns_within_20_seconds():
+def test_result_returns_within_100_seconds():
     """Check that pl_multi_process returns within 10 seconds"""
 
     start = time.time()
-    result = xla_utils.pl_multi_process(time.sleep)(25)
+    result = xla_utils.pl_multi_process(time.sleep)(125)
     end = time.time()
     elapsed_time = int(end - start)
-    assert elapsed_time <= 20
+    assert elapsed_time <= 100
     assert result is False

--- a/tests/utilities/test_xla_device_utils.py
+++ b/tests/utilities/test_xla_device_utils.py
@@ -34,12 +34,12 @@ def test_tpu_device_presence():
     assert xla_utils.XLADeviceUtils.tpu_device_exists() is True
 
 
-@patch('pytorch_lightning.utilities.xla_device_utils.TPU_TIMEOUT_CONSTANT', 10)
+@patch('pytorch_lightning.utilities.xla_device_utils.TPU_CHECK_TIMEOUT', 10)
 def test_result_returns_within_timeout_seconds():
     """Check that pl_multi_process returns within 10 seconds"""
     start = time.time()
-    result = xla_utils.pl_multi_process(time.sleep)(xla_utils.TPU_TIMEOUT_CONSTANT * 1.25)
+    result = xla_utils.pl_multi_process(time.sleep)(xla_utils.TPU_CHECK_TIMEOUT * 1.25)
     end = time.time()
     elapsed_time = int(end - start)
-    assert elapsed_time <= xla_utils.TPU_TIMEOUT_CONSTANT
+    assert elapsed_time <= xla_utils.TPU_CHECK_TIMEOUT
     assert result is False

--- a/tests/utilities/test_xla_device_utils.py
+++ b/tests/utilities/test_xla_device_utils.py
@@ -41,7 +41,7 @@ def test_result_returns_within_100_seconds():
     """Check that pl_multi_process returns within 10 seconds"""
 
     start = time.time()
-    result = xla_utils.pl_multi_process(time.sleep)(125)
+    result = xla_utils.pl_multi_process(time.sleep)(xla_utils.TPU_TIMEOUT_CONSTANT * 1.25)
     end = time.time()
     elapsed_time = int(end - start)
     assert elapsed_time <= 100


### PR DESCRIPTION
## What does this PR do?

Fixes #4829 
The TPU timeout check of 20s often results in `No TPU Devices found` Exception. Increasing it to 100s to avoid this error.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified
 - [x] **Check that target branch and milestone match!**


## Did you have fun?
Make sure you had fun coding 🙃
