### PR TITLE
[feat] Add stronger validation for checkpoint_callback argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 
+- Changed the `Trainer`'s `checkpoint_callback` argument to allow boolean values only ([#7539](https://github.com/PyTorchLightning/pytorch-lightning/pull/7539))
+
+
 - Log epoch metrics before the `on_evaluation_end` hook ([#7272](https://github.com/PyTorchLightning/pytorch-lightning/pull/7272))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 
-- Changed the `Trainer`'s `checkpoint_callback` argument to allow boolean values only ([#7539](https://github.com/PyTorchLightning/pytorch-lightning/pull/7539))
+- Changed the `Trainer`'s `checkpoint_callback` argument to allow only boolean values ([#7539](https://github.com/PyTorchLightning/pytorch-lightning/pull/7539))
 
 
 - Log epoch metrics before the `on_evaluation_end` hook ([#7272](https://github.com/PyTorchLightning/pytorch-lightning/pull/7272))

--- a/pytorch_lightning/trainer/connectors/callback_connector.py
+++ b/pytorch_lightning/trainer/connectors/callback_connector.py
@@ -54,7 +54,7 @@ class CallbackConnector:
 
         # configure checkpoint callback
         # pass through the required args to figure out defaults
-        self.configure_checkpoint_callbacks(checkpoint_callback)
+        self._configure_checkpoint_callbacks(checkpoint_callback)
 
         # configure swa callback
         self._configure_swa_callbacks()
@@ -70,11 +70,12 @@ class CallbackConnector:
         # it is important that these are the last callbacks to run
         self.trainer.callbacks = self._reorder_callbacks(self.trainer.callbacks)
 
-    def configure_checkpoint_callbacks(self, checkpoint_callback: bool) -> None:
+    def _configure_checkpoint_callbacks(self, checkpoint_callback: bool) -> None:
         if not isinstance(checkpoint_callback, bool):
-            raise MisconfigurationException(
-                f"Invalid type provided for checkpoint_callback: Expected bool but received {type(checkpoint_callback)}."
-            )
+            error_msg = f"Invalid type provided for checkpoint_callback: Expected bool but received {type(checkpoint_callback)}."
+            if isinstance(checkpoint_callback, Callback):
+                error_msg += f" Pass callback instances to the `callbacks` argument in the Trainer constructor instead."
+            raise MisconfigurationException(error_msg)
         if self._trainer_has_checkpoint_callbacks() and checkpoint_callback is False:
             raise MisconfigurationException(
                 "Trainer was configured with checkpoint_callback=False but found ModelCheckpoint"

--- a/pytorch_lightning/trainer/connectors/callback_connector.py
+++ b/pytorch_lightning/trainer/connectors/callback_connector.py
@@ -71,6 +71,7 @@ class CallbackConnector:
         self.trainer.callbacks = self._reorder_callbacks(self.trainer.callbacks)
 
     def _configure_checkpoint_callbacks(self, checkpoint_callback: bool) -> None:
+        # TODO: Remove this error in v1.5 so we rely purely on the type signature
         if not isinstance(checkpoint_callback, bool):
             error_msg = (
                 "Invalid type provided for checkpoint_callback:"

--- a/pytorch_lightning/trainer/connectors/callback_connector.py
+++ b/pytorch_lightning/trainer/connectors/callback_connector.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import os
 from datetime import timedelta
+from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 from pytorch_lightning.callbacks import Callback, ModelCheckpoint, ProgressBar, ProgressBarBase
@@ -29,14 +30,14 @@ class CallbackConnector:
 
     def on_trainer_init(
         self,
-        callbacks,
-        checkpoint_callback,
-        progress_bar_refresh_rate,
-        process_position,
-        default_root_dir,
-        weights_save_path,
-        resume_from_checkpoint,
-        stochastic_weight_avg,
+        callbacks: Optional[Union[List[Callback], Callback]],
+        checkpoint_callback: bool,
+        progress_bar_refresh_rate: Optional[int],
+        process_position: int,
+        default_root_dir: Optional[str],
+        weights_save_path: Optional[str],
+        resume_from_checkpoint: Optional[Union[Path, str]],
+        stochastic_weight_avg: bool,
         max_time: Optional[Union[str, timedelta, Dict[str, int]]] = None,
     ):
         self.trainer.resume_from_checkpoint = resume_from_checkpoint
@@ -69,7 +70,11 @@ class CallbackConnector:
         # it is important that these are the last callbacks to run
         self.trainer.callbacks = self._reorder_callbacks(self.trainer.callbacks)
 
-    def configure_checkpoint_callbacks(self, checkpoint_callback: Union[ModelCheckpoint, bool]):
+    def configure_checkpoint_callbacks(self, checkpoint_callback: bool) -> None:
+        if not isinstance(checkpoint_callback, bool):
+            raise MisconfigurationException(
+                f"Invalid type provided for checkpoint_callback: Expected bool but received {type(checkpoint_callback)}."
+            )
         if self._trainer_has_checkpoint_callbacks() and checkpoint_callback is False:
             raise MisconfigurationException(
                 "Trainer was configured with checkpoint_callback=False but found ModelCheckpoint"

--- a/pytorch_lightning/trainer/connectors/callback_connector.py
+++ b/pytorch_lightning/trainer/connectors/callback_connector.py
@@ -72,8 +72,10 @@ class CallbackConnector:
 
     def _configure_checkpoint_callbacks(self, checkpoint_callback: bool) -> None:
         if not isinstance(checkpoint_callback, bool):
-            error_msg = "Invalid type provided for checkpoint_callback: "
-            f"Expected bool but received {type(checkpoint_callback)}."
+            error_msg = (
+                "Invalid type provided for checkpoint_callback:"
+                f" Expected bool but received {type(checkpoint_callback)}."
+            )
             if isinstance(checkpoint_callback, Callback):
                 error_msg += " Pass callback instances to the `callbacks` argument in the Trainer constructor instead."
             raise MisconfigurationException(error_msg)

--- a/pytorch_lightning/trainer/connectors/callback_connector.py
+++ b/pytorch_lightning/trainer/connectors/callback_connector.py
@@ -72,9 +72,10 @@ class CallbackConnector:
 
     def _configure_checkpoint_callbacks(self, checkpoint_callback: bool) -> None:
         if not isinstance(checkpoint_callback, bool):
-            error_msg = f"Invalid type provided for checkpoint_callback: Expected bool but received {type(checkpoint_callback)}."
+            error_msg = "Invalid type provided for checkpoint_callback: "
+            f"Expected bool but received {type(checkpoint_callback)}."
             if isinstance(checkpoint_callback, Callback):
-                error_msg += f" Pass callback instances to the `callbacks` argument in the Trainer constructor instead."
+                error_msg += " Pass callback instances to the `callbacks` argument in the Trainer constructor instead."
             raise MisconfigurationException(error_msg)
         if self._trainer_has_checkpoint_callbacks() and checkpoint_callback is False:
             raise MisconfigurationException(

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -1263,4 +1263,4 @@ def test_model_checkpoint_mode_options():
 def test_trainer_checkpoint_callback_bool(tmpdir):
     mc = ModelCheckpoint(dirpath=tmpdir)
     with pytest.raises(MisconfigurationException, match="Invalid type provided for checkpoint_callback"):
-        _ = Trainer(checkpoint_callback=mc)
+        Trainer(checkpoint_callback=mc)

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -1258,3 +1258,9 @@ def test_ckpt_version_after_rerun_same_trainer(tmpdir):
 def test_model_checkpoint_mode_options():
     with pytest.raises(MisconfigurationException, match="`mode` can be .* but got unknown_option"):
         ModelCheckpoint(mode="unknown_option")
+
+
+def test_trainer_checkpoint_callback_bool(tmpdir):
+    mc = ModelCheckpoint(dirpath=tmpdir)
+    with pytest.raises(MisconfigurationException, match="Invalid type provided for checkpoint_callback"):
+        trainer = Trainer(checkpoint_callback=mc)

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -1263,4 +1263,4 @@ def test_model_checkpoint_mode_options():
 def test_trainer_checkpoint_callback_bool(tmpdir):
     mc = ModelCheckpoint(dirpath=tmpdir)
     with pytest.raises(MisconfigurationException, match="Invalid type provided for checkpoint_callback"):
-        trainer = Trainer(checkpoint_callback=mc)
+        _ = Trainer(checkpoint_callback=mc)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

This removes the option for passing a `ModelCheckpoint` instance to the checkpoint_callback argument and raises an error if the wrong type is provided. 

This argument is already typed as `bool` in the Trainer, but the callback connector was accepting `Union[bool, ModelCheckpoint]`. This can be very confusing for users who pass model checkpoint callback instances to this argument, as their callback settings are silently ignored. 

This carries forward the deprecation initially landed in https://github.com/PyTorchLightning/pytorch-lightning/pull/4336

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
