### PR TITLE
Fixing word tense

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ class LitAutoEncoder(pl.LightningModule):
         return embedding
 
     def training_step(self, batch, batch_idx):
-        # training_step defined the train loop. It is independent of forward
+        # training_step defines the train loop. It is independent of forward
         x, y = batch
         x = x.view(x.size(0), -1)
         z = self.encoder(x)


### PR DESCRIPTION
Changing "defined" to "defines" in keeping with the convention of using present tense in comments.

## What does this PR do?
Fixes word tense; increases clarity. Changed "defined" to "defines" in keeping with the convention of present tense while writing comments in code.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [X] Is this pull request ready for review? (if not, please submit in draft mode)
 - [X] Check that all items from **Before submitting** are resolved
 - [X] Make sure the title is self-explanatory and the description concisely explains the PR
 - [X] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
I did have fun. :)
