### PR TITLE
[fix] Add barriers before and after setup hook is run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added synchronization points before and after `setup` hooks are run ([#7202](https://github.com/PyTorchLightning/pytorch-lightning/pull/7202))
+
+
 - Added a `teardown` hook to `ClusterEnvironment` ([#6942](https://github.com/PyTorchLightning/pytorch-lightning/pull/6942))
 
 

--- a/pytorch_lightning/plugins/training_type/ddp.py
+++ b/pytorch_lightning/plugins/training_type/ddp.py
@@ -285,7 +285,7 @@ class DDPPlugin(ParallelPlugin):
         self.cluster_environment.teardown()
 
     def barrier(self, *args, **kwargs):
-        if torch_distrib.is_initialized():
+        if torch_distrib.is_available() and torch_distrib.is_initialized():
             torch_distrib.barrier()
 
     def broadcast(self, obj: object, src: int = 0) -> object:

--- a/pytorch_lightning/trainer/connectors/data_connector.py
+++ b/pytorch_lightning/trainer/connectors/data_connector.py
@@ -67,7 +67,6 @@ class DataConnector(object):
                 self.trainer.datamodule.prepare_data()
             model.prepare_data()
             self.trainer._is_data_prepared = True
-        self.trainer.accelerator.barrier("prepare_data")
 
     def can_prepare_data(self):
         should_call_dm_prepare_data = True

--- a/pytorch_lightning/trainer/connectors/data_connector.py
+++ b/pytorch_lightning/trainer/connectors/data_connector.py
@@ -67,6 +67,7 @@ class DataConnector(object):
                 self.trainer.datamodule.prepare_data()
             model.prepare_data()
             self.trainer._is_data_prepared = True
+        self.trainer.accelerator.barrier("prepare_data")
 
     def can_prepare_data(self):
         should_call_dm_prepare_data = True

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -456,7 +456,9 @@ class Trainer(
         self.call_hook("on_before_accelerator_backend_setup", model)
         self.accelerator.connect(model)
         self.accelerator.setup_environment()
+        self.accelerator.barrier("pre-setup")
         self.call_setup_hook(model)  # allow user to setup lightning_module in accelerator environment
+        self.accelerator.barrier("post-setup")
         self.call_configure_sharded_model(model)  # allow user to setup in model sharded environment
         self.accelerator.setup(self, model)  # note: this sets up self.lightning_module
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -456,9 +456,7 @@ class Trainer(
         self.call_hook("on_before_accelerator_backend_setup", model)
         self.accelerator.connect(model)
         self.accelerator.setup_environment()
-        self.accelerator.barrier("pre-setup")
         self.call_setup_hook(model)  # allow user to setup lightning_module in accelerator environment
-        self.accelerator.barrier("post-setup")
         self.call_configure_sharded_model(model)  # allow user to setup in model sharded environment
         self.accelerator.setup(self, model)  # note: this sets up self.lightning_module
 
@@ -1121,6 +1119,7 @@ class Trainer(
 
         self.setup(model, stage=state)
         model.setup(stage=state)
+        self.accelerator.barrier("setup")
 
     def call_configure_sharded_model(self, model: LightningModule) -> None:
         # Call configure sharded model hook if accelerator requests. In some cases

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1111,6 +1111,7 @@ class Trainer(
     def call_setup_hook(self, model: LightningModule) -> None:
         assert self.state.running, f"TrainerState: {self.state}"
         state = self._setup_state
+        self.accelerator.barrier("pre_setup")
 
         if self.datamodule is not None:
             called = getattr(self.datamodule, f'has_setup_{state}')
@@ -1119,7 +1120,7 @@ class Trainer(
 
         self.setup(model, stage=state)
         model.setup(stage=state)
-        self.accelerator.barrier("setup")
+        self.accelerator.barrier("post_setup")
 
     def call_configure_sharded_model(self, model: LightningModule) -> None:
         # Call configure sharded model hook if accelerator requests. In some cases

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1111,6 +1111,7 @@ class Trainer(
     def call_setup_hook(self, model: LightningModule) -> None:
         assert self.state.running, f"TrainerState: {self.state}"
         state = self._setup_state
+
         self.accelerator.barrier("pre_setup")
 
         if self.datamodule is not None:
@@ -1120,6 +1121,7 @@ class Trainer(
 
         self.setup(model, stage=state)
         model.setup(stage=state)
+
         self.accelerator.barrier("post_setup")
 
     def call_configure_sharded_model(self, model: LightningModule) -> None:


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
Reported on slack:
> Hi, when prepare_data_per_node=False, aren't the non-zero nodes still supposed to wait for prepare_data to be done on node 0 rank 0 before calling setup?

Currently we delay the process group initialization until `accelerator.setup_environment`. `prepare_data` is called before, which works fine for when lightning launches subprocess/spawns the trainer processes for distributed training, but not so for when the user has launched training outside of the trainer.

This adds a barrier immediately before and after the setup hook is called.

We indirectly address this by adding barriers before setup runs (to hedge against the`prepare_data` case) as well as after `setup` hooks run in case the model defines layers inside of `setup` in order to synchronize before the module is wrapped in DDP.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
