### PR TITLE
Rename `trainer._launch` to `trainer._run`

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -409,7 +409,7 @@ class Trainer(
         # Callback system
         self.on_init_end()
 
-    def _launch(
+    def _run(
         self,
         model: LightningModule,
         train_dataloader: Any = None,
@@ -855,7 +855,7 @@ class Trainer(
         self.state = TrainerState.FITTING
         self.training = True
 
-        self._launch(model, train_dataloader=train_dataloader, val_dataloaders=val_dataloaders, datamodule=datamodule)
+        self._run(model, train_dataloader=train_dataloader, val_dataloaders=val_dataloaders, datamodule=datamodule)
 
         assert self.state.stopped
         self.training = False
@@ -917,7 +917,7 @@ class Trainer(
             self.validated_ckpt_path = self.__load_ckpt_weights(ckpt_path)
 
         # run validate
-        results = self._launch(model)
+        results = self._run(model)
 
         assert self.state.stopped
         self.validating = False
@@ -978,7 +978,7 @@ class Trainer(
             self.tested_ckpt_path = self.__load_ckpt_weights(ckpt_path)
 
         # run test
-        results = self._launch(model)
+        results = self._run(model)
 
         assert self.state.stopped
         self.testing = False
@@ -1068,7 +1068,7 @@ class Trainer(
         #  Attach dataloaders (if given)
         self.data_connector.attach_dataloaders(model, predict_dataloaders=dataloaders)
 
-        results = self._launch(model)
+        results = self._run(model)
 
         assert self.state.stopped
         self.predicting = False

--- a/pytorch_lightning/tuner/batch_size_scaling.py
+++ b/pytorch_lightning/tuner/batch_size_scaling.py
@@ -189,7 +189,7 @@ def _run_power_scaling(trainer, model, new_size, batch_arg_name, max_trials, **f
         trainer.global_step = 0  # reset after each try
         try:
             # Try fit
-            trainer.tuner._launch(model, **fit_kwargs)
+            trainer.tuner._run(model, **fit_kwargs)
             # Double in size
             new_size, changed = _adjust_batch_size(trainer, batch_arg_name, factor=2.0, desc='succeeded')
         except RuntimeError as exception:
@@ -218,7 +218,7 @@ def _run_binsearch_scaling(trainer, model, new_size, batch_arg_name, max_trials,
         trainer.global_step = 0  # reset after each try
         try:
             # Try fit
-            trainer.tuner._launch(model, **fit_kwargs)
+            trainer.tuner._run(model, **fit_kwargs)
             count += 1
             if count > max_trials:
                 break

--- a/pytorch_lightning/tuner/lr_finder.py
+++ b/pytorch_lightning/tuner/lr_finder.py
@@ -176,9 +176,7 @@ def lr_find(
     model.configure_optimizers = lr_finder._exchange_scheduler(model.configure_optimizers)
 
     # Fit, lr & loss logged in callback
-    trainer.tuner._launch(
-        model, train_dataloader=train_dataloader, val_dataloaders=val_dataloaders, datamodule=datamodule
-    )
+    trainer.tuner._run(model, train_dataloader=train_dataloader, val_dataloaders=val_dataloaders, datamodule=datamodule)
 
     # Prompt if we stopped early
     if trainer.global_step != num_training:

--- a/pytorch_lightning/tuner/tuning.py
+++ b/pytorch_lightning/tuner/tuning.py
@@ -72,8 +72,8 @@ class Tuner:
         self.trainer.state = TrainerState.FINISHED
 
     def _run(self, *args: Any, **kwargs: Any) -> None:
-        """`_launch` wrapper to set the proper state during tuning, as this can be called multiple times"""
-        self.trainer.state = TrainerState.TUNING  # last `_launch` call might have set it to `FINISHED`
+        """`_run` wrapper to set the proper state during tuning, as this can be called multiple times"""
+        self.trainer.state = TrainerState.TUNING  # last `_run` call might have set it to `FINISHED`
         self.trainer.training = True
         self.trainer._run(*args, **kwargs)
         self.trainer.tuning = True

--- a/pytorch_lightning/tuner/tuning.py
+++ b/pytorch_lightning/tuner/tuning.py
@@ -71,11 +71,11 @@ class Tuner:
 
         self.trainer.state = TrainerState.FINISHED
 
-    def _launch(self, *args: Any, **kwargs: Any) -> None:
+    def _run(self, *args: Any, **kwargs: Any) -> None:
         """`_launch` wrapper to set the proper state during tuning, as this can be called multiple times"""
         self.trainer.state = TrainerState.TUNING  # last `_launch` call might have set it to `FINISHED`
         self.trainer.training = True
-        self.trainer._launch(*args, **kwargs)
+        self.trainer._run(*args, **kwargs)
         self.trainer.tuning = True
 
     def scale_batch_size(


### PR DESCRIPTION
## What does this PR do?

`launch` might be associated w/ distributed launch or process launch which isn't the case here

cc @carmocca 
Fixes https://github.com/PyTorchLightning/pytorch-lightning/pull/7232#discussion_r622322393

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes? (if necessary)
- [n/a] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [n/a] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified