### PR TITLE
Enforce Lightning module as source of truth for automatic optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
+- Removed `automatic_optimization` as a property from the training loop ([#7130](https://github.com/PyTorchLightning/pytorch-lightning/pull/7130))
+
+
 - Removed evaluation loop legacy returns for `*_epoch_end` hooks ([#6973](https://github.com/PyTorchLightning/pytorch-lightning/pull/6973))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,7 +190,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
-- Removed `automatic_optimization` as a property from the training loop ([#7130](https://github.com/PyTorchLightning/pytorch-lightning/pull/7130))
+- Removed `automatic_optimization` as a property from the training loop in favor of `LightningModule.automatic_optimization` ([#7130](https://github.com/PyTorchLightning/pytorch-lightning/pull/7130))
 
 
 - Removed evaluation loop legacy returns for `*_epoch_end` hooks ([#6973](https://github.com/PyTorchLightning/pytorch-lightning/pull/6973))

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1250,7 +1250,7 @@ class LightningModule(
                 loss.backward()
 
         """
-        if self.trainer.train_loop.automatic_optimization or self._running_manual_backward:
+        if self.automatic_optimization or self._running_manual_backward:
             loss.backward(*args, **kwargs)
 
     def toggle_optimizer(self, optimizer: Optimizer, optimizer_idx: int):
@@ -1539,7 +1539,7 @@ class LightningModule(
         avg_training_loss = None
         if running_train_loss is not None:
             avg_training_loss = running_train_loss.cpu().item()
-        elif self.trainer.train_loop.automatic_optimization:
+        elif self.automatic_optimization:
             avg_training_loss = float('NaN')
 
         tqdm_dict = {}
@@ -1558,7 +1558,7 @@ class LightningModule(
         return tqdm_dict
 
     def _verify_is_manual_optimization(self, fn_name):
-        if self.trainer.train_loop.automatic_optimization:
+        if self.automatic_optimization:
             raise MisconfigurationException(
                 f'to use {fn_name}, please disable automatic optimization:'
                 ' set model property `automatic_optimization` as False'

--- a/pytorch_lightning/trainer/configuration_validator.py
+++ b/pytorch_lightning/trainer/configuration_validator.py
@@ -78,7 +78,7 @@ class ConfigValidator(object):
 
         trainer.overriden_optimizer_step = is_overridden('optimizer_step', model)
         trainer.overriden_optimizer_zero_grad = is_overridden('optimizer_zero_grad', model)
-        automatic_optimization = trainer.train_loop.automatic_optimization
+        automatic_optimization = model.automatic_optimization
         going_to_accumulate_grad_batches = trainer.accumulation_scheduler.going_to_accumulate_grad_batches()
 
         has_overriden_optimization_functions = trainer.overriden_optimizer_step or trainer.overriden_optimizer_zero_grad

--- a/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -358,7 +358,7 @@ class LoggerConnector:
         return epoch_log_metrics, epoch_progress_bar_metrics
 
     def log_train_step_metrics(self, batch_output):
-        if self.trainer.train_loop.should_accumulate() and self.trainer.train_loop.automatic_optimization:
+        if self.trainer.train_loop.should_accumulate() and self.trainer.lightning_module.automatic_optimization:
             return
         _, batch_log_metrics = self.cached_results.update_logger_connector()
         # when metrics should be logged

--- a/pytorch_lightning/trainer/connectors/model_connector.py
+++ b/pytorch_lightning/trainer/connectors/model_connector.py
@@ -27,9 +27,6 @@ class ModelConnector:
     def copy_trainer_model_properties(self, model):
         ref_model = self.trainer.lightning_module or model
 
-        automatic_optimization = ref_model.automatic_optimization and self.trainer.train_loop.automatic_optimization
-        self.trainer.train_loop.automatic_optimization = automatic_optimization
-
         for m in [model, ref_model]:
             m.trainer = proxy(self.trainer)
             m._device_type = str(self.trainer._device_type)

--- a/pytorch_lightning/trainer/connectors/optimizer_connector.py
+++ b/pytorch_lightning/trainer/connectors/optimizer_connector.py
@@ -32,7 +32,7 @@ class OptimizerConnector:
             interval: either 'epoch' or 'step'.
             monitor_metrics: dict of possible values to monitor
         """
-        if not self.trainer.lr_schedulers or not self.trainer.train_loop.automatic_optimization:
+        if not self.trainer.lr_schedulers or not self.trainer.lightning_module.automatic_optimization:
             return
 
         for scheduler_idx, lr_scheduler in enumerate(self.trainer.lr_schedulers):

--- a/pytorch_lightning/trainer/optimizers.py
+++ b/pytorch_lightning/trainer/optimizers.py
@@ -80,7 +80,7 @@ class TrainerOptimizersMixin(ABC):
                 ' * A list of the previously described dict format, with an optional "frequency" key (int)'
             )
 
-        is_manual_optimization = not model.automatic_optimization
+        is_manual_optimization = not self.lightning_module.automatic_optimization
         lr_schedulers = self.configure_schedulers(lr_schedulers, monitor, is_manual_optimization)
         _validate_scheduler_optimizer(optimizers, lr_schedulers)
 

--- a/pytorch_lightning/trainer/optimizers.py
+++ b/pytorch_lightning/trainer/optimizers.py
@@ -28,8 +28,6 @@ from pytorch_lightning.utilities.exceptions import MisconfigurationException
 class TrainerOptimizersMixin(ABC):
 
     _lightning_optimizers: Optional[List[LightningOptimizer]]
-    # todo: Remove this once the RPCPlugin is removed
-    lightning_module: LightningModule
 
     def init_optimizers(self, model: LightningModule) -> Tuple[List, List, List]:
         self._lightning_optimizers = None
@@ -82,8 +80,7 @@ class TrainerOptimizersMixin(ABC):
                 ' * A list of the previously described dict format, with an optional "frequency" key (int)'
             )
 
-        # todo: change this to directly reference model.automatic_optimization once pipe is removed
-        is_manual_optimization = not self.lightning_module.automatic_optimization
+        is_manual_optimization = not model.automatic_optimization
         lr_schedulers = self.configure_schedulers(lr_schedulers, monitor, is_manual_optimization)
         _validate_scheduler_optimizer(optimizers, lr_schedulers)
 

--- a/pytorch_lightning/trainer/optimizers.py
+++ b/pytorch_lightning/trainer/optimizers.py
@@ -80,7 +80,7 @@ class TrainerOptimizersMixin(ABC):
                 ' * A list of the previously described dict format, with an optional "frequency" key (int)'
             )
 
-        is_manual_optimization = not self.train_loop.automatic_optimization
+        is_manual_optimization = not model.automatic_optimization
         lr_schedulers = self.configure_schedulers(lr_schedulers, monitor, is_manual_optimization)
         _validate_scheduler_optimizer(optimizers, lr_schedulers)
 

--- a/pytorch_lightning/trainer/optimizers.py
+++ b/pytorch_lightning/trainer/optimizers.py
@@ -28,6 +28,8 @@ from pytorch_lightning.utilities.exceptions import MisconfigurationException
 class TrainerOptimizersMixin(ABC):
 
     _lightning_optimizers: Optional[List[LightningOptimizer]]
+    # todo: Remove this once the RPCPlugin is removed
+    lightning_module: LightningModule
 
     def init_optimizers(self, model: LightningModule) -> Tuple[List, List, List]:
         self._lightning_optimizers = None
@@ -80,7 +82,8 @@ class TrainerOptimizersMixin(ABC):
                 ' * A list of the previously described dict format, with an optional "frequency" key (int)'
             )
 
-        is_manual_optimization = not model.automatic_optimization
+        # todo: change this to directly reference model.automatic_optimization once pipe is removed
+        is_manual_optimization = not self.lightning_module.automatic_optimization
         lr_schedulers = self.configure_schedulers(lr_schedulers, monitor, is_manual_optimization)
         _validate_scheduler_optimizer(optimizers, lr_schedulers)
 

--- a/pytorch_lightning/trainer/optimizers.py
+++ b/pytorch_lightning/trainer/optimizers.py
@@ -80,7 +80,7 @@ class TrainerOptimizersMixin(ABC):
                 ' * A list of the previously described dict format, with an optional "frequency" key (int)'
             )
 
-        is_manual_optimization = not self.lightning_module.automatic_optimization
+        is_manual_optimization = not model.automatic_optimization
         lr_schedulers = self.configure_schedulers(lr_schedulers, monitor, is_manual_optimization)
         _validate_scheduler_optimizer(optimizers, lr_schedulers)
 

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -42,7 +42,6 @@ class TrainLoop:
         self.warning_cache = WarningCache()
         self._teardown_already_run = False
         self.running_loss = TensorRunningAccum(window_length=20)
-        self.automatic_optimization = True
         self._curr_step_result = None
         self._cur_grad_norm_dict = None
         self._multiple_trainloader_mode = multiple_trainloader_mode
@@ -255,7 +254,7 @@ class TrainLoop:
         self.trainer.dev_debugger.track_train_loss_history(batch_idx, untouched_loss.detach())
 
     def _check_training_step_output(self, training_step_output):
-        if isinstance(training_step_output, torch.Tensor) and not self.automatic_optimization:
+        if isinstance(training_step_output, torch.Tensor) and not self.trainer.lightning_module.automatic_optimization:
             if training_step_output.grad_fn is None:
                 # TODO: Find why - RuntimeError: Expected to mark a variable ready only once ...
                 raise MisconfigurationException("In manual optimization, `training_step` should not return a Tensor")
@@ -290,7 +289,7 @@ class TrainLoop:
         closure_loss = None
         untouched_loss = None
 
-        if self.automatic_optimization:
+        if self.trainer.lightning_module.automatic_optimization:
             # accumulate loss. if accumulate_grad_batches==1, no effect
             closure_loss = training_step_output.minimize / self.trainer.accumulate_grad_batches
 
@@ -660,7 +659,7 @@ class TrainLoop:
                 # gradient update with accumulated gradients
 
                 else:
-                    if self.automatic_optimization:
+                    if self.trainer.lightning_module.automatic_optimization:
 
                         def train_step_and_backward_closure():
                             result = self.training_step_and_backward(
@@ -717,7 +716,7 @@ class TrainLoop:
         """
         if (
             isinstance(self.trainer.training_type_plugin, ParallelPlugin)
-            and (self.automatic_optimization or should_block_sync)
+            and (self.trainer.lightning_module.automatic_optimization or should_block_sync)
         ):
             with self.trainer.training_type_plugin.block_backward_sync():
                 yield None
@@ -740,7 +739,7 @@ class TrainLoop:
             batch_opt_idx = opt_idx if len(batch_outputs) > 1 else 0
             batch_outputs[batch_opt_idx].append(opt_closure_result.training_step_output_for_epoch_end)
 
-            if self.automatic_optimization:
+            if self.trainer.lightning_module.automatic_optimization:
                 # track total loss for logging (avoid mem leaks)
                 self.accumulated_loss.append(opt_closure_result.loss)
 
@@ -755,7 +754,7 @@ class TrainLoop:
             result = self.training_step(split_batch, batch_idx, opt_idx, hiddens)
             self._curr_step_result = result
 
-            if not self._skip_backward and self.automatic_optimization:
+            if not self._skip_backward and self.trainer.lightning_module.automatic_optimization:
                 is_first_batch_to_accumulate = batch_idx % self.trainer.accumulate_grad_batches == 0
 
                 if is_first_batch_to_accumulate:
@@ -858,14 +857,16 @@ class TrainLoop:
 
         if len(self.trainer.optimizers) > 1:
             if self.trainer.has_arg("training_step", "optimizer_idx"):
-                if not self.automatic_optimization:
+                if not self.trainer.lightning_module.automatic_optimization:
                     self.warning_cache.warn(
                         "`training_step` hook signature has changed in v1.3."
                         " `optimizer_idx` argument has been removed in case of manual optimization. Support for"
                         " the old signature will be removed in v1.5", DeprecationWarning
                     )
                 args.append(opt_idx)
-            elif not self.trainer.has_arg("training_step", "optimizer_idx") and self.automatic_optimization:
+            elif not self.trainer.has_arg(
+                "training_step", "optimizer_idx"
+            ) and self.trainer.lightning_module.automatic_optimization:
                 raise ValueError(
                     f"Your LightningModule defines {len(self.trainer.optimizers)} optimizers but"
                     ' `training_step` is missing the `optimizer_idx` argument.'
@@ -886,7 +887,7 @@ class TrainLoop:
     def prepare_optimizers(self):
         # in manual optimization we loop over all optimizers at once
         optimizers = self.get_optimizers_iterable()
-        if not self.automatic_optimization:
+        if not self.trainer.lightning_module.automatic_optimization:
             optimizers = [optimizers[0]]
         return optimizers
 
@@ -896,7 +897,7 @@ class TrainLoop:
 
         # make sure only the gradients of the current optimizer's parameters are calculated
         # in the training step to prevent dangling gradients in multiple-optimizer setup.
-        if self.automatic_optimization and len(self.trainer.optimizers) > 1:
+        if self.trainer.lightning_module.automatic_optimization and len(self.trainer.optimizers) > 1:
             model = self.trainer.lightning_module
             model.toggle_optimizer(optimizer, opt_idx)
 


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
This is further cleanup from #4317. This PR deletes the train loop's automatic optimization attribute and enforces all accesses go through the lightning module's property. This ensures we don't have divergence across these fields. Since the lightning module is the sole decider for automatic optimization, it looked very odd that the lightning module itself was referring to this property via `self.trainer.train_loop.automatic_optimization` even though `self.automatic_optimization` was already defined. Now that the trainer constructor argument for `automatic_optimization` is gone, we can simplify this. 


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
