### PR TITLE
[fix] Attach train+val dataloaders to trainer in trainer loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,6 +281,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+
+- Fixed attaching train and validation dataloaders when `reload_dataloaders_every_epoch=True` and `num_sanity_val_steps=0` ([#7207](https://github.com/PyTorchLightning/pytorch-lightning/pull/7207))
+
+
 - Added a barrier in the accelerator `teardown` to synchronize processes before execution finishes ([#6814](https://github.com/PyTorchLightning/pytorch-lightning/pull/6814))
 
 

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -60,7 +60,7 @@ class EvaluationLoop(object):
             max_batches = self.trainer.num_test_batches
         else:
             # val
-            if self.trainer.val_dataloaders is None or self.trainer.reload_dataloaders_every_epoch:
+            if self.trainer.val_dataloaders is None or (self.trainer.reload_dataloaders_every_epoch and self.trainer.current_epoch > 0):
                 self.trainer.reset_val_dataloader(model)
             if self.trainer.sanity_checking:
                 self.trainer.num_sanity_val_batches = [

--- a/pytorch_lightning/trainer/evaluation_loop.py
+++ b/pytorch_lightning/trainer/evaluation_loop.py
@@ -60,7 +60,7 @@ class EvaluationLoop(object):
             max_batches = self.trainer.num_test_batches
         else:
             # val
-            if self.trainer.val_dataloaders is None or (self.trainer.reload_dataloaders_every_epoch and self.trainer.current_epoch > 0):
+            if self.trainer.val_dataloaders is None or self.trainer.reload_dataloaders_every_epoch:
                 self.trainer.reset_val_dataloader(model)
             if self.trainer.sanity_checking:
                 self.trainer.num_sanity_val_batches = [

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -189,10 +189,10 @@ class TrainLoop:
         self.trainer.logger_connector.on_train_batch_end()
 
     def reset_train_val_dataloaders(self, model):
-        if self.trainer.train_dataloader is None or not self.trainer.reload_dataloaders_every_epoch:
+        if self.trainer.train_dataloader is None:
             self.trainer.reset_train_dataloader(model)
 
-        if self.trainer.val_dataloaders is None and not self.trainer.reload_dataloaders_every_epoch:
+        if self.trainer.val_dataloaders is None:
             self.trainer.reset_val_dataloader(model)
 
     def track_epoch_end_reduce_metrics(self, epoch_output, batch_end_outputs):

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -188,7 +188,7 @@ class TrainLoop:
         # reset batch logger internals
         self.trainer.logger_connector.on_train_batch_end()
 
-    def reset_train_val_dataloaders(self, model):
+    def reset_train_val_dataloaders(self, model) -> None:
         """
         Resets train and val dataloaders if none are attached to the trainer.
 

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -189,6 +189,12 @@ class TrainLoop:
         self.trainer.logger_connector.on_train_batch_end()
 
     def reset_train_val_dataloaders(self, model):
+        """
+        Resets train and val dataloaders if none are attached to the trainer.
+
+        The val dataloader must be initialized before training loop starts, as the training loop
+        inspects the val dataloader to determine whether to run the evaluation loop.
+        """
         if self.trainer.train_dataloader is None:
             self.trainer.reset_train_dataloader(model)
 

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -1112,14 +1112,6 @@ def test_dataloaders_load_only_once_val_interval(tmpdir):
     expected_sequence = [
         'val_dataloader',
         'train_dataloader',
-        # This has subsequent calls to val_dataloader
-        # because the training loop runs the evaluation loop,
-        # which reloads the val dataloader again.
-        # We cannot yet rely on trainer.current_epoch=0 to skip reloading
-        # the val dataloader on the first epoch because this only tracks the training epoch
-        # meaning multiple passes through the validation data within a single training epoch
-        # would not have the datalodaer reloaded.
-        # This breaks the assumption behind reload_dataloaders_every_epoch=True
         'val_dataloader',
         'val_dataloader',
         'val_dataloader',
@@ -1244,6 +1236,14 @@ def test_dataloaders_load_every_epoch_no_sanity_check(tmpdir):
     expected_sequence = [
         'train_dataloader',
         'val_dataloader',
+        # This has subsequent calls to val_dataloader
+        # because the training loop runs the evaluation loop,
+        # which reloads the val dataloader again.
+        # We cannot yet rely on trainer.current_epoch=0 to skip reloading
+        # the val dataloader on the first epoch because this only tracks the training epoch
+        # meaning multiple passes through the validation data within a single training epoch
+        # would not have the datalodaer reloaded.
+        # This breaks the assumption behind reload_dataloaders_every_epoch=True
         'val_dataloader',
         'train_dataloader',
         'val_dataloader',

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -25,6 +25,7 @@ from torch.utils.data.sampler import SequentialSampler
 
 import tests.helpers.pipelines as tpipes
 from pytorch_lightning import Callback, seed_everything, Trainer
+from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.trainer.states import TrainerState
 from pytorch_lightning.utilities import _TORCH_GREATER_EQUAL_1_6
 from pytorch_lightning.utilities.data import has_iterable_dataset, has_len
@@ -1199,7 +1200,16 @@ def test_dataloaders_load_every_epoch(tmpdir):
 @mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_dataloaders_load_every_epoch_no_sanity_check(tmpdir):
 
-    model = EvalModelTemplate()
+    class TestModel(BoringModel):
+
+        def validation_step(self, batch, batch_idx):
+            self.log("dummy_val", 5.0)
+            return super().validation_step(batch, batch_idx)
+
+    model = TestModel()
+
+    # This callback tests that the evaluation metrics are available by the time we run checkpointing
+    checkpoint_callback = ModelCheckpoint(monitor="dummy_val", save_top_k=1)
 
     # logger file to get meta
     trainer = Trainer(
@@ -1209,26 +1219,29 @@ def test_dataloaders_load_every_epoch_no_sanity_check(tmpdir):
         num_sanity_val_steps=0,
         reload_dataloaders_every_epoch=True,
         max_epochs=3,
+        callbacks=[checkpoint_callback],
     )
     trainer.fit(model)
     assert trainer.state == TrainerState.FINISHED, f"Training failed with {trainer.state}"
 
     trainer.test()
 
-    assert len(trainer.dev_debugger.val_dataloader_calls) == 3
+    assert len(trainer.dev_debugger.val_dataloader_calls) == 4
     assert len(trainer.dev_debugger.train_dataloader_calls) == 3
     assert len(trainer.dev_debugger.test_dataloader_calls) == 1
 
-    # verify the sequence
+    # # verify the sequence
     calls = trainer.dev_debugger.dataloader_sequence_calls
+
     expected_sequence = [
-        'train_dataloader',
-        'val_dataloader',
-        'train_dataloader',
-        'val_dataloader',
-        'train_dataloader',
-        'val_dataloader',
-        'test_dataloader',
+        "train_dataloader",
+        "val_dataloader",
+        "val_dataloader",
+        "train_dataloader",
+        "val_dataloader",
+        "train_dataloader",
+        "val_dataloader",
+        "test_dataloader",
     ]
     for call, expected in zip(calls, expected_sequence):
         assert call['name'] == expected

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -1112,6 +1112,14 @@ def test_dataloaders_load_only_once_val_interval(tmpdir):
     expected_sequence = [
         'val_dataloader',
         'train_dataloader',
+        # This has subsequent calls to val_dataloader
+        # because the training loop runs the evaluation loop,
+        # which reloads the val dataloader again.
+        # We cannot yet rely on trainer.current_epoch=0 to skip reloading
+        # the val dataloader on the first epoch because this only tracks the training epoch
+        # meaning multiple passes through the validation data within a single training epoch
+        # would not have the datalodaer reloaded.
+        # This breaks the assumption behind reload_dataloaders_every_epoch=True
         'val_dataloader',
         'val_dataloader',
         'val_dataloader',

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -1230,7 +1230,7 @@ def test_dataloaders_load_every_epoch_no_sanity_check(tmpdir):
     assert len(trainer.dev_debugger.train_dataloader_calls) == 3
     assert len(trainer.dev_debugger.test_dataloader_calls) == 1
 
-    # # verify the sequence
+    # verify the sequence
     calls = trainer.dev_debugger.dataloader_sequence_calls
 
     expected_sequence = [

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -1226,7 +1226,7 @@ def test_dataloaders_load_every_epoch_no_sanity_check(tmpdir):
 
     trainer.test()
 
-    assert len(trainer.dev_debugger.val_dataloader_calls) == 3
+    assert len(trainer.dev_debugger.val_dataloader_calls) == 4
     assert len(trainer.dev_debugger.train_dataloader_calls) == 3
     assert len(trainer.dev_debugger.test_dataloader_calls) == 1
 
@@ -1234,13 +1234,14 @@ def test_dataloaders_load_every_epoch_no_sanity_check(tmpdir):
     calls = trainer.dev_debugger.dataloader_sequence_calls
 
     expected_sequence = [
-        "train_dataloader",
-        "val_dataloader",
-        "train_dataloader",
-        "val_dataloader",
-        "train_dataloader",
-        "val_dataloader",
-        "test_dataloader",
+        'train_dataloader',
+        'val_dataloader',
+        'val_dataloader',
+        'train_dataloader',
+        'val_dataloader',
+        'train_dataloader',
+        'val_dataloader',
+        'test_dataloader',
     ]
     for call, expected in zip(calls, expected_sequence):
         assert call['name'] == expected

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -1242,7 +1242,7 @@ def test_dataloaders_load_every_epoch_no_sanity_check(tmpdir):
         # We cannot yet rely on trainer.current_epoch=0 to skip reloading
         # the val dataloader on the first epoch because this only tracks the training epoch
         # meaning multiple passes through the validation data within a single training epoch
-        # would not have the datalodaer reloaded.
+        # would not have the dataloader reloaded.
         # This breaks the assumption behind reload_dataloaders_every_epoch=True
         'val_dataloader',
         'train_dataloader',

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -1226,7 +1226,7 @@ def test_dataloaders_load_every_epoch_no_sanity_check(tmpdir):
 
     trainer.test()
 
-    assert len(trainer.dev_debugger.val_dataloader_calls) == 4
+    assert len(trainer.dev_debugger.val_dataloader_calls) == 3
     assert len(trainer.dev_debugger.train_dataloader_calls) == 3
     assert len(trainer.dev_debugger.test_dataloader_calls) == 1
 
@@ -1235,7 +1235,6 @@ def test_dataloaders_load_every_epoch_no_sanity_check(tmpdir):
 
     expected_sequence = [
         "train_dataloader",
-        "val_dataloader",
         "val_dataloader",
         "train_dataloader",
         "val_dataloader",


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
Fixes #7208 . 

The issue occurs because the validation dataloader is never attached to the trainer by the time we reach this stage in the training loop: https://github.com/PyTorchLightning/pytorch-lightning/blob/44d775fccfb825561937f6fa03fe258af25c2b83/pytorch_lightning/trainer/training_loop.py#L558-L560

Currently this is conditional based on this logic, which is called once at the start of training: https://github.com/PyTorchLightning/pytorch-lightning/blob/44d775fccfb825561937f6fa03fe258af25c2b83/pytorch_lightning/trainer/trainer.py#L604

Removing the `reload_dataloaders_every_epoch` check here gives me consistent behavior again.

I don't think this is a fully proper fix - we should be attaching these dataloaders to the trainer more clearly, and operating them on them for reloads later on in the training loop. 

This is a behavior change that resulted after #6075. Before, `run_evaluation` ran, which populated the dataloader settings on the trainer, and then the checkpoint callback ran. After, the checkpoint callback ran first, before run_evaluation. the check for whether we run evaluation depends on the val dataloader being present, which was being set inside of run_evaluation.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
