### PR TITLE
Fix logic error in Apex AMP

### DIFF
--- a/pytorch_lightning/plugins/precision/apex_amp.py
+++ b/pytorch_lightning/plugins/precision/apex_amp.py
@@ -157,7 +157,7 @@ class ApexMixedPrecisionPlugin(MixedPrecisionPlugin):
         # apex amp does not support closures.
         lambda_closure()
 
-        if not pl_module.automatic_optimization:
+        if pl_module.automatic_optimization:
             pl_module.trainer.call_hook("on_after_backward")
             optimizer.step()
 

--- a/pytorch_lightning/plugins/precision/apex_amp.py
+++ b/pytorch_lightning/plugins/precision/apex_amp.py
@@ -157,8 +157,9 @@ class ApexMixedPrecisionPlugin(MixedPrecisionPlugin):
         # apex amp does not support closures.
         lambda_closure()
 
-        if pl_module.automatic_optimization:
+        if not pl_module.automatic_optimization:
             pl_module.trainer.call_hook("on_after_backward")
-            optimizer.step()
+
+        optimizer.step()
 
         return False


### PR DESCRIPTION
## What does this PR do?

Within the accelerator refactor there is a small error in the Apex logic, which results in us not calling `optimizer.step` in automatic optimization. This logic should be reversed. Regarding testing, I assume we have no convergence tests in place hence Apex AMP tests did not catch this?

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified
 - [x] **Check that target branch and milestone match!**


## Did you have fun?
Make sure you had fun coding 🙃
