### PR TITLE
reduce log output size in special tests

### DIFF
--- a/tests/plugins/test_deepspeed_plugin.py
+++ b/tests/plugins/test_deepspeed_plugin.py
@@ -392,11 +392,12 @@ def test_deepspeed_assert_config_zero_offload_disabled(tmpdir, deepspeed_zero_co
 
     model = BoringModel()
     trainer = Trainer(
+        default_root_dir=tmpdir,
+        progress_bar_refresh_rate=0,
         max_epochs=1,
         plugins=[DeepSpeedPlugin(config=deepspeed_zero_config)],
         precision=16,
         gpus=1,
-        default_root_dir=tmpdir,
         callbacks=[TestCallback()]
     )
     with pytest.raises(SystemExit):
@@ -410,8 +411,8 @@ def test_deepspeed_multigpu(tmpdir, deepspeed_config):
     """
     model = BoringModel()
     trainer = Trainer(
-        plugins=[DeepSpeedPlugin(zero_optimization=False, stage=2)],
         default_root_dir=tmpdir,
+        plugins=[DeepSpeedPlugin(zero_optimization=False, stage=2)],
         gpus=2,
         fast_dev_run=True,
         precision=16,
@@ -489,8 +490,8 @@ def test_deepspeed_multigpu_stage_3(tmpdir, deepspeed_config):
     """
     model = ModelParallelBoringModel()
     trainer = Trainer(
-        plugins=[DeepSpeedPlugin(stage=3)],
         default_root_dir=tmpdir,
+        plugins=[DeepSpeedPlugin(stage=3)],
         gpus=2,
         fast_dev_run=True,
         precision=16,
@@ -507,9 +508,10 @@ def run_checkpoint_test(tmpdir, save_full_weights):
     dm = ClassifDataModule()
     ck = ModelCheckpoint(monitor="val_acc", mode="max", save_last=True, save_top_k=-1)
     trainer = Trainer(
+        default_root_dir=tmpdir,
+        progress_bar_refresh_rate=0,
         max_epochs=10,
         plugins=[DeepSpeedPlugin(stage=3, save_full_weights=save_full_weights)],
-        default_root_dir=tmpdir,
         gpus=2,
         precision=16,
         accumulate_grad_batches=2,
@@ -525,9 +527,9 @@ def run_checkpoint_test(tmpdir, save_full_weights):
     assert saved_results == results
 
     trainer = Trainer(
+        default_root_dir=tmpdir,
         max_epochs=10,
         plugins=[DeepSpeedPlugin(stage=3, save_full_weights=save_full_weights)],
-        default_root_dir=tmpdir,
         gpus=2,
         precision=16,
         accumulate_grad_batches=2,
@@ -579,6 +581,8 @@ def test_deepspeed_multigpu_stage_2_accumulated_grad_batches(tmpdir, cpu_offload
     model = ModelParallelClassificationModel()
     dm = ClassifDataModule()
     trainer = Trainer(
+        default_root_dir=tmpdir,
+        progress_bar_refresh_rate=0,
         max_epochs=5,
         plugins=[DeepSpeedPlugin(stage=2, cpu_offload=cpu_offload)],
         gpus=2,
@@ -597,8 +601,8 @@ def test_deepspeed_multigpu_test(tmpdir, deepspeed_config):
     """
     model = ModelParallelBoringModel()
     trainer = Trainer(
-        plugins=[DeepSpeedPlugin(stage=3)],
         default_root_dir=tmpdir,
+        plugins=[DeepSpeedPlugin(stage=3)],
         gpus=2,
         fast_dev_run=True,
         precision=16,


### PR DESCRIPTION
## What does this PR do?

Special tests print a lot of logs (progress bar). They get cutoff in browser view and we miss seeing failing tests.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
