### PR TITLE
split `restore_training_state` into logical parts [1 / 2]

### DIFF
--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -212,7 +212,7 @@ class CheckpointConnector:
         if not self._loaded_checkpoint:
             return
 
-        if any([key in self._loaded_checkpoint for key in DEPRECATED_CHECKPOINT_KEYS]):
+        if any(key in self._loaded_checkpoint for key in DEPRECATED_CHECKPOINT_KEYS):
             raise ValueError(
                 "The checkpoint you're attempting to load follows an"
                 " outdated schema. You can upgrade to the current schema by running"

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -236,7 +236,7 @@ class CheckpointConnector:
         if self.trainer.max_epochs is not None and self.trainer.current_epoch > self.trainer.max_epochs:
             raise MisconfigurationException(
                 f"You restored a checkpoint with current_epoch={self.trainer.current_epoch},"
-                f" but the Trainer(max_epochs={self.trainer.max_epochs})"
+                f" but you have set Trainer(max_epochs={self.trainer.max_epochs})."
             )
 
         # Division deals with global step stepping once per accumulated batch

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -115,7 +115,7 @@ class CheckpointConnector:
 
         # restore training state
         if self._loaded_checkpoint:
-            self.restore_training_state()
+            self.restore_training_state(self._loaded_checkpoint, self._load_optimizer_states)
 
         self.resume_end()
         return True
@@ -135,23 +135,77 @@ class CheckpointConnector:
         # restore model state_dict
         model.load_state_dict(checkpoint['state_dict'])
 
-    def restore_training_state(self) -> None:
+    def restore_training_state(self, checkpoint, load_optimizer_states: bool = True):
         """
-        Restore the trainer state from the pre-loaded checkpoint. This includes the precision settings, loop progress,
-        optimizer states and learning rate scheduler states.
+        Restore trainer state.
+        Model will get its change to update
+        :param checkpoint:
+        :return:
         """
-        if not self._loaded_checkpoint:
+
+        # validation
+        if load_optimizer_states and ('optimizer_states' not in checkpoint or 'lr_schedulers' not in checkpoint):
+            raise KeyError(
+                'Trying to restore training state but checkpoint contains only the model.'
+                ' This is probably due to `ModelCheckpoint.save_weights_only` being set to `True`.'
+            )
+
+        if any([key in checkpoint for key in DEPRECATED_CHECKPOINT_KEYS]):
+            raise ValueError(
+                "The checkpoint you're attempting to load follows an"
+                " outdated schema. You can upgrade to the current schema by running"
+                " `python -m pytorch_lightning.utilities.upgrade_checkpoint --file model.ckpt`"
+                " where `model.ckpt` is your checkpoint file."
+            )
+
+        self.trainer.precision_plugin.on_load_checkpoint(checkpoint)
+
+        # restore callback states
+        self.trainer.on_load_checkpoint(checkpoint)
+
+        self.trainer.train_loop.global_step = checkpoint['global_step']
+        self.trainer.train_loop.current_epoch = checkpoint['epoch']
+
+        # crash if max_epochs is lower then the current epoch from the checkpoint
+        if self.trainer.max_epochs is not None and self.trainer.current_epoch > self.trainer.max_epochs:
+            m = f"""
+            you restored a checkpoint with current_epoch={self.trainer.current_epoch}
+            but the Trainer(max_epochs={self.trainer.max_epochs})
+            """
+            raise MisconfigurationException(m)
+
+        # Division deals with global step stepping once per accumulated batch
+        # Inequality deals with different global step for odd vs even num_training_batches
+        n_accum = 1 if self.trainer.accumulate_grad_batches is None else self.trainer.accumulate_grad_batches
+        expected_steps = self.trainer.num_training_batches / n_accum
+        if self.trainer.num_training_batches != 0 and self.trainer.global_step % expected_steps > 1:
+            rank_zero_warn(
+                "You're resuming from a checkpoint that ended mid-epoch."
+                " Training will start from the beginning of the next epoch."
+                " This can cause unreliable results if further training is done,"
+                " consider using an end of epoch checkpoint."
+            )
+
+        if not load_optimizer_states:
             return
 
-        # restore precision plugin (scaler etc.)
-        self.trainer.precision_plugin.on_load_checkpoint(self._loaded_checkpoint)
+        # restore the optimizers
+        optimizer_states = checkpoint['optimizer_states']
+        for optimizer, opt_state in zip(self.trainer.optimizers, optimizer_states):
+            optimizer.load_state_dict(opt_state)
 
-        self.restore_callbacks()
+            # move optimizer to GPU 1 weight at a time
+            # avoids OOM
+            if self.trainer.root_gpu is not None:
+                for state in optimizer.state.values():
+                    for k, v in state.items():
+                        if isinstance(v, torch.Tensor):
+                            state[k] = v.cuda(self.trainer.root_gpu)
 
-        # restore progress (loops etc.)
-        self.restore_progress()
-
-        self.restore_optimizers_and_schedulers()
+        # restore the lr schedulers
+        lr_schedulers = checkpoint['lr_schedulers']
+        for scheduler, lrs_state in zip(self.trainer.lr_schedulers, lr_schedulers):
+            scheduler['scheduler'].load_state_dict(lrs_state)
 
     def restore_callbacks(self) -> None:
         """ Restores all callbacks from the pre-loaded checkpoint. """

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -234,11 +234,10 @@ class CheckpointConnector:
 
         # crash if max_epochs is lower then the current epoch from the checkpoint
         if self.trainer.max_epochs is not None and self.trainer.current_epoch > self.trainer.max_epochs:
-            m = f"""
-            you restored a checkpoint with current_epoch={self.trainer.current_epoch}
-            but the Trainer(max_epochs={self.trainer.max_epochs})
-            """
-            raise MisconfigurationException(m)
+            raise MisconfigurationException(
+                f"You restored a checkpoint with current_epoch={self.trainer.current_epoch},"
+                f" but the Trainer(max_epochs={self.trainer.max_epochs})"
+            )
 
         # Division deals with global step stepping once per accumulated batch
         # Inequality deals with different global step for odd vs even num_training_batches


### PR DESCRIPTION
## What does this PR do?

In #7900 `CheckpointConnector.restore_training_state` gets split into multiple pieces:

```
restore_callbacks()
restore_progress()
restore_optimizers()
restore_lr_schedulers()
```

This PR introduces the new functions, but they are unused. 
#7900 will then refactor the `CheckpointConnector.restore_training_state` method to use them. 

This is mainly to reduce a hard to read diff for reviews!


## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lihtning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
