### PR TITLE
Fix progress bar logging of metrics if compute_on_step=False

### DIFF
--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -297,7 +297,7 @@ class Result(Dict):
             dl_key = self._add_dataloader_idx(k, options["dataloader_idx"], add_dataloader_idx)
 
             if options['logger'] and options['on_step']:
-                if isinstance(self[k], Metric):
+                if isinstance(self[k], Metric) and self[k]._forward_cache is not None:
                     result[dl_key] = self[k]._forward_cache.detach()
                 else:
                     result[dl_key] = self[k]
@@ -406,7 +406,7 @@ class Result(Dict):
             dl_key = self._add_dataloader_idx(k, options["dataloader_idx"], add_dataloader_idx)
 
             if options['prog_bar'] and options['on_step']:
-                if isinstance(self[k], Metric):
+                if isinstance(self[k], Metric) and self[k]._forward_cache is not None:
                     result[dl_key] = self[k]._forward_cache
                 else:
                     result[dl_key] = self[k]


### PR DESCRIPTION
## What does this PR do?

Quick fix, this issue from slack:

> Hi, when using the Metrics API, I’m trying to set the compute_on_step=False when instantiating my ROC  and AveragePrecision metrics, because I want to compute these over the entire epoch (as these metrics aren’t very useful batch-wise).
> So in the training/val/test steps, I do something like self.roc(preds, truth), but I don’t log this in the step. Instead, at the epoch end, I compute auc() using the output of self.roc.compute(), which I then log, etc.
> However, if I set compute_on_step=False , then PL throws the following error at the start of Epoch 0 (validation sanity epoch runs fine):
> result[dl_key] = self[k]._forward_cache.detach()
> AttributeError: 'NoneType' object has no attribute 'detach'
> When looking at PL’s source code, it appears that if compute_on_step=False , then the _forward_cache property is set to and remains None, and is only updated to a non-None value if compute_on_step=True . Is this the intended behavior, or is this a bug? If this is intended, then how would the compute_on_step flag ever be able to set to False?
> Thanks for the help!

cc, @tchaton I'm not sure how I feel about using the `_forward_cache` attribute
of the metric; I never really intended for that to be used outside the metric
class so there could be unintended consequences down the road. We might want to
consider a more robust solution here.
