### PR TITLE
WIP - do not merge: documenting clashing of WandB logger and LightningCLI clash

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,10 +25,11 @@ channels:
     - pytorch-nightly
 
 dependencies:
-    - python>=3.6
+    - python=3.8
     - pip>20.1
+    - cudatoolkit=10.2
     - numpy>=1.16.4
-    - pytorch>=1.4
+    - pytorch=1.8.1
     - future>=0.17.1
     - PyYAML>=5.1
     - tqdm>=4.41.0
@@ -54,3 +55,5 @@ dependencies:
         - horovod>=0.21.2
         - onnxruntime>=1.3.0
         - gym>=0.17.0
+        - jsonargparse[signatures]
+        - pytorch-lightning==1.3.2

--- a/pl_examples/basic_examples/autoencoder.py
+++ b/pl_examples/basic_examples/autoencoder.py
@@ -113,11 +113,16 @@ class MyDataModule(pl.LightningDataModule):
     def test_dataloader(self):
         return DataLoader(self.mnist_test, batch_size=self.batch_size)
 
+
 class WandBandSafeConfigCallBackFixCLI(LightningCLI):
+
     def add_arguments_to_parser(self, parser):
-        parser.add_argument('save_config_callback_filename', default='',
-                help='Change config filename in order to avoid clashes with wandb.'
-                     'TODO submit PR for setting this in LightningCLI constructor/self.config')
+        parser.add_argument(
+            'save_config_callback_filename',
+            default='',
+            help='Change config filename in order to avoid clashes with wandb.'
+            'TODO submit PR for setting this in LightningCLI constructor/self.config'
+        )
 
     def before_fit(self):
         save_config_cb = [c for c in self.trainer.callbacks if isinstance(c, SaveConfigCallback)]

--- a/pl_examples/basic_examples/autoencoder.yml
+++ b/pl_examples/basic_examples/autoencoder.yml
@@ -1,0 +1,14 @@
+# See SaveConfigCallback config_filename: str = 'config.yaml'
+# This breaks the example
+save_config_callback_filename: ''   # Keeps the LightningCLI intact - do not apply workaround
+# 
+# Workaround - UNCOMMENT TO MAKE THE EXAMPLE WORKING or specify as CLI option
+# save_config_callback_filename: 'another-name-config.yaml  # See WandBandSafeConfigCallBackFixCLI
+
+
+trainer:
+  max_epochs: 3
+  logger:
+    class_path: pytorch_lightning.loggers.WandbLogger 
+    init_args:
+      name: oplatek-pl-documenting-wandb-lightningCLI-clash

--- a/pl_examples/basic_examples/autoencoder.yml
+++ b/pl_examples/basic_examples/autoencoder.yml
@@ -1,7 +1,7 @@
 # See SaveConfigCallback config_filename: str = 'config.yaml'
 # This breaks the example
 save_config_callback_filename: ''   # Keeps the LightningCLI intact - do not apply workaround
-# 
+#
 # Workaround - UNCOMMENT TO MAKE THE EXAMPLE WORKING or specify as CLI option
 # save_config_callback_filename: 'another-name-config.yaml  # See WandBandSafeConfigCallBackFixCLI
 
@@ -9,6 +9,6 @@ save_config_callback_filename: ''   # Keeps the LightningCLI intact - do not app
 trainer:
   max_epochs: 3
   logger:
-    class_path: pytorch_lightning.loggers.WandbLogger 
+    class_path: pytorch_lightning.loggers.WandbLogger
     init_args:
       name: oplatek-pl-documenting-wandb-lightningCLI-clash

--- a/pl_examples/run-example-wandb-save-config-callback-clash-workaournd.sh
+++ b/pl_examples/run-example-wandb-save-config-callback-clash-workaournd.sh
@@ -4,7 +4,7 @@
 ARGS_EXTRA_DDP=" --trainer.gpus 2 --trainer.accelerator ddp"
 ARGS_EXTRA_AMP=" --trainer.precision 16"
 
-# conda created with the following command in the git root directory 
+# conda created with the following command in the git root directory
 #   conda env create --file environment.yml --prefix $PWD/env
 #   conda activate $PWD/env
 #   pip install pytorch-lightning==1.3.2

--- a/pl_examples/run-example-wandb-save-config-callback-clash-workaournd.sh
+++ b/pl_examples/run-example-wandb-save-config-callback-clash-workaournd.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# on master branch 01109cdf0c44a150c262b65e70a7e1e64003cf93 commit
+
+ARGS_EXTRA_DDP=" --trainer.gpus 2 --trainer.accelerator ddp"
+ARGS_EXTRA_AMP=" --trainer.precision 16"
+
+# conda created with the following command in the git root directory 
+#   conda env create --file environment.yml --prefix $PWD/env
+#   conda activate $PWD/env
+#   pip install pytorch-lightning==1.3.2
+conda activate ../env
+python basic_examples/autoencoder.py --config basic_examples/autoencoder.yml ${ARGS_EXTRA_DDP} ${ARGS_EXTRA_AMP} $@


### PR DESCRIPTION
This PR documents LightningCLI.save_config_callback default filename clash
with WandB logger on basic_example autoencoder.

See run-example-wandb-save-config-callback-clash-workaournd.sh, autoencoder.{py,yml}
I used the main environment.yml to document the dependencies.


This example below reproduces the error when used default LightningCLI and WandB logger.
However, if you just change the single line in `basic_examples/autoencoder.yml`

```yaml
# save_config_callback_filename: ''   # Keeps the LightningCLI intact - do not apply workaround  this breaks 
# to
save_config_callback_filename: 'another-name-config.yaml'   # sets different filename in save_config_callback
```

It runs fine.

If you do not change anything you will be able to reproduce the error.

```bash
$ ./run-example-wandb-save-config-callback-clash-workaournd.sh   # inside the pytorch-lightning/pl_examples directory
...
Traceback (most recent call last):
    self.parser.save(self.config, config_path, skip_none=False)
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/jsonargparse/core.py", line 811, in save
  File "basic_examples/autoencoder.py", line 139, in <module>
    cli_main()
  File "basic_examples/autoencoder.py", line 132, in cli_main
    cli = WandBandSafeConfigCallBackFixCLI(LitAutoEncoder, MyDataModule, seed_everything_default=1234)
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/pytorch_lightning/utilities/cli.py", line 173, in __init__
    self.fit()
    check_overwrite(path_fc)
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/jsonargparse/core.py", line 808, in check_overwrite
  File ️"/lnwt/wojk/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/pytorch_lightning/utilities/cli.py", line 256, in fit
    self.trainer.fit(**self.fit_kwargs)
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/pytorch_lightning/trainer/trainer.py", line 458, in fit
    self._run(model)
    raise ValueError('Refusing to overwrite existing file: '+path())
ValueError: Refusing to overwrite existing file: /lnet/work/people/oplatek/pytorch-lightning/pl_examples/wandb/run-20210524_145129-1rtepmq4/files/config.yaml
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/pytorch_lightning/trainer/trainer.py", line 756, in _run
    self.dispatch()
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/pytorch_lightning/trainer/trainer.py", line 797, in dispatch
    self.accelerator.start_training(self)
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/pytorch_lightning/accelerators/accelerator.py", line 96, in start_training
    self.training_type_plugin.start_training(trainer)
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/pytorch_lightning/plugins/training_type/training_type_plugin.py", line 144, in start_training
    self._results = trainer.run_stage()
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/pytorch_lightning/trainer/trainer.py", line 807, in run_stage
    return self.run_train()
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/pytorch_lightning/trainer/trainer.py", line 855, in run_train
    self.train_loop.on_train_start()
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/pytorch_lightning/trainer/training_loop.py", line 101, in on_train_start
    self.trainer.call_hook("on_train_start")
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/pytorch_lightning/trainer/trainer.py", line 1223, in call_hook
    trainer_hook(*args, **kwargs)
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/pytorch_lightning/trainer/callback_hook.py", line 152, in on_train_start
    callback.on_train_start(self, self.lightning_module)
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/pytorch_lightning/utilities/cli.py", line 87, in on_train_start
    self.parser.save(self.config, config_path, skip_none=False)
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/jsonargparse/core.py", line 811, in save
    check_overwrite(path_fc)
  File "/lnet/work/people/oplatek/pytorch-lightning/env/lib/python3.8/site-packages/jsonargparse/core.py", line 808, in check_overwrite
    raise ValueError('Refusing to overwrite existing file: '+path())
ValueError: Refusing to overwrite existing file: /lnet/work/people/oplatek/pytorch-lightning/pl_examples/wandb/run-20210524_145129-1rtepmq4/files/config.yaml

wandb: Waiting for W&B process to finish, PID 8111
wandb: Program failed with code 1.  Press ctrl-c to abort syncing.
wandb:                                                                                
wandb: Find user logs for this run at: /lnet/work/people/oplatek/pytorch-lightning/pl_examples/wandb/run-20210524_145129-1rtepmq4/logs/debug.log
wandb: Find internal logs for this run at: /lnet/work/people/oplatek/pytorch-lightning/pl_examples/wandb/run-20210524_145129-1rtepmq4/logs/debug-internal.log
wandb: Synced 7 W&B file(s), 0 media file(s), 0 artifact file(s) and 1 other file(s)

```

I think it would be useful to pass the filename argument to the constructor of the callback so one could actually change the filename using LightningCLI argument https://github.com/PyTorchLightning/pytorch-lightning/blob/2103b5efc98669f86aafa0fa98490df2e13142b7/pytorch_lightning/utilities/cli.py#244