### PR TITLE
Profilers - do not write when there's no summary

### DIFF
--- a/pytorch_lightning/profiler/profilers.py
+++ b/pytorch_lightning/profiler/profilers.py
@@ -148,7 +148,9 @@ class BaseProfiler(AbstractProfiler):
         # so to avoid them, we open and close the files within this function
         # by calling `_prepare_streams` and `teardown`
         self._prepare_streams()
-        self._write_stream(self.summary())
+        summary = self.summary()
+        if summary:
+            self._write_stream(summary)
         if self._output_file is not None:
             self._output_file.flush()
         self.teardown(stage=self._stage)


### PR DESCRIPTION
## What does this PR do?

Avoids `PassThroughProfiler` printing empty logs whenever `describe` is called. This happens because its `summary` fn returns an empty string. This PR avoids logging in that case.

No need for CHANGELOG update as this bug is unreleased.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified