### PR TITLE
Refactor access to trainer attributes in LightningModule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed the default value for the `progress_bar_refresh_rate` Trainer argument in Google COLAB notebooks to 20 ([#5516](https://github.com/PyTorchLightning/pytorch-lightning/pull/5516))
 
 
+- Made `LightningModule.global_rank`, `LightningModule.local_rank` and `LightningModule.logger` read-only properties ([#xxxx](https://github.com/PyTorchLightning/pytorch-lightning/pull/xxxx))
+
 - Refactored Accelerators and Plugins 
     * Added base classes for plugins ([#5715](https://github.com/PyTorchLightning/pytorch-lightning/pull/5715))
     * Added parallel plugins for DP, DDP, DDPSpawn, DDP2 and Horovod ([#5714](https://github.com/PyTorchLightning/pytorch-lightning/pull/5714))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,7 +107,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed the default value for the `progress_bar_refresh_rate` Trainer argument in Google COLAB notebooks to 20 ([#5516](https://github.com/PyTorchLightning/pytorch-lightning/pull/5516))
 
 
-- Made `LightningModule.global_rank`, `LightningModule.local_rank` and `LightningModule.logger` read-only properties ([#xxxx](https://github.com/PyTorchLightning/pytorch-lightning/pull/xxxx))
+- Made `LightningModule.global_rank`, `LightningModule.local_rank` and `LightningModule.logger` read-only properties ([#5730](https://github.com/PyTorchLightning/pytorch-lightning/pull/5730))
+
 
 - Refactored Accelerators and Plugins 
     * Added base classes for plugins ([#5715](https://github.com/PyTorchLightning/pytorch-lightning/pull/5715))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Made `LightningModule.global_rank`, `LightningModule.local_rank` and `LightningModule.logger` read-only properties ([#5730](https://github.com/PyTorchLightning/pytorch-lightning/pull/5730))
 
 
+- Changed trainer-related attributes in LightningModule as read-only property: `global_rank`, `local_rank`, `logger` ([#5730](https://github.com/PyTorchLightning/pytorch-lightning/pull/5730))
+
+
 - Refactored Accelerators and Plugins 
     * Added base classes for plugins ([#5715](https://github.com/PyTorchLightning/pytorch-lightning/pull/5715))
     * Added parallel plugins for DP, DDP, DDPSpawn, DDP2 and Horovod ([#5714](https://github.com/PyTorchLightning/pytorch-lightning/pull/5714))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,9 +110,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Made `LightningModule.global_rank`, `LightningModule.local_rank` and `LightningModule.logger` read-only properties ([#5730](https://github.com/PyTorchLightning/pytorch-lightning/pull/5730))
 
 
-- Changed trainer-related attributes in LightningModule as read-only property: `global_rank`, `local_rank`, `logger` ([#5730](https://github.com/PyTorchLightning/pytorch-lightning/pull/5730))
-
-
 - Refactored Accelerators and Plugins 
     * Added base classes for plugins ([#5715](https://github.com/PyTorchLightning/pytorch-lightning/pull/5715))
     * Added parallel plugins for DP, DDP, DDPSpawn, DDP2 and Horovod ([#5714](https://github.com/PyTorchLightning/pytorch-lightning/pull/5714))

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -67,6 +67,8 @@ class LightningModule(
         "current_epoch",
         "global_step",
         "running_stage",
+        "global_rank",
+        "local_rank",
     ] + DeviceDtypeModuleMixin.__jit_unused_properties__
 
     def __init__(self, *args, **kwargs):
@@ -131,6 +133,14 @@ class LightningModule(
     def global_step(self) -> int:
         """Total training batches seen across all epochs"""
         return self.trainer.global_step if self.trainer else 0
+
+    @property
+    def global_rank(self):
+        return self.trainer.global_rank if self.trainer else 0
+
+    @property
+    def local_rank(self):
+        return self.trainer.local_rank if self.trainer else 0
 
     @example_input_array.setter
     def example_input_array(self, example: Any) -> None:

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -85,9 +85,6 @@ class LightningModule(
         #: Pointer to the trainer object
         self.trainer = None
 
-        #: Pointer to the logger object
-        self.logger = None
-
         self._distrib_type = None
         self._device_type = None
 
@@ -135,11 +132,13 @@ class LightningModule(
         return self.trainer.global_step if self.trainer else 0
 
     @property
-    def global_rank(self):
+    def global_rank(self) -> int:
+        """ The index of the current process across all nodes and devices. """
         return self.trainer.global_rank if self.trainer else 0
 
     @property
-    def local_rank(self):
+    def local_rank(self) -> int:
+        """ The index of the current process within a single node. """
         return self.trainer.local_rank if self.trainer else 0
 
     @example_input_array.setter
@@ -172,6 +171,11 @@ class LightningModule(
     @automatic_optimization.setter
     def automatic_optimization(self, automatic_optimization: bool) -> None:
         self._automatic_optimization = automatic_optimization
+
+    @property
+    def logger(self):
+        """ Reference to the logger object in the Trainer. """
+        return self.trainer.logger if self.trainer else None
 
     def print(self, *args, **kwargs) -> None:
         r"""

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -69,6 +69,7 @@ class LightningModule(
         "running_stage",
         "global_rank",
         "local_rank",
+        "logger",
     ] + DeviceDtypeModuleMixin.__jit_unused_properties__
 
     def __init__(self, *args, **kwargs):

--- a/pytorch_lightning/overrides/data_parallel.py
+++ b/pytorch_lightning/overrides/data_parallel.py
@@ -30,8 +30,7 @@ class LightningDataParallel(DataParallel):
     def __init__(self, module: LightningModule, *args, **kwargs):
         warnings.warn(
             "The usage of `LightningDataParallel` is deprecated since v1.2 and will be removed in v1.4."
-            " From now on we recommend to directly subclass `torch.nn.parallel.DataParallel`.",
-            DeprecationWarning
+            " From now on we recommend to directly subclass `torch.nn.parallel.DataParallel`.", DeprecationWarning
         )
         super().__init__(LightningParallelModule(module), *args, **kwargs)
 
@@ -67,6 +66,7 @@ class LightningParallelModule(_LightningModuleWrapperBase):
         pl_module: the model to wrap
 
     """
+
     def __init__(self, pl_module: LightningModule):
         super().__init__(pl_module)
 

--- a/pytorch_lightning/plugins/base_plugin.py
+++ b/pytorch_lightning/plugins/base_plugin.py
@@ -22,7 +22,8 @@ class Plugin(ABC):
     """Basic Plugin class to derive precision and training type plugins from."""
 
     @abstractmethod
-    def connect(self, model: torch.nn.Module, *args: Sequence, **kwargs: Sequence) -> Optional[Tuple[torch.nn.Module, Sequence, Sequence]]:
+    def connect(self, model: torch.nn.Module, *args: Sequence,
+                **kwargs: Sequence) -> Optional[Tuple[torch.nn.Module, Sequence, Sequence]]:
         """Connects the plugin with the accelerator (and thereby with trainer and model).
         Will be called by the accelerator.
         """

--- a/pytorch_lightning/plugins/precision/native_amp.py
+++ b/pytorch_lightning/plugins/precision/native_amp.py
@@ -28,6 +28,7 @@ else:
 
 
 class NativeMixedPrecisionPlugin(MixedPrecisionPlugin):
+
     def __init__(self):
         self.backend = AMPType.NATIVE
         self.scaler = torch.cuda.amp.GradScaler()

--- a/pytorch_lightning/plugins/precision/native_amp.py
+++ b/pytorch_lightning/plugins/precision/native_amp.py
@@ -18,8 +18,13 @@ import torch
 
 from pytorch_lightning.core import LightningModule
 from pytorch_lightning.plugins.precision.mixed import MixedPrecisionPlugin
-from pytorch_lightning.utilities import AMPType
+from pytorch_lightning.utilities import _NATIVE_AMP_AVAILABLE, AMPType
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
+
+if _NATIVE_AMP_AVAILABLE:
+    from torch.cuda.amp import autocast
+else:
+    autocast = None
 
 
 class NativeMixedPrecisionPlugin(MixedPrecisionPlugin):
@@ -74,6 +79,6 @@ class NativeMixedPrecisionPlugin(MixedPrecisionPlugin):
         return closure_loss
 
     @contextmanager
-    def train_step_context(self) -> Generator[torch.cuda.amp.autocast, None, None]:
+    def train_step_context(self) -> Generator[autocast, None, None]:
         """Enable autocast context"""
         yield torch.cuda.amp.autocast()

--- a/pytorch_lightning/plugins/precision/precision_plugin.py
+++ b/pytorch_lightning/plugins/precision/precision_plugin.py
@@ -37,7 +37,8 @@ class PrecisionPlugin(Plugin):
             for p in group["params"]:
                 yield p
 
-    def connect(self, model: torch.nn.Module, optimizers: Sequence, lr_schedulers: Sequence) -> Tuple[torch.nn.Module, Sequence, Sequence]:
+    def connect(self, model: torch.nn.Module, optimizers: Sequence,
+                lr_schedulers: Sequence) -> Tuple[torch.nn.Module, Sequence, Sequence]:
         """Connects this plugin to the accelerator and the training process"""
         return model, optimizers, lr_schedulers
 

--- a/pytorch_lightning/plugins/precision/sharded_native_amp.py
+++ b/pytorch_lightning/plugins/precision/sharded_native_amp.py
@@ -26,6 +26,7 @@ if _NATIVE_AMP_AVAILABLE and _FAIRSCALE_AVAILABLE:
 class ShardedNativeMixedPrecisionPlugin(NativeMixedPrecisionPlugin):
     """Mixed Precision for Sharded Training
     """
+
     def __init__(self):
         super().__init__()
         self.scaler = ShardedGradScaler()

--- a/pytorch_lightning/trainer/connectors/model_connector.py
+++ b/pytorch_lightning/trainer/connectors/model_connector.py
@@ -17,6 +17,7 @@ Root module for all distributed operations in Lightning.
 Currently supports training on CPU, GPU (dp, ddp, ddp2, horovod) and TPU.
 
 """
+from weakref import proxy
 
 
 class ModelConnector:
@@ -30,7 +31,7 @@ class ModelConnector:
         self.trainer.train_loop.automatic_optimization = automatic_optimization
 
         for m in [model, ref_model]:
-            m.trainer = self.trainer
+            m.trainer = proxy(self.trainer)
             m.logger = self.trainer.logger
             m._device_type = str(self.trainer._device_type)
             m._distrib_type = str(self.trainer._distrib_type)

--- a/pytorch_lightning/trainer/connectors/model_connector.py
+++ b/pytorch_lightning/trainer/connectors/model_connector.py
@@ -32,7 +32,6 @@ class ModelConnector:
 
         for m in [model, ref_model]:
             m.trainer = proxy(self.trainer)
-            m.logger = self.trainer.logger
             m._device_type = str(self.trainer._device_type)
             m._distrib_type = str(self.trainer._distrib_type)
             m.use_amp = self.trainer.amp_backend is not None

--- a/pytorch_lightning/trainer/connectors/model_connector.py
+++ b/pytorch_lightning/trainer/connectors/model_connector.py
@@ -39,8 +39,6 @@ class ModelConnector:
             m.tpu_local_core_rank = self.trainer.tpu_local_core_rank
             m.tpu_global_core_rank = self.trainer.tpu_global_core_rank
             m.precision = self.trainer.precision
-            m.global_rank = self.trainer.global_rank
-            m.local_rank = self.trainer.local_rank
 
     def get_model(self):
         return self._get_reference_model(self.trainer.model)

--- a/pytorch_lightning/tuner/tuning.py
+++ b/pytorch_lightning/tuner/tuning.py
@@ -50,12 +50,10 @@ class Tuner:
                 val_dataloaders=val_dataloaders,
                 datamodule=datamodule,
             )
-            model.logger = self.trainer.logger  # reset logger binding
 
         # Run learning rate finder:
         if self.trainer.auto_lr_find:
             self.internal_find_lr(model)
-            model.logger = self.trainer.logger  # reset logger binding
 
     def scale_batch_size(
             self,

--- a/tests/core/test_lightning_module.py
+++ b/tests/core/test_lightning_module.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import patch, Mock, PropertyMock
+from unittest.mock import patch, Mock
 
 import pytest
 from torch.optim import Adam, SGD

--- a/tests/core/test_lightning_module.py
+++ b/tests/core/test_lightning_module.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import patch
+from unittest.mock import patch, Mock, PropertyMock
 
 import pytest
 from torch.optim import Adam, SGD
@@ -19,6 +19,46 @@ from torch.optim import Adam, SGD
 from pytorch_lightning import Trainer
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.base import BoringModel
+
+
+def test_property_current_epoch():
+    """ Test that the current_epoch in LightningModule is accessible via the Trainer. """
+    model = BoringModel()
+    assert model.current_epoch == 0
+
+    trainer = Mock(current_epoch=123)
+    model.trainer = trainer
+    assert model.current_epoch == 123
+
+
+def test_property_global_step():
+    """ Test that the global_step in LightningModule is accessible via the Trainer. """
+    model = BoringModel()
+    assert model.global_step == 0
+
+    trainer = Mock(global_step=123)
+    model.trainer = trainer
+    assert model.global_step == 123
+
+
+def test_property_global_rank():
+    """ Test that the global rank in LightningModule is accessible via the Trainer. """
+    model = BoringModel()
+    assert model.global_rank == 0
+
+    trainer = Mock(global_rank=123)
+    model.trainer = trainer
+    assert model.global_rank == 123
+
+
+def test_property_local_rank():
+    """ Test that the local rank in LightningModule is accessible via the Trainer. """
+    model = BoringModel()
+    assert model.local_rank == 0
+
+    trainer = Mock(local_rank=123)
+    model.trainer = trainer
+    assert model.local_rank == 123
 
 
 def test_automatic_optimization(tmpdir):

--- a/tests/core/test_lightning_module.py
+++ b/tests/core/test_lightning_module.py
@@ -17,6 +17,7 @@ import pytest
 from torch.optim import Adam, SGD
 
 from pytorch_lightning import Trainer
+from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.base import BoringModel
 
@@ -59,6 +60,17 @@ def test_property_local_rank():
     trainer = Mock(local_rank=123)
     model.trainer = trainer
     assert model.local_rank == 123
+
+
+def test_property_logger(tmpdir):
+    """ Test that the logger in LightningModule is accessible via the Trainer. """
+    model = BoringModel()
+    assert model.logger is None
+
+    logger = TensorBoardLogger(tmpdir)
+    trainer = Mock(logger=logger)
+    model.trainer = trainer
+    assert model.logger == logger
 
 
 def test_automatic_optimization(tmpdir):

--- a/tests/trainer/test_lr_finder.py
+++ b/tests/trainer/test_lr_finder.py
@@ -90,6 +90,8 @@ def test_trainer_reset_correctly(tmpdir):
         assert attributes_before[key] == attributes_after[key], \
             f'Attribute {key} was not reset correctly after learning rate finder'
 
+    assert model.trainer == trainer
+
 
 @pytest.mark.parametrize('use_hparams', [False, True])
 def test_trainer_arg_bool(tmpdir, use_hparams):


### PR DESCRIPTION
## What does this PR do?

Implements read-only passthrough for the attributes that are exclusively handled by the Trainer. This avoids accidental divergence of state. Additionally, just to be safe we make the trainer a week-ref.

Refactor is also partially necessary for #5616 

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified
 - [x] **Check that target branch and milestone match!**


## Did you have fun?
Make sure you had fun coding 🙃
