### PR TITLE
Update PULL_REQUEST_TEMPLATE [skip ci]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,15 @@
 ## What does this PR do?
 
 <!--
-IMPORTANT:
- We separated bug-fix PRs and feature PRs and they shall land in master and release/1.X-dev accordingly.
- By default all PR are targeted to master which is correct for bug-fixes, but need to be change for features.
- If you miss it we can still fix it for you, just ping us... :]
-
 Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
 
 If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
--->
 
-Fixes # (issue) <- this [links related issue to this PR](https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
+The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
+-->
+Fixes #<issue_number>
 
 ## Before submitting
 - [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
@@ -34,8 +30,6 @@ Before you start reviewing make sure you have read [Review guidelines](https://g
  - [ ] Check that all items from **Before submitting** are resolved
  - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
  - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
- - [ ] **Check that target branch and milestone match!**
-
 
 ## Did you have fun?
 Make sure you had fun coding 🙃


### PR DESCRIPTION
## What does this PR do?

We moved back to the master-has-everything release strategy so the template is currently outdated. This PR fixes it :)