### PR TITLE
Fix Metric.state_dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- Fixed child `Metric` `state_dict` ([#5614](https://github.com/PyTorchLightning/pytorch-lightning/pull/5614))
+- Fixed `Metric`'s `state_dict` not included when child modules ([#5614](https://github.com/PyTorchLightning/pytorch-lightning/pull/5614))
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed child `Metric` `state_dict` ([#5614](https://github.com/PyTorchLightning/pytorch-lightning/pull/5614))
 
 
 

--- a/pytorch_lightning/metrics/metric.py
+++ b/pytorch_lightning/metrics/metric.py
@@ -284,11 +284,17 @@ class Metric(nn.Module, ABC):
         for key in self._persistent.keys():
             self._persistent[key] = mode
 
-    def state_dict(self, *args, **kwargs):
+    def state_dict(self, destination=None, prefix='', keep_vars=False):
+        destination = super().state_dict(
+            destination=destination,
+            prefix=prefix,
+            keep_vars=keep_vars
+        )
         # Register metric states to be part of the state_dict
-        state_dict = super().state_dict()
         for key in self._defaults.keys():
             if self._persistent[key]:
                 current_val = getattr(self, key)
-                state_dict.update({key: current_val})
-        return state_dict
+                if not keep_vars and torch.is_tensor(current_val):
+                    current_val = current_val.detach()
+                destination[prefix + key] = current_val
+        return destination

--- a/pytorch_lightning/metrics/metric.py
+++ b/pytorch_lightning/metrics/metric.py
@@ -294,7 +294,13 @@ class Metric(nn.Module, ABC):
         for key in self._defaults.keys():
             if self._persistent[key]:
                 current_val = getattr(self, key)
-                if not keep_vars and torch.is_tensor(current_val):
-                    current_val = current_val.detach()
+                if not keep_vars:
+                    if torch.is_tensor(current_val):
+                        current_val = current_val.detach()
+                    elif isinstance(current_val, list):
+                        current_val = [
+                            cur_v.detach() if torch.is_tensor(cur_v) else cur_v
+                            for cur_v in current_val
+                        ]
                 destination[prefix + key] = current_val
         return destination

--- a/tests/metrics/test_metric.py
+++ b/tests/metrics/test_metric.py
@@ -6,6 +6,7 @@ import cloudpickle
 import numpy as np
 import pytest
 import torch
+from torch import nn
 
 from pytorch_lightning.metrics.metric import Metric
 
@@ -201,3 +202,22 @@ def test_state_dict(tmpdir):
     assert metric.state_dict() == OrderedDict(x=0)
     metric.persistent(False)
     assert metric.state_dict() == OrderedDict()
+
+
+def test_child_metric_state_dict():
+    """ test that child metric states will be added to parent state dict """
+    class TestModule(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.metric = Dummy()
+            self.metric.add_state('a', torch.tensor(0), persistent=True)
+            self.metric.add_state('b', [], persistent=True)
+            self.metric.register_buffer('c', torch.tensor(0))
+
+    module = TestModule()
+    expected_state_dict = {
+        'metric.a': torch.tensor(0),
+        'metric.b': [],
+        'metric.c': torch.tensor(0)
+    }
+    assert module.state_dict() == expected_state_dict


### PR DESCRIPTION
## What does this PR do?

Fixes #5603 :

```python
class BoringModel(pl.LightningModule):

    def __init__(self):
        super().__init__()
        self.metric = pl.metrics.Accuracy()
        self.metric.persistent(mode=True)
```
The state of `metric` is not added to the `state_dict` of `BoringModel`.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
 - [ ] **Check that target branch and milestone match!**
