### PR TITLE
Fix argparse docs

### DIFF
--- a/docs/source/api_references.rst
+++ b/docs/source/api_references.rst
@@ -172,5 +172,5 @@ Utilities API
     :nosignatures:
 
     cli
-    argparse_utils
+    argparse
     seed

--- a/pytorch_lightning/utilities/argparse.py
+++ b/pytorch_lightning/utilities/argparse.py
@@ -134,7 +134,7 @@ def get_init_arguments_and_types(cls) -> List[Tuple[str, Tuple, Any]]:
     return name_type_default
 
 
-def get_abbrev_qualified_cls_name(cls):
+def _get_abbrev_qualified_cls_name(cls):
     assert isinstance(cls, type), repr(cls)
     if cls.__module__.startswith("pytorch_lightning."):
         # Abbreviate.
@@ -188,7 +188,7 @@ def add_argparse_args(
     if isinstance(parent_parser, _ArgumentGroup):
         raise RuntimeError("Please only pass an ArgumentParser instance.")
     if use_argument_group:
-        group_name = get_abbrev_qualified_cls_name(cls)
+        group_name = _get_abbrev_qualified_cls_name(cls)
         parser = parent_parser.add_argument_group(group_name)
     else:
         parser = ArgumentParser(
@@ -209,7 +209,7 @@ def add_argparse_args(
         if len(args_and_types) > 0:
             break
 
-    args_help = parse_args_from_docstring(cls.__init__.__doc__ or cls.__doc__ or "")
+    args_help = _parse_args_from_docstring(cls.__init__.__doc__ or cls.__doc__ or "")
 
     for arg, arg_types, arg_default in args_and_types:
         arg_types = [at for at in allowed_types if at in arg_types]
@@ -256,7 +256,7 @@ def add_argparse_args(
         return parser
 
 
-def parse_args_from_docstring(docstring: str) -> Dict[str, str]:
+def _parse_args_from_docstring(docstring: str) -> Dict[str, str]:
     arg_block_indent = None
     current_arg = None
     parsed = {}

--- a/tests/utilities/test_argparse.py
+++ b/tests/utilities/test_argparse.py
@@ -7,13 +7,13 @@ import pytest
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.utilities.argparse import (
+    _get_abbrev_qualified_cls_name,
     _gpus_allowed_type,
     _int_or_float_type,
+    _parse_args_from_docstring,
     add_argparse_args,
     from_argparse_args,
-    get_abbrev_qualified_cls_name,
     parse_argparser,
-    parse_args_from_docstring,
 )
 
 
@@ -48,7 +48,7 @@ def test_parse_argparser():
 
 
 def test_parse_args_from_docstring_normal():
-    args_help = parse_args_from_docstring(
+    args_help = _parse_args_from_docstring(
         """Constrain image dataset
 
         Args:
@@ -83,7 +83,7 @@ def test_parse_args_from_docstring_normal():
 
 
 def test_parse_args_from_docstring_empty():
-    args_help = parse_args_from_docstring(
+    args_help = _parse_args_from_docstring(
         """Constrain image dataset
 
         Args:
@@ -97,14 +97,14 @@ def test_parse_args_from_docstring_empty():
 
 
 def test_get_abbrev_qualified_cls_name():
-    assert get_abbrev_qualified_cls_name(Trainer) == "pl.Trainer"
+    assert _get_abbrev_qualified_cls_name(Trainer) == "pl.Trainer"
 
     class NestedClass:
         pass
 
     assert not __name__.startswith("pytorch_lightning.")
     expected_name = f"{__name__}.test_get_abbrev_qualified_cls_name.<locals>.NestedClass"
-    assert get_abbrev_qualified_cls_name(NestedClass) == expected_name
+    assert _get_abbrev_qualified_cls_name(NestedClass) == expected_name
 
 
 class AddArgparseArgsExampleClass:


### PR DESCRIPTION
## What does this PR do?

- Fixes docs reference. `argparse_utils` was renamed to `argparse` a bit ago.
- Hides some private functions. Otherwise, they are shown in the docs.

Reported on Slack by Seth Juarez

## Before submitting
- [n/a] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [n/a] Did you write any new necessary tests? (not for typos and docs)
- [n/a] Did you verify new and existing tests pass locally with your changes?
- [n/a] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified