### PR TITLE
Logger connector re-design `_Metadata.reduce_fx` fixes.

### DIFF
--- a/pytorch_lightning/trainer/connectors/logger_connector/logger_connector_new.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/logger_connector_new.py
@@ -141,7 +141,7 @@ class LoggerConnectorNew:
         model._current_dataloader_idx = dataloader_idx if num_dataloaders > 1 else None
 
         # track batch_size
-        self.trainer.result_collection.extract_batch_size(batch)
+        self.trainer.results.extract_batch_size(batch)
         self._batch_idx = batch_idx
 
     def update_eval_step_metrics(self) -> None:
@@ -306,6 +306,7 @@ class LoggerConnectorNew:
         return self._progress_bar_metrics
 
     def teardown(self):
+        # TODO(@awaelchli): This should be handled by the loops themselves
         self.trainer.train_loop.results.cpu()
         self.trainer.evaluation_loop._val_results.cpu()
         self.trainer.evaluation_loop._test_results.cpu()

--- a/pytorch_lightning/trainer/connectors/logger_connector/result_new.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/result_new.py
@@ -45,6 +45,13 @@ class _Sync:
     op: Union[Any, str] = 'mean'
     group: Optional[Any] = None
 
+    def __post_init__(self) -> None:
+        if isinstance(self.op, str):
+            op = self.op.lower()
+            if op == 'avg':
+                op = 'mean'
+            self.op = op
+
     @property
     def __call__(self) -> Any:
         return partial(self.fn, reduce_op=self.op, group=self.group) if self.should else self.no_op
@@ -62,11 +69,27 @@ class _Metadata:
     logger: bool = True
     on_step: bool = False
     on_epoch: bool = True
-    reduce_fx: Callable = torch.mean
+    reduce_fx: Union[str, Callable] = torch.mean
     enable_graph: bool = False
     dataloader_idx: Optional[int] = None
     metric_attribute: Optional[str] = None
     sync: _Sync = field(default_factory=_Sync)
+
+    def __post_init__(self) -> None:
+        error = (
+            'Only `self.log(..., reduce_fx={min,max,mean,sum})` are currently supported.'
+            ' Please, open an issue in `https://github.com/PyTorchLightning/pytorch-lightning/issues`.'
+            f' Found: {self.reduce_fx}'
+        )
+        if isinstance(self.reduce_fx, str):
+            reduce_fx = self.reduce_fx.lower()
+            if reduce_fx == 'avg':
+                reduce_fx = 'mean'
+            if reduce_fx not in ('min', 'max', 'mean', 'sum'):
+                raise MisconfigurationException(error)
+            self.reduce_fx = getattr(torch, reduce_fx)
+        elif self.is_custom_reduction:
+            raise MisconfigurationException(error)
 
     @property
     def forked(self) -> bool:
@@ -79,7 +102,11 @@ class _Metadata:
 
     @property
     def is_mean_reduction(self) -> bool:
-        return self.reduce_fx == torch.mean
+        return self.reduce_fx is torch.mean
+
+    @property
+    def is_sum_reduction(self) -> bool:
+        return self.reduce_fx in (torch.sum, sum)
 
     @property
     def is_max_reduction(self) -> bool:
@@ -91,7 +118,7 @@ class _Metadata:
 
     @property
     def is_custom_reduction(self) -> bool:
-        return not (self.is_mean_reduction or self.is_max_reduction or self.is_min_reduction)
+        return not (self.is_mean_reduction or self.is_max_reduction or self.is_min_reduction or self.is_sum_reduction)
 
 
 class ResultMetric(Metric, DeviceDtypeModuleMixin):
@@ -121,6 +148,8 @@ class ResultMetric(Metric, DeviceDtypeModuleMixin):
                 self.cumulated_batch_size += batch_size
             elif self.meta.is_max_reduction or self.meta.is_min_reduction:
                 self.value = self.meta.reduce_fx(self.value, value.mean())
+            elif self.meta.is_sum_reduction:
+                self.value += value.mean() * batch_size
         else:
             self.value = value  # noqa: attribute-defined-outside-init
             self._forward_cache = value._forward_cache
@@ -131,11 +160,8 @@ class ResultMetric(Metric, DeviceDtypeModuleMixin):
             if self.meta.is_mean_reduction:
                 cumulated_batch_size = self.meta.sync(self.cumulated_batch_size)
                 return value / cumulated_batch_size
-            elif self.meta.is_max_reduction or self.meta.is_min_reduction:
+            elif self.meta.is_max_reduction or self.meta.is_min_reduction or self.meta.is_sum_reduction:
                 return value
-            raise MisconfigurationException(
-                f"Only [min, max, mean] reductions are supported. Found {self.meta.reduce_fx}"
-            )
         return self.value.compute()
 
     def reset(self) -> None:
@@ -321,11 +347,6 @@ class ResultCollection(dict):
             )
         )
         if key not in self:
-            if meta.is_custom_reduction:
-                raise MisconfigurationException(
-                    'Only `self.log(..., reduce_fx={min,max,mean})` are currently supported.'
-                    ' Please, open an issue in `https://github.com/PyTorchLightning/pytorch-lightning/issues`'
-                )
             self.register_key(key, meta, value)
         elif meta != self[key].meta:
             raise MisconfigurationException(

--- a/pytorch_lightning/trainer/connectors/logger_connector/result_new.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/result_new.py
@@ -42,7 +42,7 @@ class MetricSource(LightningEnum):
 class _Sync:
     fn: Callable
     should: bool = False
-    op: Optional[str] = field(init=False, default=None)
+    op: Optional[str] = None
     group: Optional[Any] = None
 
     @property

--- a/pytorch_lightning/trainer/connectors/logger_connector/result_new.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/result_new.py
@@ -42,15 +42,8 @@ class MetricSource(LightningEnum):
 class _Sync:
     fn: Callable
     should: bool = False
-    op: Union[Any, str] = 'mean'
+    op: Optional[str] = field(init=False, default=None)
     group: Optional[Any] = None
-
-    def __post_init__(self) -> None:
-        if isinstance(self.op, str):
-            op = self.op.lower()
-            if op == 'avg':
-                op = 'mean'
-            self.op = op
 
     @property
     def __call__(self) -> Any:
@@ -90,6 +83,7 @@ class _Metadata:
             self.reduce_fx = getattr(torch, reduce_fx)
         elif self.is_custom_reduction:
             raise MisconfigurationException(error)
+        self.sync.op = self.reduce_fx.__name__
 
     @property
     def forked(self) -> bool:
@@ -306,7 +300,6 @@ class ResultCollection(dict):
         enable_graph: bool = False,
         sync_dist: bool = False,
         sync_dist_fn: Callable = _Sync.no_op,
-        sync_dist_op: Union[Any, str] = 'mean',
         sync_dist_group: Optional[Any] = None,
         dataloader_idx: Optional[int] = None,
         batch_size: Optional[int] = None,
@@ -342,7 +335,6 @@ class ResultCollection(dict):
             sync=_Sync(
                 should=sync_dist,
                 fn=sync_dist_fn,
-                op=sync_dist_op,
                 group=sync_dist_group,
             )
         )

--- a/tests/core/test_results.py
+++ b/tests/core/test_results.py
@@ -39,7 +39,7 @@ def _setup_ddp(rank, worldsize):
 def _ddp_test_fn(rank, worldsize):
     _setup_ddp(rank, worldsize)
     tensor = torch.tensor([1.0])
-    sync = _Sync(sync_ddp_if_available, should=True, op=torch.distributed.ReduceOp.SUM)
+    sync = _Sync(sync_ddp_if_available, should=True, op='SUM')
     actual = sync(tensor)
     assert actual.item() == dist.get_world_size(), "Result-Log does not work properly with DDP and Tensors"
 


### PR DESCRIPTION
## What does this PR do?

Some reduction fixes before continuing.

`sync_dist_op` will be deprecated in the next PR. Set it instead to `reduce_fx.__name__` as the list of supported `reduce_fx`s is bounded to `{min,max,sum,mean}`.

Also, refactor a test, fix an attribute, and add a TODO.

Part of #7631

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [n/a] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified