### PR TITLE
[feat] Named Parameter Groups in `LearningRateMonitor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Add support for named parameter groups in `LearningRateMonitor` ([#7987](https://github.com/PyTorchLightning/pytorch-lightning/pull/7987))
+
+
 - Add `dataclass` support for `pytorch_lightning.utilities.apply_to_collection` ([#7935](https://github.com/PyTorchLightning/pytorch-lightning/pull/7935))
 
 

--- a/pytorch_lightning/callbacks/lr_monitor.py
+++ b/pytorch_lightning/callbacks/lr_monitor.py
@@ -73,12 +73,10 @@ class LearningRateMonitor(Callback):
 
         def configure_optimizer(self):
             optimizer = torch.optim.SGD(
-                [
-                    {
-                        'params': [p for p in self.parameters()],
-                        'name': 'my_parameter_group_name'
-                    }
-                ],
+                [{
+                    'params': [p for p in self.parameters()],
+                    'name': 'my_parameter_group_name'
+                }],
                 lr=0.1
             )
             lr_scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, ...)

--- a/pytorch_lightning/callbacks/lr_monitor.py
+++ b/pytorch_lightning/callbacks/lr_monitor.py
@@ -20,7 +20,7 @@ Monitor and logs learning rate for lr schedulers during training.
 
 """
 from collections import defaultdict
-from typing import Any, DefaultDict, Dict, List, Optional, Type
+from typing import Any, DefaultDict, Set, Dict, List, Optional, Type
 
 from torch.optim.optimizer import Optimizer
 
@@ -150,11 +150,11 @@ class LearningRateMonitor(Callback):
                 use_betas = 'betas' in opt.defaults
 
                 for i, pg in enumerate(param_groups):
-                    suffix = f'/pg{i + 1}' if len(param_groups) > 1 else ''
-                    lr = self._extract_lr(pg, f'{name}{suffix}')
+                    name_and_suffix = self._add_suffix(name, param_groups, i)
+                    lr = self._extract_lr(pg, name_and_suffix)
                     latest_stat.update(lr)
                     momentum = self._extract_momentum(
-                        param_group=pg, name=f'{name}-momentum{suffix}', use_betas=use_betas
+                        param_group=pg, name=name_and_suffix.replace(name, f'{name}-momentum'), use_betas=use_betas
                     )
                     latest_stat.update(momentum)
 
@@ -192,6 +192,28 @@ class LearningRateMonitor(Callback):
         count = seen_optimizer_types[optimizer_cls]
         return name + f'-{count - 1}' if count > 1 else name
 
+    def _add_suffix(self, name: str, param_groups: List[Dict], param_group_index: int, use_names: bool = True) -> str:
+        if len(param_groups) > 1:
+            if not use_names:
+                return f'{name}/pg{param_group_index+1}'
+            else:
+                pg_name = param_groups[param_group_index].get('name', f'pg{param_group_index+1}')
+                return f'{name}/{pg_name}' 
+        else:
+            if not use_names:
+                return name 
+            else:
+                pg_name = param_groups[param_group_index].get('name')
+                return f'{name}/{pg_name}' if pg_name else name
+
+    def _duplicate_param_group_names(self, param_groups: List[Dict]) -> Set[str]:
+        names = [pg.get('name', f'pg{i+1}') for i, pg in enumerate(param_groups)]
+        unique = set(names)
+        if len(names) == len(unique):
+            return set()
+        else:
+            return set(n for n in names if names.count(n) > 1)
+
     def _find_names(self, lr_schedulers: List, add_lr_sch_names: bool = True) -> List[str]:
         # Create unique names in the case we have multiple of the same learning
         # rate scheduler + multiple parameter groups
@@ -212,15 +234,18 @@ class LearningRateMonitor(Callback):
 
             # Multiple param groups for the same scheduler
             param_groups = sch.optimizer.param_groups
+            duplicates = self._duplicate_param_group_names(param_groups)
+            if duplicates:
+                raise MisconfigurationException(
+                    'A single `Optimizer` cannot have multiple parameter groups with identical '
+                    f'`name` values. {name} has duplicated parameter group names {duplicates}'
+                )
 
             name = self._add_prefix(name, optimizer_cls, seen_optimizer_types)
 
-            if len(param_groups) != 1:
-                for i in range(len(param_groups)):
-                    temp = f'{name}/pg{i + 1}'
-                    names.append(temp)
-            else:
-                names.append(name)
+            for i in range(len(param_groups)):
+                name_and_suffix = self._add_suffix(name, param_groups, i)
+                names.append(name_and_suffix)
 
             if add_lr_sch_names:
                 self.lr_sch_names.append(name)

--- a/pytorch_lightning/callbacks/lr_monitor.py
+++ b/pytorch_lightning/callbacks/lr_monitor.py
@@ -256,9 +256,7 @@ class LearningRateMonitor(Callback):
 
             name = self._add_prefix(name, optimizer_cls, seen_optimizer_types)
 
-            for i in range(len(param_groups)):
-                name_and_suffix = self._add_suffix(name, param_groups, i)
-                names.append(name_and_suffix)
+            names.extend(self._add_suffix(name, param_groups, i) for i in range(len(param_groups)))
 
             if add_lr_sch_names:
                 self.lr_sch_names.append(name)

--- a/pytorch_lightning/callbacks/lr_monitor.py
+++ b/pytorch_lightning/callbacks/lr_monitor.py
@@ -215,12 +215,12 @@ class LearningRateMonitor(Callback):
                 return f'{name}/pg{param_group_index+1}'
             else:
                 pg_name = param_groups[param_group_index].get('name', f'pg{param_group_index+1}')
-                return f'{name}/{pg_name}' 
+                return f'{name}/{pg_name}'
         elif use_names:
             pg_name = param_groups[param_group_index].get('name')
             return f'{name}/{pg_name}' if pg_name else name
         else:
-            return name 
+            return name
 
     def _duplicate_param_group_names(self, param_groups: List[Dict]) -> Set[str]:
         names = [pg.get('name', f'pg{i+1}') for i, pg in enumerate(param_groups)]

--- a/pytorch_lightning/callbacks/lr_monitor.py
+++ b/pytorch_lightning/callbacks/lr_monitor.py
@@ -215,13 +215,12 @@ class LearningRateMonitor(Callback):
                 return f'{name}/pg{param_group_index+1}'
             else:
                 pg_name = param_groups[param_group_index].get('name', f'pg{param_group_index+1}')
-                return f'{name}/{pg_name}'
+                return f'{name}/{pg_name}' 
+        elif use_names:
+            pg_name = param_groups[param_group_index].get('name')
+            return f'{name}/{pg_name}' if pg_name else name
         else:
-            if not use_names:
-                return name
-            else:
-                pg_name = param_groups[param_group_index].get('name')
-                return f'{name}/{pg_name}' if pg_name else name
+            return name 
 
     def _duplicate_param_group_names(self, param_groups: List[Dict]) -> Set[str]:
         names = [pg.get('name', f'pg{i+1}') for i, pg in enumerate(param_groups)]

--- a/pytorch_lightning/callbacks/lr_monitor.py
+++ b/pytorch_lightning/callbacks/lr_monitor.py
@@ -220,8 +220,12 @@ class LearningRateMonitor(Callback):
         return name
 
     def _duplicate_param_group_names(self, param_groups: List[Dict]) -> Set[str]:
-        names = [pg.get('name', f'pg{i+1}') for i, pg in enumerate(param_groups)]
-        return set(n for n in names if names.count(n) > 1)
+        names = [pg.get('name', f'pg{i}') for i, pg in enumerate(param_groups, start=1)]
+        unique = set(names)
+        if len(names) == len(unique):
+            return set()
+        else:
+            return set(n for n in names if names.count(n) > 1)
 
     def _find_names(self, lr_schedulers: List, add_lr_sch_names: bool = True) -> List[str]:
         # Create unique names in the case we have multiple of the same learning

--- a/pytorch_lightning/callbacks/lr_monitor.py
+++ b/pytorch_lightning/callbacks/lr_monitor.py
@@ -55,7 +55,9 @@ class LearningRateMonitor(Callback):
     In case of multiple optimizers of same type, they will be named ``Adam``,
     ``Adam-1`` etc. If a optimizer has multiple parameter groups they will
     be named ``Adam/pg1``, ``Adam/pg2`` etc. To control naming, pass in a
-    ``name`` keyword in the construction of the learning rate schedulers
+    ``name`` keyword in the construction of the learning rate schedulers.
+    A ``name`` keyword can also be used for parameter groups in the 
+    construction of the optimizer.
 
     Example::
 
@@ -65,6 +67,21 @@ class LearningRateMonitor(Callback):
                 'scheduler': torch.optim.lr_scheduler.LambdaLR(optimizer, ...)
                 'name': 'my_logging_name'
             }
+            return [optimizer], [lr_scheduler]
+
+    Example::
+
+        def configure_optimizer(self):
+            optimizer = torch.optim.SGD(
+                [
+                    {
+                        'params': [p for p in self.parameters()], 
+                        'name': 'my_parameter_group_name'
+                    }
+                ], 
+                lr=0.1
+            )
+            lr_scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, ...)
             return [optimizer], [lr_scheduler]
 
     """

--- a/pytorch_lightning/callbacks/lr_monitor.py
+++ b/pytorch_lightning/callbacks/lr_monitor.py
@@ -20,7 +20,7 @@ Monitor and logs learning rate for lr schedulers during training.
 
 """
 from collections import defaultdict
-from typing import Any, DefaultDict, Set, Dict, List, Optional, Type
+from typing import Any, DefaultDict, Dict, List, Optional, Set, Type
 
 from torch.optim.optimizer import Optimizer
 
@@ -56,7 +56,7 @@ class LearningRateMonitor(Callback):
     ``Adam-1`` etc. If a optimizer has multiple parameter groups they will
     be named ``Adam/pg1``, ``Adam/pg2`` etc. To control naming, pass in a
     ``name`` keyword in the construction of the learning rate schedulers.
-    A ``name`` keyword can also be used for parameter groups in the 
+    A ``name`` keyword can also be used for parameter groups in the
     construction of the optimizer.
 
     Example::
@@ -75,10 +75,10 @@ class LearningRateMonitor(Callback):
             optimizer = torch.optim.SGD(
                 [
                     {
-                        'params': [p for p in self.parameters()], 
+                        'params': [p for p in self.parameters()],
                         'name': 'my_parameter_group_name'
                     }
-                ], 
+                ],
                 lr=0.1
             )
             lr_scheduler = torch.optim.lr_scheduler.LambdaLR(optimizer, ...)
@@ -215,10 +215,10 @@ class LearningRateMonitor(Callback):
                 return f'{name}/pg{param_group_index+1}'
             else:
                 pg_name = param_groups[param_group_index].get('name', f'pg{param_group_index+1}')
-                return f'{name}/{pg_name}' 
+                return f'{name}/{pg_name}'
         else:
             if not use_names:
-                return name 
+                return name
             else:
                 pg_name = param_groups[param_group_index].get('name')
                 return f'{name}/{pg_name}' if pg_name else name

--- a/pytorch_lightning/callbacks/lr_monitor.py
+++ b/pytorch_lightning/callbacks/lr_monitor.py
@@ -224,11 +224,7 @@ class LearningRateMonitor(Callback):
 
     def _duplicate_param_group_names(self, param_groups: List[Dict]) -> Set[str]:
         names = [pg.get('name', f'pg{i+1}') for i, pg in enumerate(param_groups)]
-        unique = set(names)
-        if len(names) == len(unique):
-            return set()
-        else:
-            return set(n for n in names if names.count(n) > 1)
+        return set(n for n in names if names.count(n) > 1)
 
     def _find_names(self, lr_schedulers: List, add_lr_sch_names: bool = True) -> List[str]:
         # Create unique names in the case we have multiple of the same learning

--- a/pytorch_lightning/callbacks/lr_monitor.py
+++ b/pytorch_lightning/callbacks/lr_monitor.py
@@ -217,8 +217,7 @@ class LearningRateMonitor(Callback):
         elif use_names:
             pg_name = param_groups[param_group_index].get('name')
             return f'{name}/{pg_name}' if pg_name else name
-        else:
-            return name
+        return name
 
     def _duplicate_param_group_names(self, param_groups: List[Dict]) -> Set[str]:
         names = [pg.get('name', f'pg{i+1}') for i, pg in enumerate(param_groups)]

--- a/tests/callbacks/test_lr_monitor.py
+++ b/tests/callbacks/test_lr_monitor.py
@@ -307,7 +307,7 @@ def test_lr_monitor_custom_pg_name(tmpdir):
     assert list(lr_monitor.lrs.keys()) == ['lr-SGD/linear']
 
 
-def test_lr_monitor_no_logger(tmpdir):
+def test_lr_monitor_duplicate_custom_pg_names(tmpdir):
     tutils.reset_seed()
 
     class TestModel(BoringModel):

--- a/tests/callbacks/test_lr_monitor.py
+++ b/tests/callbacks/test_lr_monitor.py
@@ -323,7 +323,7 @@ def test_lr_monitor_duplicate_custom_pg_names(tmpdir):
             return x
 
         def configure_optimizers(self):
-            optimizer = torch.optim.SGD([
+            param_groups = [
                 {
                     'params': [p for p in self.linear_a.parameters()],
                     'name': 'linear'
@@ -332,8 +332,8 @@ def test_lr_monitor_duplicate_custom_pg_names(tmpdir):
                     'params': [p for p in self.linear_b.parameters()],
                     'name': 'linear'
                 },
-            ],
-                                        lr=0.1)
+            ]
+            optimizer = torch.optim.SGD(param_groups, lr=0.1)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
             return [optimizer], [lr_scheduler]
 

--- a/tests/callbacks/test_lr_monitor.py
+++ b/tests/callbacks/test_lr_monitor.py
@@ -323,17 +323,19 @@ def test_lr_monitor_no_logger(tmpdir):
             return x
 
         def configure_optimizers(self):
-            optimizer = torch.optim.SGD([
-                {
-                    'params': [p for p in self.linear_a.parameters()],
-                    'name': 'linear'
-                },
-                {
-                    'params': [p for p in self.linear_b.parameters()],
-                    'name': 'linear'
-                },
-            ],
-                                        lr=0.1)
+            optimizer = torch.optim.SGD(
+                [
+                    {
+                        'params': [p for p in self.linear_a.parameters()],
+                        'name': 'linear'
+                    },
+                    {
+                        'params': [p for p in self.linear_b.parameters()],
+                        'name': 'linear'
+                    },
+                ],
+                lr=0.1
+            )
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
             return [optimizer], [lr_scheduler]
 

--- a/tests/callbacks/test_lr_monitor.py
+++ b/tests/callbacks/test_lr_monitor.py
@@ -332,8 +332,7 @@ def test_lr_monitor_duplicate_custom_pg_names(tmpdir):
                     'params': [p for p in self.linear_b.parameters()],
                     'name': 'linear'
                 },
-            ],
-                                        lr=0.1)
+            ], lr=0.1)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
             return [optimizer], [lr_scheduler]
 

--- a/tests/callbacks/test_lr_monitor.py
+++ b/tests/callbacks/test_lr_monitor.py
@@ -283,6 +283,72 @@ def test_lr_monitor_custom_name(tmpdir):
     assert lr_monitor.lr_sch_names == list(lr_monitor.lrs.keys()) == ['my_logging_name']
 
 
+def test_lr_monitor_custom_pg_name(tmpdir):
+
+    class TestModel(BoringModel):
+
+        def configure_optimizers(self):
+            optimizer = torch.optim.SGD([{'params': [p for p in self.layer.parameters()], 'name': 'linear'}], lr=0.1)
+            lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
+            return [optimizer], [lr_scheduler]
+
+    lr_monitor = LearningRateMonitor()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        limit_val_batches=0.1,
+        limit_train_batches=0.5,
+        callbacks=[lr_monitor],
+        progress_bar_refresh_rate=0,
+        weights_summary=None,
+    )
+    trainer.fit(TestModel())
+    assert lr_monitor.lr_sch_names == ['lr-SGD']
+    assert list(lr_monitor.lrs.keys()) == ['lr-SGD/linear']
+
+
+def test_lr_monitor_no_logger(tmpdir):
+    tutils.reset_seed()
+    class TestModel(BoringModel):    
+        def __init__(self):
+            super().__init__()
+            self.linear_a = torch.nn.Linear(32, 16)
+            self.linear_b = torch.nn.Linear(16, 2)
+
+        def forward(self, x):
+            x = self.linear_a(x)
+            x = self.linear_b(x)
+            return x
+
+        def configure_optimizers(self):
+            optimizer = torch.optim.SGD(
+                [
+                    {'params': [p for p in self.linear_a.parameters()], 'name': 'linear'},
+                    {'params': [p for p in self.linear_b.parameters()], 'name': 'linear'},
+                ], 
+                lr=0.1
+            )
+            lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
+            return [optimizer], [lr_scheduler]
+
+    lr_monitor = LearningRateMonitor()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        limit_val_batches=0.1,
+        limit_train_batches=0.5,
+        callbacks=[lr_monitor],
+        progress_bar_refresh_rate=0,
+        weights_summary=None,
+    )
+
+    with pytest.raises(
+        MisconfigurationException, 
+        match='A single `Optimizer` cannot have multiple parameter groups with identical'
+        ):
+        trainer.fit(TestModel())
+
+
 def test_multiple_optimizers_basefinetuning(tmpdir):
 
     class TestModel(BoringModel):

--- a/tests/callbacks/test_lr_monitor.py
+++ b/tests/callbacks/test_lr_monitor.py
@@ -309,7 +309,9 @@ def test_lr_monitor_custom_pg_name(tmpdir):
 
 def test_lr_monitor_no_logger(tmpdir):
     tutils.reset_seed()
-    class TestModel(BoringModel):    
+
+    class TestModel(BoringModel):
+
         def __init__(self):
             super().__init__()
             self.linear_a = torch.nn.Linear(32, 16)
@@ -321,13 +323,17 @@ def test_lr_monitor_no_logger(tmpdir):
             return x
 
         def configure_optimizers(self):
-            optimizer = torch.optim.SGD(
-                [
-                    {'params': [p for p in self.linear_a.parameters()], 'name': 'linear'},
-                    {'params': [p for p in self.linear_b.parameters()], 'name': 'linear'},
-                ], 
-                lr=0.1
-            )
+            optimizer = torch.optim.SGD([
+                {
+                    'params': [p for p in self.linear_a.parameters()],
+                    'name': 'linear'
+                },
+                {
+                    'params': [p for p in self.linear_b.parameters()],
+                    'name': 'linear'
+                },
+            ],
+                                        lr=0.1)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
             return [optimizer], [lr_scheduler]
 
@@ -343,9 +349,8 @@ def test_lr_monitor_no_logger(tmpdir):
     )
 
     with pytest.raises(
-        MisconfigurationException, 
-        match='A single `Optimizer` cannot have multiple parameter groups with identical'
-        ):
+        MisconfigurationException, match='A single `Optimizer` cannot have multiple parameter groups with identical'
+    ):
         trainer.fit(TestModel())
 
 

--- a/tests/callbacks/test_lr_monitor.py
+++ b/tests/callbacks/test_lr_monitor.py
@@ -332,7 +332,8 @@ def test_lr_monitor_duplicate_custom_pg_names(tmpdir):
                     'params': [p for p in self.linear_b.parameters()],
                     'name': 'linear'
                 },
-            ], lr=0.1)
+            ],
+                                        lr=0.1)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
             return [optimizer], [lr_scheduler]
 

--- a/tests/callbacks/test_lr_monitor.py
+++ b/tests/callbacks/test_lr_monitor.py
@@ -296,8 +296,8 @@ def test_lr_monitor_custom_pg_name(tmpdir):
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_epochs=2,
-        limit_val_batches=0.1,
-        limit_train_batches=0.5,
+        limit_val_batches=2,
+        limit_train_batches=2,
         callbacks=[lr_monitor],
         progress_bar_refresh_rate=0,
         weights_summary=None,
@@ -341,8 +341,8 @@ def test_lr_monitor_duplicate_custom_pg_names(tmpdir):
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_epochs=2,
-        limit_val_batches=0.1,
-        limit_train_batches=0.5,
+        limit_val_batches=2,
+        limit_train_batches=2,
         callbacks=[lr_monitor],
         progress_bar_refresh_rate=0,
         weights_summary=None,

--- a/tests/callbacks/test_lr_monitor.py
+++ b/tests/callbacks/test_lr_monitor.py
@@ -323,19 +323,17 @@ def test_lr_monitor_no_logger(tmpdir):
             return x
 
         def configure_optimizers(self):
-            optimizer = torch.optim.SGD(
-                [
-                    {
-                        'params': [p for p in self.linear_a.parameters()],
-                        'name': 'linear'
-                    },
-                    {
-                        'params': [p for p in self.linear_b.parameters()],
-                        'name': 'linear'
-                    },
-                ],
-                lr=0.1
-            )
+            optimizer = torch.optim.SGD([
+                {
+                    'params': [p for p in self.linear_a.parameters()],
+                    'name': 'linear'
+                },
+                {
+                    'params': [p for p in self.linear_b.parameters()],
+                    'name': 'linear'
+                },
+            ],
+                                        lr=0.1)
             lr_scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1)
             return [optimizer], [lr_scheduler]
 

--- a/tests/callbacks/test_lr_monitor.py
+++ b/tests/callbacks/test_lr_monitor.py
@@ -304,7 +304,7 @@ def test_lr_monitor_custom_pg_name(tmpdir):
     )
     trainer.fit(TestModel())
     assert lr_monitor.lr_sch_names == ['lr-SGD']
-    assert list(lr_monitor.lrs.keys()) == ['lr-SGD/linear']
+    assert list(lr_monitor.lrs) == ['lr-SGD/linear']
 
 
 def test_lr_monitor_duplicate_custom_pg_names(tmpdir):


### PR DESCRIPTION
## What does this PR do?

This PR allows the `LearningRateMonitor` callback to log the actual parameter group names, if they exist. It should fallback to prior behavior in the event that the parameter group names do not exist.

Fixes #7981

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
