### PR TITLE
Pass {fit,validate,test,predict} to setup() and teardown()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed `trainer.evaluating` to return `True` if validating or testing ([#4945](https://github.com/PyTorchLightning/pytorch-lightning/pull/4945))
 
 
-- Changed `setup()` stage argument to take any of `{fit,validate,test,predict}` ([#6386](https://github.com/PyTorchLightning/pytorch-lightning/pull/6386))
+- Changed `setup()` and `teardown()` stage argument to take any of `{fit,validate,test,predict}` ([#6386](https://github.com/PyTorchLightning/pytorch-lightning/pull/6386))
 
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Changed `trainer.evaluating` to return `True` if validating or testing ([#4945](https://github.com/PyTorchLightning/pytorch-lightning/pull/4945))
 
 
+- Changed `setup()` stage argument to take any of `{fit,validate,test,predict}` ([#6386](https://github.com/PyTorchLightning/pytorch-lightning/pull/6386))
+
+
 ### Deprecated
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed DP reduction with collection ([#6324](https://github.com/PyTorchLightning/pytorch-lightning/pull/6324))
 
 
+- Fixed `.teardown(stage='fit')` getting called during `trainer.test` ([#6386](https://github.com/PyTorchLightning/pytorch-lightning/pull/6386))
+
+
+- Fixed `.on_fit_{start,end}()` getting called during `trainer.test` ([#6386](https://github.com/PyTorchLightning/pytorch-lightning/pull/6386))
+
+
 - Fixed PyTorch Profiler with `emit_nvtx` ([#6260](https://github.com/PyTorchLightning/pytorch-lightning/pull/6260))
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -371,6 +371,7 @@ doctest_test_doctest_blocks = ''
 doctest_global_setup = """
 import importlib
 import os
+from typing import Optional
 import torch
 from torch import nn
 import pytorch_lightning as pl

--- a/docs/source/extensions/datamodules.rst
+++ b/docs/source/extensions/datamodules.rst
@@ -80,7 +80,7 @@ The equivalent DataModule just organizes the same exact code, but makes it reusa
             self.data_dir = data_dir
             self.batch_size = batch_size
 
-        def setup(self, stage=None):
+        def setup(self, stage: Optional[str] = None):
             self.mnist_test = MNIST(self.data_dir, train=False)
             mnist_full = MNIST(self.data_dir, train=True)
             self.mnist_train, self.mnist_val = random_split(mnist_full, [55000, 5000])
@@ -138,7 +138,7 @@ Here's a more realistic, complex DataModule that shows how much more reusable th
             MNIST(self.data_dir, train=True, download=True)
             MNIST(self.data_dir, train=False, download=True)
 
-        def setup(self, stage=None):
+        def setup(self, stage: Optional[str] = None):
 
             # Assign train/val datasets for use in dataloaders
             if stage == 'fit' or stage is None:
@@ -382,12 +382,12 @@ still ensures the method runs on the correct devices)
 
     dm = MNISTDataModule()
     dm.prepare_data()
-    dm.setup('fit')
+    dm.setup(stage='fit')
 
     model = Model(num_classes=dm.num_classes, width=dm.width, vocab=dm.vocab)
     trainer.fit(model, dm)
 
-    dm.setup('test')
+    dm.setup(stage='test')
     trainer.test(datamodule=dm)
 
 ----------------
@@ -403,7 +403,7 @@ You can of course use DataModules in plain PyTorch code as well.
     dm.prepare_data()
 
     # splits/transforms
-    dm.setup('fit')
+    dm.setup(stage='fit')
 
     # use data
     for batch in dm.train_dataloader():
@@ -412,7 +412,7 @@ You can of course use DataModules in plain PyTorch code as well.
         ...
 
     # lazy load test data
-    dm.setup('test')
+    dm.setup(stage='test')
     for batch in dm.test_dataloader():
         ...
 

--- a/docs/source/starter/introduction_guide.rst
+++ b/docs/source/starter/introduction_guide.rst
@@ -240,7 +240,7 @@ In this case, it's better to group the full definition of a dataset into a `Data
             tokenize()
             build_vocab()
 
-        def setup(self):
+        def setup(self, stage: Optional[str] = None):
             # called on every GPU
             vocab = load_vocab()
             self.vocab_size = len(vocab)
@@ -310,8 +310,8 @@ An alternative to using a DataModule is to defer initialization of the models mo
             download_data()
             tokenize()
 
-        def setup(self, step):
-            # step is either 'fit' or 'test' 90% of the time not relevant
+        def setup(self, stage: Optional[str] = None):
+            # step is either 'fit', 'validate', 'test', or 'predict'. 90% of the time not relevant
             data = load_data()
             num_classes = data.classes
             self.l1 = nn.Linear(..., num_classes)
@@ -598,7 +598,7 @@ In this method we do all the preparation we need to do once (instead of on every
             MNIST(os.getcwd(), train=True, download=True, transform=transforms.ToTensor())
             MNIST(os.getcwd(), train=False, download=True, transform=transforms.ToTensor())
 
-        def setup(self, stage):
+        def setup(self, stage: Optional[str] = None):
             # transform
             transform=transforms.Compose([transforms.ToTensor()])
             mnist_train = MNIST(os.getcwd(), train=True, download=False, transform=transform)

--- a/docs/source/starter/new-project.rst
+++ b/docs/source/starter/new-project.rst
@@ -651,7 +651,7 @@ Make your data code reusable by organizing it into a :class:`~pytorch_lightning.
             MNIST(os.getcwd(), train=False, download=True)
 
         # OPTIONAL, called for every GPU/machine (assigning state is OK)
-        def setup(self, stage):
+        def setup(self, stage: Optional[str] = None):
             # transforms
             transform=transforms.Compose([
                 transforms.ToTensor(),

--- a/pytorch_lightning/callbacks/base.py
+++ b/pytorch_lightning/callbacks/base.py
@@ -34,11 +34,11 @@ class Callback(abc.ABC):
         pass
 
     def setup(self, trainer, pl_module: LightningModule, stage: str) -> None:
-        """Called when fit or test begins"""
+        """Called when fit, validate, test, predict, or tune begins"""
         pass
 
     def teardown(self, trainer, pl_module: LightningModule, stage: str) -> None:
-        """Called when fit or test ends"""
+        """Called when fit, validate, test, predict, or tune ends"""
         pass
 
     def on_init_start(self, trainer) -> None:

--- a/pytorch_lightning/callbacks/base.py
+++ b/pytorch_lightning/callbacks/base.py
@@ -17,7 +17,7 @@ Abstract base class used to build new callbacks.
 """
 
 import abc
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from pytorch_lightning.core.lightning import LightningModule
 
@@ -33,11 +33,11 @@ class Callback(abc.ABC):
         """Called before accelerator is being setup"""
         pass
 
-    def setup(self, trainer, pl_module: LightningModule, stage: str) -> None:
+    def setup(self, trainer, pl_module: LightningModule, stage: Optional[str] = None) -> None:
         """Called when fit, validate, test, predict, or tune begins"""
         pass
 
-    def teardown(self, trainer, pl_module: LightningModule, stage: str) -> None:
+    def teardown(self, trainer, pl_module: LightningModule, stage: Optional[str] = None) -> None:
         """Called when fit, validate, test, predict, or tune ends"""
         pass
 

--- a/pytorch_lightning/core/datamodule.py
+++ b/pytorch_lightning/core/datamodule.py
@@ -55,10 +55,10 @@ class _DataModuleWrapper(type):
 def track_data_hook_calls(fn):
     """A decorator that checks if prepare_data/setup have been called.
 
-    - When dm.prepare_data() is called, dm.has_prepared_data gets set to True
-    - When dm.setup('fit') is called, dm.has_setup_fit gets set to True
-    - When dm.setup('test') is called, dm.has_setup_test gets set to True
-    - When dm.setup() is called without stage arg, both dm.has_setup_fit and dm.has_setup_test get set to True
+    - When ``dm.prepare_data()`` is called, ``dm.has_prepared_data`` gets set to True
+    - When ``dm.setup()``, ``dm.has_setup_{fit,validate,test}`` get set to True
+    - When ``dm.setup(stage)`` is called, where stage is any of ``{fit,validate,test,predict}``
+        it's corresponding `dm_has_setup_{stage}` gets set to True
 
     Args:
         fn (function): Function that will be tracked to see if it has been called.
@@ -77,15 +77,15 @@ def track_data_hook_calls(fn):
         if fn.__name__ == "setup":
 
             # Get stage either by grabbing from args or checking kwargs.
-            # If not provided, set call status of 'fit' and 'test' to True.
+            # If not provided, set call status of 'fit', 'validate', and 'test' to True.
             # We do this so __attach_datamodule in trainer.py doesn't mistakenly call setup('test') on trainer.test()
             stage = args[1] if len(args) > 1 else kwargs.get("stage", None)
 
-            if stage == "fit" or stage is None:
-                obj._has_setup_fit = True
-
-            if stage == "test" or stage is None:
-                obj._has_setup_test = True
+            if stage is None:
+                for s in ("fit", "validate", "test"):
+                    setattr(obj, f"_has_setup_{s}", True)
+            else:
+                setattr(obj, f"_has_setup_{stage}", True)
 
         if fn.__name__ == "prepare_data":
             obj._has_prepared_data = True
@@ -156,7 +156,9 @@ class LightningDataModule(CheckpointHooks, DataHooks, metaclass=_DataModuleWrapp
         # Private attrs to keep track of whether or not data hooks have been called yet
         self._has_prepared_data = False
         self._has_setup_fit = False
+        self._has_setup_validate = False
         self._has_setup_test = False
+        self._has_setup_predict = False
 
     @property
     def train_transforms(self):
@@ -214,31 +216,49 @@ class LightningDataModule(CheckpointHooks, DataHooks, metaclass=_DataModuleWrapp
         return self.dims
 
     @property
-    def has_prepared_data(self):
-        """Return bool letting you know if datamodule.prepare_data() has been called or not.
+    def has_prepared_data(self) -> bool:
+        """Return bool letting you know if ``datamodule.prepare_data()`` has been called or not.
 
         Returns:
-            bool: True if datamodule.prepare_data() has been called. False by default.
+            bool: True if ``datamodule.prepare_data()`` has been called. False by default.
         """
         return self._has_prepared_data
 
     @property
-    def has_setup_fit(self):
-        """Return bool letting you know if datamodule.setup('fit') has been called or not.
+    def has_setup_fit(self) -> bool:
+        """Return bool letting you know if ``datamodule.setup('fit')`` has been called or not.
 
         Returns:
-            bool: True if datamodule.setup('fit') has been called. False by default.
+            bool: True ``if datamodule.setup('fit')`` has been called. False by default.
         """
         return self._has_setup_fit
 
     @property
-    def has_setup_test(self):
-        """Return bool letting you know if datamodule.setup('test') has been called or not.
+    def has_setup_validate(self) -> bool:
+        """Return bool letting you know if ``datamodule.setup('validate')`` has been called or not.
 
         Returns:
-            bool: True if datamodule.setup('test') has been called. False by default.
+            bool: True if ``datamodule.setup('validate')`` has been called. False by default.
+        """
+        return self._has_setup_validate
+
+    @property
+    def has_setup_test(self) -> bool:
+        """Return bool letting you know if ``datamodule.setup('test')`` has been called or not.
+
+        Returns:
+            bool: True if ``datamodule.setup('test')`` has been called. False by default.
         """
         return self._has_setup_test
+
+    @property
+    def has_setup_predict(self) -> bool:
+        """Return bool letting you know if ``datamodule.setup('predict')`` has been called or not.
+
+        Returns:
+            bool: True if ``datamodule.setup('predict')`` has been called. False by default.
+        """
+        return self._has_setup_predict
 
     @abstractmethod
     def prepare_data(self, *args, **kwargs):

--- a/pytorch_lightning/core/datamodule.py
+++ b/pytorch_lightning/core/datamodule.py
@@ -57,8 +57,8 @@ def track_data_hook_calls(fn):
 
     - When ``dm.prepare_data()`` is called, ``dm.has_prepared_data`` gets set to True
     - When ``dm.setup()``, ``dm.has_setup_{fit,validate,test}`` get set to True
-    - When ``dm.setup(stage)`` is called, where stage is any of ``{fit,validate,test,predict}``
-        it's corresponding `dm_has_setup_{stage}` gets set to True
+    - When ``dm.setup(stage)`` is called, where stage is any of ``{fit,validate,test,predict}``.
+        Its corresponding `dm_has_setup_{stage}` attribute gets set to True
 
     Args:
         fn (function): Function that will be tracked to see if it has been called.
@@ -226,37 +226,37 @@ class LightningDataModule(CheckpointHooks, DataHooks, metaclass=_DataModuleWrapp
 
     @property
     def has_setup_fit(self) -> bool:
-        """Return bool letting you know if ``datamodule.setup('fit')`` has been called or not.
+        """Return bool letting you know if ``datamodule.setup(stage='fit')`` has been called or not.
 
         Returns:
-            bool: True ``if datamodule.setup('fit')`` has been called. False by default.
+            bool: True ``if datamodule.setup(stage='fit')`` has been called. False by default.
         """
         return self._has_setup_fit
 
     @property
     def has_setup_validate(self) -> bool:
-        """Return bool letting you know if ``datamodule.setup('validate')`` has been called or not.
+        """Return bool letting you know if ``datamodule.setup(stage='validate')`` has been called or not.
 
         Returns:
-            bool: True if ``datamodule.setup('validate')`` has been called. False by default.
+            bool: True if ``datamodule.setup(stage='validate')`` has been called. False by default.
         """
         return self._has_setup_validate
 
     @property
     def has_setup_test(self) -> bool:
-        """Return bool letting you know if ``datamodule.setup('test')`` has been called or not.
+        """Return bool letting you know if ``datamodule.setup(stage='test')`` has been called or not.
 
         Returns:
-            bool: True if ``datamodule.setup('test')`` has been called. False by default.
+            bool: True if ``datamodule.setup(stage='test')`` has been called. False by default.
         """
         return self._has_setup_test
 
     @property
     def has_setup_predict(self) -> bool:
-        """Return bool letting you know if ``datamodule.setup('predict')`` has been called or not.
+        """Return bool letting you know if ``datamodule.setup(stage='predict')`` has been called or not.
 
         Returns:
-            bool: True if ``datamodule.setup('predict')`` has been called. False by default.
+            bool: True if ``datamodule.setup(stage='predict')`` has been called. False by default.
         """
         return self._has_setup_predict
 

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -25,14 +25,14 @@ from pytorch_lightning.utilities import move_data_to_device, rank_zero_warn
 class ModelHooks:
     """Hooks to be used in LightningModule."""
 
-    def setup(self, stage: str) -> None:
+    def setup(self, stage: Optional[str] = None) -> None:
         """
         Called at the beginning of fit (train + validate), validate, test, predict, or tune.
         This is a good hook when you need to build models dynamically or adjust something about them.
         This hook is called on every process when using DDP.
 
         Args:
-            stage: either ``'fit'``, ``'validate'``, ``'test'``, ``'predict'``, or ``'tune'``
+            stage: either ``'fit'``, ``'validate'``, ``'test'``, or ``'predict'``
 
         Example::
 
@@ -53,12 +53,12 @@ class ModelHooks:
 
         """
 
-    def teardown(self, stage: str) -> None:
+    def teardown(self, stage: Optional[str] = None) -> None:
         """
         Called at the end of fit (train + validate), validate, test, predict, or tune.
 
         Args:
-            stage: either ``'fit'``, ``'validate'``, ``'test'``, ``'predict'``, or ``'tune'``
+            stage: either ``'fit'``, ``'validate'``, ``'test'``, or ``'predict'``
         """
 
     def on_fit_start(self) -> None:

--- a/pytorch_lightning/core/hooks.py
+++ b/pytorch_lightning/core/hooks.py
@@ -27,12 +27,12 @@ class ModelHooks:
 
     def setup(self, stage: str) -> None:
         """
-        Called at the beginning of fit and test.
+        Called at the beginning of fit (train + validate), validate, test, predict, or tune.
         This is a good hook when you need to build models dynamically or adjust something about them.
         This hook is called on every process when using DDP.
 
         Args:
-            stage: either 'fit' or 'test'
+            stage: either ``'fit'``, ``'validate'``, ``'test'``, ``'predict'``, or ``'tune'``
 
         Example::
 
@@ -55,10 +55,10 @@ class ModelHooks:
 
     def teardown(self, stage: str) -> None:
         """
-        Called at the end of fit and test.
+        Called at the end of fit (train + validate), validate, test, predict, or tune.
 
         Args:
-            stage: either 'fit' or 'test'
+            stage: either ``'fit'``, ``'validate'``, ``'test'``, ``'predict'``, or ``'tune'``
         """
 
     def on_fit_start(self) -> None:

--- a/pytorch_lightning/trainer/callback_hook.py
+++ b/pytorch_lightning/trainer/callback_hook.py
@@ -29,18 +29,18 @@ class TrainerCallbackHookMixin(ABC):
     callbacks: List[Callback] = []
     lightning_module: LightningModule
 
-    def on_before_accelerator_backend_setup(self, model):
-        """Called in the beginning of fit and test"""
+    def on_before_accelerator_backend_setup(self, model: LightningModule) -> None:
+        """Called at the beginning of fit (train + validate), validate, test, or predict, or tune."""
         for callback in self.callbacks:
             callback.on_before_accelerator_backend_setup(self, model)
 
-    def setup(self, model, stage: str):
-        """Called in the beginning of fit and test"""
+    def setup(self, model: LightningModule, stage: str) -> None:
+        """Called at the beginning of fit (train + validate), validate, test, or predict, or tune."""
         for callback in self.callbacks:
             callback.setup(self, model, stage)
 
-    def teardown(self, stage: str):
-        """Called at the end of fit and test"""
+    def teardown(self, stage: str) -> None:
+        """Called at the beginning of fit (train + validate), validate, test, or predict, or tune."""
         for callback in self.callbacks:
             callback.teardown(self, self.lightning_module, stage)
 
@@ -124,15 +124,15 @@ class TrainerCallbackHookMixin(ABC):
         for callback in self.callbacks:
             callback.on_train_end(self, self.lightning_module)
 
-    def on_pretrain_routine_start(self, model):
-        """Called when the train begins."""
+    def on_pretrain_routine_start(self) -> None:
+        """Called when the pre-train routine begins."""
         for callback in self.callbacks:
-            callback.on_pretrain_routine_start(self, model)
+            callback.on_pretrain_routine_start(self, self.lightning_module)
 
-    def on_pretrain_routine_end(self, model):
-        """Called when the train ends."""
+    def on_pretrain_routine_end(self) -> None:
+        """Called when the pre-train routine ends."""
         for callback in self.callbacks:
-            callback.on_pretrain_routine_end(self, model)
+            callback.on_pretrain_routine_end(self, self.lightning_module)
 
     def on_batch_start(self):
         """Called when the training batch begins."""

--- a/pytorch_lightning/trainer/callback_hook.py
+++ b/pytorch_lightning/trainer/callback_hook.py
@@ -15,7 +15,7 @@
 from abc import ABC
 from copy import deepcopy
 from inspect import signature
-from typing import Any, Callable, Dict, List, Type
+from typing import Any, Callable, Dict, List, Type, Optional
 
 from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.core.lightning import LightningModule
@@ -34,12 +34,12 @@ class TrainerCallbackHookMixin(ABC):
         for callback in self.callbacks:
             callback.on_before_accelerator_backend_setup(self, model)
 
-    def setup(self, model: LightningModule, stage: str) -> None:
+    def setup(self, model: LightningModule, stage: Optional[str]) -> None:
         """Called at the beginning of fit (train + validate), validate, test, or predict, or tune."""
         for callback in self.callbacks:
             callback.setup(self, model, stage)
 
-    def teardown(self, stage: str) -> None:
+    def teardown(self, stage: Optional[str] = None) -> None:
         """Called at the beginning of fit (train + validate), validate, test, or predict, or tune."""
         for callback in self.callbacks:
             callback.teardown(self, self.lightning_module, stage)

--- a/pytorch_lightning/trainer/callback_hook.py
+++ b/pytorch_lightning/trainer/callback_hook.py
@@ -40,7 +40,7 @@ class TrainerCallbackHookMixin(ABC):
             callback.setup(self, model, stage)
 
     def teardown(self, stage: Optional[str] = None) -> None:
-        """Called at the beginning of fit (train + validate), validate, test, or predict, or tune."""
+        """Called at the end of fit (train + validate), validate, test, or predict, or tune."""
         for callback in self.callbacks:
             callback.teardown(self, self.lightning_module, stage)
 

--- a/pytorch_lightning/trainer/model_hooks.py
+++ b/pytorch_lightning/trainer/model_hooks.py
@@ -22,12 +22,6 @@ class TrainerModelHooksMixin(ABC):
 
     lightning_module: LightningModule
 
-    def is_function_implemented(self, f_name, model=None):
-        if model is None:
-            model = self.lightning_module
-        f_op = getattr(model, f_name, None)
-        return callable(f_op)
-
     def has_arg(self, f_name, arg_name):
         model = self.lightning_module
         f_op = getattr(model, f_name, None)

--- a/pytorch_lightning/trainer/model_hooks.py
+++ b/pytorch_lightning/trainer/model_hooks.py
@@ -14,6 +14,7 @@
 
 import inspect
 from abc import ABC
+from typing import Optional
 
 from pytorch_lightning.core.lightning import LightningModule
 
@@ -22,7 +23,14 @@ class TrainerModelHooksMixin(ABC):
 
     lightning_module: LightningModule
 
-    def has_arg(self, f_name, arg_name):
+    def is_function_implemented(self, f_name: str, model: Optional[LightningModule] = None) -> bool:
+        # note: currently unused - kept as it is public
+        if model is None:
+            model = self.lightning_module
+        f_op = getattr(model, f_name, None)
+        return callable(f_op)
+
+    def has_arg(self, f_name: str, arg_name: str) -> bool:
         model = self.lightning_module
         f_op = getattr(model, f_name, None)
         return arg_name in inspect.signature(f_op).parameters

--- a/pytorch_lightning/trainer/states.py
+++ b/pytorch_lightning/trainer/states.py
@@ -21,10 +21,10 @@ class TrainerState(LightningEnum):
     functions such as `trainer.fit()` and `trainer.test().
 
     >>> # you can compare the type with a string
-    >>> TrainerState.FITTING == 'FITTING'
+    >>> TrainerState.FITTING == 'fit'
     True
     >>> # which is case insensitive
-    >>> TrainerState.FINISHED == 'finished'
+    >>> TrainerState.FINISHED == 'FINISHED'
     True
     """
     INITIALIZING = 'initializing'  # trainer creation

--- a/pytorch_lightning/trainer/states.py
+++ b/pytorch_lightning/trainer/states.py
@@ -27,14 +27,14 @@ class TrainerState(LightningEnum):
     >>> TrainerState.FINISHED == 'finished'
     True
     """
-    INITIALIZING = 'INITIALIZING'  # trainer creation
-    FITTING = 'FITTING'  # trainer.fit()
-    VALIDATING = 'VALIDATING'  # trainer.validate()
-    TESTING = 'TESTING'  # trainer.test()
-    PREDICTING = 'PREDICTING'  # trainer.predict()
-    TUNING = 'TUNING'  # trainer.tune()
-    FINISHED = 'FINISHED'
-    INTERRUPTED = 'INTERRUPTED'
+    INITIALIZING = 'initializing'  # trainer creation
+    FITTING = 'fit'  # trainer.fit()
+    VALIDATING = 'validate'  # trainer.validate()
+    TESTING = 'test'  # trainer.test()
+    PREDICTING = 'predict'  # trainer.predict()
+    TUNING = 'tune'  # trainer.tune()
+    FINISHED = 'finished'
+    INTERRUPTED = 'interrupted'
 
     @property
     def stopped(self) -> bool:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1031,18 +1031,20 @@ class Trainer(
         if self.datamodule is not None:
             called = getattr(self.datamodule, f'has_setup_{state}')
             if not called:
-                self.datamodule.setup(state)
+                self.datamodule.setup(stage=state)
 
-        self.setup(model, state)
-        model.setup(state)
+        self.setup(model, stage=state)
+        model.setup(stage=state)
 
     def call_teardown_hook(self, model: LightningModule) -> None:
-        assert self.state.running, f"TrainerState: {self.state}"
-        state = TrainerState.FITTING if self.state == TrainerState.TUNING else self.state
-        state = state.value
+        if self.state.running:
+            state = TrainerState.FITTING if self.state == TrainerState.TUNING else self.state
+            state = state.value
+        else:
+            state = None
 
-        self.teardown(state)
-        model.teardown(state)
+        self.teardown(stage=state)
+        model.teardown(stage=state)
 
     def _reset_result_and_set_hook_fx_name(self, hook_name):
         # on_before_zero_grad is called within training_step

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1025,8 +1025,8 @@ class Trainer(
 
     def call_setup_hook(self, model: LightningModule) -> None:
         assert self.state.running, f"TrainerState: {self.state}"
+        # 'fit' is passed for `trainer.tune()` as there aren't "tune_dataloaders"
         state = TrainerState.FITTING if self.state == TrainerState.TUNING else self.state
-        state = state.value
 
         if self.datamodule is not None:
             called = getattr(self.datamodule, f'has_setup_{state}')
@@ -1039,7 +1039,6 @@ class Trainer(
     def call_teardown_hook(self, model: LightningModule) -> None:
         if self.state.running:
             state = TrainerState.FITTING if self.state == TrainerState.TUNING else self.state
-            state = state.value
         else:
             state = None
 

--- a/tests/callbacks/test_callbacks.py
+++ b/tests/callbacks/test_callbacks.py
@@ -19,28 +19,19 @@ from tests.helpers import BoringModel
 
 
 @mock.patch("torch.save")  # need to mock torch.save or we get pickle error
-def test_trainer_callback_system(_, tmpdir):
-    """Test the callback system."""
+def test_trainer_callback_system_fit(_, tmpdir):
+    """Test the callback system for fit."""
 
     model = BoringModel()
-
     callback_mock = MagicMock()
-
-    trainer_options = dict(
+    trainer = Trainer(
         default_root_dir=tmpdir,
         callbacks=[callback_mock],
         max_epochs=1,
         limit_val_batches=1,
         limit_train_batches=3,
-        limit_test_batches=2,
         progress_bar_refresh_rate=0,
     )
-
-    # no call yet
-    callback_mock.assert_not_called()
-
-    # fit model
-    trainer = Trainer(**trainer_options)
 
     # check that only the to calls exists
     assert trainer.callbacks[0] == callback_mock
@@ -49,6 +40,7 @@ def test_trainer_callback_system(_, tmpdir):
         call.on_init_end(trainer),
     ]
 
+    # fit model
     trainer.fit(model)
 
     assert callback_mock.method_calls == [
@@ -104,8 +96,20 @@ def test_trainer_callback_system(_, tmpdir):
         call.teardown(trainer, model, 'fit'),
     ]
 
-    callback_mock.reset_mock()
-    trainer = Trainer(**trainer_options)
+
+def test_trainer_callback_system_test(tmpdir):
+    """Test the callback system for test."""
+
+    model = BoringModel()
+    callback_mock = MagicMock()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        callbacks=[callback_mock],
+        max_epochs=1,
+        limit_test_batches=2,
+        progress_bar_refresh_rate=0,
+    )
+
     trainer.test(model)
 
     assert callback_mock.method_calls == [
@@ -113,7 +117,6 @@ def test_trainer_callback_system(_, tmpdir):
         call.on_init_end(trainer),
         call.setup(trainer, model, 'test'),
         call.on_before_accelerator_backend_setup(trainer, model),
-        call.on_fit_start(trainer, model),
         call.on_test_start(trainer, model),
         call.on_test_epoch_start(trainer, model),
         call.on_test_batch_start(trainer, model, ANY, 0, 0),
@@ -123,8 +126,6 @@ def test_trainer_callback_system(_, tmpdir):
         call.on_test_epoch_end(trainer, model),
         call.on_epoch_end(trainer, model),
         call.on_test_end(trainer, model),
-        call.on_fit_end(trainer, model),
-        call.teardown(trainer, model, 'fit'),
         call.teardown(trainer, model, 'test'),
     ]
 

--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -131,17 +131,17 @@ def test_data_hooks_called(tmpdir):
     assert not dm.has_setup_predict
 
     dm.prepare_data()
-    assert dm.has_prepared_data 
+    assert dm.has_prepared_data
     assert not dm.has_setup_fit
     assert not dm.has_setup_test
     assert not dm.has_setup_validate
     assert not dm.has_setup_predict
 
     dm.setup()
-    assert dm.has_prepared_data 
-    assert dm.has_setup_fit 
-    assert dm.has_setup_test 
-    assert dm.has_setup_validate 
+    assert dm.has_prepared_data
+    assert dm.has_setup_fit
+    assert dm.has_setup_test
+    assert dm.has_setup_validate
     assert not dm.has_setup_predict
 
 
@@ -153,21 +153,21 @@ def test_data_hooks_called_verbose(tmpdir, use_kwarg):
     assert not dm.has_setup_test
 
     dm.prepare_data()
-    assert dm.has_prepared_data 
+    assert dm.has_prepared_data
     assert not dm.has_setup_fit
     assert not dm.has_setup_test
     assert not dm.has_setup_predict
 
     dm.setup(stage='fit') if use_kwarg else dm.setup('fit')
     assert dm.has_prepared_data
-    assert dm.has_setup_fit 
+    assert dm.has_setup_fit
     assert not dm.has_setup_validate
     assert not dm.has_setup_test
     assert not dm.has_setup_predict
 
     dm.setup(stage='validate') if use_kwarg else dm.setup('validate')
-    assert dm.has_prepared_data 
-    assert dm.has_setup_fit 
+    assert dm.has_prepared_data
+    assert dm.has_setup_fit
     assert dm.has_setup_validate
     assert not dm.has_setup_test
     assert not dm.has_setup_predict
@@ -180,11 +180,11 @@ def test_data_hooks_called_verbose(tmpdir, use_kwarg):
     assert not dm.has_setup_predict
 
     dm.setup(stage='predict') if use_kwarg else dm.setup('predict')
-    assert dm.has_prepared_data 
-    assert dm.has_setup_fit 
-    assert dm.has_setup_validate 
-    assert dm.has_setup_test 
-    assert dm.has_setup_predict 
+    assert dm.has_prepared_data
+    assert dm.has_setup_fit
+    assert dm.has_setup_validate
+    assert dm.has_setup_test
+    assert dm.has_setup_predict
 
 
 def test_dm_add_argparse_args(tmpdir):

--- a/tests/helpers/boring_model.py
+++ b/tests/helpers/boring_model.py
@@ -151,8 +151,10 @@ class BoringDataModule(LightningDataModule):
     def setup(self, stage: Optional[str] = None):
         if stage == "fit" or stage is None:
             self.random_train = Subset(self.random_full, indices=range(64))
-            self.random_val = Subset(self.random_full, indices=range(64, 128))
             self.dims = self.random_train[0].shape
+
+        if stage in ("fit", "validate") or stage is None:
+            self.random_val = Subset(self.random_full, indices=range(64, 128))
 
         if stage == "test" or stage is None:
             self.random_test = Subset(self.random_full, indices=range(128, 192))

--- a/tests/models/test_hooks.py
+++ b/tests/models/test_hooks.py
@@ -404,7 +404,7 @@ def test_trainer_model_hook_system(tmpdir):
             self.called.append(inspect.currentframe().f_code.co_name)
             super().on_test_end()
 
-        def teardown(self, stage: str):
+        def teardown(self, stage=None):
             self.called.append(inspect.currentframe().f_code.co_name)
             super().teardown(stage)
 
@@ -420,12 +420,12 @@ def test_trainer_model_hook_system(tmpdir):
         limit_train_batches=2,
         limit_test_batches=1,
         progress_bar_refresh_rate=0,
+        weights_summary=None,
     )
 
     assert model.called == []
 
     trainer.fit(model)
-
     expected = [
         'on_fit_start',
         'on_pretrain_routine_start',
@@ -469,11 +469,10 @@ def test_trainer_model_hook_system(tmpdir):
 
     assert model.called == expected
 
-    model2 = HookedModel()
-    trainer.test(model2)
+    model = HookedModel()
 
+    trainer.test(model, verbose=False)
     expected = [
-        'on_fit_start',
         'on_test_model_eval',
         'on_test_start',
         'on_test_epoch_start',
@@ -483,9 +482,6 @@ def test_trainer_model_hook_system(tmpdir):
         'on_epoch_end',
         'on_test_end',
         'on_test_model_train',
-        'on_fit_end',
-        'teardown',  # for 'fit'
-        'teardown',  # for 'test'
+        'teardown',
     ]
-
-    assert model2.called == expected
+    assert model.called == expected


### PR DESCRIPTION
## What does this PR do?

- Pass `{'fit','validate','test','predict'}` to `setup(stage=...)` and `teardown(stage=...)`
- Refactor teardown logic
- Fix `.on_fit_{start,end}()` getting called during `trainer.test`
- Fix `.teardown(stage='fit')` getting called during `trainer.test`
- Annotate `stage` argument for `.setup()` and `.teardown()` as `Optional`
- If the `Trainer` is interrupted, `.teardown(stage=None)` will be called

Fixes #5658, fixes #6376

Last step before `trainer.validate()` #4948 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified