### PR TITLE
Add unconditional import when type checking

### DIFF
--- a/pytorch_lightning/__init__.py
+++ b/pytorch_lightning/__init__.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 import time
+import typing
 
 _this_year = time.strftime("%Y")
 __version__ = '1.3.0dev'
@@ -50,6 +51,7 @@ if not _root_logger.hasHandlers():
 _PACKAGE_ROOT = os.path.dirname(__file__)
 _PROJECT_ROOT = os.path.dirname(_PACKAGE_ROOT)
 
+
 try:
     # This variable is injected in the __builtins__ by the build
     # process. It used to enable importing subpackages of skimage when
@@ -58,10 +60,16 @@ try:
 except NameError:
     __LIGHTNING_SETUP__: bool = False
 
-if __LIGHTNING_SETUP__:  # pragma: no-cover
-    sys.stdout.write(f'Partial import of `{__name__}` during the build process.\n')  # pragma: no-cover
-    # We are not importing the rest of the lightning during the build process, as it may not be compiled yet
-else:
+
+if typing.TYPE_CHECKING:
+    # Simplify the imports for the static type checker.
+    from pytorch_lightning import metrics
+    from pytorch_lightning.callbacks import Callback
+    from pytorch_lightning.core import LightningDataModule, LightningModule
+    from pytorch_lightning.trainer import Trainer
+    from pytorch_lightning.utilities.seed import seed_everything
+
+elif not __LIGHTNING_SETUP__:  # pragma: no-cover
     from pytorch_lightning import metrics
     from pytorch_lightning.callbacks import Callback
     from pytorch_lightning.core import LightningDataModule, LightningModule
@@ -76,6 +84,10 @@ else:
         'seed_everything',
         'metrics',
     ]
+else:
+    sys.stdout.write(f'Partial import of `{__name__}` during the build process.\n')  # pragma: no-cover
+    # We are not importing the rest of the lightning during the build process, as it may not be compiled yet
+    
 
 # for compatibility with namespace packages
 __import__('pkg_resources').declare_namespace(__name__)

--- a/pytorch_lightning/__init__.py
+++ b/pytorch_lightning/__init__.py
@@ -7,12 +7,12 @@ import time
 import typing
 
 _this_year = time.strftime("%Y")
-__version__ = "1.3.0dev"
-__author__ = "William Falcon et al."
-__author_email__ = "waf2107@columbia.edu"
-__license__ = "Apache-2.0"
-__copyright__ = f"Copyright (c) 2018-{_this_year}, {__author__}."
-__homepage__ = "https://github.com/PyTorchLightning/pytorch-lightning"
+__version__ = '1.3.0dev'
+__author__ = 'William Falcon et al.'
+__author_email__ = 'waf2107@columbia.edu'
+__license__ = 'Apache-2.0'
+__copyright__ = f'Copyright (c) 2018-{_this_year}, {__author__}.'
+__homepage__ = 'https://github.com/PyTorchLightning/pytorch-lightning'
 # this has to be simple string, see: https://github.com/pypa/twine/issues/522
 __docs__ = (
     "PyTorch Lightning is the lightweight PyTorch wrapper for ML researchers."
@@ -77,19 +77,19 @@ elif not __LIGHTNING_SETUP__:  # pragma: no-cover
     from pytorch_lightning.utilities.seed import seed_everything
 
     __all__ = [
-        "Trainer",
-        "LightningDataModule",
-        "LightningModule",
-        "Callback",
-        "seed_everything",
-        "metrics",
+        'Trainer',
+        'LightningDataModule',
+        'LightningModule',
+        'Callback',
+        'seed_everything',
+        'metrics',
     ]
 else:
     sys.stdout.write(
-        f"Partial import of `{__name__}` during the build process.\n"
+        f'Partial import of `{__name__}` during the build process.\n'
     )  # pragma: no-cover
     # We are not importing the rest of the lightning during the build process, as it may not be compiled yet
 
 
 # for compatibility with namespace packages
-__import__("pkg_resources").declare_namespace(__name__)
+__import__('pkg_resources').declare_namespace(__name__)

--- a/pytorch_lightning/__init__.py
+++ b/pytorch_lightning/__init__.py
@@ -7,12 +7,12 @@ import time
 import typing
 
 _this_year = time.strftime("%Y")
-__version__ = '1.3.0dev'
-__author__ = 'William Falcon et al.'
-__author_email__ = 'waf2107@columbia.edu'
-__license__ = 'Apache-2.0'
-__copyright__ = f'Copyright (c) 2018-{_this_year}, {__author__}.'
-__homepage__ = 'https://github.com/PyTorchLightning/pytorch-lightning'
+__version__ = "1.3.0dev"
+__author__ = "William Falcon et al."
+__author_email__ = "waf2107@columbia.edu"
+__license__ = "Apache-2.0"
+__copyright__ = f"Copyright (c) 2018-{_this_year}, {__author__}."
+__homepage__ = "https://github.com/PyTorchLightning/pytorch-lightning"
 # this has to be simple string, see: https://github.com/pypa/twine/issues/522
 __docs__ = (
     "PyTorch Lightning is the lightweight PyTorch wrapper for ML researchers."
@@ -77,17 +77,19 @@ elif not __LIGHTNING_SETUP__:  # pragma: no-cover
     from pytorch_lightning.utilities.seed import seed_everything
 
     __all__ = [
-        'Trainer',
-        'LightningDataModule',
-        'LightningModule',
-        'Callback',
-        'seed_everything',
-        'metrics',
+        "Trainer",
+        "LightningDataModule",
+        "LightningModule",
+        "Callback",
+        "seed_everything",
+        "metrics",
     ]
 else:
-    sys.stdout.write(f'Partial import of `{__name__}` during the build process.\n')  # pragma: no-cover
+    sys.stdout.write(
+        f"Partial import of `{__name__}` during the build process.\n"
+    )  # pragma: no-cover
     # We are not importing the rest of the lightning during the build process, as it may not be compiled yet
-    
+
 
 # for compatibility with namespace packages
-__import__('pkg_resources').declare_namespace(__name__)
+__import__("pkg_resources").declare_namespace(__name__)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
Without this change, when type checking using `pyre` (and possibly as well using `mypy` though I've not verified this) imports such as:

```
from pytorch_lightning import Trainer
```
raise errors due to the fact that they're only conditionally imported at the module level.

A workaround is to change imports to the following:

```
from pytorch_lightning.trainer import Trainer
```

However, large chunks of our documentation do not reflect this pattern. As such, this small update to the logic in the `__init__.py` function  makes it so that when type checking (`typing.TYPE_CHECKING === True`) the imports are unconditional, fixing any warnings from the checkers.

This is okay since the only time the imports do not occur is when were' in the build-phase of the library.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
