### PR TITLE
[FSDP] Added sharded module 4/n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `model` parameter to precision plugins' `clip_gradients` signature ([#6764](https://github.com/PyTorchLightning/pytorch-lightning/pull/6764))
 
 
+- Added `sharded_module` parameter to access sharded version of the model using Fully Sharded ([#6866](https://github.com/PyTorchLightning/pytorch-lightning/pull/6866))
+
+
 ### Changed
 
 - Renamed `pytorch_lightning.callbacks.swa` to `pytorch_lightning.callbacks.stochastic_weight_avg` ([#6259](https://github.com/PyTorchLightning/pytorch-lightning/pull/6259))

--- a/pytorch_lightning/accelerators/accelerator.py
+++ b/pytorch_lightning/accelerators/accelerator.py
@@ -518,3 +518,11 @@ class Accelerator(object):
 
     def update_global_step(self, total_batch_idx: int, current_global_step: int) -> int:
         return self.training_type_plugin.update_global_step(total_batch_idx, current_global_step)
+
+    @property
+    def sharded_module(self) -> torch.nn.Module:
+        """
+        Returns: The Sharded version of the ``LightningModule`` if using a Sharded Plugin,
+            else the model stored in the training type plugin.
+        """
+        return self.training_type_plugin.sharded_module

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1465,6 +1465,18 @@ class LightningModule(
 
         return splits
 
+    @property
+    def sharded_module(self) -> torch.nn.Module:
+        """
+        When using Fully Sharded, parameters are sharded across devices and
+        weights are flattened. It is required to use the sharded version of the module when
+        configuring optimizers and setting up training.
+
+        Returns: The Sharded version of the ``LightningModule`` module if using sharded,
+            else the model stored in the accelerator.
+        """
+        return self.trainer.sharded_module
+
     def summarize(self, mode: Optional[str] = ModelSummary.MODE_DEFAULT) -> Optional[ModelSummary]:
         model_summary = None
 

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -60,17 +60,8 @@ class LightningModule(
     # Below is for property support of JIT in PyTorch 1.7
     # since none of them is important when using JIT, we are going to ignore them.
     __jit_unused_properties__ = [
-        "datamodule",
-        "example_input_array",
-        "hparams",
-        "hparams_initial",
-        "on_gpu",
-        "current_epoch",
-        "global_step",
-        "global_rank",
-        "local_rank",
-        "logger",
-        "model_size",
+        "datamodule", "example_input_array", "hparams", "hparams_initial", "on_gpu", "current_epoch", "global_step",
+        "global_rank", "local_rank", "logger", "model_size", "sharded_module"
     ] + DeviceDtypeModuleMixin.__jit_unused_properties__
 
     def __init__(self, *args, **kwargs):

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1465,18 +1465,6 @@ class LightningModule(
 
         return splits
 
-    @property
-    def sharded_module(self) -> torch.nn.Module:
-        """
-        When using Fully Sharded, parameters are sharded across devices and
-        weights are flattened. It is required to use the sharded version of the module when
-        configuring optimizers and setting up training.
-
-        Returns: The Sharded version of the ``LightningModule`` module if using sharded,
-            else the model stored in the accelerator.
-        """
-        return self.trainer.sharded_module
-
     def summarize(self, mode: Optional[str] = ModelSummary.MODE_DEFAULT) -> Optional[ModelSummary]:
         model_summary = None
 
@@ -1864,3 +1852,15 @@ class LightningModule(
         size_mb = os.path.getsize(tmp_name) / 1e6
         os.remove(tmp_name)
         return size_mb
+
+    @property
+    def sharded_module(self) -> torch.nn.Module:
+        """
+        When using Fully Sharded, parameters are sharded across devices and
+        weights are flattened. It is required to use the sharded version of the module when
+        configuring optimizers and setting up training.
+
+        Returns: The Sharded version of the ``LightningModule`` module if using sharded,
+            else the model stored in the accelerator.
+        """
+        return self.trainer.sharded_module

--- a/pytorch_lightning/plugins/training_type/training_type_plugin.py
+++ b/pytorch_lightning/plugins/training_type/training_type_plugin.py
@@ -284,3 +284,14 @@ class TrainingTypePlugin(Plugin, ABC):
     @call_configure_sharded_model_hook.setter
     def call_configure_sharded_model_hook(self, mode: bool) -> None:
         self._call_configure_sharded_model_hook = mode
+
+    @property
+    def sharded_module(self) -> torch.nn.Module:
+        """
+        Override to pass a sharded version of the module. This is useful for configuring optimizers and training
+        with the sharded version of the ``LightningModule``.
+
+        Returns: The Sharded version of the ``LightningModule`` if using a Sharded Plugin,
+            else the model stored in the training type plugin.
+        """
+        return self.model

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -361,6 +361,14 @@ class TrainerProperties(ABC):
         return self.accelerator.lightning_module
 
     @property
+    def sharded_module(self) -> torch.nn.Module:
+        """
+        Returns: The Sharded version of the ``LightningModule`` module if using sharded,
+            else the model stored in the accelerator.
+        """
+        return self.accelerator.sharded_module
+
+    @property
     def optimizers(self) -> Optional[List[Optimizer]]:
         return self.accelerator.optimizers
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1105,6 +1105,14 @@ class Trainer(
             model.call_configure_sharded_model_hook = True
             self.accelerator.call_configure_sharded_model_hook = False
 
+    @property
+    def sharded_module(self) -> torch.nn.Module:
+        """
+        Returns: The Sharded version of the ``LightningModule`` module if using sharded,
+            else the model stored in the accelerator.
+        """
+        return self.accelerator.sharded_module
+
     def call_teardown_hook(self, model: LightningModule) -> None:
         state = self._teardown_state
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1105,14 +1105,6 @@ class Trainer(
             model.call_configure_sharded_model_hook = True
             self.accelerator.call_configure_sharded_model_hook = False
 
-    @property
-    def sharded_module(self) -> torch.nn.Module:
-        """
-        Returns: The Sharded version of the ``LightningModule`` module if using sharded,
-            else the model stored in the accelerator.
-        """
-        return self.accelerator.sharded_module
-
     def call_teardown_hook(self, model: LightningModule) -> None:
         state = self._teardown_state
 

--- a/tests/trainer/properties/test_get_model.py
+++ b/tests/trainer/properties/test_get_model.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
+import torch
 
 from pytorch_lightning import Trainer
 from tests.helpers.boring_model import BoringModel
@@ -78,5 +80,44 @@ def test_get_model_gpu(tmpdir):
         limit_val_batches=2,
         max_epochs=1,
         gpus=1,
+    )
+    trainer.fit(model)
+
+
+class TestShardedModule(BoringModel):
+
+    def __init__(self, accelerator: str):
+        super().__init__()
+        self.accelerator = accelerator
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.SGD(self.sharded_module.parameters(), lr=0.1)
+        lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
+        return [optimizer], [lr_scheduler]
+
+    def on_train_start(self) -> None:
+        if self.accelerator == 'ddp_spawn':
+            from torch.nn.parallel import DistributedDataParallel
+            assert isinstance(self.sharded_module, DistributedDataParallel)
+            assert isinstance(self.trainer.sharded_module, DistributedDataParallel)
+        else:
+            assert self.sharded_module == self
+            assert self.trainer.sharded_module == self
+
+
+@pytest.mark.parametrize(["accelerator", "num_processes"],
+                         [(None, 1), pytest.param('ddp_spawn', 2, marks=RunIf(skip_windows=True))])
+def test_get_sharded_module(tmpdir, accelerator, num_processes):
+    """
+    Tests that `trainer.sharded_module` and `model.sharded_module` extracts the accelerator model.
+    """
+
+    model = TestShardedModule(accelerator)
+
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        accelerator=accelerator,
+        num_processes=num_processes,
+        fast_dev_run=True,
     )
     trainer.fit(model)


### PR DESCRIPTION
## What does this PR do?

Adds a `sharded_module` property to the lightning module and trainer. This is required to access the wrapped FSDP model when setting up optimizers which will be added in the FSDP PR. When not using sharded, this just uses the accelerator stored model.

Currently the only other option is to ask users to do `self.trainer.accelerator.training_type_plugin.model` within `configure_optimizers` which is cumbersome.

Related to #6152 

## Explanation

`sharded_module` really is: `wrapped_model` (i.e `DDP(lightning_module)` or `FSDP(lightning_module)`). The reason we need the property is because the model states are partitioned by FSDP and references to original weights are deleted.

For example, if you implemented your `configure_optimizers` like below:

```python
def configure_optimizers(self):
    return torch.optim.Adam(self.layer.parameters(), ...)
```

when FSDP wraps your model, it flattens all your weights down and destroys the original references, so self.layer.parameters() does not exist anymore (here is the issue to track: https://github.com/facebookresearch/fairscale/issues/430#issuecomment-785463057). This is currently a limitation of FSDP that will not be changed for the foreseeable future it seems. To remedy this:

1. configure optimizers after wrapping the model if the plugin requests it (Merged)
2. Introduce a way to access the internal wrapped model from the lightning module

Originally for 2., I did `self.trainer.accelerator.training_type_plugin.model` but this is very verbose for the user. I then made a property in the lightning module called `self.accelerator_wrapped_model` which points to `FSDP(lightning_module)` . I then went with `self.sharded_module` but from conversation with @justusschock on the subject, might be better to revert to a different name that's more general.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
