### PR TITLE
fix comparing versions

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -98,7 +98,7 @@ jobs:
           # First run the same pipeline as Read-The-Docs
           cd docs
           make clean
-          make html --debug --jobs $(nproc) SPHINXOPTS="-W"
+          make html --debug --jobs $(nproc) SPHINXOPTS="-W --keep-going"
 
       - name: Upload built docs
         uses: actions/upload-artifact@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed torch distributed not available in setup hook for DDP ([#6506](https://github.com/PyTorchLightning/pytorch-lightning/pull/6506))
 
 
+- Fixed comparing required versions ([#6434](https://github.com/PyTorchLightning/pytorch-lightning/pull/6434))
+
+
 ## [1.2.4] - 2021-03-16
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,4 @@ test: clean
 
 docs: clean
 	pip install --quiet -r requirements/docs.txt
-	python -m sphinx -b html -W docs/source docs/build
+	python -m sphinx -b html -W --keep-going docs/source docs/build

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -334,6 +334,7 @@ PACKAGE_MAPPING = {
 }
 MOCK_PACKAGES = []
 if SPHINX_MOCK_REQUIREMENTS:
+    MOCK_PACKAGES += ['fairscale']
     # mock also base packages when we are on RTD since we don't install them there
     MOCK_PACKAGES += package_list_from_file(os.path.join(PATH_ROOT, 'requirements.txt'))
     MOCK_PACKAGES += package_list_from_file(os.path.join(PATH_ROOT, 'requirements', 'extra.txt'))

--- a/pl_examples/__init__.py
+++ b/pl_examples/__init__.py
@@ -18,7 +18,7 @@ _TORCHVISION_AVAILABLE = _module_available("torchvision")
 _TORCHVISION_MNIST_AVAILABLE = not bool(os.environ.get("PL_USE_MOCKED_MNIST", False))
 _DALI_AVAILABLE = _module_available("nvidia.dali")
 
-if _TORCHVISION_AVAILABLE:
+if _TORCHVISION_MNIST_AVAILABLE:
     try:
         from torchvision.datasets.mnist import MNIST
         MNIST(_DATASETS_PATH, download=True)

--- a/pl_examples/__init__.py
+++ b/pl_examples/__init__.py
@@ -18,7 +18,7 @@ _TORCHVISION_AVAILABLE = _module_available("torchvision")
 _TORCHVISION_MNIST_AVAILABLE = not bool(os.environ.get("PL_USE_MOCKED_MNIST", False))
 _DALI_AVAILABLE = _module_available("nvidia.dali")
 
-if _TORCHVISION_MNIST_AVAILABLE:
+if _TORCHVISION_AVAILABLE:
     try:
         from torchvision.datasets.mnist import MNIST
         MNIST(_DATASETS_PATH, download=True)

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """General utilities"""
+import importlib
 import operator
 import platform
 import sys
@@ -42,8 +43,15 @@ def _module_available(module_path: str) -> bool:
 
 
 def _compare_version(package: str, op, version) -> bool:
+    """Compare package version with some requirements
+
+    >>> _compare_version("torch", operator.ge, "0.1")
+    True
+    """
     try:
-        pkg_version = LooseVersion(get_distribution(package).version)
+        pkg = importlib.import_module(package)
+        assert hasattr(pkg, '__version__')
+        pkg_version = pkg.__version__
         return op(pkg_version, LooseVersion(version))
     except DistributionNotFound:
         return False

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -48,6 +48,8 @@ def _compare_version(package: str, op, version) -> bool:
     >>> _compare_version("torch", operator.ge, "0.1")
     True
     """
+    if not _module_available(package):
+        return False
     try:
         pkg = importlib.import_module(package)
         assert hasattr(pkg, '__version__')

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -20,7 +20,7 @@ from distutils.version import LooseVersion
 from importlib.util import find_spec
 
 import torch
-from pkg_resources import DistributionNotFound, get_distribution
+from pkg_resources import DistributionNotFound
 
 
 def _module_available(module_path: str) -> bool:

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -43,7 +43,8 @@ def _module_available(module_path: str) -> bool:
 
 
 def _compare_version(package: str, op, version) -> bool:
-    """Compare package version with some requirements
+    """
+    Compare package version with some requirements
 
     >>> _compare_version("torch", operator.ge, "0.1")
     True

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -57,7 +57,7 @@ def _compare_version(package: str, op, version) -> bool:
         pkg_version = LooseVersion(pkg.__version__)
     except AttributeError:
         return False
-    if str(pkg_version).endswith("__version__"):
+    if pkg.__version__.endswith("__version__"):
         # this is mock by sphinx, so it shall return True ro generate all summaries
         return True
     return op(pkg_version, LooseVersion(version))

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -14,6 +14,7 @@
 """General utilities"""
 import importlib
 import operator
+import os
 import platform
 import sys
 from distutils.version import LooseVersion
@@ -21,6 +22,9 @@ from importlib.util import find_spec
 
 import torch
 from pkg_resources import DistributionNotFound
+
+
+SPHINX_MOCK_REQUIREMENTS = int(os.environ.get('SPHINX_MOCK_REQUIREMENTS', 0))
 
 
 def _module_available(module_path: str) -> bool:
@@ -32,6 +36,8 @@ def _module_available(module_path: str) -> bool:
     >>> _module_available('bla.bla')
     False
     """
+    if SPHINX_MOCK_REQUIREMENTS:
+        return True
     try:
         return find_spec(module_path) is not None
     except AttributeError:
@@ -49,6 +55,8 @@ def _compare_version(package: str, op, version) -> bool:
     >>> _compare_version("torch", operator.ge, "0.1")
     True
     """
+    if SPHINX_MOCK_REQUIREMENTS:
+        return True
     if not _module_available(package):
         return False
     try:

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -51,7 +51,7 @@ def _compare_version(package: str, op, version) -> bool:
     """
     try:
         pkg = importlib.import_module(package)
-    except DistributionNotFound:
+    except (ModuleNotFoundError, DistributionNotFound):
         return False
     try:
         pkg_version = LooseVersion(pkg.__version__)

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -53,11 +53,12 @@ def _compare_version(package: str, op, version) -> bool:
         return False
     try:
         pkg = importlib.import_module(package)
-        assert hasattr(pkg, '__version__')
-        pkg_version = pkg.__version__
-        return op(LooseVersion(pkg_version), LooseVersion(version))
     except DistributionNotFound:
         return False
+    if not hasattr(pkg, '__version__'):
+        # in case version is not defined always return True as likely it is mocked call
+        return True
+    return op(LooseVersion(pkg.__version__), LooseVersion(version))
 
 
 _IS_WINDOWS = platform.system() == "Windows"

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -55,7 +55,7 @@ def _compare_version(package: str, op, version) -> bool:
         pkg = importlib.import_module(package)
         assert hasattr(pkg, '__version__')
         pkg_version = pkg.__version__
-        return op(pkg_version, LooseVersion(version))
+        return op(LooseVersion(pkg_version), LooseVersion(version))
     except DistributionNotFound:
         return False
 

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -36,8 +36,6 @@ def _module_available(module_path: str) -> bool:
     >>> _module_available('bla.bla')
     False
     """
-    if SPHINX_MOCK_REQUIREMENTS:
-        return True
     try:
         return find_spec(module_path) is not None
     except AttributeError:

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -57,7 +57,7 @@ def _compare_version(package: str, op, version) -> bool:
         pkg_version = LooseVersion(pkg.__version__)
     except AttributeError:
         return False
-    if pkg.__version__.endswith("__version__"):
+    if not (hasattr(pkg_version, "vstring") and hasattr(pkg_version, "version")):
         # this is mock by sphinx, so it shall return True ro generate all summaries
         return True
     return op(pkg_version, LooseVersion(version))

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -56,8 +56,7 @@ def _compare_version(package: str, op, version) -> bool:
     try:
         pkg_version = LooseVersion(pkg.__version__)
     except AttributeError:
-        # in case version is not defined always return True as likely it is mocked call
-        return True
+        return False
     if str(pkg_version).endswith("__version__"):
         # this is mock by sphinx, so it shall return True ro generate all summaries
         return True

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -61,10 +61,12 @@ def _compare_version(package: str, op, version) -> bool:
         pkg = importlib.import_module(package)
     except DistributionNotFound:
         return False
-    if not hasattr(pkg, '__version__'):
+    try:
+        pkg_version = LooseVersion(pkg.__version__)
+    except (AttributeError, ):
         # in case version is not defined always return True as likely it is mocked call
         return True
-    return op(LooseVersion(pkg.__version__), LooseVersion(version))
+    return op(pkg_version, LooseVersion(version))
 
 
 _IS_WINDOWS = platform.system() == "Windows"

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -58,7 +58,7 @@ def _compare_version(package: str, op, version) -> bool:
     except AttributeError:
         # in case version is not defined always return True as likely it is mocked call
         return True
-    if pkg_version.endswith("__version__"):
+    if str(pkg_version).endswith("__version__"):
         # this is mock by sphinx, so it shall return True ro generate all summaries
         return True
     return op(pkg_version, LooseVersion(version))

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -7,4 +7,5 @@ torchtext>=0.5
 # onnx>=1.7.0
 onnxruntime>=1.3.0
 hydra-core>=1.0
+# todo: when user standard package stream, drop `fairscale` from hard mocked docs libs
 https://github.com/PyTorchLightning/fairscale/archive/pl_1.2.0.zip

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -7,5 +7,5 @@ torchtext>=0.5
 # onnx>=1.7.0
 onnxruntime>=1.3.0
 hydra-core>=1.0
-# todo: when user standard package stream, drop `fairscale` from hard mocked docs libs
+# todo: when switch to standard package stream, drop `fairscale` from hard mocked docs libs
 https://github.com/PyTorchLightning/fairscale/archive/pl_1.2.0.zip


### PR DESCRIPTION
## What does this PR do?

here is some late update between importing pkg and getting pkg version, so Colab kernel needs to be restarted which is not very intuitive, this uses always the `package.__version__`

See in your Colab:
```
!pip install torchtext==0.6.0

print(torchtext.__version__)
# 0.6.0
from pkg_resources import get_distribution
print(get_distribution('torchtext').version)
# 0.9.0
```

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
