### PR TITLE
accelerator refactor - fix memory issue with ddp_spawn

### DIFF
--- a/pytorch_lightning/accelerators/gpu.py
+++ b/pytorch_lightning/accelerators/gpu.py
@@ -16,7 +16,6 @@ class GPUAccelerator(Accelerator):
             raise MisconfigurationException(f"Device should be GPU, got {self.root_device} instead")
         self.set_nvidia_flags()
         torch.cuda.set_device(self.root_device)
-        model.to(self.root_device)
         return super().setup(trainer, model)
 
     def on_train_start(self):

--- a/pytorch_lightning/plugins/training_type/dp.py
+++ b/pytorch_lightning/plugins/training_type/dp.py
@@ -27,6 +27,8 @@ class DataParallelPlugin(ParallelPlugin):
         super().__init__(parallel_devices=parallel_devices, cluster_environment=None)
 
     def setup(self, model):
+        # model needs to be moved to the device before it is wrapped
+        model.to(self.root_device)
         self._model = DataParallel(LightningParallelModule(model), self.parallel_devices)
 
     def reduce(self, output, *args, **kwargs):


### PR DESCRIPTION
When using ddp spawn, moving the model to gpu before processes are spawn creates extra memory usage on the root gpu. 
We already move the model to device in the plugins, so this shouldn't be necessary in setup.