### PR TITLE
tests: Remove usage of --flake8 flag

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -202,7 +202,7 @@ This is useful if you do not test against all required dependency versions.
 **Docker:** Another option is utilize the [pytorch lightning cuda base docker image](https://hub.docker.com/repository/docker/pytorchlightning/pytorch_lightning/tags?page=1&name=cuda). You can then run:
 
 ```bash
-python -m pytest pytorch_lightning tests pl_examples -v --flake8
+python -m pytest pytorch_lightning tests pl_examples -v
 ```
 
 ### Pull Request

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test: clean
 	# install APEX, see https://github.com/NVIDIA/apex#linux
 
 	# use this to run tests
-	python -m coverage run --source pytorch_lightning -m pytest pytorch_lightning tests pl_examples -v --flake8
+	python -m coverage run --source pytorch_lightning -m pytest pytorch_lightning tests pl_examples -v
 	python -m coverage report
 
 docs: clean

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,7 +2,6 @@ coverage>=5.0
 codecov>=2.1
 pytest>=5.0
 # pytest-cov
-# pytest-flake8
 flake8>=3.6
 check-manifest
 twine==3.2


### PR DESCRIPTION
## What does this PR do?

I tried running this on my venv, but got the following:
```sh
$ python -m pytest tests -v --flake8
ERROR: usage: __main__.py [options] [file_or_dir] [file_or_dir] [...]
__main__.py: error: unrecognized arguments: --flake8
  inifile: <path>/pytorch-lightning/setup.cfg
  rootdir: <path>/pytorch-lightning
```

From looking at live-code that either doesn't use `--flake8` or has it
commented out, I assume this is now a dead flag.

## Before submitting
- (N/A) Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- (N/A) Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- (N/A) Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified
 - [x] **Check that target branch and milestone match!**


## Did you have fun?

Yes :grimacing:
