### PR TITLE
Convert progress bar metrics to float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed the default of `find_unused_parameters` to `False` in DDP ([#5185](https://github.com/PyTorchLightning/pytorch-lightning/pull/5185))
 
 
-- Changed `ModelCheckpoint` version suffixes to start at 1 ([5008](https://github.com/PyTorchLightning/pytorch-lightning/pull/5008))
+- Changed `ModelCheckpoint` version suffixes to start at 1 ([#5008](https://github.com/PyTorchLightning/pytorch-lightning/pull/5008))
+
+
+- Progress bar metrics tensors are now converted to float ([#5692](https://github.com/PyTorchLightning/pytorch-lightning/pull/5692))
 
 
 - Changed the default value for the `progress_bar_refresh_rate` Trainer argument in Google COLAB notebooks to 20 ([#5516](https://github.com/PyTorchLightning/pytorch-lightning/pull/5516))

--- a/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -14,7 +14,7 @@
 import os
 from copy import deepcopy
 from pprint import pprint
-from typing import Any, Dict, Iterable, Union
+from typing import Dict, Iterable, Union
 
 import torch
 

--- a/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -37,7 +37,7 @@ class LoggerConnector:
         self._callback_metrics = MetricsHolder()
         self._evaluation_callback_metrics = MetricsHolder(to_float=True)
         self._logged_metrics = MetricsHolder()
-        self._progress_bar_metrics = MetricsHolder()
+        self._progress_bar_metrics = MetricsHolder(to_float=True)
         self.eval_loop_results = []
         self._cached_results = {stage: EpochResultStore(trainer, stage) for stage in RunningStage}
         self._cached_results[None] = EpochResultStore(trainer, None)
@@ -88,7 +88,7 @@ class LoggerConnector:
         )
         return metrics_holder.metrics
 
-    def set_metrics(self, key: str, val: Any) -> None:
+    def set_metrics(self, key: str, val: Dict) -> None:
         metrics_holder = getattr(self, f"_{key}", None)
         metrics_holder.reset(val)
 

--- a/tests/callbacks/test_progress_bar.py
+++ b/tests/callbacks/test_progress_bar.py
@@ -352,7 +352,7 @@ def test_test_progress_bar_update_amount(tmpdir, test_batches, refresh_rate, tes
     progress_bar.test_progress_bar.update.assert_has_calls([call(delta) for delta in test_deltas])
 
 
-def test_test_progress_bar_thing(tmpdir):
+def test_tensor_to_float_conversion(tmpdir):
     """Check tensor gets converted to float"""
     class TestModel(BoringModel):
         def training_step(self, batch, batch_idx):

--- a/tests/callbacks/test_progress_bar.py
+++ b/tests/callbacks/test_progress_bar.py
@@ -354,7 +354,9 @@ def test_test_progress_bar_update_amount(tmpdir, test_batches, refresh_rate, tes
 
 def test_tensor_to_float_conversion(tmpdir):
     """Check tensor gets converted to float"""
+
     class TestModel(BoringModel):
+
         def training_step(self, batch, batch_idx):
             self.log('foo', torch.tensor(0.123), prog_bar=True)
             self.log('bar', {"baz": torch.tensor([1])}, prog_bar=True)


### PR DESCRIPTION
## What does this PR do?

Fixes #5481

~~### TODO:~~
~~- Separate train/val/test metrics~~
~~- `callback_metrics` should copy the data as is, not as a reference from `progress_bar_metrics`. This way, each `MetricHolder` is free to make their own conversions without affecting other parts.~~

edit: leaving refactor out of this PR

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified
 - [x] **Check that target branch and milestone match!**
