### PR TITLE
Remove tests dir from distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     url=about.__homepage__,
     download_url='https://github.com/PyTorchLightning/pytorch-lightning',
     license=about.__license__,
-    packages=find_packages(exclude=['tests', 'tests/*', 'benchmarks', 'legacy', 'legacy/*']),
+    packages=find_packages(exclude=['tests', 'tests.*', 'benchmarks', 'legacy', 'legacy.*']),
     long_description=long_description,
     long_description_content_type='text/markdown',
     include_package_data=True,


### PR DESCRIPTION
You’re using `find_packages` wrong. It expects package paths (with `.`) not file paths.

Docs: https://setuptools.readthedocs.io/en/latest/userguide/package_discovery.html#using-find-or-find-packages