### PR TITLE
[WIP] Fix loading state dict in DeepSpeed Plugin

### DIFF
--- a/pytorch_lightning/plugins/training_type/training_type_plugin.py
+++ b/pytorch_lightning/plugins/training_type/training_type_plugin.py
@@ -220,14 +220,16 @@ class TrainingTypePlugin(Plugin, ABC):
 
         """
         ckpt = pl_load(ckpt_path, map_location=map_location)
+        self._call_load_checkpoint_hooks(ckpt)
+        self.lightning_module.load_state_dict(ckpt['state_dict'])
+        return ckpt, True
+
+    def _call_load_checkpoint_hooks(self, ckpt: str) -> None:
         # restore datamodule states
         if self.lightning_module.trainer.datamodule is not None:
             self.lightning_module.trainer.datamodule.on_load_checkpoint(ckpt)
-
         # hook: give user access to checkpoint if needed.
         self.lightning_module.on_load_checkpoint(ckpt)
-        self.lightning_module.load_state_dict(ckpt['state_dict'])
-        return ckpt, True
 
     def update_global_step(self, total_batch_idx: int, current_global_step: int) -> int:
         """


### PR DESCRIPTION
## What does this PR do?

Closes #7282 
 
This fixes an issue where if we saved a DeepSpeed checkpoint and resumed using Stage 3 where parameters are sharded, it crashes. We gather parameters as suggested in DeepSpeed at a per module level on rank 0, and load the state dict which is then updated to all processes.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
