### PR TITLE
[refactor] Add setup to profilers + _run_stage_setup to trainer 2/5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `teardown` method to `BaseProfiler` to enable subclasses defining post-profiling steps outside of `__del__` ([#6370](https://github.com/PyTorchLightning/pytorch-lightning/pull/6370))
 
 
+- Added `setup` method to `BaseProfiler` to enable subclasses defining pre-profiling steps for every process ([#6633](https://github.com/PyTorchLightning/pytorch-lightning/pull/6633))
+
+
 - Added no return warning to predict ([#6139](https://github.com/PyTorchLightning/pytorch-lightning/pull/6139))
 
 

--- a/pytorch_lightning/plugins/training_type/horovod.py
+++ b/pytorch_lightning/plugins/training_type/horovod.py
@@ -96,14 +96,14 @@ class HorovodPlugin(ParallelPlugin):
                 stack.enter_context(optimizer.skip_synchronize())
 
             # set up training routine
-            self._results = trainer.run_train()
+            self._results = trainer.run_stage()
 
         # Make sure all workers have finished training before returning to the user
         hvd.join()
 
     def start_evaluating(self, trainer):
         with ExitStack():
-            self._results = trainer.run_evaluate()
+            self._results = trainer.run_stage()
 
         # Make sure all workers have finished training before returning to the user
         hvd.join()
@@ -111,7 +111,7 @@ class HorovodPlugin(ParallelPlugin):
     def start_predicting(self, trainer):
         with ExitStack():
             # set up training routine
-            self._results = trainer.run_predict()
+            self._results = trainer.run_stage()
 
         # Make sure all workers have finished training before returning to the user
         hvd.join()

--- a/pytorch_lightning/plugins/training_type/training_type_plugin.py
+++ b/pytorch_lightning/plugins/training_type/training_type_plugin.py
@@ -132,15 +132,15 @@ class TrainingTypePlugin(Plugin, ABC):
 
     def start_training(self, trainer: 'Trainer') -> None:
         # double dispatch to initiate the training loop
-        self._results = trainer.run_train()
+        self._results = trainer.run_stage()
 
     def start_evaluating(self, trainer: 'Trainer') -> None:
         # double dispatch to initiate the test loop
-        self._results = trainer.run_evaluate()
+        self._results = trainer.run_stage()
 
     def start_predicting(self, trainer: 'Trainer') -> None:
         # double dispatch to initiate the predicting loop
-        self._results = trainer.run_predict()
+        self._results = trainer.run_stage()
 
     def training_step(self, *args, **kwargs):
         return self.lightning_module.training_step(*args, **kwargs)

--- a/pytorch_lightning/profiler/profilers.py
+++ b/pytorch_lightning/profiler/profilers.py
@@ -120,6 +120,7 @@ class PassThroughProfiler(BaseProfiler):
     """
 
     def __init__(self):
+        self.output_file = None
         super().__init__(output_streams=None)
 
     def start(self, action_name: str) -> None:

--- a/pytorch_lightning/profiler/profilers.py
+++ b/pytorch_lightning/profiler/profilers.py
@@ -61,13 +61,13 @@ class BaseProfiler(ABC):
         local_rank: Optional[int] = None,
         log_dir: Optional[str] = None
     ) -> None:
-        """Execute arbitrary post-profiling tear-down steps as defined by subclass."""
+        """Execute arbitrary pre-profiling set-up steps."""
         self.stage = stage
         self.local_rank = local_rank
         self.log_dir = log_dir
 
     def teardown(self, stage: Optional[str] = None) -> None:
-        """Execute arbitrary post-profiling tear-down steps as defined by subclass."""
+        """Execute arbitrary post-profiling tear-down steps."""
         self.stage = stage
         if self.output_file:
             self.output_file.close()

--- a/pytorch_lightning/profiler/profilers.py
+++ b/pytorch_lightning/profiler/profilers.py
@@ -55,7 +55,12 @@ class BaseProfiler(ABC):
     def stop(self, action_name: str) -> None:
         """Defines how to record the duration once an action is complete."""
 
-    def setup(self, stage: str, local_rank: Optional[int], log_dir: Optional[str]):
+    def setup(
+        self,
+        stage: Optional[str] = None,
+        local_rank: Optional[int] = None,
+        log_dir: Optional[str] = None
+    ) -> None:
         """Execute arbitrary post-profiling tear-down steps as defined by subclass."""
         self.stage = stage
         self.local_rank = local_rank
@@ -63,6 +68,7 @@ class BaseProfiler(ABC):
 
     def teardown(self, stage: Optional[str] = None) -> None:
         """Execute arbitrary post-profiling tear-down steps as defined by subclass."""
+        self.stage = stage
         if self.output_file:
             self.output_file.close()
             self.output_file = None

--- a/pytorch_lightning/profiler/pytorch.py
+++ b/pytorch_lightning/profiler/pytorch.py
@@ -162,11 +162,11 @@ class PyTorchProfiler(BaseProfiler):
         self.output_fname = output_filename
         self.output_file = None
         if local_rank is not None:
-            self.setup(None, local_rank, None)
+            self.setup(local_rank=local_rank)
             self.setup = super().setup
 
-    def setup(self, stage: str, local_rank: Optional[int], log_dir: Optional[str]):
-        super().setup(stage, local_rank, log_dir)
+    def setup(self, stage: Optional[str] = None, local_rank: Optional[int] = None, log_dir: Optional[str] = None):
+        super().setup(stage=stage, local_rank=local_rank, log_dir=log_dir)
 
         # when logging to `log.info`, only perform profiling on rank 0
         if local_rank != 0 and self.output_fname is None:

--- a/pytorch_lightning/profiler/pytorch.py
+++ b/pytorch_lightning/profiler/pytorch.py
@@ -162,11 +162,11 @@ class PyTorchProfiler(BaseProfiler):
         self.output_fname = output_filename
         self.output_file = None
         if local_rank is not None:
-            self.on_train_start(local_rank=local_rank)
-            self.on_train_start = super().on_train_start
+            self.setup(None, local_rank, None)
+            self.setup = super().setup
 
-    def on_train_start(self, local_rank: Optional[str] = None):
-        self.local_rank = local_rank
+    def setup(self, stage: str, local_rank: Optional[int], log_dir: Optional[str]):
+        super().setup(stage, local_rank, log_dir)
 
         # when logging to `log.info`, only perform profiling on rank 0
         if local_rank != 0 and self.output_fname is None:
@@ -290,16 +290,3 @@ class PyTorchProfiler(BaseProfiler):
             output_string += (f"{os.linesep}Profile stats for: {action} rank: {local_rank} {os.linesep}{stats}")
 
         return output_string
-
-    def describe(self):
-        """Logs a profile report after the conclusion of the training run."""
-        super().describe()
-        self.teardown()
-
-    def teardown(self) -> None:
-        """Close profiler's stream."""
-        if self.output_file:
-            self.output_file.close()
-
-    def __del__(self):
-        self.teardown()

--- a/pytorch_lightning/trainer/connectors/profiler_connector.py
+++ b/pytorch_lightning/trainer/connectors/profiler_connector.py
@@ -14,6 +14,8 @@
 
 from typing import Union
 
+from transformers import TrainerState
+
 from pytorch_lightning.profiler import (
     AdvancedProfiler,
     BaseProfiler,
@@ -54,7 +56,7 @@ class ProfilerConnector:
                 )
         self.trainer.profiler = profiler or PassThroughProfiler()
 
-    def setup(self):
+    def setup(self) -> None:
         trainer = self.trainer
         local_rank = trainer.local_rank if trainer.world_size > 1 else None
-        trainer.profiler.setup(trainer.setup_state, local_rank, trainer.log_dir)
+        trainer.profiler.setup(stage=trainer._setup_state, local_rank=local_rank, log_dir=trainer.log_dir)

--- a/pytorch_lightning/trainer/connectors/profiler_connector.py
+++ b/pytorch_lightning/trainer/connectors/profiler_connector.py
@@ -54,8 +54,7 @@ class ProfilerConnector:
                 )
         self.trainer.profiler = profiler or PassThroughProfiler()
 
-    def on_run_stage_setup(self):
+    def setup(self):
         trainer = self.trainer
         local_rank = trainer.local_rank if trainer.world_size > 1 else None
-        trainer.profiler.lightning_module = trainer.lightning_module
-        trainer.profiler.setup(trainer.state, local_rank, trainer.log_dir)
+        trainer.profiler.setup(trainer.setup_state, local_rank, trainer.log_dir)

--- a/pytorch_lightning/trainer/connectors/profiler_connector.py
+++ b/pytorch_lightning/trainer/connectors/profiler_connector.py
@@ -14,8 +14,6 @@
 
 from typing import Union
 
-from transformers import TrainerState
-
 from pytorch_lightning.profiler import (
     AdvancedProfiler,
     BaseProfiler,

--- a/pytorch_lightning/trainer/connectors/profiler_connector.py
+++ b/pytorch_lightning/trainer/connectors/profiler_connector.py
@@ -54,6 +54,8 @@ class ProfilerConnector:
                 )
         self.trainer.profiler = profiler or PassThroughProfiler()
 
-    def on_train_start(self, trainer):
+    def on_run_stage_setup(self):
+        trainer = self.trainer
         local_rank = trainer.local_rank if trainer.world_size > 1 else None
-        self.trainer.profiler.on_train_start(local_rank)
+        trainer.profiler.lightning_module = trainer.lightning_module
+        trainer.profiler.setup(trainer.state, local_rank, trainer.log_dir)

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -492,15 +492,14 @@ class TrainerProperties(ABC):
             self._running_stage = None
 
     @property
-    def setup_state(self):
+    def _setup_state(self) -> TrainerState:
         # 'fit' is passed for `trainer.tune()` as there aren't "tune_dataloaders"
         return TrainerState.FITTING if self.state == TrainerState.TUNING else self.state
 
     @property
-    def teardown_state(self):
+    def _teardown_state(self) -> Optional[TrainerState]:
         if self.state.running:
-            return self.setup_state
-        return None
+            return self._setup_state
 
 
 # Used to represent the concrete type TrainerProperties class methods are called on.

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -491,6 +491,17 @@ class TrainerProperties(ABC):
         elif self.sanity_checking:
             self._running_stage = None
 
+    @property
+    def setup_state(self):
+        # 'fit' is passed for `trainer.tune()` as there aren't "tune_dataloaders"
+        return TrainerState.FITTING if self.state == TrainerState.TUNING else self.state
+
+    @property
+    def teardown_state(self):
+        if self.state.running:
+            return self.setup_state
+        return None
+
 
 # Used to represent the concrete type TrainerProperties class methods are called on.
 _T = TypeVar('_T', bound=TrainerProperties)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -445,7 +445,7 @@ class Trainer(
                                 |                             ||
                          {self.dispatch}                      ||
                                 |                             ||  LIGHTNING
-                {self.accelerator.start_training}             ||
+                  {self.accelerator.start_training}           ||
                 or {self.accelerator.start_evaluating}        ||
                 or {self.accelerator.start_predicting}        ||  FLOW
                                 |                             ||
@@ -453,7 +453,7 @@ class Trainer(
                                 |                             ||  DIRECTION
                         {self.run_train}                      ||
                      or {self.run_evaluation}                 ||
-                     or  {self.run_predict}                   ||
+                     or {self.run_predict}                    ||
                                 |                             ||
                              results                          \/
         This is used to guide readers to the core loops: train, test, predict.
@@ -1065,7 +1065,7 @@ class Trainer(
 
     def call_setup_hook(self, model: LightningModule) -> None:
         assert self.state.running, f"TrainerState: {self.state}"
-        state = self.setup_state
+        state = self._setup_state
 
         if self.datamodule is not None:
             called = getattr(self.datamodule, f'has_setup_{state}')
@@ -1076,7 +1076,7 @@ class Trainer(
         model.setup(stage=state)
 
     def call_teardown_hook(self, model: LightningModule) -> None:
-        state = self.teardown_state
+        state = self._teardown_state
         self.profiler.teardown(stage=state)
         self.teardown(stage=state)
         model.teardown(stage=state)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1085,7 +1085,7 @@ class Trainer(
         else:
             state = None
 
-        self.profiler.teardown(stage=state.value)
+        self.profiler.teardown(stage=state)
         self.teardown(stage=state)
         model.teardown(stage=state)
 

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -102,9 +102,6 @@ class TrainLoop:
         # hook
         self.trainer.call_hook("on_train_start")
 
-        # provide rank to profiler
-        self.trainer.profile_connector.on_train_start(self.trainer)
-
     def setup_fit(self, model, train_dataloader=None, val_dataloaders=None, datamodule=None):
         # clean hparams
         if hasattr(model, "hparams"):


### PR DESCRIPTION
## What does this PR do?

We need to run the setup hook for every process in all accelerators. This was the case before the accelerator refactor. However, `ddp_spawn` doesn't run it per-process.

This PR fixes it.

Do not mind much the profiler changes. They will be changed further in 3/5. This does the minimum to avoid breakage

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified