### PR TITLE
fix error when logging to progress bar with reserved name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed an error when logging a progress bar metric with a reserved name ([#5620](https://github.com/PyTorchLightning/pytorch-lightning/pull/5620))
+
 
 
 

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -185,7 +185,21 @@ class TrainerProperties(ABC):
         """ Read-only for progress bar metrics. """
         ref_model = self.model if not self.data_parallel else self.model.module
         ref_model = cast(LightningModule, ref_model)
-        return dict(**ref_model.get_progress_bar_dict(), **self.logger_connector.progress_bar_metrics)
+
+        standard_metrics = ref_model.get_progress_bar_dict()
+        logged_metrics = self.logger_connector.progress_bar_metrics
+        duplicates = list(standard_metrics.keys() & logged_metrics.keys())
+        if duplicates:
+            rank_zero_warn(
+                f"The progress bar already tracks a metric with the name '{duplicates[0]}' and"
+                f" `self.log('{duplicates[0]}', ..., prog_bar=True)` will overwrite this value. "
+                f" If this is undesired, change the name or override `get_progress_bar_dict()`."
+                f" in LightingModule.",
+                UserWarning
+            )
+        all_metrics = dict(**standard_metrics)
+        all_metrics.update(**logged_metrics)
+        return all_metrics
 
     @property
     def disable_validation(self) -> bool:

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -191,7 +191,7 @@ class TrainerProperties(ABC):
         duplicates = list(standard_metrics.keys() & logged_metrics.keys())
         if duplicates:
             rank_zero_warn(
-                f"The progress bar already tracks a metric with the name '{duplicates[0]}' and"
+                f"The progress bar already tracks a metric with the name '{', '.join(duplicates)}' and"
                 f" `self.log('{duplicates[0]}', ..., prog_bar=True)` will overwrite this value. "
                 f" If this is undesired, change the name or override `get_progress_bar_dict()`"
                 f" in `LightingModule`.",

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -191,7 +191,7 @@ class TrainerProperties(ABC):
         duplicates = list(standard_metrics.keys() & logged_metrics.keys())
         if duplicates:
             rank_zero_warn(
-                f"The progress bar already tracks a metric with the name '{', '.join(duplicates)}' and"
+                f"The progress bar already tracks a metric with the name(s) '{', '.join(duplicates)}' and"
                 f" `self.log('{duplicates[0]}', ..., prog_bar=True)` will overwrite this value. "
                 f" If this is undesired, change the name or override `get_progress_bar_dict()`"
                 f" in `LightingModule`.",

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -183,18 +183,18 @@ class TrainerProperties(ABC):
     @property
     def progress_bar_dict(self) -> dict:
         """ Read-only for progress bar metrics. """
-        ref_model = self.model if not self.data_parallel else self.model.module
+        ref_model = self.get_model()
         ref_model = cast(LightningModule, ref_model)
 
         standard_metrics = ref_model.get_progress_bar_dict()
-        logged_metrics = self.logger_connector.progress_bar_metrics
+        logged_metrics = self.progress_bar_metrics
         duplicates = list(standard_metrics.keys() & logged_metrics.keys())
         if duplicates:
             rank_zero_warn(
                 f"The progress bar already tracks a metric with the name '{duplicates[0]}' and"
                 f" `self.log('{duplicates[0]}', ..., prog_bar=True)` will overwrite this value. "
-                f" If this is undesired, change the name or override `get_progress_bar_dict()`."
-                f" in LightingModule.",
+                f" If this is undesired, change the name or override `get_progress_bar_dict()`"
+                f" in `LightingModule`.",
                 UserWarning
             )
         all_metrics = dict(**standard_metrics)

--- a/tests/trainer/logging/test_logger_connector.py
+++ b/tests/trainer/logging/test_logger_connector.py
@@ -425,3 +425,21 @@ def test_epoch_results_cache_dp(tmpdir):
     )
     trainer.fit(model)
     trainer.test(model, ckpt_path=None)
+
+
+def test_logging_to_progress_bar_with_reserved_key(tmpdir):
+    """ Test that logging a metric with a reserved name to the progress bar raises a warning. """
+    class TestModel(BoringModel):
+
+        def training_step(self, *args, **kwargs):
+            output = super().training_step(*args, **kwargs)
+            self.log("loss", output["loss"], prog_bar=True)
+            return output
+
+    model = TestModel()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=2,
+    )
+    with pytest.warns(UserWarning, match="The progress bar already tracks a metric with the name 'loss'"):
+        trainer.fit(model)

--- a/tests/trainer/logging/test_logger_connector.py
+++ b/tests/trainer/logging/test_logger_connector.py
@@ -441,5 +441,5 @@ def test_logging_to_progress_bar_with_reserved_key(tmpdir):
         default_root_dir=tmpdir,
         max_steps=2,
     )
-    with pytest.warns(UserWarning, match="The progress bar already tracks a metric with the name 'loss'"):
+    with pytest.warns(UserWarning, match="The progress bar already tracks a metric with the name(s) 'loss'"):
         trainer.fit(model)

--- a/tests/trainer/logging/test_logger_connector.py
+++ b/tests/trainer/logging/test_logger_connector.py
@@ -441,5 +441,5 @@ def test_logging_to_progress_bar_with_reserved_key(tmpdir):
         default_root_dir=tmpdir,
         max_steps=2,
     )
-    with pytest.warns(UserWarning, match="The progress bar already tracks a metric with the name(s) 'loss'"):
+    with pytest.warns(UserWarning, match="The progress bar already tracks a metric with the .* 'loss'"):
         trainer.fit(model)


### PR DESCRIPTION
## What does this PR do?

Fixes #5299

The statement

```python
self.log("loss", loss, prog_bar=True)
```

currently results in an error, because the loss is already logged to the progress bar by default. 
Instead of an error message, we overwrite the progress bar dict entry by what the user logged and print a warning.

The warning was suggested by @edenlightning. Alternatively, we could also just overwrite the value without the warning because the user explicitly calls `self.log` anyway.