### PR TITLE
Fix `NeptuneLogger.log_text(step=None)`

### DIFF
--- a/pytorch_lightning/loggers/neptune.py
+++ b/pytorch_lightning/loggers/neptune.py
@@ -318,7 +318,10 @@ class NeptuneLogger(LightningLoggerBase):
             text: The value of the log (data-point).
             step: Step number at which the metrics should be recorded, must be strictly increasing
         """
-        self.experiment.log_text(log_name, text, step=step)
+        if step is None:
+            self.experiment.log_text(log_name, text)
+        else:
+            self.experiment.log_text(log_name, x=step, y=text)
 
     @rank_zero_only
     def log_image(self, log_name: str, image: Union[str, Any], step: Optional[int] = None) -> None:

--- a/tests/loggers/test_neptune.py
+++ b/tests/loggers/test_neptune.py
@@ -76,7 +76,7 @@ def test_neptune_additional_methods(neptune):
     created_experiment.log_metric.reset_mock()
 
     logger.log_text('test', 'text')
-    created_experiment.log_text.assert_called_once_with('test', 'text', step=None)
+    created_experiment.log_text.assert_called_once_with('test', 'text')
     created_experiment.log_text.reset_mock()
 
     logger.log_image('test', 'image file')


### PR DESCRIPTION
## What does this PR do?
Remove an unwanted argument to the log_text() method of the neptune logger
Fixes #7193

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified
