### PR TITLE
Check for NaN in EarlyStopping

### DIFF
--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -170,8 +170,8 @@ class EarlyStopping(Callback):
         if self.check_finite and not torch.isfinite(current):
             trainer.should_stop = True
             log.info(
-                f"[{trainer.global_rank}] Monitored metric {self.monitor} is not finite."
-                f" Current value is {current:.3f}, best value was {self.best_score:.3f}."
+                f"[{trainer.global_rank}] Monitored metric {self.monitor} = {current:.3f} is not finite."
+                f" Previous best value was {self.best_score:.3f}. Signaling Trainer to stop."
             )
 
         if self.monitor_op(current - self.min_delta, self.best_score):


### PR DESCRIPTION
## What does this PR do?

Part of #6795

Early stopping triggers when the monitor is NaN (including +/- Inf). 
This is similar to `Trainer(terminate_on_nan=True)`. The difference is that here it is only on the early stopping monitor metric and does not check the weights for finite tensors. It also defaults to `True` (in this current implementation).

TODO:
- add tests and docs

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
