### PR TITLE
apply_func.py: from torchtext.legacy.data import Batch

### DIFF
--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -21,12 +21,12 @@ from packaging import version
 
 import numpy as np
 import torch
-from torchtext import __version__ as torchtext_version
 
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.imports import _TORCHTEXT_AVAILABLE
 
 if _TORCHTEXT_AVAILABLE:
+    from torchtext import __version__ as torchtext_version
     if version.parse(torchtext_version) < version.parse('0.9.0a0+036df73'):
         from torchtext.data import Batch
     else:

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -21,12 +21,13 @@ from packaging import version
 
 import numpy as np
 import torch
+from torchtext import __version__ as torchtext_version
 
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.imports import _TORCHTEXT_AVAILABLE
 
 if _TORCHTEXT_AVAILABLE:
-    if version.parse(torchtext.__version__) < version.parse('0.9.0a0+036df73'):
+    if version.parse(torchtext_version) < version.parse('0.9.0a0+036df73'):
         from torchtext.data import Batch
     else:
         from torchtext.legacy.data import Batch

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -17,6 +17,7 @@ from collections.abc import Mapping, Sequence
 from copy import copy
 from functools import partial
 from typing import Any, Callable, Optional, Union
+from packaging import version
 
 import numpy as np
 import torch
@@ -25,7 +26,10 @@ from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.imports import _TORCHTEXT_AVAILABLE
 
 if _TORCHTEXT_AVAILABLE:
-    from torchtext.data import Batch
+    if version.parse(torchtext.__version__) < version.parse('0.9.0a0+036df73'):
+        from torchtext.data import Batch
+    else:
+        from torchtext.legacy.data import Batch
 else:
     Batch = type(None)
 

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -17,20 +17,19 @@ from collections.abc import Mapping, Sequence
 from copy import copy
 from functools import partial
 from typing import Any, Callable, Optional, Union
-from distutils.version import LooseVersion
 
 import numpy as np
 import torch
 
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.imports import _TORCHTEXT_AVAILABLE
+from pytorch_lightning.utilities.imports import _module_available
 
 if _TORCHTEXT_AVAILABLE:
-    from torchtext import __version__ as torchtext_version
-    if LooseVersion(torchtext_version) < LooseVersion('0.9.0a0+036df73'):
-        from torchtext.data import Batch
-    else:
+    if _module_available("torchtext.legacy"):
         from torchtext.legacy.data import Batch
+    else:
+        from torchtext.data import Batch
 else:
     Batch = type(None)
 

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -26,7 +26,7 @@ from pytorch_lightning.utilities.imports import _TORCHTEXT_AVAILABLE
 from pytorch_lightning.utilities.imports import _module_available
 
 if _TORCHTEXT_AVAILABLE:
-    if _module_available("torchtext.legacy"):
+    if _module_available("torchtext.legacy.data"):
         from torchtext.legacy.data import Batch
     else:
         from torchtext.data import Batch

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -17,7 +17,7 @@ from collections.abc import Mapping, Sequence
 from copy import copy
 from functools import partial
 from typing import Any, Callable, Optional, Union
-from packaging import version
+from distutils.version import LooseVersion
 
 import numpy as np
 import torch
@@ -27,7 +27,7 @@ from pytorch_lightning.utilities.imports import _TORCHTEXT_AVAILABLE
 
 if _TORCHTEXT_AVAILABLE:
     from torchtext import __version__ as torchtext_version
-    if version.parse(torchtext_version) < version.parse('0.9.0a0+036df73'):
+    if LooseVersion(torchtext_version) < LooseVersion('0.9.0a0+036df73'):
         from torchtext.data import Batch
     else:
         from torchtext.legacy.data import Batch


### PR DESCRIPTION
## What does this PR do?

The name Batch is no longer located under `torchtext.data`
Batch is now located under `torchtext.legacy.data`

--Error message--
```
File "/home/daniel/py38/lib/python3.8/site-packages/pytorch_lightning/utilities/apply_func.py", line 28, in <module>                                                      
    from torchtext.data import Batch                                                  
ImportError: cannot import name 'Batch' from 'torchtext.data' (/home/daniel/py38/lib/python3.8/site-packages/torchtext/data/__init__.py)
```

You can fix this by changing line line 28 of pytorch_lightning/utilities/apply_func.py to:
    from torchtext.legacy.data import Batch

Closes #6168
Closes #6165 

## Did you have fun?
Yes :)
