### PR TITLE
Specify packaging version to be more than 17.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ fsspec[http]>=2021.05.0, !=2021.06.0
 tensorboard>=2.2.0, !=2.5.0  # 2.5.0 GPU CI error: 'Couldn't build proto file into descriptor pool!'
 torchmetrics>=0.3.2
 pyDeprecate==0.3.1
-packaging
+packaging>=17.0
 typing-extensions  # TypedDict support for python<3.8


### PR DESCRIPTION
Older version of the `packaging` module cause an error when saving model checkpoint.

The error is in the atomic_save: `if Version(torch.__version__).release[:3] == (1, 6, 0):`

For old version of packaging (e.g., 16.8) the call produce the following errror:

`AttributeError: 'Version' object has no attribute 'release'`

## What does this PR do?

Specify packaging version to be grater or equal to 17.0 in order to avoid bug in the atomic checkpoints save

I tested packing version from 17.0 to 20.9 (latest at the time of writing) and the bug is fixed

## How to reproduce the bug

1. pip install packaging==16.8
2. Run any training that save a checkpoint

or reproducing the call at line: https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pytorch_lightning/utilities/cloud_io.py#L61

1. pip install packaging==16.8
2.  python
3. - import torch; from packaging.version import Version
4. - Version(torch.__version__).release[:3]
