### PR TITLE
Updated iterable dataset with len warning message

### DIFF
--- a/pytorch_lightning/utilities/data.py
+++ b/pytorch_lightning/utilities/data.py
@@ -41,7 +41,7 @@ def has_len(dataloader: DataLoader) -> bool:
         rank_zero_warn(
             'Your `IterableDataset` has `__len__` defined.'
             ' In combination with multi-process data loading (when num_workers > 1),'
-            ' `__len__` could be inaccurate if each worker is not configured independently
+            ' `__len__` could be inaccurate if each worker is not configured independently'
             ' to avoid having duplicate data.'
         )
     return has_len

--- a/pytorch_lightning/utilities/data.py
+++ b/pytorch_lightning/utilities/data.py
@@ -40,8 +40,8 @@ def has_len(dataloader: DataLoader) -> bool:
     if has_len and has_iterable_dataset(dataloader):
         rank_zero_warn(
             'Your `IterableDataset` has `__len__` defined.'
-            ' In combination with multi-processing data loading (e.g. batch size > 1),'
-            ' this can lead to unintended side effects since the samples will be duplicated.'
+            ' In combination with multi-process data loading (when num_workers > 1),'
+            ' `__len__` could be inaccurate if each worker is not configured independently to avoid having duplicate data.'
         )
     return has_len
 

--- a/pytorch_lightning/utilities/data.py
+++ b/pytorch_lightning/utilities/data.py
@@ -41,7 +41,8 @@ def has_len(dataloader: DataLoader) -> bool:
         rank_zero_warn(
             'Your `IterableDataset` has `__len__` defined.'
             ' In combination with multi-process data loading (when num_workers > 1),'
-            ' `__len__` could be inaccurate if each worker is not configured independently to avoid having duplicate data.'
+            ' `__len__` could be inaccurate if each worker is not configured independently
+            ' to avoid having duplicate data.'
         )
     return has_len
 


### PR DESCRIPTION
Based on pytorch docs about dataloader length and iterable datasets.

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
Fixes #6966

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
