### PR TITLE
Log epoch metrics before firing the `on_evaluation_end` hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- Log epoch metrics before the `on_evaluation_end` hook ([#7272](https://github.com/PyTorchLightning/pytorch-lightning/pull/7272))
+
 
 ### Deprecated
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1002,11 +1002,11 @@ class Trainer(
                 ],
             )
 
-        # hook
-        self.evaluation_loop.on_evaluation_end()
-
         # log epoch metrics
         eval_loop_results = self.logger_connector.get_evaluate_epoch_results()
+
+        # hook
+        self.evaluation_loop.on_evaluation_end()
 
         # save predictions to disk
         self.evaluation_loop.predictions.to_disk()

--- a/tests/trainer/loops/test_evaluation_loop.py
+++ b/tests/trainer/loops/test_evaluation_loop.py
@@ -48,15 +48,9 @@ def test_on_evaluation_epoch_end(eval_epoch_end_mock, tmpdir):
 def test_log_epoch_metrics_before_on_evaluation_end(get_evaluate_epoch_results_mock, tmpdir):
     """Test that the epoch metrics are logged before the `on_evalutaion_end` hook is fired"""
     order = []
-    expected_order = ["log_epoch_metrics", "on_validation_end"]
-
     get_evaluate_epoch_results_mock.side_effect = lambda: order.append("log_epoch_metrics")
 
     class LessBoringModel(BoringModel):
-
-        def __init__(self):
-            super().__init__()
-            self.called = []
 
         def on_validation_end(self):
             order.append("on_validation_end")
@@ -64,13 +58,10 @@ def test_log_epoch_metrics_before_on_evaluation_end(get_evaluate_epoch_results_m
 
     trainer = Trainer(
         default_root_dir=tmpdir,
-        limit_train_batches=2,
-        limit_val_batches=2,
-        max_epochs=1,
+        fast_dev_run=1,
         weights_summary=None,
         num_sanity_val_steps=0,
     )
-
     trainer.fit(LessBoringModel())
 
-    assert order == expected_order
+    assert order == ["log_epoch_metrics", "on_validation_end"]


### PR DESCRIPTION
## What does this PR do?

This PR switches the order in which the epoch metrics are logged and the `on_evaluation_end` hook is fired. Now it logs the metrics first. Fixes #7166

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
