### PR TITLE
Change `WarningCache` to subclass `set`

### DIFF
--- a/pytorch_lightning/utilities/warnings.py
+++ b/pytorch_lightning/utilities/warnings.py
@@ -14,15 +14,9 @@
 from pytorch_lightning.utilities.distributed import rank_zero_warn
 
 
-class WarningCache:
-
-    def __init__(self):
-        self.warnings = set()
+class WarningCache(set):
 
     def warn(self, m, *args, **kwargs):
-        if m not in self.warnings:
-            self.warnings.add(m)
+        if m not in self:
+            self.add(m)
             rank_zero_warn(m, *args, **kwargs)
-
-    def clear(self):
-        self.warnings.clear()


### PR DESCRIPTION
## What does this PR do?

Tiny change. Should be okay as we don't access `warnings` anywhere

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes? (if necessary)
- [n/a] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [n/a] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified