### PR TITLE
Improved EarlyStopping.patience documentation

### DIFF
--- a/notebooks/05-trainer-flags-overview.ipynb
+++ b/notebooks/05-trainer-flags-overview.ipynb
@@ -2545,7 +2545,7 @@
     "id": "7TAIerPYe_Q1"
    },
    "source": [
-    "The EarlyStopping callback runs at the end of every validation epoch, which, under the default configuration, happens after every training epoch. However, the frequency of validation can be modified by setting various parameters on the Trainer, for example check_val_every_n_epoch and val_check_interval. It must be noted that the patience parameter counts the number of validation epochs with no improvement, and not the number of training epochs. Therefore, with parameters check_val_every_n_epoch=10 and patience=3, the trainer will perform at least 40 training epochs before being stopped."
+    "The EarlyStopping callback runs at the end of every validation check, which, under the default configuration, happens after every training epoch. However, the frequency of validation can be modified by setting various parameters on the Trainer, for example check_val_every_n_epoch and val_check_interval. It must be noted that the patience parameter counts the number of validation checks with no improvement, and not the number of training epochs. Therefore, with parameters check_val_every_n_epoch=10 and patience=3, the trainer will perform at least 40 training epochs before being stopped."
    ]
   },
   {

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -38,8 +38,18 @@ class EarlyStopping(Callback):
             to qualify as an improvement, i.e. an absolute
             change of less than `min_delta`, will count as no
             improvement. Default: ``0.0``.
-        patience: number of validation epochs with no improvement
-            after which training will be stopped. Default: ``3``.
+        patience: number of validation checks with no improvement
+            after which training will be stopped. Under the default
+            configuration, one validation check happens after every
+            training epoch. However, the frequency of validation
+            can be modified by setting various parameters on the
+            Trainer, for example check_val_every_n_epoch and
+            val_check_interval. It must be noted that the patience
+            parameter counts the number of validation checks with
+            no improvement, and not the number of training epochs.
+            Therefore, with parameters check_val_every_n_epoch=10
+            and patience=3, the trainer will perform at least 40
+            training epochs before being stopped. Default: ``3``.
         verbose: verbosity mode. Default: ``False``.
         mode: one of ``'min'``, ``'max'``. In ``'min'`` mode,
             training will stop when the quantity

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -39,16 +39,11 @@ class EarlyStopping(Callback):
             change of less than `min_delta`, will count as no
             improvement. Default: ``0.0``.
         patience: number of validation checks with no improvement
-            after which training will be stopped. Under the default
-            configuration, one validation check happens after every
-            training epoch. However, the frequency of validation
-            can be modified by setting various parameters on the
-            Trainer, for example check_val_every_n_epoch and
-            val_check_interval. It must be noted that the patience
-            parameter counts the number of validation checks with
-            no improvement, and not the number of training epochs.
-            Therefore, with parameters check_val_every_n_epoch=10
-            and patience=3, the trainer will perform at least 40
+            after which training will be stopped. Under the default configuration, one validation check happens after
+            every training epoch. However, the frequency of validation can be modified by setting various parameters on
+            the Trainer, for example check_val_every_n_epoch and val_check_interval. It must be noted that the patience
+            parameter counts the number of validation checks with no improvement, and not the number of training epochs.
+            Therefore, with parameters check_val_every_n_epoch=10 and patience=3, the trainer will perform at least 40
             training epochs before being stopped. Default: ``3``.
         verbose: verbosity mode. Default: ``False``.
         mode: one of ``'min'``, ``'max'``. In ``'min'`` mode,

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -33,22 +33,27 @@ class EarlyStopping(Callback):
     Monitor a metric and stop training when it stops improving.
 
     Args:
-        monitor: quantity to be monitored. Default: ``'early_stop_on'``.
+        monitor: quantity to be monitored.
         min_delta: minimum change in the monitored quantity to qualify as an improvement, i.e. an absolute
-            change of less than `min_delta`, will count as no improvement. Default: ``0.0``.
+            change of less than `min_delta`, will count as no improvement.
         patience: number of validation checks with no improvement
             after which training will be stopped. Under the default configuration, one validation check happens after
             every training epoch. However, the frequency of validation can be modified by setting various parameters on
-            the Trainer, for example check_val_every_n_epoch and val_check_interval. It must be noted that the patience
-            parameter counts the number of validation checks with no improvement, and not the number of training epochs.
-            Therefore, with parameters check_val_every_n_epoch=10 and patience=3, the trainer will perform at least 40
-            training epochs before being stopped. Default: ``3``.
-        verbose: verbosity mode. Default: ``False``.
+            the ``Trainer``, for example ``check_val_every_n_epoch`` and ``val_check_interval``.
+
+            .. note::
+
+                It must be noted that the patience parameter counts the number of validation checks with
+                no improvement, and not the number of training epochs. Therefore, with parameters
+                ``check_val_every_n_epoch=10`` and ``patience=3``, the trainer will perform at least 40 training
+                epochs before being stopped.
+
+        verbose: verbosity mode.
         mode: one of ``'min'``, ``'max'``. In ``'min'`` mode, training will stop when the quantity
             monitored has stopped decreasing and in ``'max'`` mode it will stop when the quantity
             monitored has stopped increasing.
 
-        strict: whether to crash the training if `monitor` is not found in the validation metrics. Default: ``True``.
+        strict: whether to crash the training if `monitor` is not found in the validation metrics.
 
     Raises:
         MisconfigurationException:

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -52,7 +52,6 @@ class EarlyStopping(Callback):
         mode: one of ``'min'``, ``'max'``. In ``'min'`` mode, training will stop when the quantity
             monitored has stopped decreasing and in ``'max'`` mode it will stop when the quantity
             monitored has stopped increasing.
-
         strict: whether to crash the training if `monitor` is not found in the validation metrics.
 
     Raises:

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -34,10 +34,8 @@ class EarlyStopping(Callback):
 
     Args:
         monitor: quantity to be monitored. Default: ``'early_stop_on'``.
-        min_delta: minimum change in the monitored quantity
-            to qualify as an improvement, i.e. an absolute
-            change of less than `min_delta`, will count as no
-            improvement. Default: ``0.0``.
+        min_delta: minimum change in the monitored quantity to qualify as an improvement, i.e. an absolute
+            change of less than `min_delta`, will count as no improvement. Default: ``0.0``.
         patience: number of validation checks with no improvement
             after which training will be stopped. Under the default configuration, one validation check happens after
             every training epoch. However, the frequency of validation can be modified by setting various parameters on
@@ -46,14 +44,11 @@ class EarlyStopping(Callback):
             Therefore, with parameters check_val_every_n_epoch=10 and patience=3, the trainer will perform at least 40
             training epochs before being stopped. Default: ``3``.
         verbose: verbosity mode. Default: ``False``.
-        mode: one of ``'min'``, ``'max'``. In ``'min'`` mode,
-            training will stop when the quantity
-            monitored has stopped decreasing and in ``'max'``
-            mode it will stop when the quantity
+        mode: one of ``'min'``, ``'max'``. In ``'min'`` mode, training will stop when the quantity
+            monitored has stopped decreasing and in ``'max'`` mode it will stop when the quantity
             monitored has stopped increasing.
 
-        strict: whether to crash the training if `monitor` is
-            not found in the validation metrics. Default: ``True``.
+        strict: whether to crash the training if `monitor` is not found in the validation metrics. Default: ``True``.
 
     Raises:
         MisconfigurationException:


### PR DESCRIPTION
## What does this PR do?

The terminology "validation epochs" is a bit confusing, and idiomatic as it is not really used much elsewhere in the documentation. The documentation has been updated to say "validation checks" and explain more clearly how EarlyStopping patience works.

Fixes #6254 

## Before submitting
- [Y] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [Y] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [Y] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [Y] Did you make sure to update the documentation with your changes? (if necessary)
- [n/a] Did you write any new necessary tests? (not for typos and docs)
- [n/a] Did you verify new and existing tests pass locally with your changes?
- [n/a] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [Y] Is this pull request ready for review? (if not, please submit in draft mode)
 - [Y] Check that all items from **Before submitting** are resolved
 - [Y] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
