### PR TITLE
Fix attribute error for _gpus_arg_default loading checkpoint prior to 1.2.8

### DIFF
--- a/pytorch_lightning/utilities/argparse.py
+++ b/pytorch_lightning/utilities/argparse.py
@@ -286,7 +286,7 @@ def _gpus_allowed_type(x) -> Union[int, str]:
         return int(x)
 
 
-def _gpus_arg_default(x) -> Union[int, str]:
+def _gpus_arg_default(x) -> Union[int, str]:  # pragma: no-cover
     # unused, but here for backward compatibility with old checkpoints that need to be able to
     # unpickle the function from the checkpoint, as it was not filtered out in versions < 1.2.8
     # see: https://github.com/PyTorchLightning/pytorch-lightning/pull/6898

--- a/pytorch_lightning/utilities/argparse.py
+++ b/pytorch_lightning/utilities/argparse.py
@@ -286,6 +286,13 @@ def _gpus_allowed_type(x) -> Union[int, str]:
         return int(x)
 
 
+def _gpus_arg_default(x) -> Union[int, str]:
+    # unused, but here for backward compatibility with old checkpoints that need to be able to
+    # unpickle the function from the checkpoint, as it was not filtered out in versions < 1.2.8
+    # see: https://github.com/PyTorchLightning/pytorch-lightning/pull/6898
+    return _gpus_allowed_type(x)
+
+
 def _int_or_float_type(x) -> Union[int, float]:
     if '.' in str(x):
         return float(x)

--- a/pytorch_lightning/utilities/argparse.py
+++ b/pytorch_lightning/utilities/argparse.py
@@ -290,7 +290,7 @@ def _gpus_arg_default(x) -> Union[int, str]:  # pragma: no-cover
     # unused, but here for backward compatibility with old checkpoints that need to be able to
     # unpickle the function from the checkpoint, as it was not filtered out in versions < 1.2.8
     # see: https://github.com/PyTorchLightning/pytorch-lightning/pull/6898
-    return _gpus_allowed_type(x)
+    pass
 
 
 def _int_or_float_type(x) -> Union[int, float]:


### PR DESCRIPTION
## What does this PR do?

Fixes #7031 

I removed a function in #6898 that I should not have removed. 
Old checkpoints (<1.2.8) have this pickled, so in order to load the checkpoint back we need to have access to the source code. 

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
