### PR TITLE
[doc] Add Zero Grad `set_to_none=True` trick

### DIFF
--- a/docs/source/benchmarking/performance.rst
+++ b/docs/source/benchmarking/performance.rst
@@ -186,16 +186,14 @@ Most UNIX-based operating systems provide direct access to tmpfs through a mount
 Zero Grad ``set_to_none=True``
 ------------------------------
 
-In order to modestly improve performance, once can override :func:`~pytorch_lightning.core.lightning.LightningModule.optimizer_zero_grad`
+In order to modestly improve performance, once can override :meth:`~pytorch_lightning.core.lightning.LightningModule.optimizer_zero_grad`.
 
-For a more detailed explanation of pro / cons of this technique,
-read `this <https://pytorch.org/docs/master/optim.html#torch.optim.Optimizer.zero_grad>`__ documentation by the PyTorch team.
+For a more detailed explanation of pros / cons of this technique,
+read `this <https://pytorch.org/docs/master/optim.html#torch.optim.Optimizer.zero_grad>`_ documentation by the PyTorch team.
 
 .. testcode::
 
-    import pytorch_lightning as pl
-
-    class Model(pl.LightningModule)
+    class Model(LightningModule):
 
         def optimizer_zero_grad(self, epoch: int, batch_idx: int, optimizer: Optimizer, optimizer_idx: int):
             optimizer.zero_grad(set_to_none=True)

--- a/docs/source/benchmarking/performance.rst
+++ b/docs/source/benchmarking/performance.rst
@@ -186,7 +186,7 @@ Most UNIX-based operating systems provide direct access to tmpfs through a mount
 Zero Grad ``set_to_none=True``
 ------------------------------
 
-In order to modestly improve performance, once can override :func:`~pytorch_lightning.trainer.core.lightning.LightningModule.optimizer_zero_grad`.
+In order to modestly improve performance, once can override :func:`~pytorch_lightning.core.lightning.LightningModule.optimizer_zero_grad`
 
 For a more detailed explanation of pro / cons of this technique,
 read `this <https://pytorch.org/docs/master/optim.html#torch.optim.Optimizer.zero_grad>`__ documentation by the PyTorch team.

--- a/docs/source/benchmarking/performance.rst
+++ b/docs/source/benchmarking/performance.rst
@@ -181,3 +181,21 @@ Most UNIX-based operating systems provide direct access to tmpfs through a mount
     .. code-block:: python
 
         datamodule = MyDataModule(data_root="/dev/shm/my_data")
+
+
+Zero Grad ``set_to_none=True`
+-----------------------------
+
+In order to modestly improve performance, once can override :func:`~pytorch_lightning.trainer.core.lightning.LightningModule.optimizer_zero_grad`.
+
+For a more detailed explanation of pro / cons of this technique,
+read `this <https://pytorch.org/docs/master/optim.html#torch.optim.Optimizer.zero_grad>`__ documentation by the PyTorch team.
+
+.. testcode::
+
+    import pytorch_lightning as pl
+
+    class Model(pl.LightningModule)
+
+        def optimizer_zero_grad(self, epoch: int, batch_idx: int, optimizer: Optimizer, optimizer_idx: int):
+            optimizer.zero_grad(set_to_none=True)

--- a/docs/source/benchmarking/performance.rst
+++ b/docs/source/benchmarking/performance.rst
@@ -183,8 +183,8 @@ Most UNIX-based operating systems provide direct access to tmpfs through a mount
         datamodule = MyDataModule(data_root="/dev/shm/my_data")
 
 
-Zero Grad ``set_to_none=True`
------------------------------
+Zero Grad ``set_to_none=True``
+------------------------------
 
 In order to modestly improve performance, once can override :func:`~pytorch_lightning.trainer.core.lightning.LightningModule.optimizer_zero_grad`.
 

--- a/docs/source/benchmarking/performance.rst
+++ b/docs/source/benchmarking/performance.rst
@@ -195,5 +195,5 @@ read `this <https://pytorch.org/docs/master/optim.html#torch.optim.Optimizer.zer
 
     class Model(LightningModule):
 
-        def optimizer_zero_grad(self, epoch: int, batch_idx: int, optimizer: Optimizer, optimizer_idx: int):
+        def optimizer_zero_grad(self, epoch, batch_idx, optimizer, optimizer_idx):
             optimizer.zero_grad(set_to_none=True)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

This section add a description about set_to_none training trick.

Fixes  #6534

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
