### PR TITLE
Fix `Trainer.plugins` type declaration

### DIFF
--- a/pytorch_lightning/plugins/environments/cluster_environment.py
+++ b/pytorch_lightning/plugins/environments/cluster_environment.py
@@ -11,10 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from abc import ABC, abstractmethod
+from abc import abstractmethod
+
+from pytorch_lightning.plugins.base_plugin import Plugin
 
 
-class ClusterEnvironment(ABC):
+class ClusterEnvironment(Plugin):
     """ Specification of a cluster environment. """
 
     @abstractmethod

--- a/pytorch_lightning/plugins/environments/cluster_environment.py
+++ b/pytorch_lightning/plugins/environments/cluster_environment.py
@@ -11,12 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from abc import abstractmethod
-
-from pytorch_lightning.plugins.base_plugin import Plugin
+from abc import ABC, abstractmethod
 
 
-class ClusterEnvironment(Plugin):
+class ClusterEnvironment(ABC):
     """ Specification of a cluster environment. """
 
     @abstractmethod

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -137,7 +137,7 @@ class Trainer(
         terminate_on_nan: bool = False,
         auto_scale_batch_size: Union[str, bool] = False,
         prepare_data_per_node: bool = True,
-        plugins: Optional[Union[Plugin, str, list]] = None,
+        plugins: Optional[Union[List[Union[Plugin, str]], Plugin, str]] = None,
         amp_backend: str = 'native',
         amp_level: str = 'O2',
         distributed_backend: Optional[str] = None,

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -29,7 +29,7 @@ from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.core.memory import ModelSummary
 from pytorch_lightning.core.step_result import Result
 from pytorch_lightning.loggers import LightningLoggerBase
-from pytorch_lightning.plugins import Plugin
+from pytorch_lightning.plugins import Plugin, ClusterEnvironment
 from pytorch_lightning.profiler import BaseProfiler
 from pytorch_lightning.trainer.callback_hook import TrainerCallbackHookMixin
 from pytorch_lightning.trainer.configuration_validator import ConfigValidator
@@ -137,7 +137,8 @@ class Trainer(
         terminate_on_nan: bool = False,
         auto_scale_batch_size: Union[str, bool] = False,
         prepare_data_per_node: bool = True,
-        plugins: Optional[Union[List[Union[Plugin, str]], Plugin, str]] = None,
+        plugins: Optional[Union[List[Union[Plugin, ClusterEnvironment, str]],
+                                Plugin, ClusterEnvironment, str]] = None,
         amp_backend: str = 'native',
         amp_level: str = 'O2',
         distributed_backend: Optional[str] = None,

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -29,7 +29,8 @@ from pytorch_lightning.core.lightning import LightningModule
 from pytorch_lightning.core.memory import ModelSummary
 from pytorch_lightning.core.step_result import Result
 from pytorch_lightning.loggers import LightningLoggerBase
-from pytorch_lightning.plugins import Plugin, ClusterEnvironment
+from pytorch_lightning.plugins import Plugin
+from pytorch_lightning.plugins.environments import ClusterEnvironment
 from pytorch_lightning.profiler import BaseProfiler
 from pytorch_lightning.trainer.callback_hook import TrainerCallbackHookMixin
 from pytorch_lightning.trainer.configuration_validator import ConfigValidator
@@ -137,8 +138,7 @@ class Trainer(
         terminate_on_nan: bool = False,
         auto_scale_batch_size: Union[str, bool] = False,
         prepare_data_per_node: bool = True,
-        plugins: Optional[Union[List[Union[Plugin, ClusterEnvironment, str]],
-                                Plugin, ClusterEnvironment, str]] = None,
+        plugins: Optional[Union[List[Union[Plugin, ClusterEnvironment, str]], Plugin, ClusterEnvironment, str]] = None,
         amp_backend: str = 'native',
         amp_level: str = 'O2',
         distributed_backend: Optional[str] = None,

--- a/tests/utilities/test_cli.py
+++ b/tests/utilities/test_cli.py
@@ -27,6 +27,7 @@ import yaml
 
 from pytorch_lightning import LightningDataModule, LightningModule, Trainer
 from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint
+from pytorch_lightning.plugins.environments import SLURMEnvironment
 from pytorch_lightning.utilities import _TPU_AVAILABLE
 from pytorch_lightning.utilities.cli import LightningArgumentParser, LightningCLI, SaveConfigCallback
 from tests.helpers import BoringDataModule, BoringModel
@@ -280,6 +281,22 @@ def test_lightning_cli_args_callbacks(tmpdir):
     assert cli.trainer.ran_asserts
 
 
+def test_lightning_cli_args_cluster_environments(tmpdir):
+    plugins = [dict(class_path='pytorch_lightning.plugins.environments.SLURMEnvironment')]
+
+    class TestModel(BoringModel):
+
+        def on_fit_start(self):
+            # Ensure SLURMEnvironment is set, instead of default LightningEnvironment
+            assert isinstance(self.trainer.accelerator_connector._cluster_environment, SLURMEnvironment)
+            self.trainer.ran_asserts = True
+
+    with mock.patch('sys.argv', ['any.py', f'--trainer.plugins={json.dumps(plugins)}']):
+        cli = LightningCLI(TestModel, trainer_defaults=dict(default_root_dir=str(tmpdir), fast_dev_run=True))
+
+    assert cli.trainer.ran_asserts
+
+
 def test_lightning_cli_args(tmpdir):
 
     cli_args = [
@@ -390,6 +407,7 @@ def test_lightning_cli_print_config():
 def test_lightning_cli_submodules(tmpdir):
 
     class MainModule(BoringModel):
+
         def __init__(
             self,
             submodule1: LightningModule,


### PR DESCRIPTION
## What does this PR do?

This ensures ClusterEnvironment plugins can be specified via LightningCLI. LightningCLI relies on the type annotation and inheritance information. Without this PR, both type annotation and inheritance is incorrect, making it impossible to specify a ClusterEnvironment to `--trainer.plugins` via LightningCLI.

Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/7287

I've tested the change in practice, but haven't written unit test functions yet. I'll add them if there are no concerns about the changes.