### PR TITLE
Weekly Patch Release v1.3.3 [full merge, no squash]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+
+
+
+- Fixed `ProgressBar` pickling after calling `trainer.predict` ([#7608](https://github.com/PyTorchLightning/pytorch-lightning/pull/7608))
+
+
+
+
 ## [1.3.2] - 2021-05-18
 
 ### Changed

--- a/pytorch_lightning/callbacks/progress.py
+++ b/pytorch_lightning/callbacks/progress.py
@@ -283,6 +283,7 @@ class ProgressBar(ProgressBarBase):
         self.main_progress_bar = None
         self.val_progress_bar = None
         self.test_progress_bar = None
+        self.predict_progress_bar = None
 
     def __getstate__(self):
         # can't pickle the tqdm objects
@@ -290,6 +291,7 @@ class ProgressBar(ProgressBarBase):
         state['main_progress_bar'] = None
         state['val_progress_bar'] = None
         state['test_progress_bar'] = None
+        state['predict_progress_bar'] = None
         return state
 
     @property

--- a/tests/callbacks/test_progress_bar.py
+++ b/tests/callbacks/test_progress_bar.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import pickle
 import sys
 from typing import Optional, Union
 from unittest import mock
@@ -482,3 +483,17 @@ def test_progress_bar_print_disabled(tqdm_write, mock_print, tmpdir):
         call("test_step"),
     ])
     tqdm_write.assert_not_called()
+
+
+def test_progress_bar_can_be_pickled():
+    bar = ProgressBar()
+    trainer = Trainer(fast_dev_run=True, callbacks=[bar], max_steps=1)
+    model = BoringModel()
+
+    pickle.dumps(bar)
+    trainer.fit(model)
+    pickle.dumps(bar)
+    trainer.test(model)
+    pickle.dumps(bar)
+    trainer.predict(model)
+    pickle.dumps(bar)


### PR DESCRIPTION
## What does this PR do?

Next patch release after #7589

```
gh pr list -s merged -S 'merged:2021-05-19T16:30:00.000Z..2021-05-26T23:30:00.000Z' --json mergedAt,milestone,url,mergeCommit,title --jq 'sort_by(.mergedAt) | reverse | .[] | select((.milestone.title == "v1.3.x") or (.milestone.title == null)) | [.url, .mergeCommit.oid, .title] | join(" ")' --limit 100

https://github.com/PyTorchLightning/pytorch-lightning/pull/7692 8ba6304c73c0fd030c50d5de52cbaddfed161613 Increment the total batch idx before the accumulation early exit
https://github.com/PyTorchLightning/pytorch-lightning/pull/7683 2c10ecc232f5fb576638683e24744a5be8911c9a MAINTAINER has been deprecated
https://github.com/PyTorchLightning/pytorch-lightning/pull/7676 ad168fc4c69fb586f38a2e7396d4d981ae52aaa0 chlog for 1.3.2 + legacy test
https://github.com/PyTorchLightning/pytorch-lightning/pull/7677 8b01497e4235139edb83cd0b8efd87380a1af726 Fix global step update when the epoch is skipped
https://github.com/PyTorchLightning/pytorch-lightning/pull/7415 3f460b150aab16d1fa267251d738bada6d890675 Move parameter validation specific to TPU Training plugins
https://github.com/PyTorchLightning/pytorch-lightning/pull/7674 a54bc5dba3133cf492205e6a60ca46e8ab22c465 Fix progress bar print error when called before training
ok https://github.com/PyTorchLightning/pytorch-lightning/pull/7566 0c958c5a1f8ca8926eeaf1a2035725c15417830e Fix dataloaders are not reset when tuning the model
ok https://github.com/PyTorchLightning/pytorch-lightning/pull/7563 01109cdf0c44a150c262b65e70a7e1e64003cf93 Fix/mismatched toggle optimizer
no https://github.com/PyTorchLightning/pytorch-lightning/pull/7639 03ea68f8a2a4a7fed1ff6637380a0301a4ac97a5 Removed hparams assignment example in doc
ok https://github.com/PyTorchLightning/pytorch-lightning/pull/7592 92cf396de2fe49e89a625a200d641bd8b6aeb328 Override `broadcast_object_list` for `torch<1.8`
ok https://github.com/PyTorchLightning/pytorch-lightning/pull/7608 ed271905cf07d86af5b6d8e088b6c04813d1a8a1 Clear predict_progress_bar in ProgressBar.__getstate__
no https://github.com/PyTorchLightning/pytorch-lightning/pull/7606 6e56f56aa18746a47fdfe697e88de66a8f43edb5 docker use $(nproc)
no https://github.com/PyTorchLightning/pytorch-lightning/pull/7598 922c0a607b7c2fe095ffe0f74795dba7b410f6ba Fix incorrect code-snippet in optimizers doc
```

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
