### PR TITLE
Use property in connector for sampler

### DIFF
--- a/pytorch_lightning/accelerators/accelerator_connector.py
+++ b/pytorch_lightning/accelerators/accelerator_connector.py
@@ -257,6 +257,10 @@ class BackendConnector(object):
         return self._distrib_type == DistributedType.HOROVOD
 
     @property
+    def is_distributed(self):
+        return self.use_ddp or self.use_ddp2 or self.use_horovod or self.on_tpu
+
+    @property
     def num_gpus(self) -> int:
         gpus = self.parallel_device_ids
         if gpus is None:

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -97,9 +97,9 @@ class TrainerDataLoadingMixin(ABC):
         if not is_dataloader or is_iterable_ds:
             return dataloader
 
-        is_in_dist = self.use_ddp or self.use_ddp2 or self.use_horovod or self.use_tpu
-
-        need_dist_sampler = is_in_dist and not isinstance(dataloader.sampler, DistributedSampler)
+        need_dist_sampler = self.accelerator_connector.is_distributed and not isinstance(
+            dataloader.sampler, DistributedSampler
+        )
         if self.accelerator_connector.replace_sampler_ddp and need_dist_sampler:
             if not isinstance(dataloader.sampler, (SequentialSampler, RandomSampler)):
                 raise MisconfigurationException(


### PR DESCRIPTION
Fixes properties for sampler. For some reason I wasn't getting proper distributed kwargs being passed when using ddp sharded. This fixes the issue, and is cleaner