### PR TITLE
fix deprecated call to TPU_CHECK_TIMEOUT

### DIFF
--- a/tests/utilities/test_xla_device_utils.py
+++ b/tests/utilities/test_xla_device_utils.py
@@ -16,7 +16,7 @@ from unittest.mock import patch
 
 import pytest
 
-import pytorch_lightning.utilities.xla_device_utils as xla_utils
+import pytorch_lightning.utilities.xla_device as xla_utils
 from pytorch_lightning.utilities import _TPU_AVAILABLE, _XLA_AVAILABLE
 from tests.helpers.utils import pl_multi_process_test
 
@@ -34,7 +34,7 @@ def test_tpu_device_presence():
     assert xla_utils.XLADeviceUtils.tpu_device_exists() is True
 
 
-@patch('pytorch_lightning.utilities.xla_device_utils.TPU_CHECK_TIMEOUT', 10)
+@patch('pytorch_lightning.utilities.xla_device.TPU_CHECK_TIMEOUT', 10)
 def test_result_returns_within_timeout_seconds():
     """Check that pl_multi_process returns within 10 seconds"""
     start = time.time()


### PR DESCRIPTION
## What does this PR do?

as the path was to deprecated var the patching was not applied and it was the by far longest test
```
============================= slowest 50 durations =============================
100.12s call     tests/utilities/test_xla_device_utils.py::test_result_returns_within_timeout_seconds
12.50s call     tests/trainer/test_lr_finder.py::test_accumulation_and_early_stopping
7.63s call     tests/helpers/test_models.py::test_models[None-ParityModuleMNIST]
```

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified
 - [x] **Check that target branch and milestone match!**


## Did you have fun?
Make sure you had fun coding 🙃
