### PR TITLE
move process init to trainer init for ddp related things

### DIFF
--- a/pytorch_lightning/accelerators/accelerator.py
+++ b/pytorch_lightning/accelerators/accelerator.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import contextlib
-from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Sequence, Union
+from typing import Any, Callable, Dict, Generator, Iterable, List, Optional, Sequence, TYPE_CHECKING, Union
 
 import torch
 from torch.optim import Optimizer
@@ -29,6 +29,8 @@ from pytorch_lightning.utilities.enums import AMPType, GradClipAlgorithmType, Li
 
 _STEP_OUTPUT_TYPE = Union[torch.Tensor, Dict[str, torch.Tensor], None]
 
+if TYPE_CHECKING:
+    from pytorch_lightning.trainer.trainer import Trainer
 
 class Accelerator(object):
     """
@@ -68,7 +70,7 @@ class Accelerator(object):
         """Transfers ownership of the model to this plugin"""
         self.training_type_plugin.connect(model)
 
-    def setup_environment(self, trainer) -> None:
+    def setup_environment(self, trainer: 'Trainer') -> None:
         """
         Setup any processes or distributed connections.
         This is called before the LightningModule/DataModule setup hook

--- a/pytorch_lightning/accelerators/accelerator.py
+++ b/pytorch_lightning/accelerators/accelerator.py
@@ -32,6 +32,7 @@ _STEP_OUTPUT_TYPE = Union[torch.Tensor, Dict[str, torch.Tensor], None]
 if TYPE_CHECKING:
     from pytorch_lightning.trainer.trainer import Trainer
 
+
 class Accelerator(object):
     """
     The Accelerator Base Class.

--- a/pytorch_lightning/accelerators/accelerator.py
+++ b/pytorch_lightning/accelerators/accelerator.py
@@ -68,13 +68,13 @@ class Accelerator(object):
         """Transfers ownership of the model to this plugin"""
         self.training_type_plugin.connect(model)
 
-    def setup_environment(self) -> None:
+    def setup_environment(self, *args, **kwargs) -> None:
         """
         Setup any processes or distributed connections.
         This is called before the LightningModule/DataModule setup hook
         which allows the user to access the accelerator environment before setup is complete.
         """
-        self.training_type_plugin.setup_environment()
+        self.training_type_plugin.setup_environment(*args, **kwargs)
 
     def setup(self, trainer: 'pl.Trainer', model: LightningModule) -> None:
         """

--- a/pytorch_lightning/accelerators/accelerator.py
+++ b/pytorch_lightning/accelerators/accelerator.py
@@ -68,13 +68,13 @@ class Accelerator(object):
         """Transfers ownership of the model to this plugin"""
         self.training_type_plugin.connect(model)
 
-    def setup_environment(self, *args, **kwargs) -> None:
+    def setup_environment(self, trainer) -> None:
         """
         Setup any processes or distributed connections.
         This is called before the LightningModule/DataModule setup hook
         which allows the user to access the accelerator environment before setup is complete.
         """
-        self.training_type_plugin.setup_environment(*args, **kwargs)
+        self.training_type_plugin.setup_environment(trainer)
 
     def setup(self, trainer: 'pl.Trainer', model: LightningModule) -> None:
         """

--- a/pytorch_lightning/plugins/training_type/ddp.py
+++ b/pytorch_lightning/plugins/training_type/ddp.py
@@ -16,7 +16,7 @@ import os
 import subprocess
 import sys
 from time import sleep
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
 import numpy as np
 import torch
@@ -46,6 +46,9 @@ if _TORCH_GREATER_EQUAL_1_8:
     from pytorch_lightning.utilities.distributed import register_ddp_comm_hook
 
 log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from pytorch_lightning.trainer.trainer import Trainer
 
 
 class DDPPlugin(ParallelPlugin):
@@ -97,7 +100,7 @@ class DDPPlugin(ParallelPlugin):
     def _is_single_process_single_device(self) -> bool:
         return True
 
-    def setup_environment(self, trainer):
+    def setup_environment(self, trainer: 'Trainer'):
         # start the other scripts
         if not self.cluster_environment.creates_children() and os.environ.get("PL_IN_DDP_SUBPROCESS", "0") != "1":
             self._call_children_scripts(trainer)
@@ -107,7 +110,7 @@ class DDPPlugin(ParallelPlugin):
 
         self.setup_distributed()
 
-    def _call_children_scripts(self, trainer):
+    def _call_children_scripts(self, trainer: 'Trainer'):
 
         # bookkeeping of spawned processes
         assert self.global_rank == 0

--- a/pytorch_lightning/plugins/training_type/training_type_plugin.py
+++ b/pytorch_lightning/plugins/training_type/training_type_plugin.py
@@ -45,7 +45,7 @@ class TrainingTypePlugin(Plugin, ABC):
         """Called by the accelerator to connect the accelerator and the model with this plugin"""
         self.model = model
 
-    def setup_environment(self, trainer) -> None:
+    def setup_environment(self, trainer: 'Trainer') -> None:
         """
         Setup any processes or distributed connections.
         This is called before the LightningModule/DataModule setup hook

--- a/pytorch_lightning/plugins/training_type/training_type_plugin.py
+++ b/pytorch_lightning/plugins/training_type/training_type_plugin.py
@@ -45,7 +45,7 @@ class TrainingTypePlugin(Plugin, ABC):
         """Called by the accelerator to connect the accelerator and the model with this plugin"""
         self.model = model
 
-    def setup_environment(self) -> None:
+    def setup_environment(self, trainer) -> None:
         """
         Setup any processes or distributed connections.
         This is called before the LightningModule/DataModule setup hook

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -391,7 +391,6 @@ class Trainer(
             fast_dev_run,
         )
 
-
         self.accelerator.setup_environment(self)
 
         # Callback system

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -391,6 +391,9 @@ class Trainer(
             fast_dev_run,
         )
 
+
+        self.accelerator.setup_environment(self)
+
         # Callback system
         self.on_init_end()
 
@@ -441,7 +444,6 @@ class Trainer(
         # ----------------------------
         self.call_hook("on_before_accelerator_backend_setup", model)
         self.accelerator.connect(model)
-        self.accelerator.setup_environment()
         self.call_setup_hook(model)  # allow user to setup lightning_module in accelerator environment
         self.call_configure_sharded_model(model)  # allow user to setup in model sharded environment
         self.accelerator.setup(self, model)  # note: this sets up self.lightning_module


### PR DESCRIPTION
This moves the process init to the trainer init for all ddp-related stuff to make local rank available there.
This was the case before the accelerator refactor and just returns to an old state here.

Unfortunately, this does not work with spawn related backends, since we cannot spawn them, before we have the actual function to run (which needs the model and the info whether to run training, testing or predicting).

Any thoughts @awaelchli @tchaton @carmocca @SeanNaren 

@SeanNaren  does this interfer with fully shareded?