### PR TITLE
Enable ZeRO tests for CI, fix to/half function calls for LightningDistributedWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 
+Move lightning module to correct device type when using LightningDistributedWrapper ([#6070](https://github.com/PyTorchLightning/pytorch-lightning/pull/6070)
+
+
 ## [1.2.0] - 2021-02-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 
-Move lightning module to correct device type when using LightningDistributedWrapper ([#6070](https://github.com/PyTorchLightning/pytorch-lightning/pull/6070)
-
-
 ## [1.2.0] - 2021-02-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed incorrect yield logic for the amp autocast context manager ([#6080](https://github.com/PyTorchLightning/pytorch-lightning/pull/6080))
 
 
+Move lightning module to correct device type when using LightningDistributedWrapper ([#6070](https://github.com/PyTorchLightning/pytorch-lightning/pull/6070)
+
+
 ## [1.2.0] - 2021-02-18
 
 ### Added

--- a/pytorch_lightning/overrides/base.py
+++ b/pytorch_lightning/overrides/base.py
@@ -19,12 +19,13 @@ from torch.nn.parallel import DistributedDataParallel
 
 from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.trainer.states import RunningStage
+from pytorch_lightning.utilities.device_dtype_mixin import DeviceDtypeModuleMixin
 from pytorch_lightning.utilities.warnings import WarningCache
 
 warning_cache = WarningCache()
 
 
-class _LightningModuleWrapperBase(torch.nn.Module):
+class _LightningModuleWrapperBase(DeviceDtypeModuleMixin, torch.nn.Module):
 
     def __init__(self, pl_module: LightningModule):
         """
@@ -71,6 +72,9 @@ class _LightningModuleWrapperBase(torch.nn.Module):
             output = self.module(*inputs, **kwargs)
 
         return output
+
+    def on_post_move_to_device(self):
+        pass
 
 
 def warn_if_output_is_none(output: Any, method_name: str) -> None:

--- a/pytorch_lightning/plugins/training_type/deepspeed.py
+++ b/pytorch_lightning/plugins/training_type/deepspeed.py
@@ -49,6 +49,9 @@ class LightningDeepSpeedModule(_LightningModuleWrapperBase):
 
         return super().forward(*inputs, **kwargs)
 
+    def half(self):
+        self.module.half()
+
     @staticmethod
     def batch_to(data):
         return data.half()

--- a/pytorch_lightning/plugins/training_type/deepspeed.py
+++ b/pytorch_lightning/plugins/training_type/deepspeed.py
@@ -52,6 +52,9 @@ class LightningDeepSpeedModule(_LightningModuleWrapperBase):
     def half(self):
         self.module.half()
 
+    def to(self, *args, **kwargs):
+        self.module.to(*args, **kwargs)
+
     @staticmethod
     def batch_to(data):
         return data.half()

--- a/pytorch_lightning/plugins/training_type/deepspeed.py
+++ b/pytorch_lightning/plugins/training_type/deepspeed.py
@@ -29,7 +29,6 @@ from pytorch_lightning.plugins.training_type.ddp import DDPPlugin
 from pytorch_lightning.trainer.optimizers import _get_default_scheduler_config
 from pytorch_lightning.utilities import AMPType
 from pytorch_lightning.utilities.apply_func import apply_to_collection
-from pytorch_lightning.utilities.device_dtype_mixin import DeviceDtypeModuleMixin
 from pytorch_lightning.utilities.distributed import rank_zero_info, rank_zero_only
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.imports import _DEEPSPEED_AVAILABLE
@@ -38,7 +37,7 @@ if _DEEPSPEED_AVAILABLE:
     import deepspeed
 
 
-class LightningDeepSpeedModule(_LightningModuleWrapperBase, DeviceDtypeModuleMixin):
+class LightningDeepSpeedModule(_LightningModuleWrapperBase):
 
     def __init__(self, pl_module: LightningModule, precision: int):
         super().__init__(pl_module)
@@ -57,9 +56,6 @@ class LightningDeepSpeedModule(_LightningModuleWrapperBase, DeviceDtypeModuleMix
     def _move_float_tensors_to_half(self, batch: Any):
         batch = apply_to_collection(batch, (torch.FloatTensor, torch.cuda.FloatTensor), function=self.batch_to)
         return batch
-
-    def on_post_move_to_device(self):
-        pass
 
 
 class DeepSpeedPlugin(DDPPlugin):

--- a/pytorch_lightning/utilities/device_dtype_mixin.py
+++ b/pytorch_lightning/utilities/device_dtype_mixin.py
@@ -119,7 +119,7 @@ class DeviceDtypeModuleMixin(Module):
         self.__update_properties(device=out[0], dtype=out[1])
         return super().to(*args, **kwargs)
 
-    def cuda(self, device: Optional[int] = None) -> Module:
+    def cuda(self, device: Optional[Union[torch.device, int]] = None) -> Module:
         """Moves all model parameters and buffers to the GPU.
         This also makes associated parameters and buffers different objects. So
         it should be called before constructing optimizer if the module will
@@ -132,7 +132,8 @@ class DeviceDtypeModuleMixin(Module):
         Returns:
             Module: self
         """
-        self.__update_properties(device=torch.device('cuda', index=device))
+        property_device = device if isinstance(device, torch.device) else torch.device('cuda', index=device)
+        self.__update_properties(device=property_device)
         return super().cuda(device=device)
 
     def cpu(self) -> Module:

--- a/tests/plugins/test_deepspeed_plugin.py
+++ b/tests/plugins/test_deepspeed_plugin.py
@@ -182,7 +182,7 @@ def test_warn_deepspeed_override_backward(tmpdir):
     trainer = Trainer(
         fast_dev_run=True,
         default_root_dir=tmpdir,
-        plugins=DeepSpeedPlugin(zero_optimization=False),
+        plugins=DeepSpeedPlugin(),
         gpus=1,
     )
     with pytest.warns(UserWarning, match='Overridden backward hook in the LightningModule will be ignored'):
@@ -210,7 +210,7 @@ def test_deepspeed_run_configure_optimizers(tmpdir):
 
     model = TestModel()
     trainer = Trainer(
-        plugins=DeepSpeedPlugin(zero_optimization=False),
+        plugins=DeepSpeedPlugin(),
         default_root_dir=tmpdir,
         gpus=1,
         fast_dev_run=True,
@@ -267,7 +267,7 @@ def test_deepspeed_multigpu(tmpdir, deepspeed_config):
     """
     model = BoringModel()
     trainer = Trainer(
-        plugins=[DeepSpeedPlugin(zero_optimization=False)],
+        plugins=[DeepSpeedPlugin()],
         default_root_dir=tmpdir,
         gpus=2,
         fast_dev_run=True,
@@ -285,8 +285,8 @@ def _assert_save_model_is_equal(model, tmpdir, trainer):
     # carry out the check only on rank 0
     if trainer.global_rank == 0:
         saved_model = BoringModel.load_from_checkpoint(checkpoint_path)
-        saved_model = saved_model.float()
-        model = model.float().cpu()
+        saved_model = saved_model.half()  # model is loaded in float32 as default, move it to float16
+        model = model.cpu()
         # Assert model parameters are identical after loading
         for orig_param, trained_model_param in zip(model.parameters(), saved_model.parameters()):
             assert torch.equal(orig_param, trained_model_param)

--- a/tests/plugins/test_deepspeed_plugin.py
+++ b/tests/plugins/test_deepspeed_plugin.py
@@ -1,6 +1,5 @@
 import json
 import os
-from unittest.mock import patch
 
 import pytest
 import torch

--- a/tests/plugins/test_deepspeed_plugin.py
+++ b/tests/plugins/test_deepspeed_plugin.py
@@ -15,8 +15,7 @@ from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.helpers.boring_model import BoringModel
 
 
-@patch.object(BoringModel, 'to')
-def test_deepspeed_wrapper(mocked_to, tmpdir):
+def test_lightning_module_base_wrapper(tmpdir):
     """
         Test to ensure that a model wrapped in `LightningDeepSpeedModule` moves types and device correctly.
     """
@@ -25,10 +24,12 @@ def test_deepspeed_wrapper(mocked_to, tmpdir):
     module = LightningDeepSpeedModule(model, precision=16)
 
     module.half()
+    assert module.dtype == torch.half
     assert model.dtype == torch.half
 
-    module.to('cuda')
-    assert mocked_to.called, "LightningDeepSpeedModule did not call LightningModule `to` hook when transferring device"
+    module.to(torch.double)
+    assert module.dtype == torch.double
+    assert model.dtype == torch.double
 
 
 @pytest.fixture

--- a/tests/plugins/test_deepspeed_plugin.py
+++ b/tests/plugins/test_deepspeed_plugin.py
@@ -223,7 +223,12 @@ def test_deepspeed_run_configure_optimizers(tmpdir):
             assert isinstance(self.trainer.model.lr_scheduler, torch.optim.lr_scheduler.StepLR)
 
     model = TestModel()
-    trainer = Trainer(plugins=DeepSpeedPlugin(), default_root_dir=tmpdir, gpus=1, fast_dev_run=True, precision=16)
+    trainer = Trainer(
+        plugins=DeepSpeedPlugin(zero_optimization=False),  # disable ZeRO so our optimizers are not wrapped
+        default_root_dir=tmpdir,
+        gpus=1,
+        fast_dev_run=True
+    )
 
     trainer.fit(model)
 

--- a/tests/plugins/test_deepspeed_plugin.py
+++ b/tests/plugins/test_deepspeed_plugin.py
@@ -14,7 +14,7 @@ from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.helpers.boring_model import BoringModel
 
 
-def test_lightning_module_base_wrapper(tmpdir):
+def test_deepspeed_lightning_module(tmpdir):
     """
         Test to ensure that a model wrapped in `LightningDeepSpeedModule` moves types and device correctly.
     """
@@ -25,6 +25,11 @@ def test_lightning_module_base_wrapper(tmpdir):
     module.half()
     assert module.dtype == torch.half
     assert model.dtype == torch.half
+
+    x = torch.randn((1, 32), dtype=torch.float)
+    out = module(x)
+
+    assert out.dtype == torch.half
 
     module.to(torch.double)
     assert module.dtype == torch.double

--- a/tests/plugins/test_deepspeed_plugin.py
+++ b/tests/plugins/test_deepspeed_plugin.py
@@ -26,7 +26,25 @@ def test_deepspeed_lightning_module(tmpdir):
     assert module.dtype == torch.half
     assert model.dtype == torch.half
 
-    x = torch.randn((1, 32), dtype=torch.float)
+    module.to(torch.double)
+    assert module.dtype == torch.double
+    assert model.dtype == torch.double
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires GPU machine")
+def test_deepspeed_lightning_module_precision(tmpdir):
+    """
+        Test to ensure that a model wrapped in `LightningDeepSpeedModule` moves tensors to half when precision 16.
+    """
+
+    model = BoringModel()
+    module = LightningDeepSpeedModule(model, precision=16)
+
+    module.cuda().half()
+    assert module.dtype == torch.half
+    assert model.dtype == torch.half
+
+    x = torch.randn((1, 32), dtype=torch.float).cuda()
     out = module(x)
 
     assert out.dtype == torch.half

--- a/tests/plugins/test_deepspeed_plugin.py
+++ b/tests/plugins/test_deepspeed_plugin.py
@@ -198,12 +198,7 @@ def test_warn_deepspeed_override_backward(tmpdir):
             return loss.backward()
 
     model = TestModel()
-    trainer = Trainer(
-        fast_dev_run=True,
-        default_root_dir=tmpdir,
-        plugins=DeepSpeedPlugin(),
-        gpus=1,
-    )
+    trainer = Trainer(fast_dev_run=True, default_root_dir=tmpdir, plugins=DeepSpeedPlugin(), gpus=1, precision=16)
     with pytest.warns(UserWarning, match='Overridden backward hook in the LightningModule will be ignored'):
         trainer.fit(model)
 
@@ -228,12 +223,7 @@ def test_deepspeed_run_configure_optimizers(tmpdir):
             assert isinstance(self.trainer.model.lr_scheduler, torch.optim.lr_scheduler.StepLR)
 
     model = TestModel()
-    trainer = Trainer(
-        plugins=DeepSpeedPlugin(),
-        default_root_dir=tmpdir,
-        gpus=1,
-        fast_dev_run=True,
-    )
+    trainer = Trainer(plugins=DeepSpeedPlugin(), default_root_dir=tmpdir, gpus=1, fast_dev_run=True, precision=16)
 
     trainer.fit(model)
 
@@ -266,6 +256,7 @@ def test_deepspeed_config(tmpdir, deepspeed_config):
         default_root_dir=tmpdir,
         gpus=1,
         fast_dev_run=True,
+        precision=16
     )
 
     trainer.fit(model)

--- a/tests/utilities/test_dtype_device_mixin.py
+++ b/tests/utilities/test_dtype_device_mixin.py
@@ -101,12 +101,19 @@ def test_submodules_multi_gpu_ddp_spawn(tmpdir):
     trainer.fit(model)
 
 
+@pytest.mark.parametrize(
+    ['device'],
+    [
+        pytest.param(None),  # explicitly call without an index to see if the returning device contains an index
+        pytest.param(0),
+        pytest.param(torch.device('cuda', 0)),
+    ]
+)
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="test requires GPU machine")
-def test_gpu_device_includes_index():
+def test_gpu_cuda_device(device):
     model = TopModule()
 
-    # explicitly call without an index to see if the returning device contains an index (it should!)
-    model.cuda()
+    model.cuda(device)
 
     device = model.device
     assert device.type == 'cuda'


### PR DESCRIPTION
## What does this PR do?

Enables ZeRO tests for the CI.

I also noticed that the device types were not correct, as we do not call the lightning module device hooks. This adds the correct functionality by using the device type mixins as we do for the lightning module suggested by @awaelchli 

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
