### PR TITLE
Fix access to trainer object within configure optimizers

### DIFF
--- a/pytorch_lightning/trainer/connectors/model_connector.py
+++ b/pytorch_lightning/trainer/connectors/model_connector.py
@@ -42,6 +42,6 @@ class ModelConnector:
         return self._get_reference_model(self.trainer.model)
 
     def _get_reference_model(self, model):
-        if self.trainer.accelerator_backend:
+        if self.trainer.accelerator_backend and self.trainer.accelerator_backend.lightning_module:
             return self.trainer.accelerator_backend.lightning_module
         return model

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -405,12 +405,6 @@ class Trainer(
         Args:
             model: The model to run sanity test on.
         """
-        # --------------------------
-        # Setup??
-        # --------------------------
-
-        # set local properties on the model
-        self.model_connector.copy_trainer_model_properties(model)
 
         # init amp. Must be done here instead of __init__ to allow ddp to work
         if self.amp_backend == AMPType.NATIVE and self.precision == 16 and self._device_type != DeviceType.TPU:
@@ -448,6 +442,9 @@ class Trainer(
         # bookkeeping
         self._state = TrainerState.RUNNING
         self._set_wide_running_stage(RunningStage.TRAINING)
+
+        # set local properties on the model
+        self.model_connector.copy_trainer_model_properties(model)
 
         # ----------------------------
         # LINK DATA

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1726,3 +1726,17 @@ def test_disabled_training_for_insufficient_limit_train_batches(
     assert trainer.current_epoch == current_epoch
     assert model.training_step_invoked == should_train, f"`training_step` {error_string}"
     assert model.training_epoch_end_invoked == should_train, f"`training_epoch_end` {error_string}"
+
+
+def test_trainer_access_in_configure_optimizers(tmpdir):
+
+    class TestModel(BoringModel):
+
+        def configure_optimizers(self):
+            assert self.trainer is not None, "Expect to have access to the trainer within `configure_optimizers`"
+
+    train_data = torch.utils.data.DataLoader(RandomDataset(32, 64))
+
+    model = TestModel()
+    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=True, gpus=1)
+    trainer.fit(model, train_data)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1738,5 +1738,5 @@ def test_trainer_access_in_configure_optimizers(tmpdir):
     train_data = torch.utils.data.DataLoader(RandomDataset(32, 64))
 
     model = TestModel()
-    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=True, gpus=1)
+    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=True)
     trainer.fit(model, train_data)


### PR DESCRIPTION
## What does this PR do?

Allow access to the trainer via the model as soon as possible. This caused issues in code that worked for previous releases that required access to the trainer in `configure_optimizers`. 

In master, this is done via a duplicate call to `self.model_connector.copy_trainer_model_properties(model)` here:

https://github.com/PyTorchLightning/pytorch-lightning/blob/ba04bb31626719e150698e8b2f53d722d1626287/pytorch_lightning/trainer/training_loop.py#L108-L109

In the accelerator refactor, this has been removed hence we need to call this earlier. 
