### PR TITLE
Improvements related to save of config file by LightningCLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `on_load_checkpoint` and `on_save_checkpoint` hooks to the `PrecisionPlugin` base class ([#7831](https://github.com/PyTorchLightning/pytorch-lightning/pull/7831))
 
 
+- LightningCLI now does not aborts with a clearer message if config already exists and disables save config for fast_dev_run!=False ([#7859](https://github.com/PyTorchLightning/pytorch-lightning/discussions/7859))
+
+
+
 ### Deprecated
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,7 +165,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `on_load_checkpoint` and `on_save_checkpoint` hooks to the `PrecisionPlugin` base class ([#7831](https://github.com/PyTorchLightning/pytorch-lightning/pull/7831))
 
 
-- LightningCLI now does not aborts with a clearer message if config already exists and disables save config for fast_dev_run!=False ([#7859](https://github.com/PyTorchLightning/pytorch-lightning/discussions/7859))
+- LightningCLI now aborts with a clearer message if config already exists and disables save config for fast_dev_run!=False ([#7963](https://github.com/PyTorchLightning/pytorch-lightning/pull/7963))
 
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,7 +165,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `on_load_checkpoint` and `on_save_checkpoint` hooks to the `PrecisionPlugin` base class ([#7831](https://github.com/PyTorchLightning/pytorch-lightning/pull/7831))
 
 
-- LightningCLI now aborts with a clearer message if config already exists and disables save config for fast_dev_run!=False ([#7963](https://github.com/PyTorchLightning/pytorch-lightning/pull/7963))
+- `LightningCLI` now aborts with a clearer message if config already exists and disables save config during `fast_dev_run`([#7963](https://github.com/PyTorchLightning/pytorch-lightning/pull/7963))
 
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - LightningCLI now does not aborts with a clearer message if config already exists and disables save config for fast_dev_run!=False ([#7859](https://github.com/PyTorchLightning/pytorch-lightning/discussions/7859))
 
 
-
 ### Deprecated
 
 

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -91,7 +91,9 @@ class SaveConfigCallback(Callback):
         log_dir = trainer.log_dir or trainer.default_root_dir
         config_path = os.path.join(log_dir, self.config_filename)
         if os.path.isfile(config_path):
-            raise RuntimeError(f'{self.__class__.__name__} expected {config_path} to not exist. Aborting to avoid overwriting results of a previous run.')
+            raise RuntimeError(
+                f'{self.__class__.__name__} expected {config_path} to not exist. Aborting to avoid overwriting results of a previous run.'
+            )
         self.parser.save(self.config, config_path, skip_none=False)
 
 

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -78,7 +78,7 @@ class SaveConfigCallback(Callback):
     """Saves a LightningCLI config to the log_dir when training starts
 
     Raises:
-        RuntimeError: If in the log_dir the config file already exists to avoid overriting a previous run
+        RuntimeError: If in the log_dir the config file already exists to avoid overwriting a previous run
     """
 
     def __init__(

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -96,7 +96,8 @@ class SaveConfigCallback(Callback):
         config_path = os.path.join(log_dir, self.config_filename)
         if os.path.isfile(config_path):
             raise RuntimeError(
-                f'{type(self).__name__} expected {config_path} to not exist. Aborting to avoid overwriting results of a previous run.'
+                f'{type(self).__name__} expected {config_path} to not exist. '
+                'Aborting to avoid overwriting results of a previous run.'
             )
         self.parser.save(self.config, config_path, skip_none=False)
 

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -96,7 +96,7 @@ class SaveConfigCallback(Callback):
         config_path = os.path.join(log_dir, self.config_filename)
         if os.path.isfile(config_path):
             raise RuntimeError(
-                f'{type(self).__name__} expected {config_path} to not exist. '
+                f'{self.__class__.__name__} expected {config_path} to not exist. '
                 'Aborting to avoid overwriting results of a previous run.'
             )
         self.parser.save(self.config, config_path, skip_none=False)

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -78,7 +78,7 @@ class SaveConfigCallback(Callback):
     """Saves a LightningCLI config to the log_dir when training starts
 
     Raises:
-        RuntimeError: If in the log_dir the config file already exists to avoid overwriting a previous run
+        RuntimeError: If the config file already exists in the directory to avoid overwriting a previous run
     """
 
     def __init__(

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -75,7 +75,11 @@ class LightningArgumentParser(ArgumentParser):
 
 
 class SaveConfigCallback(Callback):
-    """Saves a LightningCLI config to the log_dir when training starts"""
+    """Saves a LightningCLI config to the log_dir when training starts
+
+    Raises:
+        RuntimeError: If in the log_dir the config file already exists to avoid overriting a previous run
+    """
 
     def __init__(
         self,
@@ -92,7 +96,7 @@ class SaveConfigCallback(Callback):
         config_path = os.path.join(log_dir, self.config_filename)
         if os.path.isfile(config_path):
             raise RuntimeError(
-                f'{self.__class__.__name__} expected {config_path} to not exist. Aborting to avoid overwriting results of a previous run.'
+                f'{type(self).__name__} expected {config_path} to not exist. Aborting to avoid overwriting results of a previous run.'
             )
         self.parser.save(self.config, config_path, skip_none=False)
 

--- a/tests/utilities/test_cli.py
+++ b/tests/utilities/test_cli.py
@@ -328,6 +328,31 @@ def test_lightning_cli_args(tmpdir):
     assert config['trainer'] == cli.config['trainer']
 
 
+def test_lightning_cli_save_config_cases(tmpdir):
+
+    config_path = tmpdir / 'config.yaml'
+    cli_args = [
+        f'--trainer.default_root_dir={tmpdir}',
+        '--trainer.logger=False',
+        '--trainer.fast_dev_run=1',
+    ]
+
+    # With fast_dev_run!=False config should not be saved
+    with mock.patch('sys.argv', ['any.py'] + cli_args):
+        cli = LightningCLI(BoringModel)
+    assert not os.path.isfile(config_path)
+
+    # With fast_dev_run==False config should be saved
+    cli_args[-1] = '--trainer.max_epochs=1'
+    with mock.patch('sys.argv', ['any.py'] + cli_args):
+        cli = LightningCLI(BoringModel)
+    assert os.path.isfile(config_path)
+
+    # Exception should be raised if config file already exists
+    with mock.patch('sys.argv', ['any.py'] + cli_args), pytest.raises(RuntimeError):
+        cli = LightningCLI(BoringModel)
+
+
 def test_lightning_cli_config_and_subclass_mode(tmpdir):
 
     config = dict(

--- a/tests/utilities/test_cli.py
+++ b/tests/utilities/test_cli.py
@@ -339,18 +339,18 @@ def test_lightning_cli_save_config_cases(tmpdir):
 
     # With fast_dev_run!=False config should not be saved
     with mock.patch('sys.argv', ['any.py'] + cli_args):
-        cli = LightningCLI(BoringModel)
+        LightningCLI(BoringModel)
     assert not os.path.isfile(config_path)
 
     # With fast_dev_run==False config should be saved
     cli_args[-1] = '--trainer.max_epochs=1'
     with mock.patch('sys.argv', ['any.py'] + cli_args):
-        cli = LightningCLI(BoringModel)
+        LightningCLI(BoringModel)
     assert os.path.isfile(config_path)
 
-    # Exception should be raised if config file already exists
+    # If run again on same directory exception should be raised since config file already exists
     with mock.patch('sys.argv', ['any.py'] + cli_args), pytest.raises(RuntimeError):
-        cli = LightningCLI(BoringModel)
+        LightningCLI(BoringModel)
 
 
 def test_lightning_cli_config_and_subclass_mode(tmpdir):


### PR DESCRIPTION
## What does this PR do?

A couple of improvements related to save of config file by LightningCLI.
- Exclude SaveConfigCallback for `fast_dev_run != False`.
- SaveConfigCallback give a clearer message if config file already exists.

Fixes #7859

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
