### PR TITLE
Correctly reset metric objects in self.log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,6 +279,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed process rank not being available right away after `Trainer` instantiation ([#6941](https://github.com/PyTorchLightning/pytorch-lightning/pull/6941))
 
 
+- Fixed metric objects passed directly to `self.log` not being reset correctly ([#7055](https://github.com/PyTorchLightning/pytorch-lightning/pull/7055))
+
+
 ## [1.2.7] - 2021-04-06
 
 ### Fixed

--- a/docs/source/common/trainer.rst
+++ b/docs/source/common/trainer.rst
@@ -130,7 +130,7 @@ So you can run it like so:
 
     if __name__ == '__main__':
         parser = ArgumentParser()
-        parser = Trainer.add_argparse_args()
+        parser = Trainer.add_argparse_args(parser)
         args = parser.parse_args()
 
         main(args)

--- a/pytorch_lightning/core/step_result.py
+++ b/pytorch_lightning/core/step_result.py
@@ -287,16 +287,12 @@ class Result(Dict):
             if options['logger'] and options['on_epoch']:
                 if isinstance(self[k], Metric):
                     result[dl_key] = self[k].compute().detach()
-                    self[k].reset()
                 else:
                     result[dl_key] = self[k]
 
             if k in self and not options['on_epoch'] and isinstance(self[k], Metric):
-                # reset metric anyway so state does not accumulate
-                # NOTE: we must compute before reseting just in case the computed value is needed
-                # later (i.e. if the step metric gets visited first, and then the epoch metric)
+                # compute for reuse later
                 self[k].compute()
-                self[k].reset()
 
         return result
 
@@ -319,16 +315,12 @@ class Result(Dict):
             if options['prog_bar'] and options['on_epoch']:
                 if isinstance(self[k], Metric):
                     result[dl_key] = self[k].compute().detach()
-                    self[k].reset()
                 else:
                     result[dl_key] = self[k]
 
             if k in self and not options['on_epoch'] and isinstance(self[k], Metric):
-                # reset metric anyway so state does not accumulate
-                # NOTE: we must compute before reseting just in case the computed value is needed
-                # later (i.e. if the step metric gets visited first, and then the epoch metric)
+                # compute for reuse later
                 self[k].compute()
-                self[k].reset()
 
         return result
 
@@ -348,7 +340,6 @@ class Result(Dict):
             if options['forked']:
                 if isinstance(self[k], Metric):
                     result[dl_key] = self[k].compute().detach()
-                    self[k].reset()
                 else:
                     result[dl_key] = self[k]
 
@@ -586,6 +577,14 @@ class Result(Dict):
         This function is used to filter metric keys for which the value isn't a Metric
         """
         return [k for k, v in self.items() if not isinstance(v, Metric)]
+
+    def reset(self):
+        """
+        Call at the end of epoch to reset all metric objects
+        """
+        for k, value in self.items():
+            if isinstance(value, Metric):
+                value.reset()
 
 
 def choose_last(x):

--- a/pytorch_lightning/trainer/connectors/logger_connector/epoch_result_store.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/epoch_result_store.py
@@ -233,6 +233,18 @@ class HookResultStore:
 
         self.has_reduced = True
 
+    def reset(self):
+        """
+        Call at the end of epoch to reset Result objects
+        """
+        for dl_idx in range(self.num_dataloaders):
+            epoch_metrics = self._internals[dl_idx]
+            if self._internal_type == ResultStoreType.INSIDE_BATCH_TRAIN_LOOP:
+                for opt_idx in list(epoch_metrics):
+                    epoch_metrics[opt_idx].reset()
+            else:
+                epoch_metrics.reset()
+
     def __getitem__(self, key: str) -> Any:
         return self._internals.get(key, None)
 
@@ -443,6 +455,9 @@ class EpochResultStore:
         return self.run_epoch_by_func_name("get_forked_metrics")
 
     def reset(self):
+        if hasattr(self, '_internals'):
+            for k, value in self._internals.items():
+                value.reset()
         self._internals = {}
         self._dataloader_idx: Optional[int] = None
         self._split_idx: Optional[int] = None

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -741,10 +741,10 @@ class Trainer(
 
         # enable train mode again
         self.evaluation_loop.on_evaluation_model_train()
-        
+
         # reset cached results
         self.logger_connector.reset()
-        
+
         torch.set_grad_enabled(True)
 
         return eval_loop_results

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -653,9 +653,6 @@ class Trainer(
             )
             self.validating = True
 
-        # reset cached results
-        self.logger_connector.reset()
-
         # prepare dataloaders
         dataloaders, max_batches = self.evaluation_loop.get_evaluation_dataloaders()
 
@@ -746,6 +743,9 @@ class Trainer(
         self.evaluation_loop.on_evaluation_model_train()
 
         torch.set_grad_enabled(True)
+
+        # reset cached results
+        self.logger_connector.reset()
 
         return eval_loop_results
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -741,11 +741,11 @@ class Trainer(
 
         # enable train mode again
         self.evaluation_loop.on_evaluation_model_train()
-
-        torch.set_grad_enabled(True)
-
+        
         # reset cached results
         self.logger_connector.reset()
+        
+        torch.set_grad_enabled(True)
 
         return eval_loop_results
 

--- a/tests/core/test_metric_result_integration.py
+++ b/tests/core/test_metric_result_integration.py
@@ -76,6 +76,7 @@ def _ddp_test_fn(rank, worldsize):
                 assert batch_expected[k] == batch_log[k]
 
         epoch_log = result.get_epoch_log_metrics()
+        result.reset()
 
         # assert metric state reset to default values
         assert metric_a.x == metric_a._defaults['x']
@@ -127,6 +128,7 @@ def test_result_metric_integration():
                 assert batch_expected[k] == batch_log[k]
 
         epoch_log = result.get_epoch_log_metrics()
+        result.reset()
 
         # assert metric state reset to default values
         assert metric_a.x == metric_a._defaults['x']

--- a/tests/trainer/logging_/test_logger_connector.py
+++ b/tests/trainer/logging_/test_logger_connector.py
@@ -22,10 +22,11 @@ from unittest import mock
 import pytest
 import torch
 from torch.utils.data import DataLoader
+from torchmetrics import Accuracy, AveragePrecision
 
+from pytorch_lightning import LightningModule
 from pytorch_lightning.callbacks.base import Callback
 from pytorch_lightning.core.step_result import Result
-from pytorch_lightning.metrics import Accuracy
 from pytorch_lightning.trainer import Trainer
 from pytorch_lightning.trainer.connectors.logger_connector.callback_hook_validator import CallbackHookNameValidator
 from pytorch_lightning.trainer.connectors.logger_connector.metrics_holder import MetricsHolder
@@ -590,3 +591,116 @@ def test_logged_metrics_steps(tmpdir):
 
     assert trainer.dev_debugger.logged_metrics[0]['global_step'] == 1
     assert trainer.dev_debugger.logged_metrics[1]['global_step'] == 3
+
+
+def test_metrics_reset(tmpdir):
+    """Tests that metrics are reset correctly after the end of the train/val/test epoch."""
+
+    class TestModel(LightningModule):
+
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(32, 1)
+
+            for stage in ['train', 'val', 'test']:
+                acc = Accuracy()
+                acc.reset = mock.Mock(side_effect=acc.reset)
+                ap = AveragePrecision(num_classes=1, pos_label=1)
+                ap.reset = mock.Mock(side_effect=ap.reset)
+                self.add_module(f"acc_{stage}", acc)
+                self.add_module(f"ap_{stage}", ap)
+
+        def forward(self, x):
+            return self.layer(x)
+
+        def _step(self, stage, batch):
+            labels = (batch.detach().sum(1) > 0).float()  # Fake some targets
+            logits = self.forward(batch)
+            loss = torch.nn.functional.binary_cross_entropy_with_logits(logits, labels.unsqueeze(1))
+            probs = torch.sigmoid(logits.detach())
+            self.log(f"loss/{stage}", loss)
+
+            acc = self._modules[f"acc_{stage}"]
+            ap = self._modules[f"ap_{stage}"]
+
+            labels_int = labels.to(torch.long)
+            acc(probs, labels_int)
+            ap(probs, labels_int)
+
+            # Metric.forward calls reset so reset the mocks here
+            acc.reset.reset_mock()
+            ap.reset.reset_mock()
+
+            self.log(f"{stage}/accuracy", acc)
+            self.log(f"{stage}/ap", ap)
+
+            return loss
+
+        def training_step(self, batch, batch_idx, *args, **kwargs):
+            return self._step('train', batch)
+
+        def validation_step(self, batch, batch_idx, *args, **kwargs):
+            return self._step('val', batch)
+
+        def test_step(self, batch, batch_idx, *args, **kwargs):
+            return self._step('test', batch)
+
+        def configure_optimizers(self):
+            optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
+            lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
+            return [optimizer], [lr_scheduler]
+
+        def train_dataloader(self):
+            return DataLoader(RandomDataset(32, 64))
+
+        def val_dataloader(self):
+            return DataLoader(RandomDataset(32, 64))
+
+        def test_dataloader(self):
+            return DataLoader(RandomDataset(32, 64))
+
+        def _assert_epoch_end(self, stage):
+            acc = self._modules[f"acc_{stage}"]
+            ap = self._modules[f"ap_{stage}"]
+
+            acc.reset.asset_not_called()
+            ap.reset.assert_not_called()
+
+        def on_train_epoch_end(self, outputs):
+            self._assert_epoch_end('train')
+
+        def on_validation_epoch_end(self, outputs):
+            self._assert_epoch_end('val')
+
+        def on_test_epoch_end(self, outputs):
+            self._assert_epoch_end('test')
+
+    def _assert_called(model, stage):
+        acc = model._modules[f"acc_{stage}"]
+        ap = model._modules[f"ap_{stage}"]
+
+        acc.reset.assert_called()
+        acc.reset.reset_mock()
+
+        ap.reset.assert_called()
+        ap.reset.reset_mock()
+
+    model = TestModel()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        limit_test_batches=2,
+        max_epochs=1,
+        progress_bar_refresh_rate=0,
+    )
+
+    trainer.fit(model)
+    _assert_called(model, 'train')
+    _assert_called(model, 'val')
+
+    trainer.validate(model)
+    _assert_called(model, 'val')
+
+    trainer.test(model)
+    _assert_called(model, 'test')

--- a/tests/trainer/logging_/test_logger_connector.py
+++ b/tests/trainer/logging_/test_logger_connector.py
@@ -679,10 +679,10 @@ def test_metrics_reset(tmpdir):
         acc = model._modules[f"acc_{stage}"]
         ap = model._modules[f"ap_{stage}"]
 
-        acc.reset.assert_called()
+        acc.reset.assert_called_once()
         acc.reset.reset_mock()
 
-        ap.reset.assert_called()
+        ap.reset.assert_called_once()
         ap.reset.reset_mock()
 
     model = TestModel()


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/7052
Since commit https://github.com/PyTorchLightning/metrics/commit/19b77cc2c290e811ae1c1ea44125776414b4e431 in torchmetrics, the integration with lightning has been broken if the metric object have been tried to be logged directly. This is because the lightning logging implicit depends on the `self._computed` variable *not* being reset whenever `reset` is called. 

This PR tries to solve this by making sure that `reset` of metric objects is only called once at the very end. Please note that I am not so familiar with the logger connection of the code base.

As an alternative we revert the changes in torchmetrics. However, it does make some sense that the `self._computed` variable should be reset when `reset` is called.

cc: @ethanwharris 



## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
