### PR TITLE
Use f-"""-string in a Trainer comment

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -449,7 +449,7 @@ class Trainer(
         # ----------------------------
         # INSPECT THE CORE LOOPS
         # ----------------------------
-        f"""
+        rf"""
              Lightning internal flow looks like this.    ||
             {self.fit} or {self.test} or {self.predict}  ||
                                 |                        ||

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -450,22 +450,22 @@ class Trainer(
         # INSPECT THE CORE LOOPS
         # ----------------------------
         rf"""
-             Lightning internal flow looks like this.    ||
-            {self.fit} or {self.test} or {self.predict}  ||
-                                |                        ||
-                        create accelerator               ||
-                                |                        ||
-                         {self.dispatch}                 ||
-                                |                        ||  LIGHTNING
-                {self.accelerator.start_training} or     ||  FLOW
-                {self.accelerator.start_evaluating} or   ||  DIRECTION
-                {self.accelerator.start_predicting}      ||
-                                |                        ||
-                        {self.run_train} or              ||
-                     {self.run_evaluation} or            ||
-                       {self.run_predict}                ||
-                                |                        ||
-                             results                     \/
+             Lightning internal flow looks like this:
+        {Trainer.fit} or {Trainer.test} or {Trainer.predict}  ||
+                                |                             ||
+                        create accelerator                    ||
+                                |                             ||
+                         {self.dispatch}                      ||
+                                |                             ||  LIGHTNING
+                {self.accelerator.start_training} or          ||  FLOW
+                {self.accelerator.start_evaluating} or        ||  DIRECTION
+                {self.accelerator.start_predicting}           ||
+                                |                             ||
+                        {self.run_train} or                   ||
+                     {self.run_evaluation} or                 ||
+                       {self.run_predict}                     ||
+                                |                             ||
+                             results                          \/
         This is used to guide readers to the core loops: train, test, predict.
         {self.run_predict} is the simplest to understand, use `Go to Definition` to read it :)
         Search for `start_training` or `start_evaluating` or `start_predicting` in

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -449,25 +449,28 @@ class Trainer(
         # ----------------------------
         # INSPECT THE CORE LOOPS
         # ----------------------------
-        #             Lightning internal flow looks like this.
-        #
-        #   trainer.fit(...) or trainer.test(...) or trainer.predict(...)   ||
-        #                                |                                  ||
-        #                        create accelerator                         ||
-        #                                |                                  ||
-        #                         trainer.dispatch                          ||  LIGHTNING
-        #                                |                                  ||
-        #    start_training or start_evaluating or start_predicting call    ||  FLOW
-        #                        from `accelerator`                         ||
-        #                                |                                  ||  DIRECTION
-        #             run_train or run_evaluate or run_predict call         ||
-        #                           from `trainer`                          ||
-        #                                |                                  ||
-        #                             results                               \/
-        # This is used to guide readers to the core loops: train, test, predict.
-        # `run_predict` is the simplest to understand, use `Go to Definition` to read it :)
-        # Search for `start_training` or `start_evaluating` or `start_predicting` in
-        # `pytorch_lightning/plugins/training_type` folder to find accelerator dispatch functions.
+        f"""
+             Lightning internal flow looks like this.    ||
+            {self.fit} or {self.test} or {self.predict}  ||
+                                |                        ||
+                        create accelerator               ||
+                                |                        ||
+                         {self.dispatch}                 ||
+                                |                        ||  LIGHTNING
+                {self.accelerator.start_training} or     ||  FLOW
+                {self.accelerator.start_evaluating} or   ||  DIRECTION
+                {self.accelerator.start_predicting}      ||
+                                |                        ||
+                        {self.run_train} or              ||
+                     {self.run_evaluation} or            ||
+                       {self.run_predict}                ||
+                                |                        ||
+                             results                     \/
+        This is used to guide readers to the core loops: train, test, predict.
+        {self.run_predict} is the simplest to understand, use `Go to Definition` to read it :)
+        Search for `start_training` or `start_evaluating` or `start_predicting` in
+        `pytorch_lightning/plugins/training_type_plugin` to find accelerator dispatch functions.
+        """
 
         # ----------------------------
         # TRAIN

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -457,10 +457,10 @@ class Trainer(
                                 |                             ||
                          {self.dispatch}                      ||
                                 |                             ||  LIGHTNING
-                {self.accelerator.start_training} or          ||  FLOW
-                {self.accelerator.start_evaluating} or        ||  DIRECTION
+                {self.accelerator.start_training} or          ||
+                {self.accelerator.start_evaluating} or        ||  FLOW
                 {self.accelerator.start_predicting}           ||
-                                |                             ||
+                                |                             ||  DIRECTION
                         {self.run_train} or                   ||
                      {self.run_evaluation} or                 ||
                        {self.run_predict}                     ||

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -449,7 +449,7 @@ class Trainer(
         # ----------------------------
         # INSPECT THE CORE LOOPS
         # ----------------------------
-        rf"""
+        f"""
              Lightning internal flow looks like this:
         {Trainer.fit} or {Trainer.test} or {Trainer.predict}  ||
                                 |                             ||
@@ -470,7 +470,7 @@ class Trainer(
         {self.run_predict} is the simplest to understand, use `Go to Definition` to read it :)
         Search for `start_training` or `start_evaluating` or `start_predicting` in
         `pytorch_lightning/plugins/training_type_plugin` to find accelerator dispatch functions.
-        """
+        """  # noqa: W605
 
         # ----------------------------
         # TRAIN


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/PyTorchLightning/pytorch-lightning/pull/4945#discussion_r588527736

This has the advantage of allowing people to inspect the definition, but without adding useless attributes

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes? (if necessary)
- [n/a] Did you write any new necessary tests? (not for typos and docs)
- [n/a] Did you verify new and existing tests pass locally with your changes?
- [n/a] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified