### PR TITLE
Enhance `val_check_interval` for multiple epochs & larger than num of the training batches

### DIFF
--- a/pytorch_lightning/trainer/connectors/data_connector.py
+++ b/pytorch_lightning/trainer/connectors/data_connector.py
@@ -17,6 +17,7 @@ from typing import List, Optional, Union
 from torch.utils.data import DataLoader
 
 from pytorch_lightning.core.datamodule import LightningDataModule
+from pytorch_lightning.utilities import rank_zero_warn
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.model_helpers import is_overridden
 
@@ -27,9 +28,15 @@ class DataConnector(object):
         self.trainer = trainer
 
     def on_trainer_init(self, check_val_every_n_epoch, reload_dataloaders_every_epoch, prepare_data_per_node):
+        CHECK_VAL_EVERY_N_EPOCH_DEFAULT = 1
         self.trainer.datamodule = None
         self.trainer.prepare_data_per_node = prepare_data_per_node
 
+        if check_val_every_n_epoch != CHECK_VAL_EVERY_N_EPOCH_DEFAULT:
+            rank_zero_warn(
+                "`check_val_every_n_epoch` was deprecated in v1.3.0."
+                " It will be removed in v1.5.0", DeprecationWarning
+            )
         self.trainer.check_val_every_n_epoch = check_val_every_n_epoch
         self.trainer.reload_dataloaders_every_epoch = reload_dataloaders_every_epoch
         self.trainer._is_data_prepared = False

--- a/pytorch_lightning/trainer/connectors/debugging_connector.py
+++ b/pytorch_lightning/trainer/connectors/debugging_connector.py
@@ -74,8 +74,8 @@ class DebuggingConnector:
         self.trainer.limit_val_batches = _determine_batch_limits(limit_val_batches, 'limit_val_batches')
         self.trainer.limit_test_batches = _determine_batch_limits(limit_test_batches, 'limit_test_batches')
         self.trainer.limit_predict_batches = _determine_batch_limits(limit_predict_batches, 'limit_predict_batches')
-        self.trainer.val_check_interval = _determine_batch_limits(val_check_interval, 'val_check_interval')
         self.trainer.overfit_batches = _determine_batch_limits(overfit_batches, 'overfit_batches')
+        self.trainer.val_check_interval = _determine_val_check_interval_limits(val_check_interval)
         self.determine_data_use_amount(self.trainer.overfit_batches)
 
     def determine_data_use_amount(self, overfit_batches: float) -> None:
@@ -95,3 +95,12 @@ def _determine_batch_limits(batches: Union[int, float], name: str) -> Union[int,
         raise MisconfigurationException(
             f'You have passed invalid value {batches} for {name}, it has to be in [0.0, 1.0] or an int.'
         )
+
+
+def _determine_val_check_interval_limits(value: Union[int, float]) -> Union[int, float]:
+    if isinstance(value, (int, float)) and value >= 0:
+        return value
+    raise MisconfigurationException(
+        f"You have passed invalid value {value} for val_check_interval,"
+        " it has to be greater than 0 and an integer or float."
+    )

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -30,6 +30,9 @@ from pytorch_lightning.utilities.data import has_iterable_dataset, has_len
 from pytorch_lightning.utilities.debugging import InternalDebugger
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.model_helpers import is_overridden
+from pytorch_lightning.utilities.warnings import WarningCache
+
+warning_cache = WarningCache()
 
 
 class TrainerDataLoadingMixin(ABC):
@@ -234,16 +237,12 @@ class TrainerDataLoadingMixin(ABC):
                 ' `num_training_batches` to use.'
             )
 
-        # determine when to check validation
-        # if int passed in, val checks that often
-        # otherwise, it checks in [0, 1.0] % range of a training epoch
         if isinstance(self.val_check_interval, int):
             self.val_check_batch = self.val_check_interval
             if self.val_check_batch > self.num_training_batches:
-                raise ValueError(
-                    f'`val_check_interval` ({self.val_check_interval}) must be less than or equal '
-                    f'to the number of the training batches ({self.num_training_batches}). '
-                    'If you want to disable validation set `limit_val_batches` to 0.0 instead.'
+                warning_cache.warn(
+                    f'`val_check_interval` ({self.val_check_interval}) is greater than '
+                    f'the number of the training batches ({self.num_training_batches}).'
                 )
         else:
             if not has_len(self.train_dataloader):

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -822,7 +822,7 @@ class TrainLoop:
 
     def should_check_val_fx(self, batch_idx, is_last_batch, on_epoch=False):
         # decide if we should run validation
-        is_val_check_batch = (batch_idx + 1) % self.trainer.val_check_batch == 0
+        is_val_check_batch = (self.trainer.global_step + 1) % self.trainer.val_check_batch == 0
         is_val_check_epoch = (self.trainer.current_epoch + 1) % self.trainer.check_val_every_n_epoch == 0
         can_check_val = self.trainer.enable_validation and is_val_check_epoch
         is_last_batch_for_infinite_dataset = is_last_batch and self.trainer.val_check_batch == float("inf")
@@ -832,7 +832,7 @@ class TrainLoop:
                             or is_last_batch_for_infinite_dataset
                             ) if on_epoch else (is_val_check_batch and not epoch_end_val_check)
 
-        return should_check_val and can_check_val
+        return should_check_val and can_check_val if self.trainer.val_check_batch <= self.trainer.num_training_batches else should_check_val
 
     def build_train_args(self, batch, batch_idx, opt_idx, hiddens):
         # enable not needing to add opt_idx to training_step

--- a/tests/deprecated_api/test_remove_1-5.py
+++ b/tests/deprecated_api/test_remove_1-5.py
@@ -104,3 +104,12 @@ def test_old_training_step_signature_with_opt_idx_manual_opt(tmpdir):
 
     with pytest.deprecated_call(match="`training_step` .* `optimizer_idx` .* manual .* will be removed in v1.5"):
         trainer.fit(model)
+
+
+def test_v1_5_0_check_val_every_n_epoch(tmpdir):
+
+    with pytest.deprecated_call(match="It will be removed in v1.5.0"):
+        Trainer(
+            default_root_dir=tmpdir,
+            check_val_every_n_epoch=3,
+        )

--- a/tests/trainer/flags/test_val_check_interval.py
+++ b/tests/trainer/flags/test_val_check_interval.py
@@ -17,26 +17,28 @@ from pytorch_lightning.trainer import Trainer
 from tests.helpers import BoringModel
 
 
+class TestModel(BoringModel):
+
+    def __init__(self):
+        super().__init__()
+        self.train_epoch_calls = 0
+        self.val_epoch_calls = 0
+
+    def on_train_epoch_start(self) -> None:
+        self.train_epoch_calls += 1
+
+    def on_validation_epoch_start(self) -> None:
+        if not self.trainer.sanity_checking:
+            self.val_epoch_calls += 1
+
+
 @pytest.mark.parametrize('max_epochs', [1, 2, 3])
 @pytest.mark.parametrize('denominator', [1, 3, 4])
 def test_val_check_interval(tmpdir, max_epochs, denominator):
 
-    class TestModel(BoringModel):
-
-        def __init__(self):
-            super().__init__()
-            self.train_epoch_calls = 0
-            self.val_epoch_calls = 0
-
-        def on_train_epoch_start(self) -> None:
-            self.train_epoch_calls += 1
-
-        def on_validation_epoch_start(self) -> None:
-            if not self.trainer.sanity_checking:
-                self.val_epoch_calls += 1
-
     model = TestModel()
     trainer = Trainer(
+        default_root_dir=tmpdir,
         max_epochs=max_epochs,
         val_check_interval=1 / denominator,
         logger=False,
@@ -45,3 +47,22 @@ def test_val_check_interval(tmpdir, max_epochs, denominator):
 
     assert model.train_epoch_calls == max_epochs
     assert model.val_epoch_calls == max_epochs * denominator
+
+
+@pytest.mark.parametrize('steps', [10, 100, 150])
+def test_val_check_interval_steps(tmpdir, steps):
+
+    max_epochs = 4
+    model = TestModel()
+    train_data_length = len(model.train_dataloader())
+
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=max_epochs,
+        val_check_interval=steps,
+        logger=False,
+    )
+    trainer.fit(model)
+
+    assert model.train_epoch_calls == max_epochs
+    assert model.val_epoch_calls == max_epochs * train_data_length // steps

--- a/tests/trainer/flags/test_val_check_interval.py
+++ b/tests/trainer/flags/test_val_check_interval.py
@@ -66,3 +66,22 @@ def test_val_check_interval_steps(tmpdir, steps):
 
     assert model.train_epoch_calls == max_epochs
     assert model.val_epoch_calls == max_epochs * train_data_length // steps
+
+
+@pytest.mark.parametrize('epochs', [0.5, 1.5, 2.4])
+def test_val_check_interval_epochs(tmpdir, epochs):
+
+    max_epochs = 4
+    model = TestModel()
+    train_data_length = len(model.train_dataloader())
+
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=max_epochs,
+        val_check_interval=epochs,
+        logger=False,
+    )
+    trainer.fit(model)
+
+    assert model.train_epoch_calls == max_epochs
+    assert model.val_epoch_calls == max_epochs // epochs


### PR DESCRIPTION
## What does this PR do?

This PR does the following:
- Enhance val_check_interval to check for multiple epochs `val_check_interval=2.0`
- Allow val_check_interval to be larger than num of the training batches #5413
- Deprecate `check_val_every_n_epoch` for v1.5 #4409 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
