### PR TITLE
Add additional requirement check for fairscale pipe

### DIFF
--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -15,6 +15,7 @@
 import importlib
 import platform
 from distutils.version import LooseVersion
+from importlib.metadata import version
 
 import torch
 
@@ -52,7 +53,8 @@ _XLA_AVAILABLE = _module_available("torch_xla")
 _FAIRSCALE_AVAILABLE = platform.system() != 'Windows' and _module_available('fairscale.nn.data_parallel')
 _RPC_AVAILABLE = platform.system() != 'Windows' and _module_available('torch.distributed.rpc')
 _GROUP_AVAILABLE = platform.system() != 'Windows' and _module_available('torch.distributed.group')
-_FAIRSCALE_PIPE_AVAILABLE = _FAIRSCALE_AVAILABLE and LooseVersion(torch.__version__) >= LooseVersion("1.6.0")
+_FAIRSCALE_PIPE_AVAILABLE = _FAIRSCALE_AVAILABLE and LooseVersion(torch.__version__) >= LooseVersion(
+    "1.6.0") and LooseVersion(version('fairscale')) <= LooseVersion("0.1.3")
 _BOLTS_AVAILABLE = _module_available('pl_bolts')
 _PYTORCH_PRUNE_AVAILABLE = _module_available('torch.nn.utils.prune')
 _TORCHVISION_AVAILABLE = _module_available('torchvision')

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -53,8 +53,10 @@ _XLA_AVAILABLE = _module_available("torch_xla")
 _FAIRSCALE_AVAILABLE = platform.system() != 'Windows' and _module_available('fairscale.nn.data_parallel')
 _RPC_AVAILABLE = platform.system() != 'Windows' and _module_available('torch.distributed.rpc')
 _GROUP_AVAILABLE = platform.system() != 'Windows' and _module_available('torch.distributed.group')
-_FAIRSCALE_PIPE_AVAILABLE = _FAIRSCALE_AVAILABLE and LooseVersion(torch.__version__) >= LooseVersion(
-    "1.6.0") and LooseVersion(pkg_resources.get_distribution('fairscale').version) <= LooseVersion("0.1.3")
+_FAIRSCALE_PIPE_AVAILABLE = _FAIRSCALE_AVAILABLE and LooseVersion(
+    torch.__version__
+) >= LooseVersion("1.6.0") and LooseVersion(pkg_resources.get_distribution('fairscale').version
+                                            ) <= LooseVersion("0.1.3")
 _BOLTS_AVAILABLE = _module_available('pl_bolts')
 _PYTORCH_PRUNE_AVAILABLE = _module_available('torch.nn.utils.prune')
 _TORCHVISION_AVAILABLE = _module_available('torchvision')

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -15,8 +15,8 @@
 import importlib
 import platform
 from distutils.version import LooseVersion
-from importlib.metadata import version
 
+import pkg_resources
 import torch
 
 
@@ -54,7 +54,7 @@ _FAIRSCALE_AVAILABLE = platform.system() != 'Windows' and _module_available('fai
 _RPC_AVAILABLE = platform.system() != 'Windows' and _module_available('torch.distributed.rpc')
 _GROUP_AVAILABLE = platform.system() != 'Windows' and _module_available('torch.distributed.group')
 _FAIRSCALE_PIPE_AVAILABLE = _FAIRSCALE_AVAILABLE and LooseVersion(torch.__version__) >= LooseVersion(
-    "1.6.0") and LooseVersion(version('fairscale')) <= LooseVersion("0.1.3")
+    "1.6.0") and LooseVersion(pkg_resources.get_distribution('fairscale').version) <= LooseVersion("0.1.3")
 _BOLTS_AVAILABLE = _module_available('pl_bolts')
 _PYTORCH_PRUNE_AVAILABLE = _module_available('torch.nn.utils.prune')
 _TORCHVISION_AVAILABLE = _module_available('torchvision')


### PR DESCRIPTION
## What does this PR do?

When using Fairscale master as defined in the docs, this could lead to version mismatches and ultimately the code crashes as the pipe API has changed. Make the pipe module available check stricter to resolve.

Pointing to 1.2 release as not super critical right now since Fairscale 0.1.5 just came out, so can save the transfer from master -> 1.2.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified
 - [x] **Check that target branch and milestone match!**


## Did you have fun?
Make sure you had fun coding 🙃
