### PR TITLE
[feat] Support iteration-based checkpointing in model checkpoint callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Deprecated
 
-- `period` has been deprecated in favor of `every_n_epochs` in the `ModelCheckpoint` callback ([#6146](https://github.com/PyTorchLightning/pytorch-lightning/pull/6146))
+- `period` has been deprecated in favor of `every_n_val_epochs` in the `ModelCheckpoint` callback ([#6146](https://github.com/PyTorchLightning/pytorch-lightning/pull/6146))
 
 
 - Deprecated `trainer.running_sanity_check` in favor of `trainer.sanity_checking` ([#4945](https://github.com/PyTorchLightning/pytorch-lightning/pull/4945))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a way to print to terminal without breaking up the progress bar ([#5470](https://github.com/PyTorchLightning/pytorch-lightning/pull/5470))
 
 - Added support to checkpoint after training batches in `ModelCheckpoint` callback ([#6146](https://github.com/PyTorchLightning/pytorch-lightning/pull/6146))
-- Added a way to print to terminal without breaking up the progress bar ([#5470](https://github.com/PyTorchLightning/pytorch-lightning/pull/5470))
-
-- Added support to checkpoint after training batches in `ModelCheckpoint` callback ([#6146](https://github.com/PyTorchLightning/pytorch-lightning/pull/6146))
 
 - Added `checkpoint` parameter to callback's `on_save_checkpoint` hook ([#6072](https://github.com/PyTorchLightning/pytorch-lightning/pull/6072))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support to checkpoint after training batches in `ModelCheckpoint` callback ([#6146](https://github.com/PyTorchLightning/pytorch-lightning/pull/6146))
 - Added a way to print to terminal without breaking up the progress bar ([#5470](https://github.com/PyTorchLightning/pytorch-lightning/pull/5470))
 
+- Added support to checkpoint after training batches in `ModelCheckpoint` callback ([#6146](https://github.com/PyTorchLightning/pytorch-lightning/pull/6146))
 
 - Added `checkpoint` parameter to callback's `on_save_checkpoint` hook ([#6072](https://github.com/PyTorchLightning/pytorch-lightning/pull/6072))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added a way to print to terminal without breaking up the progress bar ([#5470](https://github.com/PyTorchLightning/pytorch-lightning/pull/5470))
 
-- Added support to checkpoint after training batches in `ModelCheckpoint` callback ([#6146](https://github.com/PyTorchLightning/pytorch-lightning/pull/6146))
+- Added support to checkpoint after training steps in `ModelCheckpoint` callback ([#6146](https://github.com/PyTorchLightning/pytorch-lightning/pull/6146))
 
 - Added `checkpoint` parameter to callback's `on_save_checkpoint` hook ([#6072](https://github.com/PyTorchLightning/pytorch-lightning/pull/6072))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Deprecated
 
+- `period` has been deprecated in favor of `every_n_epochs` in the `ModelCheckpoint` callback ([#6146](https://github.com/PyTorchLightning/pytorch-lightning/pull/6146))
+
 
 - Deprecated `trainer.running_sanity_check` in favor of `trainer.sanity_checking` ([#4945](https://github.com/PyTorchLightning/pytorch-lightning/pull/4945))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Added a way to print to terminal without breaking up the progress bar ([#5470](https://github.com/PyTorchLightning/pytorch-lightning/pull/5470))
 
+- Added support to checkpoint after training batches in `ModelCheckpoint` callback ([#6146](https://github.com/PyTorchLightning/pytorch-lightning/pull/6146))
 
 - Added `checkpoint` parameter to callback's `on_save_checkpoint` hook ([#6072](https://github.com/PyTorchLightning/pytorch-lightning/pull/6072))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a way to print to terminal without breaking up the progress bar ([#5470](https://github.com/PyTorchLightning/pytorch-lightning/pull/5470))
 
 - Added support to checkpoint after training batches in `ModelCheckpoint` callback ([#6146](https://github.com/PyTorchLightning/pytorch-lightning/pull/6146))
+- Added a way to print to terminal without breaking up the progress bar ([#5470](https://github.com/PyTorchLightning/pytorch-lightning/pull/5470))
+
 
 - Added `checkpoint` parameter to callback's `on_save_checkpoint` hook ([#6072](https://github.com/PyTorchLightning/pytorch-lightning/pull/6072))
 

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -97,8 +97,10 @@ class ModelCheckpoint(Callback):
             To disable, set ``every_n_train_steps = 0``. This value must be non-negative.
         every_n_val_epochs: Number of validation epochs between checkpoints.
             To disable, set ``every_n_val_epochs = 0``. This value must be non-negative.
-            This is not mutually exclusive with ``every_n_val_epochs``. If both are set, pay extreme caution if also setting ``monitor``
-            as the ``monitor`` value must be available in both training and validation. This can have unintended consequences with tracking the top K models.
+            This is not mutually exclusive with ``every_n_val_epochs``.
+            If both are set, pay extreme caution if also setting ``monitor``
+            as the ``monitor`` value must be available in both training and validation.
+            This can have unintended consequences with tracking the top k models.
         period: Interval (number of epochs) between checkpoints.
 
             .. warning::
@@ -289,7 +291,7 @@ class ModelCheckpoint(Callback):
         from pytorch_lightning.trainer.states import TrainerState
         return (
             trainer.fast_dev_run  # disable checkpointing with fast_dev_run
-            or trainer.state != TrainerState.FITTING # don't save anything during non-fit
+            or trainer.state != TrainerState.FITTING  # don't save anything during non-fit
             or trainer.sanity_checking  # don't save anything during sanity check
             or self.save_top_k == 0  # no models are saved
             or self._last_global_step_saved == trainer.global_step  # already saved at the last step

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -220,7 +220,9 @@ class ModelCheckpoint(Callback):
             return
         step = trainer.total_batch_idx
         skip_batch = self.every_n_batches < 1 or ((step + 1) % self.every_n_batches != 0)
-        log.critical(f"in train batch end, every_n_batches={self.every_n_batches}, step={step}, skip_batch? {skip_batch}")
+        log.critical(
+            f"in train batch end, every_n_batches={self.every_n_batches}, step={step}, skip_batch? {skip_batch}"
+        )
         if skip_batch:
             return
         self.save_checkpoint(trainer, pl_module)

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -287,6 +287,7 @@ class ModelCheckpoint(Callback):
         self._save_last_checkpoint(trainer, monitor_candidates)
 
     def _should_skip_saving_checkpoint(self, trainer) -> bool:
+        from pytorch_lightning.trainer.states import TrainerState
         return (
             trainer.fast_dev_run  # disable checkpointing with fast_dev_run
             or trainer.state != TrainerState.FITTING # don't save anything during non-fit

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -223,6 +223,7 @@ class ModelCheckpoint(Callback):
             return
         step = trainer.global_step
         skip_batch = self.every_n_batches < 1 or ((step + 1) % self.every_n_batches != 0)
+        log.warning(f"in on_train_batch_end at step {step}, every_n_batches={self.every_n_batches}, going to skip batch? {skip_batch}")
         if skip_batch:
             return
         self.save_checkpoint(trainer, pl_module)

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -216,13 +216,9 @@ class ModelCheckpoint(Callback):
 
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx) -> None:
         if self._should_skip_saving_checkpoint(trainer):
-            log.critical("in train batch end, not saving checkpoint after trainer check")
             return
         step = trainer.total_batch_idx
         skip_batch = self.every_n_batches < 1 or ((step + 1) % self.every_n_batches != 0)
-        log.critical(
-            f"in train batch end, every_n_batches={self.every_n_batches}, step={step}, skip_batch? {skip_batch}"
-        )
         if skip_batch:
             return
         self.save_checkpoint(trainer, pl_module)
@@ -234,6 +230,9 @@ class ModelCheckpoint(Callback):
         skip = (
             self._should_skip_saving_checkpoint(trainer) or self.every_n_epochs < 1
             or (trainer.current_epoch + 1) % self.every_n_epochs != 0
+        )
+        log.critical(
+            f"in validation end, every_n_epochs={self.every_n_epochs}, period={self.period}, step={step}, skip? {skip}"
         )
         if skip:
             return

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -296,7 +296,7 @@ class ModelCheckpoint(Callback):
             trainer.fast_dev_run  # disable checkpointing with fast_dev_run
             or trainer.running_sanity_check  # don't save anything during sanity check
             or self.save_top_k == 0  # no models are saved
-            or self._last_global_step_saved == global_step  # already saved at the last step
+            or self._last_global_step_saved == trainer.global_step  # already saved at the last step
         )
 
     def __validate_init_configuration(self):

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -251,9 +251,9 @@ class ModelCheckpoint(Callback):
 
     def _should_skip_saving_checkpoint(self, trainer) -> bool:
         return (
-            trainer.fast_dev_run # disable checkpointing with fast_dev_run
+            trainer.fast_dev_run  # disable checkpointing with fast_dev_run
             or trainer.running_sanity_check  # don't save anything during sanity check
-            or self.save_top_k == 0 # no models are saved
+            or self.save_top_k == 0  # no models are saved
             or self._last_global_step_saved == global_step  # already saved at the last step
         )
 
@@ -302,9 +302,13 @@ class ModelCheckpoint(Callback):
         if self.save_top_k is not None and self.save_top_k < -1:
             raise MisconfigurationException(f'Invalid value for save_top_k={self.save_top_k}. Must be None or >= -1')
         if self.every_n_epochs == 0 or self.every_n_epochs < -1:
-            raise MisconfigurationException(f'Invalid value for every_n_epochs={self.every_n_epochs}. Must be positive or -1')
+            raise MisconfigurationException(
+                f'Invalid value for every_n_epochs={self.every_n_epochs}. Must be positive or -1'
+            )
         if self.every_n_batches == 0 or self.every_n_batches < -1:
-            raise MisconfigurationException(f'Invalid value for every_n_batches={self.every_n_batches}. Must be positive or -1')
+            raise MisconfigurationException(
+                f'Invalid value for every_n_batches={self.every_n_batches}. Must be positive or -1'
+            )
         if self.monitor is None:
             # None: save last epoch, -1: save all epochs, 0: nothing is saved
             if self.save_top_k not in (None, -1, 0):

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -184,7 +184,7 @@ class ModelCheckpoint(Callback):
         self.save_top_k = save_top_k
         self.save_weights_only = save_weights_only
         self.auto_insert_metric_name = auto_insert_metric_name
-        self.every_n_epochs = period or every_n_epochs
+        self.every_n_epochs = period if period is not None else every_n_epochs
         self.period = self.every_n_epochs
         self.every_n_batches = every_n_batches
         self._last_global_step_saved = -1
@@ -230,9 +230,6 @@ class ModelCheckpoint(Callback):
         skip = (
             self._should_skip_saving_checkpoint(trainer) or self.every_n_epochs < 1
             or (trainer.current_epoch + 1) % self.every_n_epochs != 0
-        )
-        log.critical(
-            f"in validation end, every_n_epochs={self.every_n_epochs}, period={self.period}, epoch={trainer.current_epoch}, skip? {skip}"
         )
         if skip:
             return

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -232,7 +232,7 @@ class ModelCheckpoint(Callback):
             or (trainer.current_epoch + 1) % self.every_n_epochs != 0
         )
         log.critical(
-            f"in validation end, every_n_epochs={self.every_n_epochs}, period={self.period}, step={step}, skip? {skip}"
+            f"in validation end, every_n_epochs={self.every_n_epochs}, period={self.period}, epoch={trainer.current_epoch}, skip? {skip}"
         )
         if skip:
             return

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -296,14 +296,6 @@ class ModelCheckpoint(Callback):
     def __validate_init_configuration(self):
         if self.save_top_k is not None and self.save_top_k < -1:
             raise MisconfigurationException(f'Invalid value for save_top_k={self.save_top_k}. Must be None or >= -1')
-        if self.every_n_epochs == 0 or self.every_n_epochs < -1:
-            raise MisconfigurationException(
-                f'Invalid value for every_n_epochs={self.every_n_epochs}. Must be positive or -1'
-            )
-        if self.every_n_batches == 0 or self.every_n_batches < -1:
-            raise MisconfigurationException(
-                f'Invalid value for every_n_batches={self.every_n_batches}. Must be positive or -1'
-            )
         if self.monitor is None:
             # None: save last epoch, -1: save all epochs, 0: nothing is saved
             if self.save_top_k not in (None, -1, 0):

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -231,10 +231,9 @@ class ModelCheckpoint(Callback):
         """
         checkpoints can be saved at the end of the val loop
         """
-        epoch = trainer.current_epoch
         skip = (
             self._should_skip_saving_checkpoint(trainer) or self.every_n_epochs < 1
-            or (epoch + 1) % self.every_n_epochs != 0
+            or (trainer.current_epoch + 1) % self.every_n_epochs != 0
         )
         if skip:
             return

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -98,17 +98,10 @@ class ModelCheckpoint(Callback):
         every_n_epochs: Interval (number of epochs) between checkpoints.
         every_n_batches: Interval (number of batches) between checkpoints.
         period: Interval (number of epochs) between checkpoints.
-<<<<<<< HEAD
-=======
 
             .. warning::
                This argument has been deprecated in v1.3 and will be removed in v1.5.
             Use ``every_n_epochs`` instead.
-        prefix: A string to put at the beginning of checkpoint filename.
-
-            .. warning::
-               This argument has been deprecated in v1.1 and will be removed in v1.3
->>>>>>> add tests
 
     Note:
         For extra customization, ModelCheckpoint includes the following attributes:

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -301,7 +301,8 @@ class ModelCheckpoint(Callback):
             )
         if self.every_n_train_steps > 0 and self.every_n_val_epochs > 0:
             raise MisconfigurationException(
-                f'Invalid values for every_n_train_steps={self.every_n_train_steps} and every_n_val_epochs={self.every_n_val_epochs}.'
+                f'Invalid values for every_n_train_steps={self.every_n_train_steps}'
+                ' and every_n_val_epochs={self.every_n_val_epochs}.'
                 'Both cannot be enabled at the same time.'
             )
         if self.monitor is None:

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -217,7 +217,7 @@ class ModelCheckpoint(Callback):
         if self._should_skip_saving_checkpoint(trainer):
             return
         step = trainer.global_step
-        skip_batch = self.every_n_train_steps < 1 or ((step + 1) % self.every_n_train_steps != 0)
+        skip_batch = self._every_n_train_steps < 1 or ((step + 1) % self._every_n_train_steps != 0)
         if skip_batch:
             return
         self.save_checkpoint(trainer, pl_module)
@@ -227,8 +227,8 @@ class ModelCheckpoint(Callback):
         checkpoints can be saved at the end of the val loop
         """
         skip = (
-            self._should_skip_saving_checkpoint(trainer) or self.every_n_val_epochs is None
-            or self.every_n_val_epochs < 1 or (trainer.current_epoch + 1) % self.every_n_val_epochs != 0
+            self._should_skip_saving_checkpoint(trainer) or self._every_n_val_epochs < 1
+            or (trainer.current_epoch + 1) % self._every_n_val_epochs != 0
         )
         if skip:
             return
@@ -291,18 +291,18 @@ class ModelCheckpoint(Callback):
     def __validate_init_configuration(self):
         if self.save_top_k is not None and self.save_top_k < -1:
             raise MisconfigurationException(f'Invalid value for save_top_k={self.save_top_k}. Must be None or >= -1')
-        if self.every_n_train_steps < 0:
+        if self._every_n_train_steps < 0:
             raise MisconfigurationException(
-                f'Invalid value for every_n_train_steps={self.every_n_train_steps}. Must be >= 0'
+                f'Invalid value for every_n_train_steps={self._every_n_train_steps}. Must be >= 0'
             )
-        if self.every_n_val_epochs < 0:
+        if self._every_n_val_epochs < 0:
             raise MisconfigurationException(
-                f'Invalid value for every_n_val_epochs={self.every_n_val_epochs}. Must be >= 0'
+                f'Invalid value for every_n_val_epochs={self._every_n_val_epochs}. Must be >= 0'
             )
-        if self.every_n_train_steps > 0 and self.every_n_val_epochs > 0:
+        if self._every_n_train_steps > 0 and self._every_n_val_epochs > 0:
             raise MisconfigurationException(
-                f'Invalid values for every_n_train_steps={self.every_n_train_steps}'
-                ' and every_n_val_epochs={self.every_n_val_epochs}.'
+                f'Invalid values for every_n_train_steps={self._every_n_train_steps}'
+                ' and every_n_val_epochs={self._every_n_val_epochs}.'
                 'Both cannot be enabled at the same time.'
             )
         if self.monitor is None:
@@ -358,12 +358,12 @@ class ModelCheckpoint(Callback):
         # Default to running once after each validation epoch if neither
         # every_n_train_steps nor every_n_val_epochs is set
         if every_n_train_steps is None and every_n_val_epochs is None:
-            self.every_n_val_epochs = 1
-            self.every_n_train_steps = 0
+            self._every_n_val_epochs = 1
+            self._every_n_train_steps = 0
             log.debug("Both every_n_train_steps and every_n_val_epochs are not set. Setting every_n_val_epochs=1")
         else:
-            self.every_n_val_epochs = every_n_val_epochs or 0
-            self.every_n_train_steps = every_n_train_steps or 0
+            self._every_n_val_epochs = every_n_val_epochs or 0
+            self._every_n_train_steps = every_n_train_steps or 0
 
         # period takes precedence over every_n_val_epochs for backwards compatibility
         if period is not None:
@@ -371,9 +371,9 @@ class ModelCheckpoint(Callback):
                 'Argument `period` in `ModelCheckpoint` is deprecated in v1.3 and will be removed in v1.5.'
                 ' Please use `every_n_val_epochs` instead.', DeprecationWarning
             )
-            self.every_n_val_epochs = period
+            self._every_n_val_epochs = period
 
-        self._period = self.every_n_val_epochs
+        self._period = self._every_n_val_epochs
 
     @property
     def period(self) -> Optional[int]:

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -253,7 +253,7 @@ class ModelCheckpoint(Callback):
         self.best_model_score = callback_state["best_model_score"]
         self.best_model_path = callback_state["best_model_path"]
 
-    def save_checkpoint(self, trainer, unused):
+    def save_checkpoint(self, trainer, unused: Optional = None):
         """
         Performs the main logic around saving a checkpoint.
         This method runs on all ranks, it is the responsibility of `self.save_function`
@@ -289,7 +289,8 @@ class ModelCheckpoint(Callback):
     def _should_skip_saving_checkpoint(self, trainer) -> bool:
         return (
             trainer.fast_dev_run  # disable checkpointing with fast_dev_run
-            or trainer.running_sanity_check  # don't save anything during sanity check
+            or trainer.state != TrainerState.FITTING # don't save anything during non-fit
+            or trainer.sanity_checking  # don't save anything during sanity check
             or self.save_top_k == 0  # no models are saved
             or self._last_global_step_saved == trainer.global_step  # already saved at the last step
         )

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -233,7 +233,7 @@ class ModelCheckpoint(Callback):
         """
         checkpoints can be saved at the end of the val loop
         """
-        if self._should_skip_saving_checkpoint(trainer) or self.every_n_epochs < 0:
+        if self._should_skip_saving_checkpoint(trainer) or self.every_n_epochs < 1:
             return
         epoch = trainer.current_epoch
         if (epoch + 1) % self.every_n_epochs == 0:

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -223,7 +223,7 @@ class ModelCheckpoint(Callback):
         if self._should_skip_saving_checkpoint(trainer):
             return
         step = trainer.global_step
-        skip_step = self.every_n_steps < 1 or ((step + 1) % self.every_n_steps != 0)
+        skip_step = self.every_n_batches < 1 or ((step + 1) % self.every_n_batches != 0)
         if skip_step:
             return
         self.save_checkpoint(trainer, pl_module)

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -265,7 +265,6 @@ class ModelCheckpoint(Callback):
                 " has been removed. Support for the old signature will be removed in v1.5", DeprecationWarning
             )
 
-        epoch = trainer.current_epoch
         global_step = trainer.global_step
 
         self._add_backward_monitor_support(trainer)

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -186,8 +186,8 @@ class ModelCheckpoint(Callback):
         self.save_top_k = save_top_k
         self.save_weights_only = save_weights_only
         self.auto_insert_metric_name = auto_insert_metric_name
-        self.period = every_n_epochs
-        self.every_n_epochs = every_n_epochs
+        self.every_n_epochs = period or every_n_epochs
+        self.period = self.every_n_epochs
         self.every_n_batches = every_n_batches
         self._last_global_step_saved = -1
         self.current_score = None
@@ -204,8 +204,6 @@ class ModelCheckpoint(Callback):
                 'Argument `period` is deprecated in v1.3 and will be removed in v1.5.'
                 ' Please use `every_n_epochs` instead.', DeprecationWarning
             )
-            self.every_n_epochs = period
-            self.period = period
 
         self.__init_monitor_mode(monitor, mode)
         self.__init_ckpt_dir(dirpath, filename, save_top_k)
@@ -221,7 +219,7 @@ class ModelCheckpoint(Callback):
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx) -> None:
         if self._should_skip_saving_checkpoint(trainer):
             return
-        step = trainer.global_step
+        step = trainer.total_batch_idx
         skip_batch = self.every_n_steps < 1 or ((step + 1) % self.every_n_steps != 0)
         if skip_batch:
             return

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -294,11 +294,11 @@ class ModelCheckpoint(Callback):
     def __validate_init_configuration(self):
         if self.save_top_k is not None and self.save_top_k < -1:
             raise MisconfigurationException(f'Invalid value for save_top_k={self.save_top_k}. Must be None or >= -1')
-        if self.every_n_epochs <= -1:
+        if self.every_n_epochs < 0:
             raise MisconfigurationException(
                 f'Invalid value for every_n_epochs={self.every_n_epochs}. Must be non-negative.'
             )
-        if self.every_n_batches <= -1:
+        if self.every_n_batches < 0:
             raise MisconfigurationException(
                 f'Invalid value for every_n_batches={self.every_n_batches}. Must be non-negative.'
             )

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -231,11 +231,14 @@ class ModelCheckpoint(Callback):
         """
         checkpoints can be saved at the end of the val loop
         """
-        if self._should_skip_saving_checkpoint(trainer) or self.every_n_epochs < 1:
-            return
         epoch = trainer.current_epoch
-        if (epoch + 1) % self.every_n_epochs == 0:
-            self.save_checkpoint(trainer, pl_module)
+        skip = (
+            self._should_skip_saving_checkpoint(trainer) or self.every_n_epochs < 1
+            or (epoch + 1) % self.every_n_epochs != 0
+        )
+        if skip:
+            return
+        self.save_checkpoint(trainer, pl_module)
 
     def on_save_checkpoint(self, trainer, pl_module, checkpoint: Dict[str, Any]) -> Dict[str, Any]:
         return {

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -94,7 +94,7 @@ class ModelCheckpoint(Callback):
             saved (``model.save_weights(filepath)``), else the full model
             is saved (``model.save(filepath)``).
         every_n_epochs: Interval (number of epochs) between checkpoints.
-        every_n_batches: Interval (number of batches) between checkpoints.
+        every_n_batches: Interval (number of training batches) between checkpoints.
         period: Interval (number of epochs) between checkpoints.
 
             .. warning::

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -38,8 +38,6 @@ from pytorch_lightning.utilities.warnings import WarningCache
 log = logging.getLogger(__name__)
 warning_cache = WarningCache()
 
-log = logging.getLogger(__name__)
-
 
 class ModelCheckpoint(Callback):
     r"""
@@ -218,9 +216,11 @@ class ModelCheckpoint(Callback):
 
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx) -> None:
         if self._should_skip_saving_checkpoint(trainer):
+            log.critical("in train batch end, not saving checkpoint after trainer check")
             return
         step = trainer.total_batch_idx
         skip_batch = self.every_n_batches < 1 or ((step + 1) % self.every_n_batches != 0)
+        log.critical(f"in train batch end, every_n_batches={self.every_n_batches}, step={step}, skip_batch? {skip_batch}")
         if skip_batch:
             return
         self.save_checkpoint(trainer, pl_module)
@@ -294,14 +294,6 @@ class ModelCheckpoint(Callback):
     def __validate_init_configuration(self):
         if self.save_top_k is not None and self.save_top_k < -1:
             raise MisconfigurationException(f'Invalid value for save_top_k={self.save_top_k}. Must be None or >= -1')
-        if self.every_n_epochs < 0:
-            raise MisconfigurationException(
-                f'Invalid value for every_n_epochs={self.every_n_epochs}. Must be non-negative.'
-            )
-        if self.every_n_batches < 0:
-            raise MisconfigurationException(
-                f'Invalid value for every_n_batches={self.every_n_batches}. Must be non-negative.'
-            )
         if self.monitor is None:
             # None: save last epoch, -1: save all epochs, 0: nothing is saved
             if self.save_top_k not in (None, -1, 0):

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -101,6 +101,7 @@ class ModelCheckpoint(Callback):
 
             .. warning::
                This argument has been deprecated in v1.3 and will be removed in v1.5.
+
             Use ``every_n_epochs`` instead.
 
     Note:

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -220,7 +220,7 @@ class ModelCheckpoint(Callback):
         if self._should_skip_saving_checkpoint(trainer):
             return
         step = trainer.total_batch_idx
-        skip_batch = self.every_n_steps < 1 or ((step + 1) % self.every_n_steps != 0)
+        skip_batch = self.every_n_batches < 1 or ((step + 1) % self.every_n_batches != 0)
         if skip_batch:
             return
         self.save_checkpoint(trainer, pl_module)

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -222,8 +222,8 @@ class ModelCheckpoint(Callback):
         if self._should_skip_saving_checkpoint(trainer):
             return
         step = trainer.global_step
-        skip_step = self.every_n_steps < 1 or ((step + 1) % self.every_n_steps != 0)
-        if skip_step:
+        skip_batch = self.every_n_batches < 1 or ((step + 1) % self.every_n_batches != 0)
+        if skip_batch:
             return
         self.save_checkpoint(trainer, pl_module)
 

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -222,8 +222,7 @@ class ModelCheckpoint(Callback):
         if self._should_skip_saving_checkpoint(trainer):
             return
         step = trainer.global_step
-        skip_batch = self.every_n_batches < 1 or ((step + 1) % self.every_n_batches != 0)
-        log.warning(f"in on_train_batch_end at step {step}, every_n_batches={self.every_n_batches}, going to skip batch? {skip_batch}")
+        skip_batch = self.every_n_steps < 1 or ((step + 1) % self.every_n_steps != 0)
         if skip_batch:
             return
         self.save_checkpoint(trainer, pl_module)

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -175,7 +175,7 @@ class ModelCheckpoint(Callback):
         mode: str = "min",
         auto_insert_metric_name: bool = True
         every_n_epochs: int = 1,
-        every_n_batches: int = -1,
+        every_n_batches: int = 0,
         period: Optional[int] = None,
     ):
         super().__init__()
@@ -293,13 +293,13 @@ class ModelCheckpoint(Callback):
     def __validate_init_configuration(self):
         if self.save_top_k is not None and self.save_top_k < -1:
             raise MisconfigurationException(f'Invalid value for save_top_k={self.save_top_k}. Must be None or >= -1')
-        if self.every_n_epochs == 0 or self.every_n_epochs < -1:
+        if self.every_n_epochs <= -1:
             raise MisconfigurationException(
-                f'Invalid value for every_n_epochs={self.every_n_epochs}. Must be positive or -1'
+                f'Invalid value for every_n_epochs={self.every_n_epochs}. Must be non-negative.'
             )
-        if self.every_n_batches == 0 or self.every_n_batches < -1:
+        if self.every_n_batches <= -1:
             raise MisconfigurationException(
-                f'Invalid value for every_n_batches={self.every_n_batches}. Must be positive or -1'
+                f'Invalid value for every_n_batches={self.every_n_batches}. Must be non-negative.'
             )
         if self.monitor is None:
             # None: save last epoch, -1: save all epochs, 0: nothing is saved

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -356,13 +356,15 @@ class ModelCheckpoint(Callback):
 
         # Default to running once after each validation epoch if neither
         # every_n_train_steps nor every_n_val_epochs is set
-        self.every_n_val_epochs = every_n_val_epochs or 0
-        self.every_n_train_steps = every_n_train_steps or 0
-        if self.every_n_train_steps == 0 and self.every_n_val_epochs == 0:
+        if every_n_train_steps is None and every_n_val_epochs is None:
             self.every_n_val_epochs = 1
+            self.every_n_train_steps = 0
             log.debug("Both every_n_train_steps and every_n_val_epochs are not set. Setting every_n_val_epochs=1")
+        else:
+            self.every_n_val_epochs = every_n_val_epochs or 0
+            self.every_n_train_steps = every_n_train_steps or 0
 
-        # period takes precedence for every_n_val_epochs for backwards compatibility
+        # period takes precedence over every_n_val_epochs for backwards compatibility
         if period is not None:
             rank_zero_warn(
                 'Argument `period` in `ModelCheckpoint` is deprecated in v1.3 and will be removed in v1.5.'

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -249,14 +249,6 @@ class ModelCheckpoint(Callback):
         self.best_model_score = callback_state["best_model_score"]
         self.best_model_path = callback_state["best_model_path"]
 
-    def _should_skip_saving_checkpoint(self, trainer) -> bool:
-        return (
-            trainer.fast_dev_run  # disable checkpointing with fast_dev_run
-            or trainer.running_sanity_check  # don't save anything during sanity check
-            or self.save_top_k == 0  # no models are saved
-            or self._last_global_step_saved == global_step  # already saved at the last step
-        )
-
     def save_checkpoint(self, trainer, pl_module):
         """
         Performs the main logic around saving a checkpoint.

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -293,7 +293,6 @@ class ModelCheckpoint(Callback):
             trainer.fast_dev_run  # disable checkpointing with fast_dev_run
             or trainer.state != TrainerState.FITTING  # don't save anything during non-fit
             or trainer.sanity_checking  # don't save anything during sanity check
-            or self.save_top_k == 0  # no models are saved
             or self._last_global_step_saved == trainer.global_step  # already saved at the last step
         )
 

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -204,6 +204,7 @@ class ModelCheckpoint(Callback):
                 ' Please use `every_n_epochs` instead.', DeprecationWarning
             )
             self.every_n_epochs = period
+            self.period = period
 
         self.__init_monitor_mode(monitor, mode)
         self.__init_ckpt_dir(dirpath, filename, save_top_k)

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -673,7 +673,7 @@ def test_ckpt_every_n_batches_and_every_n_epochs(tmpdir, every_n_epochs):
     trainer.fit(model)
     expected_steps_for_ckpt = [
         i for i in range(epoch_step_length * max_epochs)
-        if (i % every_n_batches) == 0 or (i * epoch_step_length % every_n_epochs == 0)
+        if ((i+1) % every_n_batches) == 0 or (i+1) % (every_n_epochs * epoch_step_length) == 0)
     ]
     expected_ckpt_files = [f"step={step}.ckpt" for step in expected_steps_for_ckpt]
     assert set(os.listdir(tmpdir)) == set(expected_ckpt_files)

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -581,9 +581,8 @@ def test_model_checkpoint_period(tmpdir, period: int):
         default_root_dir=tmpdir,
         callbacks=[checkpoint_callback],
         max_epochs=epochs,
-        limit_train_batches=0.1,
-        limit_val_batches=0.1,
-        val_check_interval=1.0,
+        limit_train_batches=1,
+        limit_val_batches=1,
         logger=False,
     )
     trainer.fit(model)

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -531,13 +531,9 @@ def test_invalid_every_n_epoch(tmpdir):
 
 def test_invalid_every_n_batches(tmpdir):
     """ Test that an exception is raised for every_n_batches = 0 or < -1. """
-    with pytest.raises(
-        MisconfigurationException, match=r'Invalid value for every_n_batches=0*'
-    ):
+    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_batches=0*'):
         ModelCheckpoint(dirpath=tmpdir, every_n_batches=0)
-    with pytest.raises(
-        MisconfigurationException, match=r'Invalid value for every_n_batches=-2*'
-    ):
+    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_batches=-2*'):
         ModelCheckpoint(dirpath=tmpdir, every_n_batches=-2)
 
     # These should not fail

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -673,7 +673,7 @@ def test_ckpt_every_n_batches_and_every_n_epochs(tmpdir, every_n_epochs):
     trainer.fit(model)
     expected_steps_for_ckpt = [
         i for i in range(epoch_step_length * max_epochs)
-        if ((i+1) % every_n_batches) == 0 or (i+1) % (every_n_epochs * epoch_step_length) == 0)
+        if ((i + 1) % every_n_batches) == 0 or (i + 1) % (every_n_epochs * epoch_step_length) == 0
     ]
     expected_ckpt_files = [f"step={step}.ckpt" for step in expected_steps_for_ckpt]
     assert set(os.listdir(tmpdir)) == set(expected_ckpt_files)

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -520,15 +520,15 @@ def test_invalid_every_n_epoch(tmpdir):
     with pytest.raises(
         MisconfigurationException, match=r'Invalid value for every_n_epochs=0*'
     ):
-        ModelCheckpoint(dirpath=tmpdir, every_n_epochs=0)
+        ModelCheckpoint(dirpath=tmpdir, every_n_epochs=0, period=None)
     with pytest.raises(
         MisconfigurationException, match=r'Invalid value for every_n_epochs=-2*'
     ):
-        ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-2)
+        ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-2, period=None)
 
     # These should not fail
-    ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-1)
-    ModelCheckpoint(dirpath=tmpdir, every_n_epochs=3)
+    ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-1, period=None)
+    ModelCheckpoint(dirpath=tmpdir, every_n_epochs=3, period=None)
 
 
 def test_invalid_every_n_batches(tmpdir):

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -434,11 +434,8 @@ def test_model_checkpoint_format_checkpoint_name(tmpdir):
 
     # auto_insert_metric_name=False
     ckpt_name = ModelCheckpoint._format_checkpoint_name(
-        'epoch={epoch:03d}-val_acc={val/acc}',
-        3,
-        2,
-        {'val/acc': 0.03},
-        auto_insert_metric_name=False)
+        'epoch={epoch:03d}-val_acc={val/acc}', 3, 2, {'val/acc': 0.03}, auto_insert_metric_name=False
+    )
     assert ckpt_name == 'epoch=003-val_acc=0.03'
 
 

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -514,20 +514,18 @@ def test_none_monitor_top_k(tmpdir):
     ModelCheckpoint(dirpath=tmpdir, save_top_k=-1)
     ModelCheckpoint(dirpath=tmpdir, save_top_k=0)
 
+
 def test_invalid_every_n_epoch(tmpdir):
     """ Test that an exception is raised for every_n_epochs = 0 or < -1. """
-    with pytest.raises(
-        MisconfigurationException, match=r'Invalid value for every_n_epochs=0*'
-    ):
+    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_epochs=0*'):
         ModelCheckpoint(dirpath=tmpdir, every_n_epochs=0)
-    with pytest.raises(
-        MisconfigurationException, match=r'Invalid value for every_n_epochs=-2*'
-    ):
+    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_epochs=-2*'):
         ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-2)
 
     # These should not fail
     ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-1)
     ModelCheckpoint(dirpath=tmpdir, every_n_epochs=3)
+
 
 def test_invalid_every_n_batches(tmpdir):
     """ Test that an exception is raised for every_n_batches = 0 or < -1. """

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -653,9 +653,10 @@ def test_ckpt_every_n_batches(tmpdir):
 def test_ckpt_every_n_batches_and_every_n_epochs(tmpdir, every_n_epochs):
     """ Tests that checkpoints are taken every 30 steps and every epochs """
     model = LogInTwoMethods()
+    every_n_batches = 30
     checkpoint_callback = ModelCheckpoint(
         every_n_epochs=every_n_epochs,
-        every_n_batches=30,
+        every_n_batches=every_n_batches,
         dirpath=tmpdir,
         save_top_k=-1,
         save_last=False,
@@ -674,7 +675,7 @@ def test_ckpt_every_n_batches_and_every_n_epochs(tmpdir, every_n_epochs):
         i for i in range(epoch_step_length * max_epochs)
         if (i % every_n_batches) == 0 or (i * epoch_step_length % every_n_epochs == 0)
     ]
-    expected_ckpt_files = [f"step={step}.ckpt" for step in step]
+    expected_ckpt_files = [f"step={step}.ckpt" for step in expected_steps_for_ckpt]
     assert set(os.listdir(tmpdir)) == set(expected_ckpt_files)
 
 

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -514,6 +514,7 @@ def test_none_monitor_top_k(tmpdir):
     ModelCheckpoint(dirpath=tmpdir, save_top_k=-1)
     ModelCheckpoint(dirpath=tmpdir, save_top_k=0)
 
+
 def test_invalid_every_n_epoch(tmpdir):
     """ Test that an exception is raised for every_n_epochs = 0 or < -1. """
     with pytest.raises(
@@ -528,6 +529,7 @@ def test_invalid_every_n_epoch(tmpdir):
     # These should not fail
     ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-1)
     ModelCheckpoint(dirpath=tmpdir, every_n_epochs=3)
+
 
 def test_invalid_every_n_batches(tmpdir):
     """ Test that an exception is raised for every_n_batches = 0 or < -1. """
@@ -613,7 +615,12 @@ def test_model_checkpoint_period(tmpdir, period: int):
 def test_model_checkpoint_every_n_epochs(tmpdir, every_n_epochs):
     model = LogInTwoMethods()
     epochs = 5
-    checkpoint_callback = ModelCheckpoint(dirpath=tmpdir, filename='{epoch}', save_top_k=-1, every_n_epochs=every_n_epochs)
+    checkpoint_callback = ModelCheckpoint(
+        dirpath=tmpdir,
+        filename='{epoch}',
+        save_top_k=-1,
+        every_n_epochs=every_n_epochs
+    )
     trainer = Trainer(
         default_root_dir=tmpdir,
         callbacks=[checkpoint_callback],
@@ -628,12 +635,19 @@ def test_model_checkpoint_every_n_epochs(tmpdir, every_n_epochs):
     # check that the correct ckpts were created
     expected = [f'epoch={e}.ckpt' for e in range(epochs) if not (e + 1) % every_n_epochs] if every_n_epochs > 0 else []
     assert set(os.listdir(tmpdir)) == set(expected)
+
 
 @pytest.mark.parametrize("every_n_epochs", list(range(4)))
 def test_model_checkpoint_every_n_epochs_and_no_period(tmpdir, every_n_epochs):
     model = LogInTwoMethods()
     epochs = 5
-    checkpoint_callback = ModelCheckpoint(dirpath=tmpdir, filename='{epoch}', save_top_k=-1, every_n_epochs=every_n_epochs, period=None)
+    checkpoint_callback = ModelCheckpoint(
+        dirpath=tmpdir,
+        filename='{epoch}',
+        save_top_k=-1,
+        every_n_epochs=every_n_epochs,
+        period=None
+    )
     trainer = Trainer(
         default_root_dir=tmpdir,
         callbacks=[checkpoint_callback],
@@ -648,6 +662,7 @@ def test_model_checkpoint_every_n_epochs_and_no_period(tmpdir, every_n_epochs):
     # check that the correct ckpts were created
     expected = [f'epoch={e}.ckpt' for e in range(epochs) if not (e + 1) % every_n_epochs] if every_n_epochs > 0 else []
     assert set(os.listdir(tmpdir)) == set(expected)
+
 
 def test_ckpt_every_n_steps(tmpdir):
     """ Tests that the checkpoints are saved every n training steps. """
@@ -671,19 +686,17 @@ def test_ckpt_every_n_steps(tmpdir):
     )
 
     trainer.fit(model)
-    self.assertCountEqual(
-        os.listdir(tmpdir),
-        [
-            "step=15.ckpt",
-            "step=31.ckpt",
-            "step=47.ckpt",
-            "step=63.ckpt",
-            "step=79.ckpt",
-            "step=95.ckpt",
-            "step=111.ckpt",
-            "step=127.ckpt",
-        ],
-    )
+    expected = [
+        "step=15.ckpt",
+        "step=31.ckpt",
+        "step=47.ckpt",
+        "step=63.ckpt",
+        "step=79.ckpt",
+        "step=95.ckpt",
+        "step=111.ckpt",
+        "step=127.ckpt",
+    ]
+    assert set(os.listdir(tmpdir)) == set(expected)
 
 def test_ckpt_every_n_steps_and_every_n_epochs(tmpdir):
     """ Tests that checkpoints are taken every 30 steps and every epochs """
@@ -703,18 +716,16 @@ def test_ckpt_every_n_steps_and_every_n_epochs(tmpdir):
         logger=False,
     )
     trainer.fit(model)
-    self.assertCountEqual(
-        os.listdir(tmpdir),
-        [
-            "epoch=0-step=29.ckpt",
-            "epoch=0-step=59.ckpt",
-            "epoch=0-step=63.ckpt",
-            "epoch=1-step=89.ckpt",
-            "epoch=1-step=119.ckpt",
-            "epoch=1-step=127.ckpt",
-            "epoch=1-step=127-v0.ckpt",
-        ],
-    )
+    expected = [
+        "epoch=0-step=29.ckpt",
+        "epoch=0-step=59.ckpt",
+        "epoch=0-step=63.ckpt",
+        "epoch=1-step=89.ckpt",
+        "epoch=1-step=119.ckpt",
+        "epoch=1-step=127.ckpt",
+        "epoch=1-step=127-v0.ckpt",
+    ]
+    assert set(os.listdir(tmpdir)) == set(expected)
 
 
 def test_model_checkpoint_topk_zero(tmpdir):

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -515,30 +515,6 @@ def test_none_monitor_top_k(tmpdir):
     ModelCheckpoint(dirpath=tmpdir, save_top_k=0)
 
 
-def test_invalid_every_n_epoch(tmpdir):
-    """ Test that an exception is raised for every_n_epochs = 0 or < -1. """
-    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_epochs=0*'):
-        ModelCheckpoint(dirpath=tmpdir, every_n_epochs=0, period=None)
-    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_epochs=-2*'):
-        ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-2, period=None)
-
-    # These should not fail
-    ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-1, period=None)
-    ModelCheckpoint(dirpath=tmpdir, every_n_epochs=3, period=None)
-
-
-def test_invalid_every_n_batches(tmpdir):
-    """ Test that an exception is raised for every_n_batches = 0 or < -1. """
-    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_batches=0*'):
-        ModelCheckpoint(dirpath=tmpdir, every_n_batches=0)
-    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_batches=-2*'):
-        ModelCheckpoint(dirpath=tmpdir, every_n_batches=-2)
-
-    # These should not fail
-    ModelCheckpoint(dirpath=tmpdir, every_n_batches=-1)
-    ModelCheckpoint(dirpath=tmpdir, every_n_batches=3)
-
-
 def test_none_monitor_save_last(tmpdir):
     """ Test that a warning appears for save_last=True with monitor=None. """
     with pytest.warns(UserWarning, match=r'ModelCheckpoint.*is a redundant.*'):

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -516,27 +516,17 @@ def test_none_monitor_top_k(tmpdir):
 
 
 def test_invalid_every_n_epoch(tmpdir):
-    """ Test that an exception is raised for every_n_epochs = 0 or < -1. """
-    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_epochs=-1*'):
-        ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-1)
-    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_epochs=-2*'):
-        ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-2)
-
-    # These should not fail
+    """ Test different configurations for every_n_epochs. """
     ModelCheckpoint(dirpath=tmpdir, every_n_epochs=0, every_n_batches=1)
     ModelCheckpoint(dirpath=tmpdir, every_n_epochs=3)
+    ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-1, every_n_batches=1)
 
 
 def test_invalid_every_n_batches(tmpdir):
-    """ Test that an exception is raised for every_n_batches = 0 or < -1. """
-    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_batches=-1*'):
-        ModelCheckpoint(dirpath=tmpdir, every_n_batches=-1)
-    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_batches=-2*'):
-        ModelCheckpoint(dirpath=tmpdir, every_n_batches=-2)
-
-    # These should not fail
+    """ Test different configurations for every_n_batches. """
     ModelCheckpoint(dirpath=tmpdir, every_n_batches=0)
     ModelCheckpoint(dirpath=tmpdir, every_n_batches=3)
+    ModelCheckpoint(dirpath=tmpdir, every_n_batches=-1, every_n_epochs=2)
 
 
 def test_none_monitor_save_last(tmpdir):

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -517,13 +517,9 @@ def test_none_monitor_top_k(tmpdir):
 
 def test_invalid_every_n_epoch(tmpdir):
     """ Test that an exception is raised for every_n_epochs = 0 or < -1. """
-    with pytest.raises(
-        MisconfigurationException, match=r'Invalid value for every_n_epochs=0*'
-    ):
+    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_epochs=0*'):
         ModelCheckpoint(dirpath=tmpdir, every_n_epochs=0, period=None)
-    with pytest.raises(
-        MisconfigurationException, match=r'Invalid value for every_n_epochs=-2*'
-    ):
+    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_epochs=-2*'):
         ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-2, period=None)
 
     # These should not fail
@@ -533,13 +529,9 @@ def test_invalid_every_n_epoch(tmpdir):
 
 def test_invalid_every_n_batches(tmpdir):
     """ Test that an exception is raised for every_n_batches = 0 or < -1. """
-    with pytest.raises(
-        MisconfigurationException, match=r'Invalid value for every_n_batches=0*'
-    ):
+    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_batches=0*'):
         ModelCheckpoint(dirpath=tmpdir, every_n_batches=0)
-    with pytest.raises(
-        MisconfigurationException, match=r'Invalid value for every_n_batches=-2*'
-    ):
+    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_batches=-2*'):
         ModelCheckpoint(dirpath=tmpdir, every_n_batches=-2)
 
     # These should not fail
@@ -616,10 +608,7 @@ def test_model_checkpoint_every_n_epochs(tmpdir, every_n_epochs):
     model = LogInTwoMethods()
     epochs = 5
     checkpoint_callback = ModelCheckpoint(
-        dirpath=tmpdir,
-        filename='{epoch}',
-        save_top_k=-1,
-        every_n_epochs=every_n_epochs
+        dirpath=tmpdir, filename='{epoch}', save_top_k=-1, every_n_epochs=every_n_epochs
     )
     trainer = Trainer(
         default_root_dir=tmpdir,
@@ -642,11 +631,7 @@ def test_model_checkpoint_every_n_epochs_and_no_period(tmpdir, every_n_epochs):
     model = LogInTwoMethods()
     epochs = 5
     checkpoint_callback = ModelCheckpoint(
-        dirpath=tmpdir,
-        filename='{epoch}',
-        save_top_k=-1,
-        every_n_epochs=every_n_epochs,
-        period=None
+        dirpath=tmpdir, filename='{epoch}', save_top_k=-1, every_n_epochs=every_n_epochs, period=None
     )
     trainer = Trainer(
         default_root_dir=tmpdir,
@@ -697,6 +682,7 @@ def test_ckpt_every_n_batches(tmpdir):
         "step=127.ckpt",
     ]
     assert set(os.listdir(tmpdir)) == set(expected)
+
 
 def test_ckpt_every_n_batches_and_every_n_epochs(tmpdir):
     """ Tests that checkpoints are taken every 30 steps and every epochs """

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -514,6 +514,36 @@ def test_none_monitor_top_k(tmpdir):
     ModelCheckpoint(dirpath=tmpdir, save_top_k=-1)
     ModelCheckpoint(dirpath=tmpdir, save_top_k=0)
 
+def test_invalid_every_n_epoch(tmpdir):
+    """ Test that an exception is raised for every_n_epochs = 0 or < -1. """
+    with pytest.raises(
+        MisconfigurationException, match=r'Invalid value for every_n_epochs=0*'
+    ):
+        ModelCheckpoint(dirpath=tmpdir, every_n_epochs=0)
+    with pytest.raises(
+        MisconfigurationException, match=r'Invalid value for every_n_epochs=-2*'
+    ):
+        ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-2)
+
+    # These should not fail
+    ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-1)
+    ModelCheckpoint(dirpath=tmpdir, every_n_epochs=3)
+
+def test_invalid_every_n_batches(tmpdir):
+    """ Test that an exception is raised for every_n_batches = 0 or < -1. """
+    with pytest.raises(
+        MisconfigurationException, match=r'Invalid value for every_n_batches=0*'
+    ):
+        ModelCheckpoint(dirpath=tmpdir, every_n_batches=0)
+    with pytest.raises(
+        MisconfigurationException, match=r'Invalid value for every_n_batches=-2*'
+    ):
+        ModelCheckpoint(dirpath=tmpdir, every_n_batches=-2)
+
+    # These should not fail
+    ModelCheckpoint(dirpath=tmpdir, every_n_batches=-1)
+    ModelCheckpoint(dirpath=tmpdir, every_n_batches=3)
+
 
 def test_none_monitor_save_last(tmpdir):
     """ Test that a warning appears for save_last=True with monitor=None. """

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -614,9 +614,8 @@ def test_model_checkpoint_every_n_epochs(tmpdir, every_n_epochs):
         default_root_dir=tmpdir,
         callbacks=[checkpoint_callback],
         max_epochs=epochs,
-        limit_train_batches=0.1,
-        limit_val_batches=0.1,
-        val_check_interval=1.0,
+        limit_train_batches=1,
+        limit_val_batches=1,
         logger=False,
     )
     trainer.fit(model)
@@ -637,9 +636,8 @@ def test_model_checkpoint_every_n_epochs_and_no_period(tmpdir, every_n_epochs):
         default_root_dir=tmpdir,
         callbacks=[checkpoint_callback],
         max_epochs=epochs,
-        limit_train_batches=0.1,
-        limit_val_batches=0.1,
-        val_check_interval=1.0,
+        limit_train_batches=1,
+        limit_val_batches=1,
         logger=False,
     )
     trainer.fit(model)
@@ -653,16 +651,15 @@ def test_ckpt_every_n_batches(tmpdir):
     """ Tests that the checkpoints are saved every n training steps. """
 
     model = LogInTwoMethods()
-
+    every_n_batches = 16
     trainer = Trainer(
         default_root_dir=tmpdir,
-        min_epochs=2,
         max_epochs=2,
         progress_bar_refresh_rate=0,
         checkpoint_callback=ModelCheckpoint(
             filename="{step}",
             every_n_epochs=0,
-            every_n_batches=16,
+            every_n_batches=every_n_batches,
             dirpath=tmpdir,
             save_top_k=-1,
             save_last=False,
@@ -671,16 +668,7 @@ def test_ckpt_every_n_batches(tmpdir):
     )
 
     trainer.fit(model)
-    expected = [
-        "step=15.ckpt",
-        "step=31.ckpt",
-        "step=47.ckpt",
-        "step=63.ckpt",
-        "step=79.ckpt",
-        "step=95.ckpt",
-        "step=111.ckpt",
-        "step=127.ckpt",
-    ]
+    expected=[f"step={i}.ckpt" for i in range(15, 128, every_n_batches)]
     assert set(os.listdir(tmpdir)) == set(expected)
 
 
@@ -689,9 +677,7 @@ def test_ckpt_every_n_batches_and_every_n_epochs(tmpdir):
     model = LogInTwoMethods()
     trainer = Trainer(
         default_root_dir=tmpdir,
-        min_epochs=2,
         max_epochs=2,
-        progress_bar_refresh_rate=0,
         checkpoint_callback=ModelCheckpoint(
             every_n_epochs=1,
             every_n_batches=30,

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -685,7 +685,6 @@ def test_ckpt_every_n_batches_and_every_n_epochs(tmpdir):
         "epoch=1-step=89.ckpt",
         "epoch=1-step=119.ckpt",
         "epoch=1-step=127.ckpt",
-        "epoch=1-step=127-v0.ckpt",
     ]
     assert set(os.listdir(tmpdir)) == set(expected)
 

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -545,7 +545,10 @@ def test_invalid_every_n_train_steps(tmpdir):
 
 
 def test_invalid_every_n_train_steps_val_epochs_combination(tmpdir):
-    """ Make sure that a MisconfigurationException is raised if both every_n_val_epochs and every_n_train_steps are enabled together. """
+    """
+    Test that a MisconfigurationException is raised if both
+    every_n_val_epochs and every_n_train_steps are enabled together.
+    """
     with pytest.raises(MisconfigurationException, match=r'.*Both cannot be enabled at the same time'):
         ModelCheckpoint(dirpath=tmpdir, every_n_train_steps=1, every_n_val_epochs=2)
     # These should not fail

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -517,25 +517,25 @@ def test_none_monitor_top_k(tmpdir):
 
 def test_invalid_every_n_epoch(tmpdir):
     """ Test that an exception is raised for every_n_epochs = 0 or < -1. """
-    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_epochs=0*'):
-        ModelCheckpoint(dirpath=tmpdir, every_n_epochs=0)
+    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_epochs=-1*'):
+        ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-1)
     with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_epochs=-2*'):
         ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-2)
 
     # These should not fail
-    ModelCheckpoint(dirpath=tmpdir, every_n_epochs=-1)
+    ModelCheckpoint(dirpath=tmpdir, every_n_epochs=0, every_n_batches=1)
     ModelCheckpoint(dirpath=tmpdir, every_n_epochs=3)
 
 
 def test_invalid_every_n_batches(tmpdir):
     """ Test that an exception is raised for every_n_batches = 0 or < -1. """
-    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_batches=0*'):
-        ModelCheckpoint(dirpath=tmpdir, every_n_batches=0)
+    with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_batches=-1*'):
+        ModelCheckpoint(dirpath=tmpdir, every_n_batches=-1)
     with pytest.raises(MisconfigurationException, match=r'Invalid value for every_n_batches=-2*'):
         ModelCheckpoint(dirpath=tmpdir, every_n_batches=-2)
 
     # These should not fail
-    ModelCheckpoint(dirpath=tmpdir, every_n_batches=-1)
+    ModelCheckpoint(dirpath=tmpdir, every_n_batches=0)
     ModelCheckpoint(dirpath=tmpdir, every_n_batches=3)
 
 
@@ -661,7 +661,7 @@ def test_ckpt_every_n_batches(tmpdir):
         progress_bar_refresh_rate=0,
         checkpoint_callback=ModelCheckpoint(
             filename="{step}",
-            every_n_epochs=-1,
+            every_n_epochs=0,
             every_n_batches=16,
             dirpath=tmpdir,
             save_top_k=-1,

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -559,8 +559,8 @@ def test_invalid_every_n_train_steps_val_epochs_combination(tmpdir):
 def test_none_every_n_train_steps_val_epochs(tmpdir):
     checkpoint_callback = ModelCheckpoint(dirpath=tmpdir)
     assert checkpoint_callback.period == 1
-    assert checkpoint_callback.every_n_val_epochs == 1
-    assert checkpoint_callback.every_n_train_steps == 0
+    assert checkpoint_callback._every_n_val_epochs == 1
+    assert checkpoint_callback._every_n_train_steps == 0
 
 
 def test_model_checkpoint_save_last_none_monitor(tmpdir, caplog):

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -664,7 +664,7 @@ def test_model_checkpoint_every_n_epochs_and_no_period(tmpdir, every_n_epochs):
     assert set(os.listdir(tmpdir)) == set(expected)
 
 
-def test_ckpt_every_n_steps(tmpdir):
+def test_ckpt_every_n_batches(tmpdir):
     """ Tests that the checkpoints are saved every n training steps. """
 
     model = LogInTwoMethods()
@@ -677,7 +677,7 @@ def test_ckpt_every_n_steps(tmpdir):
         checkpoint_callback=ModelCheckpoint(
             filename="{step}",
             every_n_epochs=-1,
-            every_n_steps=16,
+            every_n_batches=16,
             dirpath=tmpdir,
             save_top_k=-1,
             save_last=False,
@@ -698,7 +698,7 @@ def test_ckpt_every_n_steps(tmpdir):
     ]
     assert set(os.listdir(tmpdir)) == set(expected)
 
-def test_ckpt_every_n_steps_and_every_n_epochs(tmpdir):
+def test_ckpt_every_n_batches_and_every_n_epochs(tmpdir):
     """ Tests that checkpoints are taken every 30 steps and every epochs """
     model = LogInTwoMethods()
     trainer = Trainer(
@@ -708,7 +708,7 @@ def test_ckpt_every_n_steps_and_every_n_epochs(tmpdir):
         progress_bar_refresh_rate=0,
         checkpoint_callback=ModelCheckpoint(
             every_n_epochs=1,
-            every_n_steps=30,
+            every_n_batches=30,
             dirpath=tmpdir,
             save_top_k=-1,
             save_last=False,

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -668,7 +668,7 @@ def test_ckpt_every_n_batches(tmpdir):
     )
 
     trainer.fit(model)
-    expected=[f"step={i}.ckpt" for i in range(15, 128, every_n_batches)]
+    expected = [f"step={i}.ckpt" for i in range(15, 128, every_n_batches)]
     assert set(os.listdir(tmpdir)) == set(expected)
 
 

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -672,7 +672,7 @@ def test_ckpt_every_n_batches_and_every_n_epochs(tmpdir):
         dirpath=tmpdir,
         save_top_k=-1,
         save_last=False,
-    ),
+    )
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_epochs=2,

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -642,18 +642,19 @@ def test_ckpt_every_n_batches(tmpdir):
 
     model = LogInTwoMethods()
     every_n_batches = 16
+    checkpoint_callback = ModelCheckpoint(
+        filename="{step}",
+        every_n_epochs=0,
+        every_n_batches=every_n_batches,
+        dirpath=tmpdir,
+        save_top_k=-1,
+        save_last=False,
+    )
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_epochs=2,
         progress_bar_refresh_rate=0,
-        checkpoint_callback=ModelCheckpoint(
-            filename="{step}",
-            every_n_epochs=0,
-            every_n_batches=every_n_batches,
-            dirpath=tmpdir,
-            save_top_k=-1,
-            save_last=False,
-        ),
+        callbacks=[checkpoint_callback],
         logger=False,
     )
 
@@ -665,16 +666,17 @@ def test_ckpt_every_n_batches(tmpdir):
 def test_ckpt_every_n_batches_and_every_n_epochs(tmpdir):
     """ Tests that checkpoints are taken every 30 steps and every epochs """
     model = LogInTwoMethods()
+    checkpoint_callback = ModelCheckpoint(
+        every_n_epochs=1,
+        every_n_batches=30,
+        dirpath=tmpdir,
+        save_top_k=-1,
+        save_last=False,
+    ),
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_epochs=2,
-        checkpoint_callback=ModelCheckpoint(
-            every_n_epochs=1,
-            every_n_batches=30,
-            dirpath=tmpdir,
-            save_top_k=-1,
-            save_last=False,
-        ),
+        callbacks=[checkpoint_callback],
         logger=False,
     )
     trainer.fit(model)

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -649,6 +649,73 @@ def test_model_checkpoint_every_n_epochs_and_no_period(tmpdir, every_n_epochs):
     expected = [f'epoch={e}.ckpt' for e in range(epochs) if not (e + 1) % every_n_epochs] if every_n_epochs > 0 else []
     assert set(os.listdir(tmpdir)) == set(expected)
 
+def test_ckpt_every_n_steps(tmpdir):
+    """ Tests that the checkpoints are saved every n training steps. """
+
+    model = LogInTwoMethods()
+
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        min_epochs=2,
+        max_epochs=2,
+        progress_bar_refresh_rate=0,
+        checkpoint_callback=ModelCheckpoint(
+            filename="{step}",
+            every_n_epochs=-1,
+            every_n_steps=16,
+            dirpath=tmpdir,
+            save_top_k=-1,
+            save_last=False,
+        ),
+        logger=False,
+    )
+
+    trainer.fit(model)
+    self.assertCountEqual(
+        os.listdir(tmpdir),
+        [
+            "step=15.ckpt",
+            "step=31.ckpt",
+            "step=47.ckpt",
+            "step=63.ckpt",
+            "step=79.ckpt",
+            "step=95.ckpt",
+            "step=111.ckpt",
+            "step=127.ckpt",
+        ],
+    )
+
+def test_ckpt_every_n_steps_and_every_n_epochs(tmpdir):
+    """ Tests that checkpoints are taken every 30 steps and every epochs """
+    model = LogInTwoMethods()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        min_epochs=2,
+        max_epochs=2,
+        progress_bar_refresh_rate=0,
+        checkpoint_callback=ModelCheckpoint(
+            every_n_epochs=1,
+            every_n_steps=30,
+            dirpath=tmpdir,
+            save_top_k=-1,
+            save_last=False,
+        ),
+        logger=False,
+    )
+    trainer.fit(model)
+    self.assertCountEqual(
+        os.listdir(tmpdir),
+        [
+            "epoch=0-step=29.ckpt",
+            "epoch=0-step=59.ckpt",
+            "epoch=0-step=63.ckpt",
+            "epoch=1-step=89.ckpt",
+            "epoch=1-step=119.ckpt",
+            "epoch=1-step=127.ckpt",
+            "epoch=1-step=127-v0.ckpt",
+        ],
+    )
+
 
 def test_model_checkpoint_topk_zero(tmpdir):
     """ Test that no checkpoints are saved when save_top_k=0. """

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -614,7 +614,7 @@ def test_model_checkpoint_period(tmpdir, period: int):
     assert set(os.listdir(tmpdir)) == set(expected)
 
 
-@pytest.mark.parametrize("every_n_val_epochs", list(range(1, 4)))
+@pytest.mark.parametrize("every_n_val_epochs", list(range(4)))
 def test_model_checkpoint_every_n_val_epochs(tmpdir, every_n_val_epochs):
     model = LogInTwoMethods()
     epochs = 5

--- a/tests/deprecated_api/test_remove_1-5.py
+++ b/tests/deprecated_api/test_remove_1-5.py
@@ -78,6 +78,7 @@ def test_v1_5_0_old_callback_on_save_checkpoint(tmpdir):
         trainer.save_checkpoint(filepath)
 
 
+<<<<<<< HEAD
 def test_v1_5_0_running_sanity_check():
     trainer = Trainer()
     with pytest.deprecated_call(match='has been renamed to `Trainer.sanity_checking`'):
@@ -104,3 +105,10 @@ def test_old_training_step_signature_with_opt_idx_manual_opt(tmpdir):
 
     with pytest.deprecated_call(match="`training_step` .* `optimizer_idx` .* manual .* will be removed in v1.5"):
         trainer.fit(model)
+=======
+def test_v1_5_0_model_checkpoint_period(tmpdir):
+    with no_warning_call(DeprecationWarning):
+        ModelCheckpoint(dirpath=tmpdir)
+    with pytest.deprecated_call(match="is deprecated in v1.3 and will be removed in v1.5"):
+        ModelCheckpoint(dirpath=tmpdir, period=1)
+>>>>>>> Update test_remove_1-5.py

--- a/tests/deprecated_api/test_remove_1-5.py
+++ b/tests/deprecated_api/test_remove_1-5.py
@@ -78,7 +78,6 @@ def test_v1_5_0_old_callback_on_save_checkpoint(tmpdir):
         trainer.save_checkpoint(filepath)
 
 
-<<<<<<< HEAD
 def test_v1_5_0_running_sanity_check():
     trainer = Trainer()
     with pytest.deprecated_call(match='has been renamed to `Trainer.sanity_checking`'):
@@ -105,10 +104,10 @@ def test_old_training_step_signature_with_opt_idx_manual_opt(tmpdir):
 
     with pytest.deprecated_call(match="`training_step` .* `optimizer_idx` .* manual .* will be removed in v1.5"):
         trainer.fit(model)
-=======
+
+
 def test_v1_5_0_model_checkpoint_period(tmpdir):
     with no_warning_call(DeprecationWarning):
         ModelCheckpoint(dirpath=tmpdir)
     with pytest.deprecated_call(match="is deprecated in v1.3 and will be removed in v1.5"):
         ModelCheckpoint(dirpath=tmpdir, period=1)
->>>>>>> Update test_remove_1-5.py


### PR DESCRIPTION
## What does this PR do?

Fixes #2534

This supports checkpointing periodically after a user-specified number of training batches to complement the end of validation epoch-based checkpointing currently supported. This is useful for large training runs and for purely iteration-based training.

We checkpoint after training batches because the model state doesn't change during validation. This means the training metrics will be used for the monitor keys if configured to checkpoint this way.

To do so:
- We add a new argument `every_n_train_steps` to the callback constructor which dictates the frequency with which we'll checkpoint. If `every_n_train_steps = 0` then this feature is disabled.
- The `period` name is ambiguous with this addition: therefore we introduce a new argument `every_n_val_epochs` to be more clear as to when it's applied and mark `period` as deprecated
- We retain the existing functionality of checkpointing after each validation epoch
- These triggers for when to save the checkpoint must be mutually exclusive to avoid additional complexity with handling monitor values and top-K results across different phases (train, val)

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
