### PR TITLE
Fix the condition for calling update_learning_rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,6 +366,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     * Remove hardcoding of local rank in accelerator connector ([#6878](https://github.com/PyTorchLightning/pytorch-lightning/pull/6878))
 
 
+- Fixed incorrect number of calls to LR scheduler when `check_val_every_n_epoch > 1` ([#7032](https://github.com/PyTorchLightning/pytorch-lightning/pull/7032))
+
+
 ## [1.2.7] - 2021-04-06
 
 ### Fixed

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -563,7 +563,7 @@ class TrainLoop:
         should_train_only = self.trainer.disable_validation or should_skip_eval
 
         # update epoch level lr_schedulers if no val loop outside train loop is triggered
-        if (val_loop_called and not should_check_val) or should_train_only:
+        if (not val_loop_called and not should_check_val) or should_train_only:
             self.trainer.optimizer_connector.update_learning_rates(interval='epoch')
 
         if should_train_only:

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -563,7 +563,7 @@ class TrainLoop:
         should_train_only = self.trainer.disable_validation or should_skip_eval
 
         # update epoch level lr_schedulers if no val loop outside train loop is triggered
-        if (not val_loop_called and not should_check_val) or should_train_only:
+        if not should_check_val or should_train_only:
             self.trainer.optimizer_connector.update_learning_rates(interval='epoch')
 
         if should_train_only:

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -472,7 +472,6 @@ class TrainLoop:
 
         train_dataloader = self.trainer.data_connector.get_profiled_train_dataloader(train_dataloader)
         dataloader_idx = 0
-        val_loop_called = False
 
         batch_idx = None
         is_last_batch = None
@@ -514,7 +513,6 @@ class TrainLoop:
                 self.trainer.validating = True
                 self.trainer._run_evaluation()
                 self.trainer.training = True
-                val_loop_called = True
 
             # -----------------------------------------
             # SAVE LOGGERS (ie: Tensorboard, etc...)

--- a/tests/trainer/optimization/test_optimizers.py
+++ b/tests/trainer/optimization/test_optimizers.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import mock
+
 import pytest
 import torch
 from torch import optim
@@ -577,21 +579,20 @@ def test_warn_invalid_scheduler_key_in_manual_optimization(tmpdir):
         trainer.fit(model)
 
 
-class TestModel(BoringModel):
-
-    def configure_optimizers(self):
-        # Adagrad creates state tensors immediately, model is not yet on GPU.
-        return optim.Adagrad(self.parameters())
-
-    def on_train_start(self, *args, **kwargs):
-        opt = self.optimizers()
-        _, state = next(iter(opt.state.items()))
-        assert state["sum"].device == torch.device("cuda", self.local_rank) == self.device
-
-
 @RunIf(min_gpus=2, special=True)
 def test_optimizer_state_on_device(tmpdir):
     """ Test that optimizers that create state initially at instantiation still end up with the state on the GPU. """
+    class TestModel(BoringModel):
+
+        def configure_optimizers(self):
+            # Adagrad creates state tensors immediately, model is not yet on GPU.
+            return optim.Adagrad(self.parameters())
+
+        def on_train_start(self, *args, **kwargs):
+            opt = self.optimizers()
+            _, state = next(iter(opt.state.items()))
+            assert state["sum"].device == torch.device("cuda", self.local_rank) == self.device
+
     model = TestModel()
     trainer = Trainer(
         default_root_dir=tmpdir,
@@ -600,3 +601,21 @@ def test_optimizer_state_on_device(tmpdir):
         fast_dev_run=True,
     )
     trainer.fit(model)
+
+
+@pytest.mark.parametrize("check_val_every_n_epoch", [1, 2])
+@mock.patch("torch.optim.lr_scheduler.StepLR.step")
+def test_lr_scheduler_update_frequency(mocked_sched, check_val_every_n_epoch, tmpdir):
+    epochs = 4
+    expected_steps = epochs + 1  # every LRScheduler gets called once at init
+
+    model = BoringModel()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        check_val_every_n_epoch=check_val_every_n_epoch,
+        max_epochs=epochs,
+    )
+    trainer.fit(model)
+    assert mocked_sched.call_count == expected_steps

--- a/tests/trainer/optimization/test_optimizers.py
+++ b/tests/trainer/optimization/test_optimizers.py
@@ -582,6 +582,7 @@ def test_warn_invalid_scheduler_key_in_manual_optimization(tmpdir):
 @RunIf(min_gpus=2, special=True)
 def test_optimizer_state_on_device(tmpdir):
     """ Test that optimizers that create state initially at instantiation still end up with the state on the GPU. """
+
     class TestModel(BoringModel):
 
         def configure_optimizers(self):

--- a/tests/trainer/optimization/test_optimizers.py
+++ b/tests/trainer/optimization/test_optimizers.py
@@ -605,7 +605,7 @@ def test_optimizer_state_on_device(tmpdir):
 
 @pytest.mark.parametrize("check_val_every_n_epoch", [1, 2])
 @mock.patch("torch.optim.lr_scheduler.StepLR.step")
-def test_lr_scheduler_update_frequency(mocked_sched, check_val_every_n_epoch, tmpdir):
+def test_lr_scheduler_epoch_step_frequency(mocked_sched, check_val_every_n_epoch, tmpdir):
     epochs = 4
     expected_steps = epochs + 1  # every LRScheduler gets called once at init
 


### PR DESCRIPTION
## What does this PR do?

This pull request fixes the condition for `update_learning_rates` to be called in `training_loop.py`.

`update_learning_rates` in the `OptimizerConnector` class is called from several places. In the `training_loop.py`, one of the calling conditions is missing a `not`.

As a result, when Trainer's `check_val_every_n_epoch` is set to a value greater than 2, the learning rate is not updated as expected. For example, if `check_val_every_n_epoch` is set to 2, the learning rate will be updated only once every 2 epochs.

### more detail

The current condition for calling `update_learning_rates` is as follows.

```
if (val_loop_called and not should_check_val) or should_train_only
```

The comment above the line says "_update epoch level lr_schedulers if no val loop outside train loop is triggered_". Current code doesn't work as the comment expects.

This pull request fixes this issue by inserting `not` before the `val_loop_called`.


Fixes #6616

By the way, we can assume that `update_learning_rates` does not have any side effects (in fact, I check the current behavior of PyTorch-Lightning by writing a custom learning rate rule by myself. Currently, it is called twice in one epoch). So, I think we can call it every time in the training loop without thinking anything difficult. However, since I don't understand the whole code of this project, I kept the amount of changes in this pull request as small as possible.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified