### PR TITLE
Add warnings to on_before/after_batch_transfer hooks

### DIFF
--- a/docs/source/extensions/datamodules.rst
+++ b/docs/source/extensions/datamodules.rst
@@ -319,6 +319,9 @@ Override to alter or apply augmentations to your batch before it is transferred 
             return batch
 
 
+.. warning::
+    The hook signature will change once the dataloader_idx is supported as an argument.
+
 .. note:: This hook only runs on single GPU training and DDP (no data-parallel).
 
 
@@ -333,6 +336,9 @@ Override to alter or apply augmentations to your batch after it is transferred t
             batch['x'] = gpu_transforms(batch['x'])
             return batch
 
+
+.. warning::
+    The hook signature will change once the dataloader_idx is supported as an argument.
 
 .. note::
     This hook only runs on single GPU training and DDP (no data-parallel). This hook

--- a/docs/source/extensions/datamodules.rst
+++ b/docs/source/extensions/datamodules.rst
@@ -297,12 +297,15 @@ Override to define how you want to move an arbitrary batch to a device.
 .. testcode::
 
     class MNISTDataModule(LightningDataModule):
-        def transfer_batch_to_device(self, batch, device):
+        def transfer_batch_to_device(self, batch, device, dataloader_idx):
             x = batch['x']
             x = CustomDataWrapper(x)
             batch['x'] = x.to(device)
             return batch
 
+
+.. warning::
+    Currently dataloader_idx always returns 0 and will be updated to support the true idx in the future.
 
 .. note:: This hook only runs on single GPU training and DDP (no data-parallel).
 

--- a/docs/source/extensions/datamodules.rst
+++ b/docs/source/extensions/datamodules.rst
@@ -305,7 +305,8 @@ Override to define how you want to move an arbitrary batch to a device.
 
 
 .. warning::
-    Currently dataloader_idx always returns 0 and will be updated to support the true idx in the future.
+
+    Currently ``dataloader_idx`` always returns 0 and will be updated to support the true ``idx`` in the future.
 
 .. note:: This hook only runs on single GPU training and DDP (no data-parallel).
 
@@ -341,7 +342,8 @@ Override to alter or apply augmentations to your batch after it is transferred t
 
 
 .. warning::
-    Currently dataloader_idx always returns 0 and will be updated to support the true idx in the future.
+
+    Currently ``dataloader_idx`` always returns 0 and will be updated to support the true ``idx`` in the future.
 
 .. note::
     This hook only runs on single GPU training and DDP (no data-parallel). This hook

--- a/docs/source/extensions/datamodules.rst
+++ b/docs/source/extensions/datamodules.rst
@@ -297,16 +297,12 @@ Override to define how you want to move an arbitrary batch to a device.
 .. testcode::
 
     class MNISTDataModule(LightningDataModule):
-        def transfer_batch_to_device(self, batch, device, dataloader_idx):
+        def transfer_batch_to_device(self, batch, device):
             x = batch['x']
             x = CustomDataWrapper(x)
             batch['x'] = x.to(device)
             return batch
 
-
-.. warning::
-
-    Currently ``dataloader_idx`` always returns 0 and will be updated to support the true ``idx`` in the future.
 
 .. note:: This hook only runs on single GPU training and DDP (no data-parallel).
 

--- a/docs/source/extensions/datamodules.rst
+++ b/docs/source/extensions/datamodules.rst
@@ -314,13 +314,13 @@ Override to alter or apply augmentations to your batch before it is transferred 
 .. testcode::
 
     class MNISTDataModule(LightningDataModule):
-        def on_before_batch_transfer(self, batch):
+        def on_before_batch_transfer(self, batch, dataloader_idx):
             batch['x'] = transforms(batch['x'])
             return batch
 
 
 .. warning::
-    The hook signature will change once the dataloader_idx is supported as an argument.
+    Currently dataloader_idx always returns 0 and will be updated to support the true idx in the future.
 
 .. note:: This hook only runs on single GPU training and DDP (no data-parallel).
 
@@ -332,13 +332,13 @@ Override to alter or apply augmentations to your batch after it is transferred t
 .. testcode::
 
     class MNISTDataModule(LightningDataModule):
-        def on_after_batch_transfer(self, batch):
+        def on_after_batch_transfer(self, batch, dataloader_idx):
             batch['x'] = gpu_transforms(batch['x'])
             return batch
 
 
 .. warning::
-    The hook signature will change once the dataloader_idx is supported as an argument.
+    Currently dataloader_idx always returns 0 and will be updated to support the true idx in the future.
 
 .. note::
     This hook only runs on single GPU training and DDP (no data-parallel). This hook

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -565,12 +565,10 @@ class DataHooks:
             will have an argument ``dataloader_idx`` which matches the order here.
         """
 
-    def transfer_batch_to_device(self, batch: Any, device: Optional[torch.device] = None, dataloader_idx=0) -> Any:
+    def transfer_batch_to_device(self, batch: Any, device: Optional[torch.device] = None) -> Any:
         """
         Override this hook if your :class:`~torch.utils.data.DataLoader` returns tensors
         wrapped in a custom data structure.
-
-        .. warning:: ``dataloader_idx`` always returns 0, and will be updated to support the true ``idx`` in the future.
 
         The data types listed below (and any arbitrary nesting of them) are supported out of the box:
 
@@ -596,20 +594,19 @@ class DataHooks:
         Args:
             batch: A batch of data that needs to be transferred to a new device.
             device: The target device as defined in PyTorch.
-            dataloader_idx: DataLoader idx for batch
 
         Returns:
             A reference to the data on the new device.
 
         Example::
 
-            def transfer_batch_to_device(self, batch, device, dataloader_idx):
+            def transfer_batch_to_device(self, batch, device):
                 if isinstance(batch, CustomBatch):
                     # move all tensors in your custom data structure to the device
                     batch.samples = batch.samples.to(device)
                     batch.targets = batch.targets.to(device)
                 else:
-                    batch = super().transfer_batch_to_device(data, device, dataloader_idx)
+                    batch = super().transfer_batch_to_device(data, device)
                 return batch
 
         See Also:

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -616,24 +616,25 @@ class DataHooks:
         device = device or self.device
         return move_data_to_device(batch, device)
 
-    def on_before_batch_transfer(self, batch):
+    def on_before_batch_transfer(self, batch, dataloader_idx):
         """
         Override to alter or apply batch augmentations to your batch before it is transferred to the device.
 
-        .. warning:: The hook signature will change once the dataloader_idx is supported as an argument.
+        .. warning:: dataloader_idx always returns 0, and will be updated to support the true idx in the future.
 
         Note:
             This hook only runs on single GPU training and DDP (no data-parallel).
 
         Args:
             batch: A batch of data that needs to be altered or augmented.
+            dataloader_idx: DataLoader idx for batch (Default: 0)
 
         Returns:
             A batch of data
 
         Example::
 
-            def on_before_batch_transfer(self, batch):
+            def on_before_batch_transfer(self, batch, dataloader_idx):
                 batch['x'] = transforms(batch['x'])
                 return batch
 
@@ -643,24 +644,25 @@ class DataHooks:
         """
         return batch
 
-    def on_after_batch_transfer(self, batch):
+    def on_after_batch_transfer(self, batch, dataloader_idx):
         """
         Override to alter or apply batch augmentations to your batch after it is transferred to the device.
 
-        .. warning:: The hook signature will change once the dataloader_idx is supported as an argument.
+        .. warning:: dataloader_idx always returns 0, and will be updated to support the true idx in the future.
 
         Note:
             This hook only runs on single GPU training and DDP (no data-parallel).
 
         Args:
             batch: A batch of data that needs to be altered or augmented.
+            dataloader_idx: DataLoader idx for batch (Default: 0)
 
         Returns:
             A batch of data
 
         Example::
 
-            def on_after_batch_transfer(self, batch):
+            def on_after_batch_transfer(self, batch, dataloader_idx):
                 batch['x'] = gpu_transforms(batch['x'])
                 return batch
 

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -570,7 +570,7 @@ class DataHooks:
         Override this hook if your :class:`~torch.utils.data.DataLoader` returns tensors
         wrapped in a custom data structure.
 
-        .. warning:: dataloader_idx always returns 0, and will be updated to support the true idx in the future.
+        .. warning:: ``dataloader_idx`` always returns 0, and will be updated to support the true ``idx`` in the future.
 
         The data types listed below (and any arbitrary nesting of them) are supported out of the box:
 
@@ -596,7 +596,7 @@ class DataHooks:
         Args:
             batch: A batch of data that needs to be transferred to a new device.
             device: The target device as defined in PyTorch.
-            dataloader_idx: DataLoader idx for batch (Default: 0)
+            dataloader_idx: DataLoader idx for batch
 
         Returns:
             A reference to the data on the new device.
@@ -630,7 +630,7 @@ class DataHooks:
 
         Args:
             batch: A batch of data that needs to be altered or augmented.
-            dataloader_idx: DataLoader idx for batch (Default: 0)
+            dataloader_idx: DataLoader idx for batch
 
         Returns:
             A batch of data
@@ -651,7 +651,7 @@ class DataHooks:
         """
         Override to alter or apply batch augmentations to your batch after it is transferred to the device.
 
-        .. warning:: dataloader_idx always returns 0, and will be updated to support the true idx in the future.
+        .. warning:: ``dataloader_idx`` always returns 0, and will be updated to support the true ``idx`` in the future.
 
         Note:
             This hook only runs on single GPU training and DDP (no data-parallel).

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -565,10 +565,12 @@ class DataHooks:
             will have an argument ``dataloader_idx`` which matches the order here.
         """
 
-    def transfer_batch_to_device(self, batch: Any, device: Optional[torch.device] = None) -> Any:
+    def transfer_batch_to_device(self, batch: Any, device: Optional[torch.device] = None, dataloader_idx=0) -> Any:
         """
         Override this hook if your :class:`~torch.utils.data.DataLoader` returns tensors
         wrapped in a custom data structure.
+
+        .. warning:: dataloader_idx always returns 0, and will be updated to support the true idx in the future.
 
         The data types listed below (and any arbitrary nesting of them) are supported out of the box:
 
@@ -594,19 +596,20 @@ class DataHooks:
         Args:
             batch: A batch of data that needs to be transferred to a new device.
             device: The target device as defined in PyTorch.
+            dataloader_idx: DataLoader idx for batch (Default: 0)
 
         Returns:
             A reference to the data on the new device.
 
         Example::
 
-            def transfer_batch_to_device(self, batch, device):
+            def transfer_batch_to_device(self, batch, device, dataloader_idx):
                 if isinstance(batch, CustomBatch):
                     # move all tensors in your custom data structure to the device
                     batch.samples = batch.samples.to(device)
                     batch.targets = batch.targets.to(device)
                 else:
-                    batch = super().transfer_batch_to_device(data, device)
+                    batch = super().transfer_batch_to_device(data, device, dataloader_idx)
                 return batch
 
         See Also:

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -620,6 +620,8 @@ class DataHooks:
         """
         Override to alter or apply batch augmentations to your batch before it is transferred to the device.
 
+        .. warning:: The hook signature will change once the dataloader_idx is supported as an argument.
+
         Note:
             This hook only runs on single GPU training and DDP (no data-parallel).
 
@@ -644,6 +646,8 @@ class DataHooks:
     def on_after_batch_transfer(self, batch):
         """
         Override to alter or apply batch augmentations to your batch after it is transferred to the device.
+
+        .. warning:: The hook signature will change once the dataloader_idx is supported as an argument.
 
         Note:
             This hook only runs on single GPU training and DDP (no data-parallel).

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -181,7 +181,7 @@ class LightningModule(
 
     def _apply_batch_transfer_handler(self, batch: Any, device: Optional[torch.device] = None, dataloader_idx: int = 0):
         batch = self.on_before_batch_transfer(batch, dataloader_idx)
-        batch = self.transfer_batch_to_device(batch, device, dataloader_idx)
+        batch = self.transfer_batch_to_device(batch, device)
         batch = self.on_after_batch_transfer(batch, dataloader_idx)
         return batch
 

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -181,7 +181,7 @@ class LightningModule(
 
     def _apply_batch_transfer_handler(self, batch: Any, device: Optional[torch.device] = None, dataloader_idx: int = 0):
         batch = self.on_before_batch_transfer(batch, dataloader_idx)
-        batch = self.transfer_batch_to_device(batch, device)
+        batch = self.transfer_batch_to_device(batch, device, dataloader_idx)
         batch = self.on_after_batch_transfer(batch, dataloader_idx)
         return batch
 

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -179,10 +179,10 @@ class LightningModule(
         """ Reference to the logger object in the Trainer. """
         return self.trainer.logger if self.trainer else None
 
-    def _apply_batch_transfer_handler(self, batch: Any, device: Optional[torch.device] = None):
-        batch = self.on_before_batch_transfer(batch)
+    def _apply_batch_transfer_handler(self, batch: Any, device: Optional[torch.device] = None, dataloader_idx: int = 0):
+        batch = self.on_before_batch_transfer(batch, dataloader_idx)
         batch = self.transfer_batch_to_device(batch, device)
-        batch = self.on_after_batch_transfer(batch)
+        batch = self.on_after_batch_transfer(batch, dataloader_idx)
         return batch
 
     def print(self, *args, **kwargs) -> None:

--- a/pytorch_lightning/plugins/training_type/deepspeed.py
+++ b/pytorch_lightning/plugins/training_type/deepspeed.py
@@ -305,13 +305,7 @@ class DeepSpeedPlugin(DDPPlugin):
         precision = self.lightning_module.trainer.accelerator_connector.precision
         if precision == 16:
             if "amp" not in self.config and amp_type == AMPType.NATIVE:
-                self.config["fp16"] = {
-                    "enabled": True,
-                    "loss_scale": 0,
-                    "loss_scale_window": 1000,
-                    "hysteresis": 2,
-                    "min_loss_scale": 1
-                }
+                self.config["fp16"] = {"enabled": True}
             elif "apex" not in self.config and amp_type == AMPType.APEX:
                 self.config["amp"] = {
                     "enabled": True,

--- a/pytorch_lightning/plugins/training_type/deepspeed.py
+++ b/pytorch_lightning/plugins/training_type/deepspeed.py
@@ -305,7 +305,13 @@ class DeepSpeedPlugin(DDPPlugin):
         precision = self.lightning_module.trainer.accelerator_connector.precision
         if precision == 16:
             if "amp" not in self.config and amp_type == AMPType.NATIVE:
-                self.config["fp16"] = {"enabled": True}
+                self.config["fp16"] = {
+                    "enabled": True,
+                    "loss_scale": 0,
+                    "loss_scale_window": 1000,
+                    "hysteresis": 2,
+                    "min_loss_scale": 1
+                }
             elif "apex" not in self.config and amp_type == AMPType.APEX:
                 self.config["amp"] = {
                     "enabled": True,

--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -451,7 +451,7 @@ def test_dm_apply_batch_transfer_handler(get_module_mock):
             batch.targets *= 2
             return batch
 
-        def transfer_batch_to_device(self, batch, device):
+        def transfer_batch_to_device(self, batch, device, dataloader_idx):
             self.transfer_batch_to_device_hook_rank = self.rank
             self.rank += 1
             batch.samples = batch.samples.to(device)

--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -451,7 +451,7 @@ def test_dm_apply_batch_transfer_handler(get_module_mock):
             batch.targets *= 2
             return batch
 
-        def transfer_batch_to_device(self, batch, device, dataloader_idx):
+        def transfer_batch_to_device(self, batch, device):
             self.transfer_batch_to_device_hook_rank = self.rank
             self.rank += 1
             batch.samples = batch.samples.to(device)

--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -438,13 +438,13 @@ def test_dm_apply_batch_transfer_handler(get_module_mock):
         on_before_batch_transfer_hook_rank = None
         on_after_batch_transfer_hook_rank = None
 
-        def on_before_batch_transfer(self, batch):
+        def on_before_batch_transfer(self, batch, dataloader_idx):
             self.on_before_batch_transfer_hook_rank = self.rank
             self.rank += 1
             batch.samples += 1
             return batch
 
-        def on_after_batch_transfer(self, batch):
+        def on_after_batch_transfer(self, batch, dataloader_idx):
             assert batch.samples.device == batch.targets.device == expected_device
             self.on_after_batch_transfer_hook_rank = self.rank
             self.rank += 1

--- a/tests/models/test_hooks.py
+++ b/tests/models/test_hooks.py
@@ -173,7 +173,7 @@ def test_apply_batch_transfer_handler(model_getter_mock):
             batch.targets *= 2
             return batch
 
-        def transfer_batch_to_device(self, batch, device):
+        def transfer_batch_to_device(self, batch, device, dataloader_idx):
             self.transfer_batch_to_device_hook_rank = self.rank
             self.rank += 1
             batch.samples = batch.samples.to(device)

--- a/tests/models/test_hooks.py
+++ b/tests/models/test_hooks.py
@@ -173,7 +173,7 @@ def test_apply_batch_transfer_handler(model_getter_mock):
             batch.targets *= 2
             return batch
 
-        def transfer_batch_to_device(self, batch, device, dataloader_idx):
+        def transfer_batch_to_device(self, batch, device):
             self.transfer_batch_to_device_hook_rank = self.rank
             self.rank += 1
             batch.samples = batch.samples.to(device)

--- a/tests/models/test_hooks.py
+++ b/tests/models/test_hooks.py
@@ -160,13 +160,13 @@ def test_apply_batch_transfer_handler(model_getter_mock):
         on_before_batch_transfer_hook_rank = None
         on_after_batch_transfer_hook_rank = None
 
-        def on_before_batch_transfer(self, batch):
+        def on_before_batch_transfer(self, batch, dataloader_idx):
             self.on_before_batch_transfer_hook_rank = self.rank
             self.rank += 1
             batch.samples += 1
             return batch
 
-        def on_after_batch_transfer(self, batch):
+        def on_after_batch_transfer(self, batch, dataloader_idx):
             assert batch.samples.device == batch.targets.device == expected_device
             self.on_after_batch_transfer_hook_rank = self.rank
             self.rank += 1


### PR DESCRIPTION
## What does this PR do?

Adds warnings that the API will change in the future to support dataloader idx.

Related to #6058 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
