### PR TITLE
Delete `on_after_backward` unused argument

### DIFF
--- a/pytorch_lightning/trainer/training_loop.py
+++ b/pytorch_lightning/trainer/training_loop.py
@@ -246,7 +246,7 @@ class TrainLoop:
         opt_idx = int(np.argmax(self.optimizer_freq_cumsum > current_place_in_loop))
         return [(opt_idx, self.trainer.optimizers[opt_idx])]
 
-    def on_after_backward(self, training_step_output, batch_idx, untouched_loss):
+    def on_after_backward(self, batch_idx, untouched_loss):
         # insert after step hook
         self.trainer.call_hook("on_after_backward")
 
@@ -760,7 +760,7 @@ class TrainLoop:
                     # hook - call this hook only
                     # when gradients have finished to accumulate
                     if not self.should_accumulate():
-                        self.on_after_backward(result.training_step_output, batch_idx, result.loss)
+                        self.on_after_backward(batch_idx, result.loss)
 
                     # check if loss or model weights are nan
                     if self.trainer.terminate_on_nan:


### PR DESCRIPTION
## What does this PR do?

Delete an unused argument

@aniketmaurya @Borda I thought `vulture` is supposed to warn about this. I tried running the tool manually on the file and it didn't output anything

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes? (if necessary)
- [n/a] Did you write any new necessary tests? (not for typos and docs)
- [n/a] Did you verify new and existing tests pass locally with your changes?
- [n/a] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified