### PR TITLE
deprecate hpc_load() and integrate it with restore()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Deprecated default value of `monitor` argument in EarlyStopping callback to enforce `monitor` as a required argument ([#7907](https://github.com/PyTorchLightning/pytorch-lightning/pull/7907))
 
 
+- Deprecated the use of `CheckpointConnector.hpc_load()` in favor of `CheckpointConnector.restore()` ([#7652](https://github.com/PyTorchLightning/pytorch-lightning/pull/7652))
+
+
 ### Removed
 
 - Removed `ProfilerConnector` ([#7654](https://github.com/PyTorchLightning/pytorch-lightning/pull/7654))

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -50,7 +50,7 @@ class CheckpointConnector:
         dir_path_hpc = str(self.trainer.weights_save_path)
         max_version = self.max_ckpt_version_in_folder(dir_path_hpc, "hpc_ckpt_")
         if max_version is not None:
-            return f"{dir_path_hpc}/hpc_ckpt_{max_version}.ckpt"
+            return os.path.join(dir_path_hpc, f"hpc_ckpt_{max_version}.ckpt")
 
     def resume_start(self) -> None:
         """

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -21,8 +21,13 @@ import torch
 
 import pytorch_lightning
 from pytorch_lightning.core.lightning import LightningModule
-from pytorch_lightning.utilities import _OMEGACONF_AVAILABLE, DeviceType, rank_zero_info, rank_zero_warn, \
-    rank_zero_deprecation
+from pytorch_lightning.utilities import (
+    _OMEGACONF_AVAILABLE,
+    DeviceType,
+    rank_zero_deprecation,
+    rank_zero_info,
+    rank_zero_warn,
+)
 from pytorch_lightning.utilities.cloud_io import atomic_save, get_filesystem
 from pytorch_lightning.utilities.cloud_io import load as pl_load
 from pytorch_lightning.utilities.exceptions import MisconfigurationException

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -261,6 +261,7 @@ class CheckpointConnector:
     def hpc_load(self, checkpoint_path: str):
         """
         Attempts to restore the full training and model state from a HPC checkpoint file.
+        
         .. deprecated::
             `CheckpointConnector.hpc_load` was deprecated in v1.4 and will be removed in v1.6.
             Use `CheckpointConnector.restore` instead.

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -261,7 +261,7 @@ class CheckpointConnector:
     def hpc_load(self, checkpoint_path: str):
         """
         Attempts to restore the full training and model state from a HPC checkpoint file.
-        
+
         .. deprecated::
             `CheckpointConnector.hpc_load` was deprecated in v1.4 and will be removed in v1.6.
             Use `CheckpointConnector.restore` instead.

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -135,6 +135,10 @@ class CheckpointConnector:
         # hook: give user access to checkpoint if needed.
         model.on_load_checkpoint(checkpoint)
 
+        # call hpc specific hook
+        if self.hpc_resume_path is not None:
+            model.on_hpc_load(self._loaded_checkpoint)
+
         # restore model state_dict
         self.trainer.training_type_plugin.load_model_state_dict(checkpoint)
 
@@ -366,6 +370,7 @@ class CheckpointConnector:
 
             self.trainer.precision_plugin.on_save_checkpoint(checkpoint)
 
+        # dump hyper-parameters
         # dump hyper-parameters
         if model.hparams:
             if hasattr(model, '_hparams_name'):

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -379,9 +379,8 @@ class CheckpointConnector:
         """
         Attempts to restore the full training and model state from a HPC checkpoint file.
 
-        .. deprecated::
-            `CheckpointConnector.hpc_load` was deprecated in v1.4 and will be removed in v1.6.
-            Use `CheckpointConnector.restore` instead.
+        .. deprecated::v1.4
+            Will be removed in v1.6. Use :meth:`restore` instead.
         """
         rank_zero_deprecation(
             "`CheckpointConnector.hpc_load()` was deprecated in v1.4 and will be removed in v1.6."

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -371,7 +371,6 @@ class CheckpointConnector:
             self.trainer.precision_plugin.on_save_checkpoint(checkpoint)
 
         # dump hyper-parameters
-        # dump hyper-parameters
         if model.hparams:
             if hasattr(model, '_hparams_name'):
                 checkpoint[LightningModule.CHECKPOINT_HYPER_PARAMS_NAME] = model._hparams_name

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -29,7 +29,6 @@ from pytorch_lightning.utilities import (
     rank_zero_warn,
 )
 from pytorch_lightning.utilities.cloud_io import atomic_save, get_filesystem
-from pytorch_lightning.utilities.cloud_io import load as pl_load
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.upgrade_checkpoint import KEYS_MAPPING as DEPRECATED_CHECKPOINT_KEYS
 

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -257,19 +257,6 @@ class CheckpointConnector:
     # ----------------------------------
     # PRIVATE OPS
     # ----------------------------------
-    def hpc_load(self, checkpoint_path: str):
-        """
-        Attempts to restore the full training and model state from a HPC checkpoint file.
-
-        .. deprecated::
-            `CheckpointConnector.hpc_load` was deprecated in v1.4 and will be removed in v1.6.
-            Use `CheckpointConnector.restore` instead.
-        """
-        rank_zero_deprecation(
-            "`CheckpointConnector.hpc_load()` was deprecated in v1.4 and will be removed in v1.6."
-            " Use `CheckpointConnector.restore()` instead."
-        )
-        self.restore(checkpoint_path)
 
     def hpc_save(self, folderpath: str, logger):
         # make sure the checkpoint folder exists
@@ -387,6 +374,20 @@ class CheckpointConnector:
             self.trainer.datamodule.on_save_checkpoint(checkpoint)
 
         return checkpoint
+
+    def hpc_load(self, checkpoint_path: str) -> None:
+        """
+        Attempts to restore the full training and model state from a HPC checkpoint file.
+
+        .. deprecated::
+            `CheckpointConnector.hpc_load` was deprecated in v1.4 and will be removed in v1.6.
+            Use `CheckpointConnector.restore` instead.
+        """
+        rank_zero_deprecation(
+            "`CheckpointConnector.hpc_load()` was deprecated in v1.4 and will be removed in v1.6."
+            " Use `CheckpointConnector.restore()` instead."
+        )
+        self.restore(checkpoint_path)
 
     def max_ckpt_version_in_folder(self, dir_path: Union[str, Path], name_key: str = 'ckpt_') -> Optional[int]:
         """List up files in `dir_path` with `name_key`, then yield maximum suffix number.

--- a/tests/deprecated_api/test_remove_1-4.py
+++ b/tests/deprecated_api/test_remove_1-4.py
@@ -66,3 +66,16 @@ def test_v1_4_0_deprecated_checkpoint_on(tmpdir):
 
     with pytest.deprecated_call(match=r"Relying on.*is deprecated in v1.2 and will be removed in v1.4"):
         trainer.fit(TestModel())
+
+
+def test_v1_4_0_deprecated_hpc_load(tmpdir):
+    model = BoringModel()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+    )
+    trainer.fit(model)
+    trainer.checkpoint_connector.hpc_save(tmpdir, trainer.logger)
+    checkpoint_path = trainer.checkpoint_connector.get_max_ckpt_path_from_folder(str(tmpdir))
+    with pytest.deprecated_call(match=r"`CheckpointConnector.hpc_load\(\)` was deprecated in v1.4"):
+        trainer.checkpoint_connector.hpc_load(checkpoint_path)

--- a/tests/helpers/pipelines.py
+++ b/tests/helpers/pipelines.py
@@ -91,7 +91,7 @@ def run_model_test(
         trainer.checkpoint_connector.hpc_save(save_dir, logger)
         # test HPC loading
         checkpoint_path = trainer.checkpoint_connector.get_max_ckpt_path_from_folder(save_dir)
-        trainer.checkpoint_connector.hpc_load(checkpoint_path, on_gpu=on_gpu)
+        trainer.checkpoint_connector.restore(checkpoint_path)
 
 
 @torch.no_grad()

--- a/tests/models/data/horovod/train_default_model.py
+++ b/tests/models/data/horovod/train_default_model.py
@@ -87,7 +87,7 @@ def run_test_from_config(trainer_options, on_gpu, check_size=True):
     trainer.checkpoint_connector.hpc_save(ckpt_path, trainer.logger)
     # test HPC loading
     checkpoint_path = trainer.checkpoint_connector.get_max_ckpt_path_from_folder(ckpt_path)
-    trainer.checkpoint_connector.hpc_load(checkpoint_path, on_gpu=on_gpu)
+    trainer.checkpoint_connector.restore(checkpoint_path)
 
     if on_gpu:
         trainer = Trainer(gpus=1, accelerator='horovod', max_epochs=1)

--- a/tests/trainer/connectors/test_callback_connector.py
+++ b/tests/trainer/connectors/test_callback_connector.py
@@ -1,3 +1,16 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import logging
 from unittest.mock import Mock
 

--- a/tests/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/trainer/connectors/test_checkpoint_connector.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from unittest.mock import Mock
 
 import torch
 
@@ -41,19 +42,21 @@ def test_hpc_hook_calls(tmpdir):
         default_root_dir=tmpdir,
         max_steps=1,
         checkpoint_callback=False,
+        logger=False,
     )
     trainer.fit(model)
     connector = trainer.checkpoint_connector
-    connector.hpc_save(tmpdir, logger=trainer.logger)
+    connector.hpc_save(tmpdir, logger=Mock())
     assert model.hpc_save_called == 1
     assert model.hpc_load_called == 0
 
     # new training run, restore from hpc checkpoint file automatically
-    assert set(os.listdir(tmpdir)) == {"hpc_ckpt_1.ckpt", "lightning_logs"}
+    assert set(os.listdir(tmpdir)) == {"hpc_ckpt_1.ckpt"}
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_steps=1,
         checkpoint_callback=False,
+        logger=False,
     )
     trainer.fit(model)
     assert model.hpc_save_called == 1

--- a/tests/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/trainer/connectors/test_checkpoint_connector.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from pathlib import Path
 
 import torch
 
@@ -87,11 +86,7 @@ def test_hpc_restore_attempt(tmpdir):
         torch.nn.init.constant_(param, 0)
 
     # case 2: explicit resume path provided, restore hpc anyway
-    trainer = Trainer(
-        default_root_dir=tmpdir,
-        max_steps=3,
-        resume_from_checkpoint="not existing"
-    )
+    trainer = Trainer(default_root_dir=tmpdir, max_steps=3, resume_from_checkpoint="not existing")
     trainer.fit(model)
 
     for param in model.parameters():

--- a/tests/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/trainer/connectors/test_checkpoint_connector.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from pathlib import Path
 
 import torch
@@ -59,12 +60,14 @@ def test_hpc_restore_attempt(tmpdir):
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_steps=1,
+        checkpoint_callback=False,
+        logger=False,
     )
     trainer.fit(model)
 
     hpc_ckpt_path = tmpdir / "hpc_ckpt_3.ckpt"
     trainer.save_checkpoint(hpc_ckpt_path)
-    assert Path(hpc_ckpt_path).exists()
+    assert os.listdir(tmpdir) == ["hpc_ckpt_3.ckpt"]
 
     # set weights to zero
     for param in model.parameters():
@@ -74,6 +77,8 @@ def test_hpc_restore_attempt(tmpdir):
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_steps=2,
+        checkpoint_callback=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -82,7 +87,11 @@ def test_hpc_restore_attempt(tmpdir):
         torch.nn.init.constant_(param, 0)
 
     # case 2: explicit resume path provided, restore hpc anyway
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=2, resume_from_checkpoint="not existing")
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=3,
+        resume_from_checkpoint="not existing"
+    )
     trainer.fit(model)
 
     for param in model.parameters():

--- a/tests/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/trainer/connectors/test_checkpoint_connector.py
@@ -1,0 +1,107 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pathlib import Path
+
+import torch
+
+from pytorch_lightning import Trainer
+from tests.helpers import BoringModel
+
+
+def test_preloaded_checkpoint_lifecycle(tmpdir):
+    """ Tests that the preloaded checkpoint contents gets cleared from memory when it is not required anymore. """
+    model = BoringModel()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+    )
+    trainer.fit(model)
+
+    connector = trainer.checkpoint_connector
+
+    assert not trainer.resume_from_checkpoint
+    assert not connector.resume_checkpoint_path
+    assert not connector._loaded_checkpoint
+
+    connector.resume_start()
+    assert not connector.resume_checkpoint_path
+    assert not connector._loaded_checkpoint
+    connector.resume_end()
+    assert not connector.resume_checkpoint_path
+    assert not connector._loaded_checkpoint
+
+    ckpt_path = trainer.checkpoint_callback.best_model_path
+    trainer = Trainer(default_root_dir=tmpdir, max_steps=2, resume_from_checkpoint=ckpt_path)
+    connector = trainer.checkpoint_connector
+    connector.resume_start()
+    assert connector.resume_checkpoint_path == ckpt_path
+    assert connector._loaded_checkpoint
+    assert isinstance(connector._loaded_checkpoint, dict)
+    connector.resume_end()
+    assert not connector.resume_checkpoint_path
+    assert not connector._loaded_checkpoint
+
+
+def test_hpc_restore_attempt(tmpdir):
+    """ Test that restore() attempts to restore the hpc_ckpt with highest priority. """
+    model = BoringModel()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+    )
+    trainer.fit(model)
+
+    hpc_ckpt_path = tmpdir / "hpc_ckpt_3.ckpt"
+    trainer.save_checkpoint(hpc_ckpt_path)
+    assert Path(hpc_ckpt_path).exists()
+
+    # set weights to zero
+    for param in model.parameters():
+        torch.nn.init.constant_(param, 0)
+
+    # case 1: restore hpc first, no explicit resume path provided
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=2,
+    )
+    trainer.fit(model)
+
+    for param in model.parameters():
+        assert param.abs().sum() > 0
+        torch.nn.init.constant_(param, 0)
+
+    # case 2: explicit resume path provided, restore hpc anyway
+    trainer = Trainer(default_root_dir=tmpdir, max_steps=2, resume_from_checkpoint="not existing")
+    trainer.fit(model)
+
+    for param in model.parameters():
+        assert param.abs().sum() > 0
+
+
+def test_hpc_max_ckpt_version(tmpdir):
+    """ Test that the CheckpointConnector is able to find the hpc checkpoint file with the highest version. """
+    model = BoringModel()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+    )
+    trainer.fit(model)
+    trainer.save_checkpoint(tmpdir / "hpc_ckpt.ckpt")
+    trainer.save_checkpoint(tmpdir / "hpc_ckpt_0.ckpt")
+    trainer.save_checkpoint(tmpdir / "hpc_ckpt_3.ckpt")
+    trainer.save_checkpoint(tmpdir / "hpc_ckpt_33.ckpt")
+
+    assert trainer.checkpoint_connector.hpc_resume_path == tmpdir / "hpc_ckpt_33.ckpt"
+    assert trainer.checkpoint_connector.max_ckpt_version_in_folder(tmpdir) == 33
+    assert trainer.checkpoint_connector.max_ckpt_version_in_folder(tmpdir / "not" / "existing") is None

--- a/tests/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/trainer/connectors/test_checkpoint_connector.py
@@ -147,6 +147,6 @@ def test_hpc_max_ckpt_version(tmpdir):
     trainer.save_checkpoint(tmpdir / "hpc_ckpt_3.ckpt")
     trainer.save_checkpoint(tmpdir / "hpc_ckpt_33.ckpt")
 
-    assert trainer.checkpoint_connector.hpc_resume_path == tmpdir / "hpc_ckpt_33.ckpt"
+    assert trainer.checkpoint_connector.hpc_resume_path == str(tmpdir / "hpc_ckpt_33.ckpt")
     assert trainer.checkpoint_connector.max_ckpt_version_in_folder(tmpdir) == 33
     assert trainer.checkpoint_connector.max_ckpt_version_in_folder(tmpdir / "not" / "existing") is None


### PR DESCRIPTION
## What does this PR do?

Part of #7652

`CheckpointConnector.hpc_load()` does the same thing as `CheckpointConnector()`, except it additionally calls a hook
on_hpc_load on the module. This hook calling is now taken care of in `restore()`.
Now we can properly deprecate the hpc_load for `restore()` to remove the code duplication.

The unit tests added here ensure that `restore()` behaves the same as the deprecated `hpc_load`!

Also closes #5371 

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
