### PR TITLE
Correct parameter name in doc string

### DIFF
--- a/pytorch_lightning/callbacks/finetuning.py
+++ b/pytorch_lightning/callbacks/finetuning.py
@@ -77,7 +77,7 @@ class BaseFinetuning(Callback):
                 # When `current_epoch` is 10, feature_extractor will start training.
                 if current_epoch == self._unfreeze_at_epoch:
                     self.unfreeze_and_add_param_group(
-                        module=pl_module.feature_extractor,
+                        modules=pl_module.feature_extractor,
                         optimizer=optimizer,
                         train_bn=True,
                     )


### PR DESCRIPTION
`unfreeze_and_add_param_group` expects `modules` rather than `module`

## What does this PR do?

This PR corrects a parameter name in the documentation of `BaseFinetuning`
