### PR TITLE
[IPU] Remove grad_fn check 4.5/n

### DIFF
--- a/pytorch_lightning/trainer/connectors/logger_connector/result_new.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/result_new.py
@@ -264,8 +264,6 @@ class ResultCollection(dict):
         if loss is not None:
             if not isinstance(loss, torch.Tensor):
                 raise ValueError(f"`Result.minimize` must be a `torch.Tensor`, found: {loss}")
-            if loss.grad_fn is None:
-                raise RuntimeError("`Result.minimize` must have a `grad_fn`")
         self._minimize = loss
 
     @property


### PR DESCRIPTION
## What does this PR do?

Removes a check in the new Results object as the IPU returns a tensor that already has updated the gradients. This check allows the code to handle minimization and just uses the collection as a store.

EDIT: changed milestone to 1.4 because this is on the new logger connector

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
