### PR TITLE
fix gpus default for Trainer.add_argparse_args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `EarlyStopping` logic when `min_epochs` or `min_steps` requirement is not met ([#6705](https://github.com/PyTorchLightning/pytorch-lightning/pull/6705))
 
 
+- Fixed `--gpus` default for parser returned by `Trainer.add_argparse_args` ([#6898](https://github.com/PyTorchLightning/pytorch-lightning/pull/6898))
+
+
 ## [1.2.7] - 2021-04-06
 
 ### Fixed

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -40,7 +40,6 @@ from pytorch_lightning.core.saving import ALLOWED_CONFIG_TYPES, ModelIO, PRIMITI
 from pytorch_lightning.core.step_result import Result
 from pytorch_lightning.utilities import rank_zero_deprecation, rank_zero_warn
 from pytorch_lightning.utilities.apply_func import apply_to_collection, convert_to_tensors
-from pytorch_lightning.utilities.argparse import _gpus_arg_default
 from pytorch_lightning.utilities.device_dtype_mixin import DeviceDtypeModuleMixin
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.parsing import AttributeDict, collect_init_args, get_init_args

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -40,6 +40,7 @@ from pytorch_lightning.core.saving import ALLOWED_CONFIG_TYPES, ModelIO, PRIMITI
 from pytorch_lightning.core.step_result import Result
 from pytorch_lightning.utilities import rank_zero_deprecation, rank_zero_warn
 from pytorch_lightning.utilities.apply_func import apply_to_collection, convert_to_tensors
+from pytorch_lightning.utilities.argparse import _gpus_arg_default
 from pytorch_lightning.utilities.device_dtype_mixin import DeviceDtypeModuleMixin
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.parsing import AttributeDict, collect_init_args, get_init_args
@@ -1698,6 +1699,9 @@ class LightningModule(
             raise ValueError(f"Unsupported config type of {type(hp)}.")
 
         if isinstance(hp, dict) and isinstance(self.hparams, dict):
+            # for k, v in hp.items():
+            #     if v == _gpus_arg_default:
+            #         hp[k] = _gpus_arg_default()
             self.hparams.update(hp)
         else:
             self._hparams = hp

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1699,9 +1699,6 @@ class LightningModule(
             raise ValueError(f"Unsupported config type of {type(hp)}.")
 
         if isinstance(hp, dict) and isinstance(self.hparams, dict):
-            # for k, v in hp.items():
-            #     if v == _gpus_arg_default:
-            #         hp[k] = _gpus_arg_default()
             self.hparams.update(hp)
         else:
             self._hparams = hp

--- a/pytorch_lightning/utilities/argparse.py
+++ b/pytorch_lightning/utilities/argparse.py
@@ -287,10 +287,6 @@ def _gpus_allowed_type(x) -> Union[int, str]:
         return int(x)
 
 
-def _gpus_arg_default(x) -> Union[int, str]:
-    return _gpus_allowed_type(x)
-
-
 def _int_or_float_type(x) -> Union[int, float]:
     if '.' in str(x):
         return float(x)

--- a/pytorch_lightning/utilities/argparse.py
+++ b/pytorch_lightning/utilities/argparse.py
@@ -232,7 +232,6 @@ def add_argparse_args(
 
         if arg == 'gpus' or arg == 'tpu_cores':
             use_type = _gpus_allowed_type
-            arg_default = None
 
         # hack for types in (int, float)
         if len(arg_types) == 2 and int in set(arg_types) and float in set(arg_types):

--- a/pytorch_lightning/utilities/argparse.py
+++ b/pytorch_lightning/utilities/argparse.py
@@ -232,7 +232,7 @@ def add_argparse_args(
 
         if arg == 'gpus' or arg == 'tpu_cores':
             use_type = _gpus_allowed_type
-            arg_default = _gpus_arg_default
+            arg_default = None
 
         # hack for types in (int, float)
         if len(arg_types) == 2 and int in set(arg_types) and float in set(arg_types):

--- a/pytorch_lightning/utilities/device_parser.py
+++ b/pytorch_lightning/utilities/device_parser.py
@@ -59,11 +59,6 @@ def parse_gpu_ids(gpus: Optional[Union[int, str, List[int]]]) -> Optional[List[i
     If no GPUs are available but the value of gpus variable indicates request for GPUs
     then a MisconfigurationException is raised.
     """
-
-    # nothing was passed into the GPUs argument
-    if callable(gpus):
-        return None
-
     # Check that gpus param is None, Int, String or List
     _check_data_type(gpus)
 
@@ -97,10 +92,6 @@ def parse_tpu_cores(tpu_cores: Union[int, str, List]) -> Optional[Union[List[int
     Returns:
         a list of tpu_cores to be used or ``None`` if no TPU cores were requested
     """
-
-    if callable(tpu_cores):
-        return None
-
     _check_data_type(tpu_cores)
 
     if isinstance(tpu_cores, str):

--- a/tests/loggers/test_wandb.py
+++ b/tests/loggers/test_wandb.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import os
 import pickle
-import types
 from argparse import ArgumentParser
 from unittest import mock
 

--- a/tests/loggers/test_wandb.py
+++ b/tests/loggers/test_wandb.py
@@ -175,6 +175,7 @@ def test_wandb_sanitize_callable_params(tmpdir):
     params = WandbLogger._convert_params(params)
     params = WandbLogger._flatten_dict(params)
     params = WandbLogger._sanitize_callable_params(params)
+    assert params["gpus"] == "None"
     assert params["something"] == "something"
     assert params["wrapper_something"] == "wrapper_something"
     assert params["wrapper_something_wo_name"] == "<lambda>"

--- a/tests/loggers/test_wandb.py
+++ b/tests/loggers/test_wandb.py
@@ -172,11 +172,9 @@ def test_wandb_sanitize_callable_params(tmpdir):
     params.wrapper_something_wo_name = lambda: lambda: '1'
     params.wrapper_something = wrapper_something
 
-    assert isinstance(params.gpus, types.FunctionType)
     params = WandbLogger._convert_params(params)
     params = WandbLogger._flatten_dict(params)
     params = WandbLogger._sanitize_callable_params(params)
-    assert params["gpus"] == '_gpus_arg_default'
     assert params["something"] == "something"
     assert params["wrapper_something"] == "wrapper_something"
     assert params["wrapper_something_wo_name"] == "<lambda>"

--- a/tests/trainer/test_trainer_cli.py
+++ b/tests/trainer/test_trainer_cli.py
@@ -175,13 +175,13 @@ def test_argparse_args_parsing(cli_args, expected):
     assert Trainer.from_argparse_args(args)
 
 
-@pytest.mark.parametrize(['cli_args', 'expected_gpu'], [
-    pytest.param('', None),
-    pytest.param('--gpus 1', [0]),
-    pytest.param('--gpus 0,', [0]),
+@pytest.mark.parametrize(['cli_args', 'expected_parsed', 'expected_device_ids'], [
+    pytest.param('', None, None),
+    pytest.param('--gpus 1', 1, [0]),
+    pytest.param('--gpus 0,', '0,', [0]),
 ])
 @RunIf(min_gpus=1)
-def test_argparse_args_parsing_gpus(cli_args, expected_gpu):
+def test_argparse_args_parsing_gpus(cli_args, expected_parsed, expected_device_ids):
     """Test multi type argument with bool."""
     cli_args = cli_args.split(' ') if cli_args else []
     with mock.patch("argparse._sys.argv", ["any.py"] + cli_args):
@@ -189,9 +189,9 @@ def test_argparse_args_parsing_gpus(cli_args, expected_gpu):
         parser = Trainer.add_argparse_args(parent_parser=parser)
         args = Trainer.parse_argparser(parser)
 
+    assert args.gpus == expected_parsed
     trainer = Trainer.from_argparse_args(args)
-    assert trainer.data_parallel_device_ids == expected_gpu
-    assert args.gpus == expected_gpu
+    assert trainer.data_parallel_device_ids == expected_device_ids
 
 
 @RunIf(min_python="3.7.0")

--- a/tests/trainer/test_trainer_cli.py
+++ b/tests/trainer/test_trainer_cli.py
@@ -176,6 +176,7 @@ def test_argparse_args_parsing(cli_args, expected):
 
 
 @pytest.mark.parametrize(['cli_args', 'expected_gpu'], [
+    pytest.param('', None),
     pytest.param('--gpus 1', [0]),
     pytest.param('--gpus 0,', [0]),
 ])
@@ -190,6 +191,7 @@ def test_argparse_args_parsing_gpus(cli_args, expected_gpu):
 
     trainer = Trainer.from_argparse_args(args)
     assert trainer.data_parallel_device_ids == expected_gpu
+    assert args.gpus == expected_gpu
 
 
 @RunIf(min_python="3.7.0")

--- a/tests/utilities/test_argparse.py
+++ b/tests/utilities/test_argparse.py
@@ -7,7 +7,7 @@ import pytest
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.utilities.argparse import (
-    _gpus_arg_default,
+    _gpus_allowed_type,
     _int_or_float_type,
     add_argparse_args,
     from_argparse_args,
@@ -205,9 +205,9 @@ def test_add_argparse_args_no_argument_group():
     assert args.my_parameter == 2
 
 
-def test_gpus_arg_default():
-    assert _gpus_arg_default('1,2') == '1,2'
-    assert _gpus_arg_default('1') == 1
+def test_gpus_allowed_type():
+    assert _gpus_allowed_type('1,2') == '1,2'
+    assert _gpus_allowed_type('1') == 1
 
 
 def test_int_or_float_type():


### PR DESCRIPTION
## What does this PR do?


Fixes #6549
Fixes #6263

The default for gpus and tpu_cores was a function, but it should be `None` as in the Trainer.
This fixes a pickle issue, when the function is passed into the model via Model(**vars(args)).
It would prevent unpickling outside pytorch lightning (or when PL code changes).

**Newly added test case fails on master.**


## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
