### PR TITLE
Temporary fix to be BC compatible with torchtext

### DIFF
--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -25,7 +25,7 @@ from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.imports import _TORCHTEXT_AVAILABLE
 
 if _TORCHTEXT_AVAILABLE:
-    from torchtext.data import Batch
+    from torchtext.legacy.data import Batch
 else:
     Batch = type(None)
 


### PR DESCRIPTION
## What does this PR do?

`torchtext.data.Batch` was deprecated (and moved to `torchtext.legacy.data.Batch`, which breaks PyTorch Lightning

Until PyTorch Lightning can use the new API, it should use the legacy version to allow PyTorch nightly (torch, torchtext) users to keep using PyTorch lightning during development

Fixes #6165
