### PR TITLE
Add _gpus_arg_default in argparse_utils for backward compatibility

### DIFF
--- a/pytorch_lightning/utilities/argparse_utils.py
+++ b/pytorch_lightning/utilities/argparse_utils.py
@@ -3,3 +3,7 @@ from pytorch_lightning.utilities import rank_zero_deprecation
 rank_zero_deprecation("`argparse_utils` package has been renamed to `argparse` since v1.2 and will be removed in v1.4")
 
 from pytorch_lightning.utilities.argparse import *  # noqa: F403 E402 F401
+
+# for backward compatibility with old checkpoints (versions < 1.2.0)
+# that need to be able to unpickle the function from the checkpoint
+from pytorch_lightning.utilities.argparse import _gpus_arg_default  # noqa: E402 F401 # isort: skip


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #7400.

`pytorch_lightning/utilities/argparse_utils.py` was renamed to `pytorch_lightning/utilities/argparse.py` at PL 1.2.0.

A checkpoint saved in PL < 1.2 tries to use argparse.utils._gpus_arg_default() which does not exists in PL >= 1.2.0.

```python
# pytorch_lightning/utilities/argparse_utils.py
from pytorch_lightning.utilities.argparse import *
```

The current solution for backward compatibility above does not work since the function starts with an underscore.


## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
