### PR TITLE
Deprecate the default `EarlyStopping` callback monitor value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Deprecated `self.log(sync_dist_op)` in favor of `self.log(reduce_fx)`. ([#7891](https://github.com/PyTorchLightning/pytorch-lightning/pull/7891))
 
 
-- Deprecated `monitor` argument in EarlyStopping will be required. ([#7907](https://github.com/PyTorchLightning/pytorch-lightning/pull/7907))
+- Deprecated default value of `monitor` argument in EarlyStopping callback to enforce `monitor` as a required argument ([#7907](https://github.com/PyTorchLightning/pytorch-lightning/pull/7907))
 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Deprecated `self.log(sync_dist_op)` in favor of `self.log(reduce_fx)`. ([#7891](https://github.com/PyTorchLightning/pytorch-lightning/pull/7891))
 
 
+- Deprecated `monitor` argument in EarlyStopping will be required. ([#7907](https://github.com/PyTorchLightning/pytorch-lightning/pull/7907))
+
+
 ### Removed
 
 - Removed `ProfilerConnector` ([#7654](https://github.com/PyTorchLightning/pytorch-lightning/pull/7654))

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -121,7 +121,8 @@ class EarlyStopping(Callback):
 
         if monitor is None:
             rank_zero_deprecation(
-                "The `monitor` argument will be required to be set starting in v1.6. For backward compatibility, setting this to `early_stop_on`."
+                "The `monitor` argument will be required to be set starting in v1.6."
+                " For backward compatibility, setting this to `early_stop_on`."
             )
         self.monitor = monitor or 'early_stop_on'
 

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -121,10 +121,10 @@ class EarlyStopping(Callback):
 
         if monitor is None:
             rank_zero_deprecation(
-                "The `monitor` argument will be required to be set starting in v1.6."
+                "The `EarlyStopping(monitor)` argument will be required starting in v1.6."
                 " For backward compatibility, setting this to `early_stop_on`."
             )
-        self.monitor = monitor or 'early_stop_on'
+        self.monitor = monitor or "early_stop_on"
 
     def _validate_condition_metric(self, logs):
         monitor_val = logs.get(self.monitor)

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -26,7 +26,7 @@ import torch
 
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks.base import Callback
-from pytorch_lightning.utilities import rank_zero_warn, rank_zero_deprecation
+from pytorch_lightning.utilities import rank_zero_deprecation, rank_zero_warn
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 log = logging.getLogger(__name__)
@@ -119,12 +119,11 @@ class EarlyStopping(Callback):
         self.min_delta *= 1 if self.monitor_op == torch.gt else -1
         torch_inf = torch.tensor(np.Inf)
         self.best_score = torch_inf if self.monitor_op == torch.lt else -torch_inf
-
+        
         if self.monitor is None:
             rank_zero_deprecation(
-                "The `monitor` argument has been depreceated. It will be removed in a further release."
+                "The `monitor` argument has been changed."
             )
-
     def _validate_condition_metric(self, logs):
         monitor_val = logs.get(self.monitor)
 
@@ -185,8 +184,8 @@ class EarlyStopping(Callback):
         logs = trainer.callback_metrics
 
         if (
-            trainer.fast_dev_run or  # disable early_stopping with fast_dev_run
-            not self._validate_condition_metric(logs)  # short circuit if metric not present
+            trainer.fast_dev_run  # disable early_stopping with fast_dev_run
+            or not self._validate_condition_metric(logs)  # short circuit if metric not present
         ):
             return
 

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -88,7 +88,7 @@ class EarlyStopping(Callback):
 
     def __init__(
         self,
-        monitor: str = Optional[None],
+        monitor: Optional[str] = None,
         min_delta: float = 0.0,
         patience: int = 3,
         verbose: bool = False,

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -88,7 +88,7 @@ class EarlyStopping(Callback):
 
     def __init__(
         self,
-        monitor: str = None,
+        monitor: str = Optional[None],
         min_delta: float = 0.0,
         patience: int = 3,
         verbose: bool = False,
@@ -100,7 +100,6 @@ class EarlyStopping(Callback):
         check_on_train_epoch_end: bool = False,
     ):
         super().__init__()
-        self.monitor = monitor
         self.min_delta = min_delta
         self.patience = patience
         self.verbose = verbose
@@ -119,10 +118,13 @@ class EarlyStopping(Callback):
         self.min_delta *= 1 if self.monitor_op == torch.gt else -1
         torch_inf = torch.tensor(np.Inf)
         self.best_score = torch_inf if self.monitor_op == torch.lt else -torch_inf
-
-        if self.monitor is None:
-            rank_zero_deprecation("The `monitor` argument has been changed.")
-
+        
+        if monitor is None:
+            rank_zero_deprecation(
+                "The `monitor` argument will be required to be set starting in v1.6. For backward compatibility, setting this to `early_stop_on`."
+            )
+        self.monitor = monitor or 'early_stop_on'
+        
     def _validate_condition_metric(self, logs):
         monitor_val = logs.get(self.monitor)
 

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -119,11 +119,10 @@ class EarlyStopping(Callback):
         self.min_delta *= 1 if self.monitor_op == torch.gt else -1
         torch_inf = torch.tensor(np.Inf)
         self.best_score = torch_inf if self.monitor_op == torch.lt else -torch_inf
-        
+
         if self.monitor is None:
-            rank_zero_deprecation(
-                "The `monitor` argument has been changed."
-            )
+            rank_zero_deprecation("The `monitor` argument has been changed.")
+
     def _validate_condition_metric(self, logs):
         monitor_val = logs.get(self.monitor)
 

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -26,7 +26,7 @@ import torch
 
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks.base import Callback
-from pytorch_lightning.utilities import rank_zero_warn
+from pytorch_lightning.utilities import rank_zero_warn, rank_zero_deprecation
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 log = logging.getLogger(__name__)
@@ -88,7 +88,7 @@ class EarlyStopping(Callback):
 
     def __init__(
         self,
-        monitor: str = 'early_stop_on',
+        monitor: str = None,
         min_delta: float = 0.0,
         patience: int = 3,
         verbose: bool = False,
@@ -119,6 +119,11 @@ class EarlyStopping(Callback):
         self.min_delta *= 1 if self.monitor_op == torch.gt else -1
         torch_inf = torch.tensor(np.Inf)
         self.best_score = torch_inf if self.monitor_op == torch.lt else -torch_inf
+
+        if self.monitor is None:
+            rank_zero_deprecation(
+                "The `monitor` argument has been depreceated. It will be removed in a further release."
+            )
 
     def _validate_condition_metric(self, logs):
         monitor_val = logs.get(self.monitor)
@@ -180,8 +185,8 @@ class EarlyStopping(Callback):
         logs = trainer.callback_metrics
 
         if (
-            trainer.fast_dev_run  # disable early_stopping with fast_dev_run
-            or not self._validate_condition_metric(logs)  # short circuit if metric not present
+            trainer.fast_dev_run or  # disable early_stopping with fast_dev_run
+            not self._validate_condition_metric(logs)  # short circuit if metric not present
         ):
             return
 

--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -118,13 +118,13 @@ class EarlyStopping(Callback):
         self.min_delta *= 1 if self.monitor_op == torch.gt else -1
         torch_inf = torch.tensor(np.Inf)
         self.best_score = torch_inf if self.monitor_op == torch.lt else -torch_inf
-        
+
         if monitor is None:
             rank_zero_deprecation(
                 "The `monitor` argument will be required to be set starting in v1.6. For backward compatibility, setting this to `early_stop_on`."
             )
         self.monitor = monitor or 'early_stop_on'
-        
+
     def _validate_condition_metric(self, logs):
         monitor_val = logs.get(self.monitor)
 

--- a/tests/deprecated_api/test_remove_1-6.py
+++ b/tests/deprecated_api/test_remove_1-6.py
@@ -15,9 +15,9 @@
 import pytest
 
 from pytorch_lightning import Trainer
+from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.plugins.training_type import DDPPlugin, DDPSpawnPlugin
 from tests.helpers import BoringDataModule, BoringModel
-from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 
 
 def test_v1_6_0_trainer_model_hook_mixin(tmpdir):
@@ -174,6 +174,10 @@ def test_v1_6_0_datamodule_hooks_calls(tmpdir):
     assert dm.setup_calls == ['fit', None]
     assert dm.teardown_calls == ['validate', 'test']
 
+
 def test_v1_6_0_early_stopping_monitor(tmpdir):
-    with pytest.deprecated_call(match="The `monitor` argument will be required to be set starting in v1.6. For backward compatibility, setting this to `early_stop_on`."):
+    with pytest.deprecated_call(
+        match=
+        "The `monitor` argument will be required to be set starting in v1.6. For backward compatibility, setting this to `early_stop_on`."
+    ):
         EarlyStopping()

--- a/tests/deprecated_api/test_remove_1-6.py
+++ b/tests/deprecated_api/test_remove_1-6.py
@@ -177,7 +177,7 @@ def test_v1_6_0_datamodule_hooks_calls(tmpdir):
 
 def test_v1_6_0_early_stopping_monitor(tmpdir):
     with pytest.deprecated_call(
-        match="The `EarlyStopping(monitor)` argument will be required starting in v1.6."
+        match=r"The `EarlyStopping\(monitor\)` argument will be required starting in v1.6."
         " For backward compatibility, setting this to `early_stop_on`."
     ):
         EarlyStopping()

--- a/tests/deprecated_api/test_remove_1-6.py
+++ b/tests/deprecated_api/test_remove_1-6.py
@@ -17,6 +17,7 @@ import pytest
 from pytorch_lightning import Trainer
 from pytorch_lightning.plugins.training_type import DDPPlugin, DDPSpawnPlugin
 from tests.helpers import BoringDataModule, BoringModel
+from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 
 
 def test_v1_6_0_trainer_model_hook_mixin(tmpdir):
@@ -172,3 +173,7 @@ def test_v1_6_0_datamodule_hooks_calls(tmpdir):
     assert dm.prepare_data_calls == 1
     assert dm.setup_calls == ['fit', None]
     assert dm.teardown_calls == ['validate', 'test']
+
+def test_v1_6_0_early_stopping_monitor(tmpdir):
+    with pytest.deprecated_call(match="The `monitor` argument will be required to be set starting in v1.6. For backward compatibility, setting this to `early_stop_on`."):
+        EarlyStopping()

--- a/tests/deprecated_api/test_remove_1-6.py
+++ b/tests/deprecated_api/test_remove_1-6.py
@@ -177,7 +177,7 @@ def test_v1_6_0_datamodule_hooks_calls(tmpdir):
 
 def test_v1_6_0_early_stopping_monitor(tmpdir):
     with pytest.deprecated_call(
-        match="The `monitor` argument will be required to be set starting in v1.6."
+        match="The `EarlyStopping(monitor)` argument will be required starting in v1.6."
         " For backward compatibility, setting this to `early_stop_on`."
     ):
         EarlyStopping()

--- a/tests/deprecated_api/test_remove_1-6.py
+++ b/tests/deprecated_api/test_remove_1-6.py
@@ -177,7 +177,7 @@ def test_v1_6_0_datamodule_hooks_calls(tmpdir):
 
 def test_v1_6_0_early_stopping_monitor(tmpdir):
     with pytest.deprecated_call(
-        match=
-        "The `monitor` argument will be required to be set starting in v1.6. For backward compatibility, setting this to `early_stop_on`."
+        match="The `monitor` argument will be required to be set starting in v1.6."
+        " For backward compatibility, setting this to `early_stop_on`."
     ):
         EarlyStopping()


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
 Please also include relevant motivation and context.
 List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->
Removes the default value for the monitor argument from the early stopping callback. Also adds the deprecation message.
Fixes #7894 

## Before submitting
- [X] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [X] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
