### PR TITLE
fix appending 'dataloader_idx_i' breaks checkpoint name

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -298,7 +298,7 @@ class LightningModule(
                 )
 
             # make sure user doesn't introduce logic for multi-dataloaders
-            if "/dataloader_idx_" in name:
+            if "(dataloader_idx_" in name:
                 raise MisconfigurationException(
                     f"Logged key: {name} should not contain information about dataloader_idx."
                 )

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -241,7 +241,7 @@ class Result(Dict):
 
     def _add_dataloader_idx(self, k: str, dataloader_idx: Union[int, None], add_dataloader_idx: bool) -> str:
         if dataloader_idx is not None and add_dataloader_idx:
-            return f"{k}/dataloader_idx_{dataloader_idx}"
+            return f"{k}(dataloader_idx_{dataloader_idx})"
         return k
 
     def get_batch_log_metrics(self, include_forked_originals=True, add_dataloader_idx=False) -> dict:

--- a/tests/trainer/logging_/test_eval_loop_logging.py
+++ b/tests/trainer/logging_/test_eval_loop_logging.py
@@ -385,8 +385,8 @@ def test_multi_dataloaders_add_suffix_properly(tmpdir):
     )
     results = trainer.test(model)
 
-    assert {"test_loss/dataloader_idx_0", "test_loss_epoch/dataloader_idx_0"} == set(results[0])
-    assert {"test_loss/dataloader_idx_1", "test_loss_epoch/dataloader_idx_1"} == set(results[1])
+    assert {"test_loss(dataloader_idx_0)", "test_loss_epoch(dataloader_idx_0)"} == set(results[0])
+    assert {"test_loss(dataloader_idx_1)", "test_loss_epoch(dataloader_idx_1)"} == set(results[1])
 
 
 def test_single_dataloader_no_suffix_added(tmpdir):
@@ -651,7 +651,7 @@ def test_log_works_in_test_callback(tmpdir):
                 num_dl_ext = ''
                 if pl_module._current_dataloader_idx is not None:
                     dl_idx = pl_module._current_dataloader_idx
-                    num_dl_ext = f"/dataloader_idx_{dl_idx}"
+                    num_dl_ext = f"(dataloader_idx_{dl_idx})"
                     func_name += num_dl_ext
 
                 # catch information for verification
@@ -777,7 +777,7 @@ def test_log_works_in_test_callback(tmpdir):
     trainer.callback_metrics.pop("debug_epoch")
 
     for dl_idx in range(num_dataloaders):
-        key = f"test_loss/dataloader_idx_{dl_idx}"
+        key = f"test_loss(dataloader_idx_{dl_idx})"
         assert key in trainer.callback_metrics
         assert torch.stack(model.manual_mean[str(dl_idx)]).mean() == trainer.callback_metrics[key]
         trainer.callback_metrics.pop(key)

--- a/tests/trainer/logging_/test_logger_connector.py
+++ b/tests/trainer/logging_/test_logger_connector.py
@@ -554,8 +554,8 @@ def test_auto_add_dataloader_idx(tmpdir, add_dataloader_idx):
 
     # Check that the correct keys exist
     if add_dataloader_idx:
-        assert 'val_loss/dataloader_idx_0' in logged
-        assert 'val_loss/dataloader_idx_1' in logged
+        assert 'val_loss(dataloader_idx_0)' in logged
+        assert 'val_loss(dataloader_idx_1)' in logged
     else:
         assert 'val_loss_custom_naming_0' in logged
         assert 'val_loss_custom_naming_1' in logged


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
When there are multiple validation dataloaders, `log` will append `/dataloader_idx_<i>` to the metric name. e.g. `self.log('accuracy')` results in metric name `accuracy/dataloader_idx_0`.

On the other hand, we can specify `filename` in `ModelCheckpoint` as `"name_{metric_name:.2f}"` and the `"{}"` will be replaced by the metric value according to the metric name.

Now the problem is when metric name is `"accuracy/dataloader_idx_0"`, and to get the value of it we specify `filename` of `ModelCheckpoint` as `"name_{accuracy/dataloader_idx_0:.2f}"`, the checkpoint will be saved as `"dataloader_idx_0=0.89.ckpt"` under a directory `"name_accuracy"`

So I change `"/dataloader_idx_<i>"` to `"(dataloader_idx_<i>)"` to solve this problem.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary) -> no need
- [x] Did you write any new necessary tests? (not for typos and docs) -> no need
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings) -> no need

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
