### PR TITLE
fix info message when max training time reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed print errors in `ProgressBar` when `trainer.fit` is not called ([#7674](https://github.com/PyTorchLightning/pytorch-lightning/pull/7674))
 
 
+- Fixed formatting of info message when max training time reached ([#7780](https://github.com/PyTorchLightning/pytorch-lightning/pull/7780))
+
+
 ## [1.3.2] - 2021-05-18
 
 ### Changed

--- a/pytorch_lightning/callbacks/timer.py
+++ b/pytorch_lightning/callbacks/timer.py
@@ -170,4 +170,6 @@ class Timer(Callback):
         should_stop = trainer.accelerator.broadcast(should_stop)
         trainer.should_stop = trainer.should_stop or should_stop
         if should_stop and self._verbose:
-            rank_zero_info(f"Time limit reached. Elapsed time is {self.time_elapsed}. Signaling Trainer to stop.")
+            rank_zero_info(
+                f"Time limit reached. Elapsed time is {self.time_elapsed(RunningStage.TRAINING)}."
+                f" Signaling Trainer to stop.")

--- a/pytorch_lightning/callbacks/timer.py
+++ b/pytorch_lightning/callbacks/timer.py
@@ -171,5 +171,4 @@ class Timer(Callback):
         trainer.should_stop = trainer.should_stop or should_stop
         if should_stop and self._verbose:
             elapsed = timedelta(seconds=int(self.time_elapsed(RunningStage.TRAINING)))
-            rank_zero_info(
-                f"Time limit reached. Elapsed time is {elapsed}. Signaling Trainer to stop.")
+            rank_zero_info(f"Time limit reached. Elapsed time is {elapsed}. Signaling Trainer to stop.")

--- a/pytorch_lightning/callbacks/timer.py
+++ b/pytorch_lightning/callbacks/timer.py
@@ -170,6 +170,6 @@ class Timer(Callback):
         should_stop = trainer.accelerator.broadcast(should_stop)
         trainer.should_stop = trainer.should_stop or should_stop
         if should_stop and self._verbose:
+            elapsed = timedelta(seconds=int(self.time_elapsed(RunningStage.TRAINING)))
             rank_zero_info(
-                f"Time limit reached. Elapsed time is {self.time_elapsed(RunningStage.TRAINING)}."
-                f" Signaling Trainer to stop.")
+                f"Time limit reached. Elapsed time is {elapsed}. Signaling Trainer to stop.")

--- a/tests/callbacks/test_timer.py
+++ b/tests/callbacks/test_timer.py
@@ -95,7 +95,7 @@ def test_timer_time_remaining(time_mock):
     assert round(timer.time_elapsed()) == 3
 
 
-def test_timer_stops_training(tmpdir):
+def test_timer_stops_training(tmpdir, caplog):
     """ Test that the timer stops training before reaching max_epochs """
     model = BoringModel()
     duration = timedelta(milliseconds=100)
@@ -106,9 +106,12 @@ def test_timer_stops_training(tmpdir):
         max_epochs=1000,
         callbacks=[timer],
     )
-    trainer.fit(model)
+    with caplog.at_level(logging.INFO):
+        trainer.fit(model)
     assert trainer.global_step > 1
     assert trainer.current_epoch < 999
+    assert "Time limit reached." in caplog.text
+    assert "Signaling Trainer to stop." in caplog.text
 
 
 @pytest.mark.parametrize("interval", ["step", "epoch"])


### PR DESCRIPTION
## What does this PR do?

Fixes #7778

Fixes incorrect formatting of time remaining.
Now shows a message properly formatted:

> Time limit reached. Elapsed time is 0:00:03. Signaling Trainer to stop.


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
