### PR TITLE
Move save_hyperparameters to its own function

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1645,7 +1645,7 @@ class LightningModule(
             "arg1": 1
             "arg3": 3.14
         """
-        # the frame needs to be create in this file.
+        # the frame needs to be created in this file.
         if not frame:
             frame = inspect.currentframe().f_back
         save_hyperparameters(self, *args, ignore=ignore, frame=frame)

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1645,6 +1645,9 @@ class LightningModule(
             "arg1": 1
             "arg3": 3.14
         """
+        # the frame needs to be create in this file.
+        if not frame:
+            frame = inspect.currentframe().f_back
         save_hyperparameters(self, *args, ignore=ignore, frame=frame)
 
     def _set_hparams(self, hp: Union[dict, Namespace, str]) -> None:

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -42,7 +42,7 @@ from pytorch_lightning.utilities import rank_zero_deprecation, rank_zero_warn
 from pytorch_lightning.utilities.apply_func import apply_to_collection, convert_to_tensors
 from pytorch_lightning.utilities.device_dtype_mixin import DeviceDtypeModuleMixin
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities.parsing import AttributeDict, collect_init_args, get_init_args
+from pytorch_lightning.utilities.parsing import AttributeDict, collect_init_args, save_hyperparameters
 from pytorch_lightning.utilities.types import EPOCH_OUTPUT, STEP_OUTPUT
 
 log = logging.getLogger(__name__)
@@ -1647,36 +1647,7 @@ class LightningModule(
         """
         if not frame:
             frame = inspect.currentframe().f_back
-        init_args = get_init_args(frame)
-        assert init_args, "failed to inspect the self init"
-
-        if ignore is not None:
-            if isinstance(ignore, str):
-                ignore = [ignore]
-            if isinstance(ignore, (list, tuple)):
-                ignore = [arg for arg in ignore if isinstance(arg, str)]
-            init_args = {k: v for k, v in init_args.items() if k not in ignore}
-
-        if not args:
-            # take all arguments
-            hp = init_args
-            self._hparams_name = "kwargs" if hp else None
-        else:
-            # take only listed arguments in `save_hparams`
-            isx_non_str = [i for i, arg in enumerate(args) if not isinstance(arg, str)]
-            if len(isx_non_str) == 1:
-                hp = args[isx_non_str[0]]
-                cand_names = [k for k, v in init_args.items() if v == hp]
-                self._hparams_name = cand_names[0] if cand_names else None
-            else:
-                hp = {arg: init_args[arg] for arg in args if isinstance(arg, str)}
-                self._hparams_name = "kwargs"
-
-        # `hparams` are expected here
-        if hp:
-            self._set_hparams(hp)
-        # make deep copy so  there is not other runtime changes reflected
-        self._hparams_initial = copy.deepcopy(self._hparams)
+        save_hyperparameters(self, *args, ignore=ignore, frame=frame)
 
     def _set_hparams(self, hp: Union[dict, Namespace, str]) -> None:
         if isinstance(hp, Namespace):

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1645,8 +1645,6 @@ class LightningModule(
             "arg1": 1
             "arg3": 3.14
         """
-        if not frame:
-            frame = inspect.currentframe().f_back
         save_hyperparameters(self, *args, ignore=ignore, frame=frame)
 
     def _set_hparams(self, hp: Union[dict, Namespace, str]) -> None:

--- a/pytorch_lightning/utilities/parsing.py
+++ b/pytorch_lightning/utilities/parsing.py
@@ -169,66 +169,7 @@ def save_hyperparameters(
     ignore: Optional[Union[Sequence[str], str]] = None,
     frame: Optional[types.FrameType] = None
 ) -> None:
-    """Save model arguments to ``hparams`` attribute.
-
-    Args:
-        args: single object of `dict`, `NameSpace` or `OmegaConf`
-            or string names or arguments from class ``__init__``
-        ignore: an argument name or a list of argument names from
-            class ``__init__`` to be ignored
-        frame: a frame object. Default is None
-
-    Example::
-        >>> class ManuallyArgsModel(pl.LightningModule):
-        ...     def __init__(obj, arg1, arg2, arg3):
-        ...         super().__init__()
-        ...         # manually assign arguments
-        ...         obj.save_hyperparameters('arg1', 'arg3')
-        ...     def forward(obj, *args, **kwargs):
-        ...         ...
-        >>> model = ManuallyArgsModel(1, 'abc', 3.14)
-        >>> model.hparams
-        "arg1": 1
-        "arg3": 3.14
-
-        >>> class AutomaticArgsModel(pl.LightningModule):
-        ...     def __init__(obj, arg1, arg2, arg3):
-        ...         super().__init__()
-        ...         # equivalent automatic
-        ...         obj.save_hyperparameters()
-        ...     def forward(obj, *args, **kwargs):
-        ...         ...
-        >>> model = AutomaticArgsModel(1, 'abc', 3.14)
-        >>> model.hparams
-        "arg1": 1
-        "arg2": abc
-        "arg3": 3.14
-
-        >>> class SingleArgModel(pl.LightningModule):
-        ...     def __init__(obj, params):
-        ...         super().__init__()
-        ...         # manually assign single argument
-        ...         obj.save_hyperparameters(params)
-        ...     def forward(obj, *args, **kwargs):
-        ...         ...
-        >>> model = SingleArgModel(Namespace(p1=1, p2='abc', p3=3.14))
-        >>> model.hparams
-        "p1": 1
-        "p2": abc
-        "p3": 3.14
-
-        >>> class ManuallyArgsModel(pl.LightningModule):
-        ...     def __init__(obj, arg1, arg2, arg3):
-        ...         super().__init__()
-        ...         # pass argument(s) to ignore as a string or in a list
-        ...         obj.save_hyperparameters(ignore='arg2')
-        ...     def forward(obj, *args, **kwargs):
-        ...         ...
-        >>> model = ManuallyArgsModel(1, 'abc', 3.14)
-        >>> model.hparams
-        "arg1": 1
-        "arg3": 3.14
-    """
+    """See :meth:`~pytorch_lightning.core.lightning.LightningModule.save_hyperparameters`"""
     if not frame:
         frame = inspect.currentframe().f_back
     init_args = get_init_args(frame)

--- a/pytorch_lightning/utilities/parsing.py
+++ b/pytorch_lightning/utilities/parsing.py
@@ -18,7 +18,6 @@ import types
 from argparse import Namespace
 from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
-import pytorch_lightning as pl
 from pytorch_lightning.utilities import rank_zero_warn
 
 

--- a/pytorch_lightning/utilities/parsing.py
+++ b/pytorch_lightning/utilities/parsing.py
@@ -168,7 +168,7 @@ def save_hyperparameters(
     ignore: Optional[Union[Sequence[str], str]] = None,
     frame: Optional[types.FrameType] = None
 ) -> None:
-    """See :meth:`~pytorch_lightning.core.lightning.LightningModule.save_hyperparameters`"""
+    """See :meth:`~pytorch_lightning.LightningModule.save_hyperparameters`"""
     if not frame:
         frame = inspect.currentframe().f_back
     init_args = get_init_args(frame)


### PR DESCRIPTION
## What does this PR do?
### Motivation

Would like to add `save_hyperparemeters` to Flash Preprocess / Postprocess, so we don't pickle the object.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
