### PR TITLE
fix trainer not resetting lightning_optimizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed PyTorch Profiler with `emit_nvtx` ([#6260](https://github.com/PyTorchLightning/pytorch-lightning/pull/6260))
 
 
-- Fixed `trainer.test` from `best_path` hangs after calling `trainer.fit`  ([#6272](https://github.com/PyTorchLightning/pytorch-lightning/pull/6272))
+- Fixed `trainer.test` from `best_path` hangs after calling `trainer.fit` ([#6272](https://github.com/PyTorchLightning/pytorch-lightning/pull/6272))
+
+
+- Fixed `Trainer` not resetting `lightning_optimizers` when calling `Trainer.fit()` multiple times ([#6372](https://github.com/PyTorchLightning/pytorch-lightning/pull/6372))
 
 
 ## [1.2.2] - 2021-03-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,9 +86,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed PyTorch Profiler with `emit_nvtx` ([#6260](https://github.com/PyTorchLightning/pytorch-lightning/pull/6260))
 
 
-- Fixed `trainer.test` from `best_path` hangs after calling `trainer.fit` ([#6272](https://github.com/PyTorchLightning/pytorch-lightning/pull/6272))
-
-
 - Fixed `Trainer` not resetting `lightning_optimizers` when calling `Trainer.fit()` multiple times ([#6372](https://github.com/PyTorchLightning/pytorch-lightning/pull/6372))
 
 

--- a/pytorch_lightning/trainer/optimizers.py
+++ b/pytorch_lightning/trainer/optimizers.py
@@ -27,7 +27,10 @@ from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 class TrainerOptimizersMixin(ABC):
 
+    _lightning_optimizers: Optional[List[LightningOptimizer]]
+
     def init_optimizers(self, model: LightningModule) -> Tuple[List, List, List]:
+        self._lightning_optimizers = None
         optim_conf = model.configure_optimizers()
         if optim_conf is None:
             rank_zero_warn(

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -19,7 +19,7 @@ from argparse import Namespace
 from copy import deepcopy
 from distutils.version import LooseVersion
 from pathlib import Path
-from unittest.mock import ANY, call, patch, Mock
+from unittest.mock import ANY, call, patch
 
 import cloudpickle
 import pytest
@@ -1794,6 +1794,7 @@ def test_init_optimizers_resets_lightning_optimizers(tmpdir):
         assert trainer.lightning_optimizers[0].optimizer is trainer.optimizers[0]
 
     class OptimizerSpy(Callback):
+
         def on_fit_start(self, *args, **kwargs):
             compare_optimizers()
 
@@ -1803,7 +1804,7 @@ def test_init_optimizers_resets_lightning_optimizers(tmpdir):
         default_root_dir=tmpdir,
         max_epochs=1,
         auto_lr_find=True,
-        callbacks=[OptimizerSpy()]
+        callbacks=[OptimizerSpy()],
     )
 
     trainer.tune(model)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -19,7 +19,7 @@ from argparse import Namespace
 from copy import deepcopy
 from distutils.version import LooseVersion
 from pathlib import Path
-from unittest.mock import ANY, call, patch
+from unittest.mock import ANY, call, patch, Mock
 
 import cloudpickle
 import pytest
@@ -1785,3 +1785,33 @@ def test_train_loop_system(tmpdir):
         "training_step",
         "backward",
     ]
+
+
+def test_init_optimizers_resets_lightning_optimizers(tmpdir):
+    """ Test that the Trainer resets the `lightning_optimizers` list everytime new optimizers get initialized. """
+
+    def compare_optimizers():
+        assert trainer.lightning_optimizers[0].optimizer is trainer.optimizers[0]
+
+    class OptimizerSpy(Callback):
+        def on_fit_start(self, *args, **kwargs):
+            compare_optimizers()
+
+    model = BoringModel()
+    model.lr = 0.2
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        auto_lr_find=True,
+        callbacks=[OptimizerSpy()]
+    )
+
+    trainer.tune(model)
+    compare_optimizers()
+
+    trainer.fit(model)
+    compare_optimizers()
+
+    trainer.max_epochs = 2  # simulate multiple fit calls
+    trainer.fit(model)
+    compare_optimizers()

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1793,18 +1793,12 @@ def test_init_optimizers_resets_lightning_optimizers(tmpdir):
     def compare_optimizers():
         assert trainer.lightning_optimizers[0].optimizer is trainer.optimizers[0]
 
-    class OptimizerSpy(Callback):
-
-        def on_fit_start(self, *args, **kwargs):
-            compare_optimizers()
-
     model = BoringModel()
     model.lr = 0.2
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_epochs=1,
         auto_lr_find=True,
-        callbacks=[OptimizerSpy()],
     )
 
     trainer.tune(model)


### PR DESCRIPTION
## What does this PR do?

When calling `Trainer.fit` multiple times there is a bug where in the second fit the optimization would use the
lightning optimizers from the first model because it is still hanging on to the old list. 

The fix is to reset the list when new optimizers are requested from the model. 
This way the lightning optimizers get re-wrapped when the training loop starts.

Fixes #6285

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
