### PR TITLE
[blocked by #8080] assert memory is released after every test

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,7 +93,7 @@ def tmpdir_server(tmpdir):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def assert_cuda_memory_differential():
+def assert_cuda_memory_freed():
     memory_start = torch.cuda.memory_allocated()
     yield
     memory_end = torch.cuda.memory_allocated()

--- a/tests/trainer/loops/test_evaluation_loop.py
+++ b/tests/trainer/loops/test_evaluation_loop.py
@@ -77,6 +77,8 @@ def test_log_epoch_metrics_before_on_evaluation_end(update_eval_epoch_metrics_mo
 def test_memory_consumption_validation(tmpdir):
     """Test that the training batch is no longer in GPU memory when running validation"""
 
+    initial_memory = torch.cuda.memory_allocated(0)
+
     class BoringLargeBatchModel(BoringModel):
 
         @property
@@ -95,14 +97,14 @@ def test_memory_consumption_validation(tmpdir):
             # there is a batch and the boring model, but not two batches on gpu, assume 32 bit = 4 bytes
             lower = 101 * self.num_params * 4
             upper = 201 * self.num_params * 4
-            assert lower < torch.cuda.memory_allocated(0) < upper
+            assert lower < torch.cuda.memory_allocated(0) - initial_memory < upper
             return super().training_step(batch, batch_idx)
 
         def validation_step(self, batch, batch_idx):
             # there is a batch and the boring model, but not two batches on gpu, assume 32 bit = 4 bytes
             lower = 101 * self.num_params * 4
             upper = 201 * self.num_params * 4
-            assert lower < torch.cuda.memory_allocated(0) < upper
+            assert lower < torch.cuda.memory_allocated(0) - initial_memory < upper
             return super().validation_step(batch, batch_idx)
 
     torch.cuda.empty_cache()

--- a/tests/trainer/loops/test_evaluation_loop.py
+++ b/tests/trainer/loops/test_evaluation_loop.py
@@ -77,7 +77,7 @@ def test_log_epoch_metrics_before_on_evaluation_end(update_eval_epoch_metrics_mo
 def test_memory_consumption_validation(tmpdir):
     """Test that the training batch is no longer in GPU memory when running validation"""
 
-    initial_memory = torch.cuda.memory_allocated(0)
+    initial_memory = 0  # torch.cuda.memory_allocated(0)
 
     class BoringLargeBatchModel(BoringModel):
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -987,7 +987,8 @@ def test_gradient_clipping_by_value(tmpdir):
     trainer.fit(model)
 
 
-@RunIf(min_gpus=999, amp_native=True)
+# @RunIf(min_gpus=999, amp_native=True)
+@RunIf(min_gpus=1, amp_native=True)
 def test_gradient_clipping_fp16(tmpdir):
     """
     Test gradient clipping with fp16

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -987,7 +987,7 @@ def test_gradient_clipping_by_value(tmpdir):
     trainer.fit(model)
 
 
-@RunIf(min_gpus=1, amp_native=True)
+@RunIf(min_gpus=999, amp_native=True)
 def test_gradient_clipping_fp16(tmpdir):
     """
     Test gradient clipping with fp16


### PR DESCRIPTION
## What does this PR do?

DRAFT to investigate which tests leave allocated memory behind. 
Follow up to #8029 

blocked by #8080 

These tests leave some memory behind:

```python
ERROR tests/trainer/test_trainer.py::test_gradient_clipping_fp16 - ValueError...
ERROR tests/tuner/test_scale_batch_size.py::test_auto_scale_batch_size_trainer_arg[power]
ERROR tests/tuner/test_scale_batch_size.py::test_auto_scale_batch_size_with_amp


ValueError: Test left CUDA memory allocated: 6.0 MB
```

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
