### PR TITLE
[doc] Improve Multiple Val/Test Dataloaders with simultaneous batches option

### DIFF
--- a/docs/source/advanced/multiple_loaders.rst
+++ b/docs/source/advanced/multiple_loaders.rst
@@ -115,7 +115,7 @@ Test/Val dataloaders
 --------------------
 For validation and test dataloaders, lightning also gives you the additional
 option of passing multiple dataloaders back from each call. You can choose to pass
-the batches sequentially or simultaneously, as isdone for the training step.
+the batches sequentially or simultaneously, as is done for the training step.
 The default mode for validation and test dataloaders is sequential.
 
 See the following for more details for the default sequential option:

--- a/docs/source/advanced/multiple_loaders.rst
+++ b/docs/source/advanced/multiple_loaders.rst
@@ -65,7 +65,7 @@ dataloaders).
 
 However, with lightning you can also return multiple loaders and lightning will take care of batch combination.
 
-For more details please have a look at :attr:`~pytorch_lightning.trainer.trainer.Trainer.params.multiple_trainloader_mode`
+For more details please have a look at :paramref:`~pytorch_lightning.trainer.trainer.Trainer.multiple_trainloader_mode`
 
 .. testcode::
 

--- a/docs/source/advanced/multiple_loaders.rst
+++ b/docs/source/advanced/multiple_loaders.rst
@@ -65,7 +65,7 @@ dataloaders).
 
 However, with lightning you can also return multiple loaders and lightning will take care of batch combination.
 
-For more details please have a look at :attr:`~pytorch_lightning.trainer.trainer.Trainer.multiple_trainloader_mode`
+For more details please have a look at :attr:`~pytorch_lightning.trainer.trainer.Trainer.params.multiple_trainloader_mode`
 
 .. testcode::
 
@@ -114,9 +114,11 @@ be returned
 Test/Val dataloaders
 --------------------
 For validation and test dataloaders, lightning also gives you the additional
-option of passing multiple dataloaders back from each call.
+option of passing multiple dataloaders back from each call. You can choose to pass
+the batches sequentially or simultaneously, as isdone for the training step.
+The default mode for validation and test dataloaders is sequential.
 
-See the following for more details:
+See the following for more details for the default sequential option:
 
 - :meth:`~pytorch_lightning.core.datamodule.LightningDataModule.val_dataloader`
 - :meth:`~pytorch_lightning.core.datamodule.LightningDataModule.test_dataloader`
@@ -127,3 +129,17 @@ See the following for more details:
         loader_1 = Dataloader()
         loader_2 = Dataloader()
         return [loader_1, loader_2]
+
+To combine batches of multiple test and validation dataloaders simultaneously, one
+needs to wrap the dataloaders with `CombinedLoader`.
+
+.. testcode::
+
+    from pytorch_lightning.trainer.supporters import CombinedLoader
+
+    def val_dataloader(self):
+        loader_1 = Dataloader()
+        loader_2 = Dataloader()
+        loaders = {'a': loader_a,'b': loader_b}
+        combined_loaders = CombinedLoader(loaders, "max_size_cycle")
+        return combined_loaders


### PR DESCRIPTION

## What does this PR do?
Adds documentation of how to combine batches of multiple test and val datasets.
Following discussion on slack, until a proper flag is implemented to enable consistent behavior of multiple dataloaders for training and test/val, this is a valid workaround. Please see issue https://github.com/PyTorchLightning/pytorch-lightning/issues/6233
 

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
