### PR TITLE
Deprecate `@auto_move_data` in favor of `trainer.predict`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,7 +136,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Deprecated `PytorchProfiler(profiled_functions)` in favor of `record_functions` ([#6349](https://github.com/PyTorchLightning/pytorch-lightning/pull/6349))
 
 
-- Deprecated `@auto_move_data` in favor of `trainer.predict` ([]())
+- Deprecated `@auto_move_data` in favor of `trainer.predict` ([#6993](https://github.com/PyTorchLightning/pytorch-lightning/pull/6993))
 
 
 - Deprecated metrics in favor of `torchmetrics` ([#6505](https://github.com/PyTorchLightning/pytorch-lightning/pull/6505),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Deprecated `PytorchProfiler(profiled_functions)` in favor of `record_functions` ([#6349](https://github.com/PyTorchLightning/pytorch-lightning/pull/6349))
 
 
+- Deprecated `@auto_move_data` in favor of `trainer.predict` ([]())
+
+
 - Deprecated metrics in favor of `torchmetrics` ([#6505](https://github.com/PyTorchLightning/pytorch-lightning/pull/6505),
     [#6530](https://github.com/PyTorchLightning/pytorch-lightning/pull/6530),
     [#6540](https://github.com/PyTorchLightning/pytorch-lightning/pull/6540),

--- a/docs/source/common/trainer.rst
+++ b/docs/source/common/trainer.rst
@@ -174,33 +174,6 @@ Once you're done training, feel free to run the test set!
 
 ------------
 
-Deployment / prediction
------------------------
-You just trained a LightningModule which is also just a torch.nn.Module.
-Use it to do whatever!
-
-.. code-block:: python
-
-    # load model
-    pretrained_model = LightningModule.load_from_checkpoint(PATH)
-    pretrained_model.freeze()
-
-    # use it for finetuning
-    def forward(self, x):
-        features = pretrained_model(x)
-        classes = classifier(features)
-
-    # or for prediction
-    out = pretrained_model(x)
-    api_write({'response': out}
-
-
-You may wish to run the model on a variety of devices. Instead of moving the data
-manually to the correct device, decorate the forward method (or any other method you use for inference)
-with :func:`~pytorch_lightning.core.decorators.auto_move_data` and Lightning will take care of the rest.
-
-------------
-
 Reproducibility
 ---------------
 

--- a/docs/source/starter/introduction_guide.rst
+++ b/docs/source/starter/introduction_guide.rst
@@ -855,7 +855,8 @@ In this case, we've set this LightningModel to predict logits. But we could also
     x = mnist_image()
     feature_maps = model(x)
 
-Or maybe we have a model that we use to do generation
+Or maybe we have a model that we use to do generation.
+A :class:`~pytorch_lightning.core.lightning.LightningModule` is also just a :class:`torch.nn.Module`.
 
 .. testcode::
 
@@ -880,8 +881,11 @@ Or maybe we have a model that we use to do generation
     generated_imgs = model(z)
 
 
-To perform inference at scale, it is possible to use ``trainer.predict`` with LightningModule ``predict_step`` function
-By default, LightningModule ``predict_step`` calls forward, but it can be overriden to add any processing logic.
+To perform inference at scale, it is possible to use :meth:`~pytorch_lightning.trainer.trainer.Trainer.predict`
+with :meth:`~pytorch_lightning.core.lightning.LightningModule.predict_step`
+By default, :meth:`~pytorch_lightning.core.lightning.LightningModule.predict_step`
+calls :meth:`~pytorch_lightning.core.lightning.LightningModule.forward`,
+but it can be overridden to add any processing logic.
 
 .. code-block:: python
 
@@ -899,14 +903,18 @@ By default, LightningModule ``predict_step`` calls forward, but it can be overri
     trainer.predict(model, datamodule)
 
 
-How you split up what goes in ``forward`` vs ``training_step`` vs ``predict`` depends on how you want to use this model for
-prediction.
-However, we recommend ``forward`` to contain only tensor operation with your model, ``training_step`` to encapsulate ``forward`` logic with logging,
-metrics and loss computation and ``predict`` to encapsulate ``forward`` with preprocess, postprocess functions.
+How you split up what goes in :meth:`~pytorch_lightning.core.lightning.LightningModule.forward`
+vs :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`
+vs :meth:`~pytorch_lightning.core.lightning.LightningModule.predict_step` depends on how you want to use this model for prediction.
+However, we recommend :meth:`~pytorch_lightning.core.lightning.LightningModule.forward` to contain only tensor operations with your model.
+:meth:`~pytorch_lightning.core.lightning.LightningModule.training_step` to encapsulate
+:meth:`~pytorch_lightning.core.lightning.LightningModule.forward` logic with logging, metrics, and loss computation.
+:meth:`~pytorch_lightning.core.lightning.LightningModule.predict_step` to encapsulate
+:meth:`~pytorch_lightning.core.lightning.LightningModule.forward` with any necessary preprocess or postprocess functions.
 
 ----------------
 
-The nonessentials
+The non-essentials
 ==================
 
 Extensibility

--- a/pytorch_lightning/core/__init__.py
+++ b/pytorch_lightning/core/__init__.py
@@ -19,4 +19,3 @@ __all__ = [
     'LightningDataModule',
     'LightningModule',
 ]
-# __call__ = __all__

--- a/pytorch_lightning/core/decorators.py
+++ b/pytorch_lightning/core/decorators.py
@@ -16,7 +16,7 @@
 from functools import wraps
 from typing import Callable
 
-from pytorch_lightning.utilities import rank_zero_warn
+from pytorch_lightning.utilities import rank_zero_deprecation, rank_zero_warn
 
 
 def auto_move_data(fn: Callable) -> Callable:
@@ -60,6 +60,11 @@ def auto_move_data(fn: Callable) -> Callable:
 
         args, kwargs = self.transfer_batch_to_device((args, kwargs))
         return fn(self, *args, **kwargs)
+
+    rank_zero_deprecation(
+        "The `@auto_move_data` decorator is deprecated in v1.3 and will be removed in v1.5."
+        f" Please use `trainer.predict` instead for inference. The decorator was applied to `{fn.__name__}`"
+    )
 
     return auto_transfer_args
 

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -485,53 +485,14 @@ class LightningModule(
 
     def forward(self, *args, **kwargs):
         r"""
-        Same as :meth:`torch.nn.Module.forward()`, however in Lightning you want this to define
-        the operations you want to use for prediction (i.e.: on a server or as a feature extractor).
-
-        Normally you'd call ``self()`` from your :meth:`training_step` method.
-        This makes it easy to write a complex system for training with the outputs
-        you'd want in a prediction setting.
-
-        You may also find the :func:`~pytorch_lightning.core.decorators.auto_move_data` decorator useful
-        when using the module outside Lightning in a production setting.
+        Same as :meth:`torch.nn.Module.forward()`.
 
         Args:
             *args: Whatever you decide to pass into the forward method.
             **kwargs: Keyword arguments are also possible.
 
         Return:
-            Predicted output
-
-        Examples::
-
-            # example if we were using this model as a feature extractor
-            def forward(self, x):
-                feature_maps = self.convnet(x)
-                return feature_maps
-
-            def training_step(self, batch, batch_idx):
-                x, y = batch
-                feature_maps = self(x)
-                logits = self.classifier(feature_maps)
-
-                # ...
-                return loss
-
-            # splitting it this way allows model to be used a feature extractor
-            model = MyModelAbove()
-
-            inputs = server.get_request()
-            results = model(inputs)
-            server.write_results(results)
-
-            # -------------
-            # This is in stark contrast to torch.nn.Module where normally you would have this:
-            def forward(self, batch):
-                x, y = batch
-                feature_maps = self.convnet(x)
-                logits = self.classifier(feature_maps)
-                return logits
-
+            Your model's output
         """
         return super().forward(*args, **kwargs)
 
@@ -1073,7 +1034,17 @@ class LightningModule(
 
     def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: Optional[int] = None):
         """
-        Use this function with trainer.predict(...). Override if you need to add any processing logic.
+        Step function called during :meth:`~pytorch_lightning.trainer.trainer.Trainer.predict`
+        By default, it calls :meth:`~pytorch_lightning.core.lightning.LightningModule.forward`.
+        Override to add any processing logic.
+
+        Args:
+            batch: Current batch
+            batch_idx: Index of current batch
+            dataloader_idx: Index of the current dataloader
+
+        Return:
+            Predicted output
         """
         return self(batch)
 

--- a/tests/deprecated_api/test_remove_1-5.py
+++ b/tests/deprecated_api/test_remove_1-5.py
@@ -20,6 +20,7 @@ from torch import optim
 
 from pytorch_lightning import Callback, Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
+from pytorch_lightning.core.decorators import auto_move_data
 from pytorch_lightning.loggers import WandbLogger
 from pytorch_lightning.profiler import AdvancedProfiler, BaseProfiler, PyTorchProfiler, SimpleProfiler
 from pytorch_lightning.trainer.callback_hook import warning_cache as callback_warning_cache
@@ -231,3 +232,13 @@ def test_v1_5_0_trainer_training_trick_mixin(tmpdir):
     dummy_loss = torch.tensor(1.0)
     with pytest.deprecated_call(match="is deprecated in v1.3 and will be removed in v1.5"):
         trainer.detect_nan_tensors(dummy_loss)
+
+
+def test_v1_5_0_auto_move_data():
+    with pytest.deprecated_call(match="deprecated in v1.3 and will be removed in v1.5.*was applied to `bar`"):
+
+        class Foo:
+
+            @auto_move_data
+            def bar(self):
+                pass


### PR DESCRIPTION
## What does this PR do?

See title.

This was added in 0.8.0.

A [quick code search](https://github.com/search?q=%22auto_move_data%22&type=code) shows some users of this feature, but many don't use it correctly or assume it's required. Additionally, we want people to use `predict`.

Also improves predict docs.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified