### PR TITLE
[bugfix] Add support for default base64 precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,6 +304,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed metric objects passed directly to `self.log` not being reset correctly ([#7055](https://github.com/PyTorchLightning/pytorch-lightning/pull/7055))
 
 
+- Fixed `torch.float64` is the default dtype in `{}_step` function of the LightningModule when using `precision=64` ([#7107](https://github.com/PyTorchLightning/pytorch-lightning/pull/7107))
+
+
 ## [1.2.7] - 2021-04-06
 
 ### Fixed

--- a/pytorch_lightning/plugins/precision/double.py
+++ b/pytorch_lightning/plugins/precision/double.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from functools import wraps, partial
-from typing import Any, List, Tuple, Optional, Callable 
+from functools import partial, wraps
+from typing import Any, Callable, List, Optional, Tuple
 
 import torch
 import torch.nn as nn
-from torch.optim import Optimizer
 from torch import dtype
+from torch.optim import Optimizer
 
 from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.plugins.precision.precision_plugin import PrecisionPlugin
@@ -52,7 +52,9 @@ class _DoublePrecisionPatch:
         @wraps(old_method)
         def new_method(*args: Any, **kwargs: Any) -> Any:
             _torch_tensor_ref = torch.tensor
-            torch.tensor = partial(DoublePrecisionPlugin.wrapping_function, wrapped_func=torch.tensor, default_dtype=torch.float64)
+            torch.tensor = partial(
+                DoublePrecisionPlugin.wrapping_function, wrapped_func=torch.tensor, default_dtype=torch.float64
+            )
             out = old_method(
                 *_DoublePrecisionPatch._move_float_tensors_to_double(args),
                 **_DoublePrecisionPatch._move_float_tensors_to_double(kwargs)

--- a/tests/plugins/test_double_plugin.py
+++ b/tests/plugins/test_double_plugin.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 import pytest
 import torch
-from typing import Optional, Callable
-from torch._C import dtype
-from torch.functional import Tensor
 from torch.utils.data import DataLoader, Dataset
 
 from pytorch_lightning import Trainer


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

This PR makes the precision 64 the default in the {}_step context.

Fixes #6927

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
