### PR TITLE
Pass `current_epoch`/`global_step` as monitor candidates [1/2]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed `mode='auto'` from `EarlyStopping` ([#6167](https://github.com/PyTorchLightning/pytorch-lightning/pull/6167))
 
 
+- Removed `epoch` and `step` arguments from `ModelCheckpoint.format_checkpoint_name()`, these are now included in the `metrics` argument ([#7344](https://github.com/PyTorchLightning/pytorch-lightning/pull/7344))
+
+
 - Removed legacy references for magic keys in the `Result` object ([#6016](https://github.com/PyTorchLightning/pytorch-lightning/pull/6016))
 
 

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -29,10 +29,12 @@ import numpy as np
 import torch
 import yaml
 
+import pytorch_lightning as pl
 from pytorch_lightning.callbacks.base import Callback
 from pytorch_lightning.utilities import rank_zero_deprecation, rank_zero_info, rank_zero_only, rank_zero_warn
 from pytorch_lightning.utilities.cloud_io import get_filesystem
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
+from pytorch_lightning.utilities.types import _METRIC, STEP_OUTPUT
 from pytorch_lightning.utilities.warnings import WarningCache
 
 log = logging.getLogger(__name__)
@@ -205,13 +207,13 @@ class ModelCheckpoint(Callback):
         self.best_model_path = ""
         self.last_model_path = ""
 
-        self.__init_monitor_mode(monitor, mode)
+        self.__init_monitor_mode(mode)
         self.__init_ckpt_dir(dirpath, filename, save_top_k)
         self.__init_triggers(every_n_train_steps, every_n_val_epochs, period)
         self.__validate_init_configuration()
         self._save_function = None
 
-    def on_pretrain_routine_start(self, trainer, pl_module):
+    def on_pretrain_routine_start(self, trainer: 'pl.Trainer', pl_module: 'pl.LightningModule') -> None:
         """
         When pretrain routine starts we build the ckpt dir on the fly
         """
@@ -219,7 +221,8 @@ class ModelCheckpoint(Callback):
         self._save_function = trainer.save_checkpoint
 
     def on_train_batch_end(
-        self, trainer, pl_module, outputs: Any, batch: Any, batch_idx: int, dataloader_idx: int
+        self, trainer: 'pl.Trainer', pl_module: 'pl.LightningModule', outputs: STEP_OUTPUT, batch: Any, batch_idx: int,
+        dataloader_idx: int
     ) -> None:
         """ Save checkpoint on train batch end if we meet the criteria for `every_n_train_steps` """
         if self._should_skip_saving_checkpoint(trainer):
@@ -230,7 +233,7 @@ class ModelCheckpoint(Callback):
             return
         self.save_checkpoint(trainer)
 
-    def on_validation_end(self, trainer, pl_module) -> None:
+    def on_validation_end(self, trainer: 'pl.Trainer', pl_module: 'pl.LightningModule') -> None:
         """ Save a checkpoint at the end of the validation stage. """
         skip = (
             self._should_skip_saving_checkpoint(trainer) or self._every_n_val_epochs < 1
@@ -240,7 +243,8 @@ class ModelCheckpoint(Callback):
             return
         self.save_checkpoint(trainer)
 
-    def on_save_checkpoint(self, trainer, pl_module, checkpoint: Dict[str, Any]) -> Dict[str, Any]:
+    def on_save_checkpoint(self, trainer: 'pl.Trainer', pl_module: 'pl.LightningModule',
+                           checkpoint: Dict[str, Any]) -> Dict[str, Any]:
         return {
             "monitor": self.monitor,
             "best_model_score": self.best_model_score,
@@ -249,11 +253,13 @@ class ModelCheckpoint(Callback):
             "dirpath": self.dirpath
         }
 
-    def on_load_checkpoint(self, callback_state: Dict[str, Any]):
+    def on_load_checkpoint(
+        self, trainer: 'pl.Trainer', pl_module: 'pl.LightningModule', callback_state: Dict[str, Any]
+    ) -> None:
         self.best_model_score = callback_state["best_model_score"]
         self.best_model_path = callback_state["best_model_path"]
 
-    def save_checkpoint(self, trainer, unused: Optional = None):
+    def save_checkpoint(self, trainer: 'pl.Trainer', unused: Optional['pl.LightningModule'] = None) -> None:
         """
         Performs the main logic around saving a checkpoint. This method runs on all ranks.
         It is the responsibility of `trainer.save_checkpoint` to correctly handle the behaviour in distributed training,
@@ -265,6 +271,7 @@ class ModelCheckpoint(Callback):
                 " has been removed. Support for the old signature will be removed in v1.5"
             )
 
+        epoch = trainer.current_epoch
         global_step = trainer.global_step
 
         self._add_backward_monitor_support(trainer)
@@ -274,7 +281,7 @@ class ModelCheckpoint(Callback):
         self._last_global_step_saved = global_step
 
         # what can be monitored
-        monitor_candidates = self._monitor_candidates(trainer)
+        monitor_candidates = self._monitor_candidates(trainer, epoch=epoch, step=global_step)
 
         # callback supports multiple simultaneous modes
         # here we call each mode sequentially
@@ -285,7 +292,7 @@ class ModelCheckpoint(Callback):
         # Mode 3: save last checkpoints
         self._save_last_checkpoint(trainer, monitor_candidates)
 
-    def _should_skip_saving_checkpoint(self, trainer) -> bool:
+    def _should_skip_saving_checkpoint(self, trainer: 'pl.Trainer') -> bool:
         from pytorch_lightning.trainer.states import TrainerFn
         return (
             trainer.fast_dev_run  # disable checkpointing with fast_dev_run
@@ -294,7 +301,7 @@ class ModelCheckpoint(Callback):
             or self._last_global_step_saved == trainer.global_step  # already saved at the last step
         )
 
-    def __validate_init_configuration(self):
+    def __validate_init_configuration(self) -> None:
         if self.save_top_k is not None and self.save_top_k < -1:
             raise MisconfigurationException(f'Invalid value for save_top_k={self.save_top_k}. Must be None or >= -1')
         if self._every_n_train_steps < 0:
@@ -329,8 +336,12 @@ class ModelCheckpoint(Callback):
                     ' will duplicate the last checkpoint saved.'
                 )
 
-    def __init_ckpt_dir(self, dirpath, filename, save_top_k):
-
+    def __init_ckpt_dir(
+        self,
+        dirpath: Optional[Union[str, Path]],
+        filename: Optional[str],
+        save_top_k: Optional[int],
+    ) -> None:
         self._fs = get_filesystem(str(dirpath) if dirpath else '')
 
         if (
@@ -342,10 +353,10 @@ class ModelCheckpoint(Callback):
         if dirpath and self._fs.protocol == 'file':
             dirpath = os.path.realpath(dirpath)
 
-        self.dirpath: Union[str, None] = dirpath or None
-        self.filename = filename or None
+        self.dirpath = dirpath
+        self.filename = filename
 
-    def __init_monitor_mode(self, monitor, mode):
+    def __init_monitor_mode(self, mode: str) -> None:
         torch_inf = torch.tensor(np.Inf)
         mode_dict = {
             "min": (torch_inf, "min"),
@@ -414,12 +425,12 @@ class ModelCheckpoint(Callback):
         self._save_function = value
 
     @rank_zero_only
-    def _del_model(self, filepath: str):
+    def _del_model(self, filepath: str) -> None:
         if self._fs.exists(filepath):
             self._fs.rm(filepath)
             log.debug(f"Removed checkpoint: {filepath}")
 
-    def _save_model(self, trainer, filepath: str):
+    def _save_model(self, trainer: 'pl.Trainer', filepath: str) -> None:
         if trainer.training_type_plugin.rpc_enabled:
             # RPCPlugin manages saving all model states
             # TODO: the rpc plugin should wrap trainer.save_checkpoint
@@ -428,7 +439,7 @@ class ModelCheckpoint(Callback):
         else:
             self._do_save(trainer, filepath)
 
-    def _do_save(self, trainer, filepath: str):
+    def _do_save(self, trainer: 'pl.Trainer', filepath: str) -> None:
         # in debugging, track when we save checkpoints
         trainer.dev_debugger.track_checkpointing_history(filepath)
 
@@ -439,7 +450,7 @@ class ModelCheckpoint(Callback):
         # delegate the saving to the trainer
         trainer.save_checkpoint(filepath, self.save_weights_only)
 
-    def check_monitor_top_k(self, trainer, current: Optional[torch.Tensor] = None) -> bool:
+    def check_monitor_top_k(self, trainer: 'pl.Trainer', current: Optional[torch.Tensor] = None) -> bool:
         if current is None:
             return False
 
@@ -470,9 +481,7 @@ class ModelCheckpoint(Callback):
     def _format_checkpoint_name(
         cls,
         filename: Optional[str],
-        epoch: int,
-        step: int,
-        metrics: Dict[str, Any],
+        metrics: Dict[str, _METRIC],
         prefix: str = "",
         auto_insert_metric_name: bool = True
     ) -> str:
@@ -483,7 +492,6 @@ class ModelCheckpoint(Callback):
         # check and parse user passed keys in the string
         groups = re.findall(r"(\{.*?)[:\}]", filename)
         if len(groups) >= 0:
-            metrics.update({"epoch": epoch, 'step': step})
             for group in groups:
                 name = group[1:]
 
@@ -499,36 +507,36 @@ class ModelCheckpoint(Callback):
 
         return filename
 
-    def format_checkpoint_name(self, epoch: int, step: int, metrics: Dict[str, Any], ver: Optional[int] = None) -> str:
+    def format_checkpoint_name(self, metrics: Dict[str, _METRIC], ver: Optional[int] = None) -> str:
         """Generate a filename according to the defined template.
 
         Example::
 
             >>> tmpdir = os.path.dirname(__file__)
             >>> ckpt = ModelCheckpoint(dirpath=tmpdir, filename='{epoch}')
-            >>> os.path.basename(ckpt.format_checkpoint_name(0, 1, metrics={}))
+            >>> os.path.basename(ckpt.format_checkpoint_name(dict(epoch=0)))
             'epoch=0.ckpt'
             >>> ckpt = ModelCheckpoint(dirpath=tmpdir, filename='{epoch:03d}')
-            >>> os.path.basename(ckpt.format_checkpoint_name(5, 2, metrics={}))
+            >>> os.path.basename(ckpt.format_checkpoint_name(dict(epoch=5)))
             'epoch=005.ckpt'
             >>> ckpt = ModelCheckpoint(dirpath=tmpdir, filename='{epoch}-{val_loss:.2f}')
-            >>> os.path.basename(ckpt.format_checkpoint_name(2, 3, metrics=dict(val_loss=0.123456)))
+            >>> os.path.basename(ckpt.format_checkpoint_name(dict(epoch=2, val_loss=0.123456)))
             'epoch=2-val_loss=0.12.ckpt'
             >>> ckpt = ModelCheckpoint(dirpath=tmpdir,
             ... filename='epoch={epoch}-validation_loss={val_loss:.2f}',
             ... auto_insert_metric_name=False)
-            >>> os.path.basename(ckpt.format_checkpoint_name(2, 3, metrics=dict(val_loss=0.123456)))
+            >>> os.path.basename(ckpt.format_checkpoint_name(dict(epoch=2, val_loss=0.123456)))
             'epoch=2-validation_loss=0.12.ckpt'
             >>> ckpt = ModelCheckpoint(dirpath=tmpdir, filename='{missing:d}')
-            >>> os.path.basename(ckpt.format_checkpoint_name(0, 4, metrics={}))
+            >>> os.path.basename(ckpt.format_checkpoint_name({}))
             'missing=0.ckpt'
             >>> ckpt = ModelCheckpoint(filename='{step}')
-            >>> os.path.basename(ckpt.format_checkpoint_name(0, 0, {}))
+            >>> os.path.basename(ckpt.format_checkpoint_name(dict(step=0)))
             'step=0.ckpt'
 
         """
         filename = self._format_checkpoint_name(
-            self.filename, epoch, step, metrics, auto_insert_metric_name=self.auto_insert_metric_name
+            self.filename, metrics, auto_insert_metric_name=self.auto_insert_metric_name
         )
 
         if ver is not None:
@@ -537,7 +545,7 @@ class ModelCheckpoint(Callback):
         ckpt_name = f"{filename}{self.FILE_EXTENSION}"
         return os.path.join(self.dirpath, ckpt_name) if self.dirpath else ckpt_name
 
-    def __resolve_ckpt_dir(self, trainer):
+    def __resolve_ckpt_dir(self, trainer: 'pl.Trainer') -> None:
         """
         Determines model checkpoint save directory at runtime. References attributes from the
         trainer's logger to determine where to save checkpoints.
@@ -577,7 +585,7 @@ class ModelCheckpoint(Callback):
         if not trainer.fast_dev_run and trainer.is_global_zero:
             self._fs.makedirs(self.dirpath, exist_ok=True)
 
-    def _add_backward_monitor_support(self, trainer):
+    def _add_backward_monitor_support(self, trainer: 'pl.Trainer') -> None:
         metrics = trainer.logger_connector.callback_metrics
         deprecation_warning = False
 
@@ -596,7 +604,7 @@ class ModelCheckpoint(Callback):
                 " and use it as `Trainer(callbacks=[mc])`.", DeprecationWarning
             )
 
-    def _validate_monitor_key(self, trainer):
+    def _validate_monitor_key(self, trainer: 'pl.Trainer') -> None:
         metrics = trainer.logger_connector.callback_metrics
 
         # validate metric
@@ -610,36 +618,29 @@ class ModelCheckpoint(Callback):
 
     def _get_metric_interpolated_filepath_name(
         self,
-        monitor_candidates: Dict[str, Any],
-        epoch: int,
-        step: int,
-        trainer,
+        monitor_candidates: Dict[str, _METRIC],
+        trainer: 'pl.Trainer',
         del_filepath: Optional[str] = None,
     ) -> str:
-        filepath = self.format_checkpoint_name(epoch, step, monitor_candidates)
+        filepath = self.format_checkpoint_name(monitor_candidates)
 
         version_cnt = self.STARTING_VERSION
         while self.file_exists(filepath, trainer) and filepath != del_filepath:
-            filepath = self.format_checkpoint_name(epoch, step, monitor_candidates, ver=version_cnt)
+            filepath = self.format_checkpoint_name(monitor_candidates, ver=version_cnt)
             version_cnt += 1
 
         return filepath
 
-    def _monitor_candidates(self, trainer):
+    def _monitor_candidates(self, trainer: 'pl.Trainer', epoch: int, step: int) -> Dict[str, _METRIC]:
         monitor_candidates = deepcopy(trainer.logger_connector.callback_metrics)
-        monitor_candidates.update(step=trainer.global_step, epoch=trainer.current_epoch)
+        monitor_candidates.update(epoch=epoch, step=step)
         return monitor_candidates
 
-    def _save_last_checkpoint(self, trainer, monitor_candidates: Dict[str, Any]):
+    def _save_last_checkpoint(self, trainer: 'pl.Trainer', monitor_candidates: Dict[str, _METRIC]) -> None:
         if not self.save_last:
             return
 
-        filepath = self._format_checkpoint_name(
-            self.CHECKPOINT_NAME_LAST,
-            trainer.current_epoch,
-            trainer.global_step,
-            monitor_candidates,
-        )
+        filepath = self._format_checkpoint_name(self.CHECKPOINT_NAME_LAST, monitor_candidates)
         filepath = os.path.join(self.dirpath, f"{filepath}{self.FILE_EXTENSION}")
 
         self._save_model(trainer, filepath)
@@ -649,29 +650,24 @@ class ModelCheckpoint(Callback):
 
         self.last_model_path = filepath
 
-    def _save_top_k_checkpoint(self, trainer, monitor_candidates: Dict[str, Any]):
+    def _save_top_k_checkpoint(self, trainer: 'pl.Trainer', monitor_candidates: Dict[str, _METRIC]) -> None:
         if self.monitor is None or self.save_top_k == 0:
             return
 
         current = monitor_candidates.get(self.monitor)
-        epoch = monitor_candidates.get("epoch")
-        step = monitor_candidates.get("step")
 
         if self.check_monitor_top_k(trainer, current):
-            self._update_best_and_save(current, epoch, step, trainer, monitor_candidates)
+            self._update_best_and_save(current, trainer, monitor_candidates)
         elif self.verbose:
+            epoch = monitor_candidates.get("epoch")
+            step = monitor_candidates.get("step")
             rank_zero_info(f"Epoch {epoch:d}, global step {step:d}: {self.monitor} was not in top {self.save_top_k}")
 
-    def _save_none_monitor_checkpoint(self, trainer, monitor_candidates: Dict[str, Any]):
+    def _save_none_monitor_checkpoint(self, trainer: 'pl.Trainer', monitor_candidates: Dict[str, _METRIC]) -> None:
         if self.monitor is not None or self.save_top_k == 0:
             return
 
-        filepath = self._get_metric_interpolated_filepath_name(
-            monitor_candidates,
-            trainer.current_epoch,
-            trainer.global_step,
-            trainer,
-        )
+        filepath = self._get_metric_interpolated_filepath_name(monitor_candidates, trainer)
         self._save_model(trainer, filepath)
 
         if (
@@ -682,12 +678,12 @@ class ModelCheckpoint(Callback):
 
         self.best_model_path = filepath
 
-    def _is_valid_monitor_key(self, metrics):
+    def _is_valid_monitor_key(self, metrics: Dict[str, _METRIC]) -> bool:
         return self.monitor in metrics or len(metrics) == 0
 
     def _update_best_and_save(
-        self, current: torch.Tensor, epoch: int, step: int, trainer, monitor_candidates: Dict[str, Any]
-    ):
+        self, current: torch.Tensor, trainer: 'pl.Trainer', monitor_candidates: Dict[str, _METRIC]
+    ) -> None:
         k = len(self.best_k_models) + 1 if self.save_top_k == -1 else self.save_top_k
 
         del_filepath = None
@@ -699,7 +695,7 @@ class ModelCheckpoint(Callback):
         if isinstance(current, torch.Tensor) and torch.isnan(current):
             current = torch.tensor(float('inf' if self.mode == "min" else '-inf'))
 
-        filepath = self._get_metric_interpolated_filepath_name(monitor_candidates, epoch, step, trainer, del_filepath)
+        filepath = self._get_metric_interpolated_filepath_name(monitor_candidates, trainer, del_filepath)
 
         # save the current score
         self.current_score = current
@@ -716,6 +712,8 @@ class ModelCheckpoint(Callback):
         self.best_model_score = self.best_k_models[self.best_model_path]
 
         if self.verbose:
+            epoch = monitor_candidates.get("epoch")
+            step = monitor_candidates.get("step")
             rank_zero_info(
                 f"Epoch {epoch:d}, global step {step:d}: {self.monitor} reached {current:0.5f}"
                 f' (best {self.best_model_score:0.5f}), saving model to "{filepath}" as top {k}'
@@ -725,7 +723,7 @@ class ModelCheckpoint(Callback):
         if del_filepath is not None and filepath != del_filepath:
             self._del_model(del_filepath)
 
-    def to_yaml(self, filepath: Optional[Union[str, Path]] = None):
+    def to_yaml(self, filepath: Optional[Union[str, Path]] = None) -> None:
         """
         Saves the `best_k_models` dict containing the checkpoint
         paths with the corresponding scores to a YAML file.
@@ -736,7 +734,7 @@ class ModelCheckpoint(Callback):
         with self._fs.open(filepath, "w") as fp:
             yaml.dump(best_k, fp)
 
-    def file_exists(self, filepath: Union[str, Path], trainer) -> bool:
+    def file_exists(self, filepath: Union[str, Path], trainer: 'pl.Trainer') -> bool:
         """
         Checks if a file exists on rank 0 and broadcasts the result to all other ranks, preventing
         the internal state to diverge between ranks.

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -221,8 +221,13 @@ class ModelCheckpoint(Callback):
         self._save_function = trainer.save_checkpoint
 
     def on_train_batch_end(
-        self, trainer: 'pl.Trainer', pl_module: 'pl.LightningModule', outputs: STEP_OUTPUT, batch: Any, batch_idx: int,
-        dataloader_idx: int
+        self,
+        trainer: 'pl.Trainer',
+        pl_module: 'pl.LightningModule',
+        outputs: STEP_OUTPUT,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int,
     ) -> None:
         """ Save checkpoint on train batch end if we meet the criteria for `every_n_train_steps` """
         if self._should_skip_saving_checkpoint(trainer):
@@ -243,8 +248,12 @@ class ModelCheckpoint(Callback):
             return
         self.save_checkpoint(trainer)
 
-    def on_save_checkpoint(self, trainer: 'pl.Trainer', pl_module: 'pl.LightningModule',
-                           checkpoint: Dict[str, Any]) -> Dict[str, Any]:
+    def on_save_checkpoint(
+        self,
+        trainer: 'pl.Trainer',
+        pl_module: 'pl.LightningModule',
+        checkpoint: Dict[str, Any],
+    ) -> Dict[str, Any]:
         return {
             "monitor": self.monitor,
             "best_model_score": self.best_model_score,

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -87,9 +87,7 @@ class CheckpointConnector:
         # Try to read the checkpoint file at `checkpoint_path`. If not exist, do not restore checkpoint.
         fs = get_filesystem(checkpoint_path)
         if not fs.exists(checkpoint_path):
-            raise FileNotFoundError(
-                f"Checkpoint at {checkpoint_path} not found. Aborting training."
-            )
+            raise FileNotFoundError(f"Checkpoint at {checkpoint_path} not found. Aborting training.")
 
         checkpoint, load_optimizer_states = self.trainer.training_type_plugin.restore_model_state_from_ckpt_path(
             checkpoint_path, map_location=lambda storage, loc: storage

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -411,50 +411,53 @@ def test_model_checkpoint_no_extraneous_invocations(tmpdir):
 
 def test_model_checkpoint_format_checkpoint_name(tmpdir):
     # empty filename:
-    ckpt_name = ModelCheckpoint._format_checkpoint_name('', 3, 2, {})
+    ckpt_name = ModelCheckpoint._format_checkpoint_name('', {'epoch': 3, 'step': 2})
     assert ckpt_name == 'epoch=3-step=2'
 
-    ckpt_name = ModelCheckpoint._format_checkpoint_name(None, 3, 2, {}, prefix='test')
+    ckpt_name = ModelCheckpoint._format_checkpoint_name(None, {'epoch': 3, 'step': 2}, prefix='test')
     assert ckpt_name == 'test-epoch=3-step=2'
 
     # no groups case:
-    ckpt_name = ModelCheckpoint._format_checkpoint_name('ckpt', 3, 2, {}, prefix='test')
+    ckpt_name = ModelCheckpoint._format_checkpoint_name('ckpt', {}, prefix='test')
     assert ckpt_name == 'test-ckpt'
 
     # no prefix
-    ckpt_name = ModelCheckpoint._format_checkpoint_name('{epoch:03d}-{acc}', 3, 2, {'acc': 0.03})
+    ckpt_name = ModelCheckpoint._format_checkpoint_name('{epoch:03d}-{acc}', {'epoch': 3, 'acc': 0.03})
     assert ckpt_name == 'epoch=003-acc=0.03'
 
     # prefix
     char_org = ModelCheckpoint.CHECKPOINT_JOIN_CHAR
     ModelCheckpoint.CHECKPOINT_JOIN_CHAR = '@'
-    ckpt_name = ModelCheckpoint._format_checkpoint_name('{epoch},{acc:.5f}', 3, 2, {'acc': 0.03}, prefix='test')
+    ckpt_name = ModelCheckpoint._format_checkpoint_name('{epoch},{acc:.5f}', {'epoch': 3, 'acc': 0.03}, prefix='test')
     assert ckpt_name == 'test@epoch=3,acc=0.03000'
     ModelCheckpoint.CHECKPOINT_JOIN_CHAR = char_org
 
     # no dirpath set
-    ckpt_name = ModelCheckpoint(monitor='early_stop_on', dirpath=None).format_checkpoint_name(3, 2, {})
+    ckpt_name = ModelCheckpoint(monitor='early_stop_on', dirpath=None).format_checkpoint_name({'epoch': 3, 'step': 2})
     assert ckpt_name == 'epoch=3-step=2.ckpt'
-    ckpt_name = ModelCheckpoint(monitor='early_stop_on', dirpath='').format_checkpoint_name(5, 4, {})
+    ckpt_name = ModelCheckpoint(monitor='early_stop_on', dirpath='').format_checkpoint_name({'epoch': 5, 'step': 4})
     assert ckpt_name == 'epoch=5-step=4.ckpt'
 
     # CWD
-    ckpt_name = ModelCheckpoint(monitor='early_stop_on', dirpath='.').format_checkpoint_name(3, 4, {})
+    ckpt_name = ModelCheckpoint(monitor='early_stop_on', dirpath='.').format_checkpoint_name({'epoch': 3, 'step': 4})
     assert ckpt_name == str(Path('.').resolve() / 'epoch=3-step=4.ckpt')
 
     # with version
     ckpt = ModelCheckpoint(monitor='early_stop_on', dirpath=tmpdir, filename='name')
-    ckpt_name = ckpt.format_checkpoint_name(3, 2, {}, ver=3)
+    ckpt_name = ckpt.format_checkpoint_name({}, ver=3)
     assert ckpt_name == tmpdir / 'name-v3.ckpt'
 
     # using slashes
     ckpt = ModelCheckpoint(monitor='early_stop_on', dirpath=None, filename='{epoch}_{val/loss:.5f}')
-    ckpt_name = ckpt.format_checkpoint_name(4, 3, {'val/loss': 0.03})
+    ckpt_name = ckpt.format_checkpoint_name({'epoch': 4, 'val/loss': 0.03})
     assert ckpt_name == 'epoch=4_val/loss=0.03000.ckpt'
 
     # auto_insert_metric_name=False
     ckpt_name = ModelCheckpoint._format_checkpoint_name(
-        'epoch={epoch:03d}-val_acc={val/acc}', 3, 2, {'val/acc': 0.03}, auto_insert_metric_name=False
+        'epoch={epoch:03d}-val_acc={val/acc}', {
+            'epoch': 3,
+            'val/acc': 0.03
+        }, auto_insert_metric_name=False
     )
     assert ckpt_name == 'epoch=003-val_acc=0.03'
 
@@ -504,7 +507,7 @@ def test_model_checkpoint_save_last(tmpdir):
     )
     trainer.fit(model)
     last_filename = model_checkpoint._format_checkpoint_name(
-        ModelCheckpoint.CHECKPOINT_NAME_LAST, trainer.current_epoch, trainer.global_step, {}
+        ModelCheckpoint.CHECKPOINT_NAME_LAST, {'epoch': trainer.current_epoch}
     )
     last_filename = last_filename + '.ckpt'
     assert str(tmpdir / last_filename) == model_checkpoint.last_model_path

--- a/tests/deprecated_api/test_remove_1-5.py
+++ b/tests/deprecated_api/test_remove_1-5.py
@@ -171,8 +171,8 @@ def test_v1_5_0_old_callback_on_load_checkpoint(tmpdir):
     with no_deprecated_call(match="old signature will be removed in v1.5"):
         trainer.fit(model)
 
-    with pytest.deprecated_call(match="old signature will be removed in v1.5"):
-        trainer = Trainer(**trainer_kwargs, resume_from_checkpoint=chk.last_model_path)
+    trainer = Trainer(**trainer_kwargs, resume_from_checkpoint=chk.last_model_path)
+    with no_deprecated_call(match="old signature will be removed in v1.5"):
         trainer.fit(model)
 
 


### PR DESCRIPTION
## What does this PR do?

Refactor necessary for #6997

Instead of passing these as arguments everywhere, treat them as any other `monitor_candidate`s

Also some non-exhaustive typing in signatures.

### Question

Should I deprecate the signature change to `format_checkpoint_name`?

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [n/a] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [n/a] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review
 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified