### PR TITLE
Typo LightningMoule -> LightningModule

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -247,7 +247,7 @@ class LightningModule(
         The default behavior per hook is as follows
 
         .. csv-table:: ``*`` also applies to the test loop
-           :header: "LightningMoule Hook", "on_step", "on_epoch", "prog_bar", "logger"
+           :header: "LightningModule Hook", "on_step", "on_epoch", "prog_bar", "logger"
            :widths: 20, 10, 10, 10, 10
 
            "training_step", "T", "F", "F", "T"


### PR DESCRIPTION
Just a typo I noticed while reading the API doc