### PR TITLE
prevent memory test failing due to earlier test leaking memory

### DIFF
--- a/tests/trainer/loops/test_evaluation_loop.py
+++ b/tests/trainer/loops/test_evaluation_loop.py
@@ -77,6 +77,8 @@ def test_log_epoch_metrics_before_on_evaluation_end(update_eval_epoch_metrics_mo
 def test_memory_consumption_validation(tmpdir):
     """Test that the training batch is no longer in GPU memory when running validation"""
 
+    initial_memory = torch.cuda.memory_allocated(0)
+
     class BoringLargeBatchModel(BoringModel):
 
         @property
@@ -95,14 +97,14 @@ def test_memory_consumption_validation(tmpdir):
             # there is a batch and the boring model, but not two batches on gpu, assume 32 bit = 4 bytes
             lower = 101 * self.num_params * 4
             upper = 201 * self.num_params * 4
-            assert lower < torch.cuda.memory_allocated(0) < upper
+            assert lower < torch.cuda.memory_allocated(0) - initial_memory < upper
             return super().training_step(batch, batch_idx)
 
         def validation_step(self, batch, batch_idx):
             # there is a batch and the boring model, but not two batches on gpu, assume 32 bit = 4 bytes
             lower = 101 * self.num_params * 4
             upper = 201 * self.num_params * 4
-            assert lower < torch.cuda.memory_allocated(0) < upper
+            assert lower < torch.cuda.memory_allocated(0) - initial_memory < upper
             return super().validation_step(batch, batch_idx)
 
     torch.cuda.empty_cache()


### PR DESCRIPTION
## What does this PR do?

This PR unblocks master failing in a flaky test.

I observed the other day that the test

```
tests/trainer/loops/test_evaluation_loop:test_memory_consumption_validation
```

is failing when running together with other tests, but never failing alone. 

When running all tests together and monitoring `nvidia-smi`, we can see that early on after a few tests the GPU memory goes up to 500MB but never drops back down even when running CPU tests. 
This indicates that there is a process hanging and CUDA memory leaking from one test to the next. 

This PR attempts to prevent the above test failing due to too much memory being allocated, by measuring only the residual that the current test is using since the start.

## Findings

These tests leave some memory behind:
```
ERROR tests/trainer/test_trainer.py::test_gradient_clipping_fp16 - ValueError...
ERROR tests/tuner/test_scale_batch_size.py::test_auto_scale_batch_size_trainer_arg[power]
ERROR tests/tuner/test_scale_batch_size.py::test_auto_scale_batch_size_with_amp


ValueError: Test left CUDA memory allocated: 6.0 MB
```

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
