### PR TITLE
[CI] Move DeepSpeed into CUDA image, remove DeepSpeed install from azure

### DIFF
--- a/.github/workflows/events-nightly.yml
+++ b/.github/workflows/events-nightly.yml
@@ -3,6 +3,7 @@ name: Nightly events
 # https://jasonet.co/posts/scheduled-actions/
 # https://github.community/t/distinct-job-for-each-schedule/17811/2
 on:
+  push: {}  # fixme
   schedule:
     - cron: "0 0 * * *" # At the end of every day
 

--- a/.github/workflows/events-nightly.yml
+++ b/.github/workflows/events-nightly.yml
@@ -3,7 +3,6 @@ name: Nightly events
 # https://jasonet.co/posts/scheduled-actions/
 # https://github.community/t/distinct-job-for-each-schedule/17811/2
 on:
-  push: {}  # fixme
   schedule:
     - cron: "0 0 * * *" # At the end of every day
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,11 +62,6 @@ jobs:
         pip list
       displayName: 'Install dependencies'
 
-    - bash: |
-        # Temporary fix till DeepSpeed release, move this into CUDA image
-        pip install deepspeed@git+https://github.com/microsoft/DeepSpeed@ec8b1cb
-      displayName: 'Install DeepSpeed'
-
     - script: |
         python tests/collect_env_details.py
       displayName: 'Env details'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,8 +77,6 @@ jobs:
       displayName: 'Testing: standard'
 
     - bash: |
-        # Required for Ninja binary for building extensions, which is installed at this location
-        export PATH=$PATH:/home/AzDevOps_azpcontainer/.local/bin
         sh tests/special_tests.sh
       displayName: 'Testing: special'
 

--- a/dockers/base-cuda/Dockerfile
+++ b/dockers/base-cuda/Dockerfile
@@ -112,6 +112,11 @@ RUN \
     rm -rf apex
 
 RUN \
+    # install DeepSpeed from source.
+    # todo: swap to pypi release once DeepSpeed releases a new version.
+    pip install deepspeed@git+https://github.com/microsoft/DeepSpeed@ec8b1cb
+
+RUN \
     # Show what we have
     pip --version && \
     pip list && \


### PR DESCRIPTION
## What does this PR do?

Moves DeepSpeed to be installed within the CUDA image, and the azure pipeline to not install it everytime.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
