### PR TITLE
[fix] Better support for rank_zero_only setting for SLURM and torchelastic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Set better defaults for `rank_zero_only.rank` when training is launched with SLURM and torchelastic ([#6802](https://github.com/PyTorchLightning/pytorch-lightning/pull/6802/))
+
+
 - Sanitize `None` params during pruning ([#6836](https://github.com/PyTorchLightning/pytorch-lightning/pull/6836))
 
 
@@ -204,22 +207,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 - Fixed torch distributed not available in setup hook for DDP ([#6506](https://github.com/PyTorchLightning/pytorch-lightning/pull/6506))
-
-
-- Fixed TPU Colab hang issue, post training ([#6816](https://github.com/PyTorchLightning/pytorch-lightning/pull/6816))
-
-
-- Enforce an epoch scheduler interval when using SWA ([#6588](https://github.com/PyTorchLightning/pytorch-lightning/pull/6588))
-
-
-- Fixed an issue with `IterableDataset` when `__len__` is not defined ([#6828](https://github.com/PyTorchLightning/pytorch-lightning/pull/6828))
-
-
-- Fixed `EarlyStopping` logic when `min_epochs` or `min_steps` requirement is not met ([#6705](https://github.com/PyTorchLightning/pytorch-lightning/pull/6705))
-
-
-- Fixed a bug where `TensorBoardLogger` would give a warning and not log correctly to a symbolic link `save_dir` ([#6730](https://github.com/PyTorchLightning/pytorch-lightning/pull/6730))
-
 
 ## [1.2.6] - 2021-03-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,22 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed torch distributed not available in setup hook for DDP ([#6506](https://github.com/PyTorchLightning/pytorch-lightning/pull/6506))
 
+
+- Fixed TPU Colab hang issue, post training ([#6816](https://github.com/PyTorchLightning/pytorch-lightning/pull/6816))
+
+
+- Enforce an epoch scheduler interval when using SWA ([#6588](https://github.com/PyTorchLightning/pytorch-lightning/pull/6588))
+
+
+- Fixed an issue with `IterableDataset` when `__len__` is not defined ([#6828](https://github.com/PyTorchLightning/pytorch-lightning/pull/6828))
+
+
+- Fixed `EarlyStopping` logic when `min_epochs` or `min_steps` requirement is not met ([#6705](https://github.com/PyTorchLightning/pytorch-lightning/pull/6705))
+
+
+- Fixed a bug where `TensorBoardLogger` would give a warning and not log correctly to a symbolic link `save_dir` ([#6730](https://github.com/PyTorchLightning/pytorch-lightning/pull/6730))
+
+
 ## [1.2.6] - 2021-03-30
 
 ### Changed

--- a/pytorch_lightning/utilities/distributed.py
+++ b/pytorch_lightning/utilities/distributed.py
@@ -43,9 +43,17 @@ def rank_zero_only(fn):
 
     return wrapped_fn
 
+# TODO: this should be part of the cluster environment
+def _get_local_rank() -> int:
+    local_rank_keys = ('LOCAL_RANK', 'SLURM_LOCALID')
+    for key in local_rank_keys:
+        rank = os.environ.get(key)
+        if rank is not None:
+            return int(rank)
+    return 0
 
 # add the attribute to the function but don't overwrite in case Trainer has already set it
-rank_zero_only.rank = getattr(rank_zero_only, 'rank', int(os.environ.get('LOCAL_RANK', 0)))
+rank_zero_only.rank = getattr(rank_zero_only, 'rank', _get_local_rank())
 
 
 def _warn(*args, **kwargs):

--- a/pytorch_lightning/utilities/distributed.py
+++ b/pytorch_lightning/utilities/distributed.py
@@ -43,6 +43,7 @@ def rank_zero_only(fn):
 
     return wrapped_fn
 
+
 # TODO: this should be part of the cluster environment
 def _get_local_rank() -> int:
     local_rank_keys = ('LOCAL_RANK', 'SLURM_LOCALID')
@@ -51,6 +52,7 @@ def _get_local_rank() -> int:
         if rank is not None:
             return int(rank)
     return 0
+
 
 # add the attribute to the function but don't overwrite in case Trainer has already set it
 rank_zero_only.rank = getattr(rank_zero_only, 'rank', _get_local_rank())

--- a/pytorch_lightning/utilities/distributed.py
+++ b/pytorch_lightning/utilities/distributed.py
@@ -45,9 +45,9 @@ def rank_zero_only(fn):
 
 
 # TODO: this should be part of the cluster environment
-def _get_local_rank() -> int:
-    local_rank_keys = ('LOCAL_RANK', 'SLURM_LOCALID')
-    for key in local_rank_keys:
+def _get_rank() -> int:
+    rank_keys = ('LOCAL_RANK', 'SLURM_PROCID')
+    for key in rank_keys:
         rank = os.environ.get(key)
         if rank is not None:
             return int(rank)
@@ -55,7 +55,7 @@ def _get_local_rank() -> int:
 
 
 # add the attribute to the function but don't overwrite in case Trainer has already set it
-rank_zero_only.rank = getattr(rank_zero_only, 'rank', _get_local_rank())
+rank_zero_only.rank = getattr(rank_zero_only, 'rank', _get_rank())
 
 
 def _warn(*args, **kwargs):

--- a/pytorch_lightning/utilities/distributed.py
+++ b/pytorch_lightning/utilities/distributed.py
@@ -46,7 +46,7 @@ def rank_zero_only(fn):
 
 # TODO: this should be part of the cluster environment
 def _get_rank() -> int:
-    rank_keys = ('LOCAL_RANK', 'SLURM_PROCID')
+    rank_keys = ('RANK', 'SLURM_PROCID', 'LOCAL_RANK')
     for key in rank_keys:
         rank = os.environ.get(key)
         if rank is not None:

--- a/tests/utilities/distributed.py
+++ b/tests/utilities/distributed.py
@@ -75,16 +75,21 @@ def test_rank_zero_torchelastic():
     assert x == 1
 
 
-@mock.patch.dict(os.environ, {"RANK": "1", "SLURM_PROCID": "2", "LOCAL_RANK": "3"})
-def test_rank_zero_none_set():
+@pytest.mark.parametrize("rank_key,rank", [
+    ("RANK", "1"),
+    ("SLURM_PROCID", "2"),
+    ("LOCAL_RANK", "3"),
+])
+def test_rank_zero_none_set(rank_key, rank):
     """ Test that function is not called when rank environment variables are not global zero. """
 
-    from pytorch_lightning.utilities.distributed import _get_rank, rank_zero_only
-    rank_zero_only.rank = _get_rank()
+    with mock.patch.dict(os.environ, {rank_key: rank}):
+        from pytorch_lightning.utilities.distributed import _get_rank, rank_zero_only
+        rank_zero_only.rank = _get_rank()
 
-    @rank_zero_only
-    def foo():
-        return 1
+        @rank_zero_only
+        def foo():
+            return 1
 
-    x = foo()
-    assert x is None
+        x = foo()
+        assert x is None

--- a/tests/utilities/distributed.py
+++ b/tests/utilities/distributed.py
@@ -16,6 +16,7 @@ import subprocess
 import sys
 from pathlib import Path
 from subprocess import TimeoutExpired
+from unittest import mock
 
 import pytorch_lightning
 
@@ -42,3 +43,48 @@ def call_training_script(module_file, cli_args, method, tmpdir, timeout=60):
         p.kill()
         std, err = p.communicate()
     return std, err
+
+
+@mock.patch.dict(os.environ, {"SLURM_PROCID": "0"})
+def test_rank_zero_slurm():
+    """ Test that SLURM environment variables are properly checked for rank_zero_only. """
+    from pytorch_lightning.utilities.distributed import _get_rank, rank_zero_only
+    rank_zero_only.rank = _get_rank()
+
+    @rank_zero_only
+    def foo():
+        # The return type is optional because on non-zero ranks it will not be called
+        return 1
+
+    x = foo()
+    assert x == 1
+
+
+@mock.patch.dict(os.environ, {"RANK": "0"})
+def test_rank_zero_torchelastic():
+    """ Test that torchelastic environment variables are properly checked for rank_zero_only. """
+    from pytorch_lightning.utilities.distributed import _get_rank, rank_zero_only
+    rank_zero_only.rank = _get_rank()
+
+    @rank_zero_only
+    def foo():
+        # The return type is optional because on non-zero ranks it will not be called
+        return 1
+
+    x = foo()
+    assert x == 1
+
+
+@mock.patch.dict(os.environ, {"RANK": "1", "SLURM_PROCID": "2", "LOCAL_RANK": "3"})
+def test_rank_zero_none_set():
+    """ Test that function is not called when rank environment variables are not global zero. """
+
+    from pytorch_lightning.utilities.distributed import _get_rank, rank_zero_only
+    rank_zero_only.rank = _get_rank()
+
+    @rank_zero_only
+    def foo():
+        return 1
+
+    x = foo()
+    assert x is None

--- a/tests/utilities/test_distributed.py
+++ b/tests/utilities/test_distributed.py
@@ -1,0 +1,67 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from unittest import mock
+
+import pytest
+
+
+@mock.patch.dict(os.environ, {"SLURM_PROCID": "0"})
+def test_rank_zero_slurm():
+    """ Test that SLURM environment variables are properly checked for rank_zero_only. """
+    from pytorch_lightning.utilities.distributed import _get_rank, rank_zero_only
+    rank_zero_only.rank = _get_rank()
+
+    @rank_zero_only
+    def foo():
+        # The return type is optional because on non-zero ranks it will not be called
+        return 1
+
+    x = foo()
+    assert x == 1
+
+
+@mock.patch.dict(os.environ, {"RANK": "0"})
+def test_rank_zero_torchelastic():
+    """ Test that torchelastic environment variables are properly checked for rank_zero_only. """
+    from pytorch_lightning.utilities.distributed import _get_rank, rank_zero_only
+    rank_zero_only.rank = _get_rank()
+
+    @rank_zero_only
+    def foo():
+        # The return type is optional because on non-zero ranks it will not be called
+        return 1
+
+    x = foo()
+    assert x == 1
+
+
+@pytest.mark.parametrize("rank_key,rank", [
+    ("RANK", "1"),
+    ("SLURM_PROCID", "2"),
+    ("LOCAL_RANK", "3"),
+])
+def test_rank_zero_none_set(rank_key, rank):
+    """ Test that function is not called when rank environment variables are not global zero. """
+
+    with mock.patch.dict(os.environ, {rank_key: rank}):
+        from pytorch_lightning.utilities.distributed import _get_rank, rank_zero_only
+        rank_zero_only.rank = _get_rank()
+
+        @rank_zero_only
+        def foo():
+            return 1
+
+        x = foo()
+        assert x is None

--- a/tests/utilities/test_distributed.py
+++ b/tests/utilities/test_distributed.py
@@ -18,7 +18,7 @@ from unittest import mock
 import pytest
 
 
-@pytest.mark.parameterize("env_vars", [{"RANK": "0"}, {"SLURM_PROCID": "0"}])
+@pytest.mark.parametrize("env_vars", [{"RANK": "0"}, {"SLURM_PROCID": "0"}])
 def test_rank_zero_known_cluster_envs(env_vars: Mapping[str, str]):
     """ Test that SLURM environment variables are properly checked for rank_zero_only. """
     from pytorch_lightning.utilities.distributed import _get_rank, rank_zero_only
@@ -36,7 +36,7 @@ def test_rank_zero_known_cluster_envs(env_vars: Mapping[str, str]):
         assert x == 1
 
 
-@pytest.mark.parameterize("rank_key,rank", [
+@pytest.mark.parametrize("rank_key,rank", [
     ("RANK", "1"),
     ("SLURM_PROCID", "2"),
     ("LOCAL_RANK", "3"),


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
Fixes #6797

This is a mitigation for the issue. The environment variable handling is currently split in a few different places:
- in this file
- in the accelerator connector
- in the cluster environment

This needs to be consolidated to better support more custom cluster environments in the future. For now this is a quickfix for SLURM users until we can come up with a better design.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
