### PR TITLE
Re-attempt slurm auto resume call if non-shell call fails

### DIFF
--- a/pytorch_lightning/trainer/connectors/slurm_connector.py
+++ b/pytorch_lightning/trainer/connectors/slurm_connector.py
@@ -40,7 +40,14 @@ class SLURMConnector:
 
             # requeue job
             log.info(f'requeing job {job_id}...')
-            result = call(cmd)
+            try:
+                result = call(cmd)
+            except FileNotFoundError:
+                # This can occur if a subprocess call to `scontrol` is run outside a shell context
+                # Re-attempt call (now with shell context). If any error is raised, propagate to user.
+                # When running a shell command, it should be passed as a single string.
+                joint_cmd = [str(x) for x in cmd]
+                result = call(' '.join(joint_cmd), shell=True)
 
             # print result text
             if result == 0:


### PR DESCRIPTION
Signed-off-by: smajumdar <titu1994@gmail.com>

## What does this PR do?

`SLURMConnector` attempts to call `scontrol requeue {job_id}` without a shell context, which on some HPC systems will raise the following (truncated) error - because the subprocess call is not under a shell context.

```python
...
  File "/opt/conda/lib/python3.8/site-packages/pytorch_lightning/trainer/connectors/slurm_connector.py", line 97, in sig_handler
    result = call(cmd)
  File "/opt/conda/lib/python3.8/subprocess.py", line 340, in call
    with Popen(*popenargs, **kwargs) as p:
  File "/opt/conda/lib/python3.8/subprocess.py", line 854, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/opt/conda/lib/python3.8/subprocess.py", line 1702, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: 'scontrol'
``` 

This PR attempts the default approach (subprocess call without shell context), and if it catches the above `FileNotFoundError` - will reattempt the command - but using a shell context this time. 

<!--
IMPORTANT:
 We separated bug-fix PRs and feature PRs and they shall land in master and release/1.X-dev accordingly.
 By default all PR are targeted to master which is correct for bug-fixes, but need to be change for features.
 If you miss it we can still fix it for you, just ping us... :]

Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
-->

Fixes # (issue) <- N/A

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)  -- Discussed via Slack.
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
 - [ ] **Check that target branch and milestone match!**


## Did you have fun?
Make sure you had fun coding 🙃
