### PR TITLE
fix amp/apex misconfiguration error for cpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,20 +24,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed incorrect yield logic for the amp autocast context manager ([#6080](https://github.com/PyTorchLightning/pytorch-lightning/pull/6080))
 
 
-- Made the `Plugin.reduce` method more consistent across all Plugins to reflect a mean-reduction by default ([#6011](https://github.com/PyTorchLightning/pytorch-lightning/pull/6011)
+- Made the `Plugin.reduce` method more consistent across all Plugins to reflect a mean-reduction by default ([#6011](https://github.com/PyTorchLightning/pytorch-lightning/pull/6011))
 
 
 - Fixed priority of plugin/accelerator when setting distributed mode ([#6089](https://github.com/PyTorchLightning/pytorch-lightning/pull/6089))
 
 
-- Move lightning module to correct device type when using LightningDistributedWrapper ([#6070](https://github.com/PyTorchLightning/pytorch-lightning/pull/6070)
+- Move lightning module to correct device type when using LightningDistributedWrapper ([#6070](https://github.com/PyTorchLightning/pytorch-lightning/pull/6070))
+
+
+- Fixed error message for AMP + CPU incompatibility ([#6107](https://github.com/PyTorchLightning/pytorch-lightning/pull/6107))
 
 
 ## [1.2.0] - 2021-02-18
 
 ### Added
 
-- Added `DataType`, `AverageMethod` and `MDMCAverageMethod` enum in metrics ([#5657](https://github.com/PyTorchLightning/pytorch-lightning/pull/5689)
+- Added `DataType`, `AverageMethod` and `MDMCAverageMethod` enum in metrics ([#5657](https://github.com/PyTorchLightning/pytorch-lightning/pull/5689))
 - Added support for summarized model total params size in megabytes ([#5590](https://github.com/PyTorchLightning/pytorch-lightning/pull/5590))
 - Added support for multiple train loaders ([#1959](https://github.com/PyTorchLightning/pytorch-lightning/pull/1959))
 - Added `Accuracy` metric now generalizes to Top-k accuracy for (multi-dimensional) multi-class inputs using the `top_k` parameter ([#4838](https://github.com/PyTorchLightning/pytorch-lightning/pull/4838))

--- a/pytorch_lightning/accelerators/cpu.py
+++ b/pytorch_lightning/accelerators/cpu.py
@@ -7,7 +7,7 @@ class CPUAccelerator(Accelerator):
 
     def setup(self, trainer, model):
         if isinstance(self.precision_plugin, MixedPrecisionPlugin):
-            MisconfigurationException("amp + cpu is not supported.  Please use a GPU option")
+            raise MisconfigurationException("amp + cpu is not supported.  Please use a GPU option")
 
         if "cpu" not in str(self.root_device):
             raise MisconfigurationException(f"Device should be CPU, got {self.root_device} instead")

--- a/pytorch_lightning/accelerators/cpu.py
+++ b/pytorch_lightning/accelerators/cpu.py
@@ -7,7 +7,7 @@ class CPUAccelerator(Accelerator):
 
     def setup(self, trainer, model):
         if isinstance(self.precision_plugin, MixedPrecisionPlugin):
-            raise MisconfigurationException("amp + cpu is not supported.  Please use a GPU option")
+            raise MisconfigurationException("amp + cpu is not supported. Please use a GPU option")
 
         if "cpu" not in str(self.root_device):
             raise MisconfigurationException(f"Device should be CPU, got {self.root_device} instead")

--- a/tests/accelerators/test_cpu.py
+++ b/tests/accelerators/test_cpu.py
@@ -1,0 +1,20 @@
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from pytorch_lightning.accelerators import CPUAccelerator
+from pytorch_lightning.plugins import SingleDevicePlugin, NativeMixedPrecisionPlugin
+from pytorch_lightning.utilities.exceptions import MisconfigurationException
+
+
+def test_unsupported_precision_plugins():
+    """ Test error messages are raised for unsupported precision plugins with CPU. """
+    trainer = Mock()
+    model = Mock()
+    accelerator = CPUAccelerator(
+        training_type_plugin=SingleDevicePlugin(torch.device("cpu")),
+        precision_plugin=NativeMixedPrecisionPlugin()
+    )
+    with pytest.raises(MisconfigurationException, match=r"amp \+ cpu is not supported."):
+        accelerator.setup(trainer=trainer, model=model)

--- a/tests/accelerators/test_cpu.py
+++ b/tests/accelerators/test_cpu.py
@@ -4,7 +4,8 @@ import pytest
 import torch
 
 from pytorch_lightning.accelerators import CPUAccelerator
-from pytorch_lightning.plugins import SingleDevicePlugin, NativeMixedPrecisionPlugin
+from pytorch_lightning.plugins import SingleDevicePlugin
+from pytorch_lightning.plugins.precision import MixedPrecisionPlugin
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 
@@ -14,7 +15,7 @@ def test_unsupported_precision_plugins():
     model = Mock()
     accelerator = CPUAccelerator(
         training_type_plugin=SingleDevicePlugin(torch.device("cpu")),
-        precision_plugin=NativeMixedPrecisionPlugin()
+        precision_plugin=MixedPrecisionPlugin()
     )
     with pytest.raises(MisconfigurationException, match=r"amp \+ cpu is not supported."):
         accelerator.setup(trainer=trainer, model=model)

--- a/tests/plugins/test_apex_plugin.py
+++ b/tests/plugins/test_apex_plugin.py
@@ -4,10 +4,8 @@ from unittest import mock
 import pytest
 
 from pytorch_lightning import Trainer
-from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.plugins import ApexMixedPrecisionPlugin
 from pytorch_lightning.utilities import _APEX_AVAILABLE
-from tests.helpers.boring_model import BoringModel
 
 
 @pytest.mark.skipif(not _APEX_AVAILABLE, reason="test requires apex")
@@ -23,30 +21,19 @@ from tests.helpers.boring_model import BoringModel
 )
 @mock.patch('torch.cuda.device_count', return_value=2)
 @pytest.mark.parametrize(
-    ['ddp_backend', 'gpus', 'num_processes'],
-    [('ddp_cpu', None, 2), ('ddp', 2, 0), ('ddp2', 2, 0), ('ddp_spawn', 2, 0)],
+    ['ddp_backend', 'gpus'],
+    [('ddp', 2), ('ddp2', 2), ('ddp_spawn', 2)],
 )
-def test_amp_choice_default_ddp_cpu(tmpdir, ddp_backend, gpus, num_processes):
+def test_amp_choice_default_ddp(mocked_device_count, ddp_backend, gpus):
 
-    class CB(Callback):
-
-        def on_fit_start(self, trainer, pl_module):
-            assert isinstance(trainer.precision_plugin, ApexMixedPrecisionPlugin)
-            raise SystemExit()
-
-    model = BoringModel()
     trainer = Trainer(
         fast_dev_run=True,
         precision=16,
         amp_backend='apex',
         gpus=gpus,
-        num_processes=num_processes,
         accelerator=ddp_backend,
-        callbacks=[CB()],
     )
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
+    assert isinstance(trainer.precision_plugin, ApexMixedPrecisionPlugin)
 
 
 @pytest.mark.skipif(not _APEX_AVAILABLE, reason="test requires apex")
@@ -62,31 +49,20 @@ def test_amp_choice_default_ddp_cpu(tmpdir, ddp_backend, gpus, num_processes):
 )
 @mock.patch('torch.cuda.device_count', return_value=2)
 @pytest.mark.parametrize(
-    ['ddp_backend', 'gpus', 'num_processes'],
-    [('ddp_cpu', None, 2), ('ddp', 2, 0), ('ddp2', 2, 0), ('ddp_spawn', 2, 0)],
+    ['ddp_backend', 'gpus'],
+    [('ddp', 2), ('ddp2', 2), ('ddp_spawn', 2)],
 )
-def test_amp_choice_custom_ddp_cpu(tmpdir, ddp_backend, gpus, num_processes):
+def test_amp_choice_custom_ddp(mocked_device_count, ddp_backend, gpus):
 
     class MyApexPlugin(ApexMixedPrecisionPlugin):
         pass
 
-    class CB(Callback):
-
-        def on_fit_start(self, trainer, pl_module):
-            assert isinstance(trainer.precision_plugin, MyApexPlugin)
-            raise SystemExit()
-
-    model = BoringModel()
     trainer = Trainer(
         fast_dev_run=True,
         precision=16,
         amp_backend='apex',
         gpus=gpus,
-        num_processes=num_processes,
         accelerator=ddp_backend,
         plugins=[MyApexPlugin(amp_level="O2")],
-        callbacks=[CB()],
     )
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
+    assert isinstance(trainer.precision_plugin, MyApexPlugin)


### PR DESCRIPTION
## What does this PR do?

Fixes #6097

Apex/amp and CPU are not compatible.
The MisconfigurationError was never raised and tests are flawed, because they would run on ddp_cpu yet never get to the point where an error is raised because of early SystemExit...

More tests for accelerators will be added in #6102 

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
