### PR TITLE
[bugfix] Minor improvements to `apply_to_collection` and type signature of `log_dict`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `apply_to_collection` works on Custom Collections now ([#7851](https://github.com/PyTorchLightning/pytorch-lightning/pull/7851))
+
 - Fixed ambiguous warning when both overfit and train dataloader shuffling are enabled ([#7685](https://github.com/PyTorchLightning/pytorch-lightning/pull/7685))
 
 - Fixed dataloaders are not reset when tuning the model ([#7566](https://github.com/PyTorchLightning/pytorch-lightning/pull/7566))

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -26,7 +26,7 @@ from abc import ABC
 from argparse import Namespace
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, TYPE_CHECKING, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, TYPE_CHECKING, Union
 
 import torch
 from torch import ScriptModule, Tensor
@@ -363,7 +363,7 @@ class LightningModule(
 
     def log_dict(
         self,
-        dictionary: Dict[str, _METRIC_COLLECTION],
+        dictionary: Mapping[str, _METRIC_COLLECTION],
         prog_bar: bool = False,
         logger: bool = True,
         on_step: Optional[bool] = None,

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import operator
 from abc import ABC
+from collections import OrderedDict
 from collections.abc import Mapping, Sequence
 from copy import copy
 from functools import partial
@@ -92,12 +93,12 @@ def apply_to_collection(
 
     # Recursively apply to collection items
     if isinstance(data, Mapping):
-        out = []  # can't use dict, need to preserve order if `OrderedDict`
+        out = []
         for k, v in data.items():
             v = apply_to_collection(v, dtype, function, *args, wrong_dtype=wrong_dtype, **kwargs)
             if include_none or v is not None:
                 out.append((k, v))
-        return elem_type(out)
+        return elem_type(OrderedDict(out))
 
     is_namedtuple = _is_namedtuple(data)
     is_sequence = isinstance(data, Sequence) and not isinstance(data, str)

--- a/tests/utilities/test_apply_func.py
+++ b/tests/utilities/test_apply_func.py
@@ -86,6 +86,7 @@ def test_recursive_application_to_collection():
 
     # custom mappings
     class _CustomCollection(dict):
+
         def __init__(self, initial_dict):
             super().__init__(initial_dict)
 

--- a/tests/utilities/test_apply_func.py
+++ b/tests/utilities/test_apply_func.py
@@ -84,6 +84,15 @@ def test_recursive_application_to_collection():
     reduced = apply_to_collection(OrderedDict([('b', 2), ('a', 1)]), int, lambda x: str(x))
     assert reduced == OrderedDict([('b', '2'), ('a', '1')])
 
+    # custom mappings
+    class _CustomCollection(dict):
+        def __init__(self, initial_dict):
+            super().__init__(initial_dict)
+
+    to_reduce = _CustomCollection({'a': 1, 'b': 2, 'c': 3})
+    reduced = apply_to_collection(to_reduce, int, lambda x: str(x))
+    assert reduced == _CustomCollection({'a': '1', 'b': '2', 'c': '3'})
+
 
 def test_apply_to_collection_include_none():
     to_reduce = [1, 2, 3.4, 5.6, 7]


### PR DESCRIPTION
## What does this PR do?

### Improve `apply_to_collection` to continue working with CfgNode from yacs
The existing implementation assumes that `elem_type` is constructible from `Iterate[Tuple[K, V]]`. This will fail for custom collections.

Specifically, this fails with `CfgNode` (from YAQS) (https://github.com/rbgirshick/yacs/blob/master/yacs/config.py#L74) which is used in Detectron2Go. We use the `save_hyperameters` function on this object, which eventually calls `apply_to_collection`. The code before PR #7769 worked fine, but the existing code raises an error since `CfgNode` cannot be constructed from a List of Tuples.

See for discussion: https://github.com/PyTorchLightning/pytorch-lightning/pull/7769#discussion_r646192063

### Improved type signature for `log_dict`

When merging into our codebase, we noticed that the new type signature for `log_dict` is overly restrictive. PR #7771 improved the type of the `dictionary` parameter from `dict` to `Dict[str, Union[Union[Metric, torch.Tensor, Number], Dict[str, Union[Metric, torch.Tensor, Number]]]]]`. 

However, given `Dict[K, V]` implies mutability (eg, the function might mutate the dictionary), the type checker defines it as invariant (see https://github.com/python/mypy/issues/2300#issuecomment-255398899). As such, `Dict[str, torch.Tensor]` is no longer a valid type to pass to `log_dict`, which is unintended.

Given that `dictionary` parameter appears to be read-only in `log_dict`, the easiest fix is to change from `Dict[K, V]` to `Mapping[K, V]`. I believe this better matches the intention of the `log_dict` function, unless we truly intend for the parameter to be mutable.

See for discussion: https://github.com/PyTorchLightning/pytorch-lightning/pull/7771#discussion_r646194033


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
