### PR TITLE
Deprecate moved warning functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Deprecated default value of `monitor` argument in EarlyStopping callback to enforce `monitor` as a required argument ([#7907](https://github.com/PyTorchLightning/pytorch-lightning/pull/7907))
 
 
+- Deprecated importing `rank_zero_{warn,deprecation}` directly from `pytorch_lightning.utilities.distributed` ([#8085](https://github.com/PyTorchLightning/pytorch-lightning/pull/8085))
+
+
 - Deprecated the use of `CheckpointConnector.hpc_load()` in favor of `CheckpointConnector.restore()` ([#7652](https://github.com/PyTorchLightning/pytorch-lightning/pull/7652))
 
 

--- a/pytorch_lightning/utilities/distributed.py
+++ b/pytorch_lightning/utilities/distributed.py
@@ -77,8 +77,8 @@ def rank_zero_warn(*args, stacklevel: int = 5, **kwargs):
 def rank_zero_deprecation(*args, stacklevel: int = 5, **kwargs):
     from pytorch_lightning.utilities.warnings import rank_zero_deprecation
     rank_zero_deprecation(
-        '`pytorch_lightning.utilities.distributed.rank_zero_warn` has been moved to'
-        ' `pytorch_lightning.utilities.rank_zero_warn` in v1.3.8 and will be removed in v1.6'
+        '`pytorch_lightning.utilities.distributed.rank_zero_deprecation` has been moved to'
+        ' `pytorch_lightning.utilities.rank_zero_deprecation` in v1.3.8 and will be removed in v1.6'
     )
     return rank_zero_deprecation(*args, stacklevel=stacklevel, **kwargs)
 

--- a/pytorch_lightning/utilities/distributed.py
+++ b/pytorch_lightning/utilities/distributed.py
@@ -69,7 +69,7 @@ def rank_zero_warn(*args, stacklevel: int = 5, **kwargs):
     from pytorch_lightning.utilities.warnings import rank_zero_deprecation, rank_zero_warn
     rank_zero_deprecation(
         '`pytorch_lightning.utilities.distributed.rank_zero_warn` has been moved to'
-        ' `pytorch_lightning.utilities.rank_zero_warn` in v1.3.8 and will be removed in v1.6'
+        ' `pytorch_lightning.utilities.rank_zero_warn` in v1.3.7 and will be removed in v1.6'
     )
     return rank_zero_warn(*args, stacklevel=stacklevel, **kwargs)
 
@@ -78,7 +78,7 @@ def rank_zero_deprecation(*args, stacklevel: int = 5, **kwargs):
     from pytorch_lightning.utilities.warnings import rank_zero_deprecation
     rank_zero_deprecation(
         '`pytorch_lightning.utilities.distributed.rank_zero_deprecation` has been moved to'
-        ' `pytorch_lightning.utilities.rank_zero_deprecation` in v1.3.8 and will be removed in v1.6'
+        ' `pytorch_lightning.utilities.rank_zero_deprecation` in v1.3.7 and will be removed in v1.6'
     )
     return rank_zero_deprecation(*args, stacklevel=stacklevel, **kwargs)
 

--- a/pytorch_lightning/utilities/distributed.py
+++ b/pytorch_lightning/utilities/distributed.py
@@ -65,6 +65,24 @@ def _get_rank() -> int:
 rank_zero_only.rank = getattr(rank_zero_only, 'rank', _get_rank())
 
 
+def rank_zero_warn(*args, stacklevel: int = 5, **kwargs):
+    from pytorch_lightning.utilities.warnings import rank_zero_deprecation, rank_zero_warn
+    rank_zero_deprecation(
+        '`pytorch_lightning.utilities.distributed.rank_zero_warn` has been moved to'
+        ' `pytorch_lightning.utilities.rank_zero_warn` in v1.3.8 and will be removed in v1.6'
+    )
+    return rank_zero_warn(*args, stacklevel=stacklevel, **kwargs)
+
+
+def rank_zero_deprecation(*args, stacklevel: int = 5, **kwargs):
+    from pytorch_lightning.utilities.warnings import rank_zero_deprecation
+    rank_zero_deprecation(
+        '`pytorch_lightning.utilities.distributed.rank_zero_warn` has been moved to'
+        ' `pytorch_lightning.utilities.rank_zero_warn` in v1.3.8 and will be removed in v1.6'
+    )
+    return rank_zero_deprecation(*args, stacklevel=stacklevel, **kwargs)
+
+
 def _info(*args, stacklevel: int = 2, **kwargs):
     if python_version() >= "3.8.0":
         kwargs['stacklevel'] = stacklevel

--- a/tests/deprecated_api/test_remove_1-6.py
+++ b/tests/deprecated_api/test_remove_1-6.py
@@ -17,6 +17,7 @@ import pytest
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.plugins.training_type import DDPPlugin, DDPSpawnPlugin
+from pytorch_lightning.utilities.distributed import rank_zero_deprecation, rank_zero_warn
 from pytorch_lightning.utilities.model_helpers import is_overridden
 from tests.helpers import BoringDataModule, BoringModel
 
@@ -235,3 +236,10 @@ def test_v1_6_0_train_loop(tmpdir):
         match=r"`Trainer.train_loop` has been renamed to `Trainer.fit_loop` and will be removed in v1.6."
     ):
         _ = trainer.train_loop
+
+
+def test_v1_6_0_rank_zero_warnings_moved():
+    with pytest.deprecated_call(match='in v1.3.8 and will be removed in v1.6'):
+        rank_zero_warn('test')
+    with pytest.deprecated_call(match='in v1.3.8 and will be removed in v1.6'):
+        rank_zero_deprecation('test')

--- a/tests/deprecated_api/test_remove_1-6.py
+++ b/tests/deprecated_api/test_remove_1-6.py
@@ -239,7 +239,7 @@ def test_v1_6_0_train_loop(tmpdir):
 
 
 def test_v1_6_0_rank_zero_warnings_moved():
-    with pytest.deprecated_call(match='in v1.3.8 and will be removed in v1.6'):
+    with pytest.deprecated_call(match='in v1.3.7 and will be removed in v1.6'):
         rank_zero_warn('test')
-    with pytest.deprecated_call(match='in v1.3.8 and will be removed in v1.6'):
+    with pytest.deprecated_call(match='in v1.3.7 and will be removed in v1.6'):
         rank_zero_deprecation('test')


### PR DESCRIPTION
## What does this PR do?

Keep BC for users importing these utility functions from the specific `distributed.py` file

To be included in the 1.3.8 release

Closes #8084

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified