### PR TITLE
fix progress bar jittering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed recursive passing of `wrong_type` keyword argument in `pytorch_lightning.utilities.apply_to_collection` ([#7433](https://github.com/PyTorchLightning/pytorch-lightning/pull/7433))
 
 
+- Fixed progress bar jittering when loss precision changes rapidly ([#7532](https://github.com/PyTorchLightning/pytorch-lightning/pull/7532))
+
 
 ## [1.3.1] - 2021-05-11
 

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1630,7 +1630,7 @@ class LightningModule(
 
         tqdm_dict = {}
         if avg_training_loss is not None:
-            tqdm_dict["loss"] = f"{avg_training_loss:.3f}"
+            tqdm_dict["loss"] = f"{avg_training_loss:#.3g}"
 
         module_tbptt_enabled = self.truncated_bptt_steps > 0
         trainer_tbptt_enabled = self.trainer.truncated_bptt_steps is not None and self.trainer.truncated_bptt_steps > 0

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1630,7 +1630,7 @@ class LightningModule(
 
         tqdm_dict = {}
         if avg_training_loss is not None:
-            tqdm_dict["loss"] = f"{avg_training_loss:.3g}"
+            tqdm_dict["loss"] = f"{avg_training_loss:.3f}"
 
         module_tbptt_enabled = self.truncated_bptt_steps > 0
         trainer_tbptt_enabled = self.trainer.truncated_bptt_steps is not None and self.trainer.truncated_bptt_steps > 0


### PR DESCRIPTION
## What does this PR do?

1. Avoid progress bar blowing up with digits when loss explodes -> use scientific notation, e.g., 1.00e+06 instead of 1000000. 
2. Add trailing 0's to decimal places to avoid jittering progress bar when precision changes rapidly. 

Currently, this is the best I can do:

```python
for num in [0.00001, 0.01, 0.1, 1.0, 10., 100., 1000., 1e6, 1e100]:
    print(f"{num:.3f}" if log10(num) < 1 else f"{num:<5g}")
```
Formatted (includes white space padding):

```
0.000
0.010
0.100
1.000
10  
100 
1000
1e+06
1e+100
```

Reported on Slack. 

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
