### PR TITLE
Move `training_output` validation to after `train_step_end`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fixed `_check_training_step_output` to be called after `train_step_end` to support more flexible accomodations ([#7868](https://github.com/PyTorchLightning/pytorch-lightning/pull/7868))
+
 - Fixed `apply_to_collection` works on Custom Collections now ([#7851](https://github.com/PyTorchLightning/pytorch-lightning/pull/7851))
 
 - Fixed ambiguous warning when both overfit and train dataloader shuffling are enabled ([#7685](https://github.com/PyTorchLightning/pytorch-lightning/pull/7685))

--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -296,9 +296,9 @@ class TrainLoop:
 
             self.trainer.logger_connector.cache_logged_metrics()
 
-            self._check_training_step_output(training_step_output)
-
             training_step_output = self.trainer.call_hook("training_step_end", training_step_output)
+
+            self._check_training_step_output(training_step_output)
 
             training_step_output_for_epoch_end, training_step_output = self._process_training_step_output(
                 training_step_output, split_batch

--- a/tests/trainer/loops/test_training_loop.py
+++ b/tests/trainer/loops/test_training_loop.py
@@ -154,7 +154,6 @@ def test_warning_invalid_trainstep_output(tmpdir, output):
 
         def training_step(self, batch, batch_idx):
             return output
-            
 
     model = InvalidTrainStepModel()
 
@@ -168,18 +167,21 @@ def test_warning_invalid_trainstep_output(tmpdir, output):
     ):
         trainer.fit(model)
 
+
 def test_warning_valid_train_step_end(tmpdir):
+
     class ValidTrainStepEndModel(BoringModel):
+
         def training_step(self, batch, batch_idx):
             output = self(batch)
-            return { 'output': output, 'batch': batch }
+            return {'output': output, 'batch': batch}
 
         def training_step_end(self, outputs):
             loss = self.loss(outputs['batch'], outputs['output'])
             return loss
 
-    # No error is raised 
+    # No error is raised
     model = ValidTrainStepEndModel()
     trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=1)
-    
+
     trainer.fit(model)

--- a/tests/trainer/loops/test_training_loop.py
+++ b/tests/trainer/loops/test_training_loop.py
@@ -150,12 +150,13 @@ def test_should_stop_mid_epoch(tmpdir):
 @pytest.mark.parametrize(['output'], [(5., ), ({'a': 5}, )])
 def test_warning_invalid_trainstep_output(tmpdir, output):
 
-    class TestModel(BoringModel):
+    class InvalidTrainStepModel(BoringModel):
 
         def training_step(self, batch, batch_idx):
             return output
+            
 
-    model = TestModel()
+    model = InvalidTrainStepModel()
 
     trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=1)
     with pytest.raises(
@@ -166,3 +167,19 @@ def test_warning_invalid_trainstep_output(tmpdir, output):
         )
     ):
         trainer.fit(model)
+
+def test_warning_valid_train_step_end(tmpdir):
+    class ValidTrainStepEndModel(BoringModel):
+        def training_step(self, batch, batch_idx):
+            output = self(batch)
+            return { 'output': output, 'batch': batch }
+
+        def training_step_end(self, outputs):
+            loss = self.loss(outputs['batch'], outputs['output'])
+            return loss
+
+    # No error is raised 
+    model = ValidTrainStepEndModel()
+    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=1)
+    
+    trainer.fit(model)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
See comments in https://github.com/PyTorchLightning/pytorch-lightning/pull/7779/files#r646750001.

We have a downstream `LightningModule` that does not conform to these expectations. It defines a `trainign_step_end` which returns the `loss` (after accumulating partial outputs from `training_step`) but where each `training_step` does not return a loss or a `Mapping` containing a key `loss`. 

This still works with automatic optimization since the `training_step_end` function collects the results from `training_step` and itself returns a `torch.Tensor` corresponding to the loss.

So the question is: If I *do* define `training_step_end`, should I be allowed to not return a `loss` from `training_step` as long as I return it on `training_step_end`? 

Assuming an affirmative to the above, this PR makes it so the validation occurs after `training_step_end.`

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
