### PR TITLE
[Hot Fix] Give priority to plugins to set distributed mode, and then accelerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed incorrect yield logic for the amp autocast context manager ([#6080](https://github.com/PyTorchLightning/pytorch-lightning/pull/6080))
 
 
+- Fixed priority of plugin/accelerator when setting distributed mode ([#6089](https://github.com/PyTorchLightning/pytorch-lightning/pull/6089))
+
 ## [1.2.0] - 2021-02-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed priority of plugin/accelerator when setting distributed mode ([#6089](https://github.com/PyTorchLightning/pytorch-lightning/pull/6089))
 
+
 ## [1.2.0] - 2021-02-18
 
 ### Added

--- a/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -122,6 +122,9 @@ class AcceleratorConnector(object):
 
         self.configure_slurm_ddp()
 
+        # set cluster env after slurm is configured if using slurm
+        self._cluster_environment = self.select_cluster_environment()
+
         self.accelerator = self.select_accelerator()
 
         # override dist backend when using tpus
@@ -198,7 +201,7 @@ class AcceleratorConnector(object):
 
         self._training_type_plugin = training_type
         self._precision_plugin = precision
-        self._cluster_environment = cluster_environment or self.select_cluster_environment()
+        self._cluster_environment = cluster_environment
 
     @property
     def precision_plugin(self) -> PrecisionPlugin:

--- a/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -116,14 +116,10 @@ class AcceleratorConnector(object):
 
         self.parallel_device_ids = device_parser.parse_gpu_ids(self.gpus)
 
-        self.handle_given_plugins(plugins)
-        if self._distrib_type is None:
-            self.set_distributed_mode()
-
+        self.set_distributed_mode()
         self.configure_slurm_ddp()
 
-        # set cluster env after slurm is configured if using slurm
-        self._cluster_environment = self.select_cluster_environment()
+        self.handle_given_plugins(plugins)
 
         self.accelerator = self.select_accelerator()
 
@@ -167,6 +163,9 @@ class AcceleratorConnector(object):
 
         for plug in plugins:
             if isinstance(plug, str):
+                # Reset the distributed type as the user has overridden training type
+                # via the plugins argument
+                self._distrib_type = None
                 self.set_distributed_mode(plug)
 
             elif isinstance(plug, TrainingTypePlugin):
@@ -201,7 +200,7 @@ class AcceleratorConnector(object):
 
         self._training_type_plugin = training_type
         self._precision_plugin = precision
-        self._cluster_environment = cluster_environment
+        self._cluster_environment = cluster_environment or self.select_cluster_environment()
 
     @property
     def precision_plugin(self) -> PrecisionPlugin:

--- a/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -116,10 +116,11 @@ class AcceleratorConnector(object):
 
         self.parallel_device_ids = device_parser.parse_gpu_ids(self.gpus)
 
-        self.set_distributed_mode()
-        self.configure_slurm_ddp()
-
         self.handle_given_plugins(plugins)
+        if not self._distrib_type:
+            self.set_distributed_mode()
+
+        self.configure_slurm_ddp()
 
         self.accelerator = self.select_accelerator()
 

--- a/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -117,7 +117,7 @@ class AcceleratorConnector(object):
         self.parallel_device_ids = device_parser.parse_gpu_ids(self.gpus)
 
         self.handle_given_plugins(plugins)
-        if not self._distrib_type:
+        if self._distrib_type is None:
             self.set_distributed_mode()
 
         self.configure_slurm_ddp()
@@ -197,7 +197,6 @@ class AcceleratorConnector(object):
                 )
 
         self._training_type_plugin = training_type
-        self._training_type_plugin = self.training_type_plugin
         self._precision_plugin = precision
         self._cluster_environment = cluster_environment or self.select_cluster_environment()
 


### PR DESCRIPTION
## What does this PR do?

Fixes the broken API case where:

```python
Trainer(gpus=1, plugins='ddp_sharded', accelerator='ddp')
```

Because of the logic within the accelerator connector, the plugin is never set correctly, and the accelerator takes priority. We reverse the priority, and I'll make an issue for a RFC to fix this API.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
