### PR TITLE
Add torchelastic check when sanitizing GPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Add support for calling scripts using the module syntax (`python -m package.script`) ([#8073](https://github.com/PyTorchLightning/pytorch-lightning/pull/8073))
 
 
+- Add torchelastic check when sanitizing GPUs ([#8095](https://github.com/PyTorchLightning/pytorch-lightning/pull/8095))
+
+
 ### Changed
 
 

--- a/pytorch_lightning/utilities/device_parser.py
+++ b/pytorch_lightning/utilities/device_parser.py
@@ -81,8 +81,7 @@ def parse_gpu_ids(gpus: Optional[Union[int, str, List[int]]]) -> Optional[List[i
         raise MisconfigurationException("GPUs requested but none are available.")
 
     if TorchElasticEnvironment.is_using_torchelastic() and len(gpus) != 1 and len(_get_all_available_gpus()) == 1:
-        # omit sanity check on torchelastic
-        # as by default shows one visible GPU per process
+        # omit sanity check on torchelastic as by default shows one visible GPU per process
         return gpus
 
     gpus = _sanitize_gpu_ids(gpus)

--- a/pytorch_lightning/utilities/device_parser.py
+++ b/pytorch_lightning/utilities/device_parser.py
@@ -16,6 +16,7 @@ from typing import Any, List, MutableSequence, Optional, Tuple, Union
 
 import torch
 
+from pytorch_lightning.plugins.environments import TorchElasticEnvironment
 from pytorch_lightning.utilities import _TPU_AVAILABLE, rank_zero_deprecation
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.imports import _compare_version
@@ -78,6 +79,12 @@ def parse_gpu_ids(gpus: Optional[Union[int, str, List[int]]]) -> Optional[List[i
     gpus = _normalize_parse_gpu_input_to_list(gpus)
     if not gpus:
         raise MisconfigurationException("GPUs requested but none are available.")
+
+    if TorchElasticEnvironment.is_using_torchelastic() and len(gpus) != 1 and len(_get_all_available_gpus()) == 1:
+        # omit sanity check on torchelastic
+        # as by default shows one visible GPU per process
+        return gpus
+
     gpus = _sanitize_gpu_ids(gpus)
 
     return gpus

--- a/tests/models/test_gpu.py
+++ b/tests/models/test_gpu.py
@@ -347,7 +347,7 @@ def test_non_blocking():
 @pytest.mark.parametrize("gpus", [[0, 1, 2], 2, '0'])
 def test_torchelastic_gpu_parsing(mocked_device_count, gpus):
     """
-    Ensure when using torchelastic and nproc_per_node is set to the default of 1
+    Ensure when using torchelastic and nproc_per_node is set to the default of 1 per GPU device
     That we omit sanitizing the gpus as only one of the GPUs is visible.
     """
     trainer = Trainer(gpus=gpus)

--- a/tests/models/test_gpu.py
+++ b/tests/models/test_gpu.py
@@ -14,9 +14,9 @@
 import operator
 import os
 from collections import namedtuple
+from unittest import mock
 from unittest.mock import patch
 
-import mock
 import pytest
 import torch
 

--- a/tests/models/test_gpu.py
+++ b/tests/models/test_gpu.py
@@ -23,6 +23,7 @@ import torch
 import tests.helpers.pipelines as tpipes
 import tests.helpers.utils as tutils
 from pytorch_lightning import Trainer
+from pytorch_lightning.plugins.environments import TorchElasticEnvironment
 from pytorch_lightning.utilities import device_parser
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.imports import _compare_version
@@ -221,6 +222,29 @@ def test_parse_gpu_returns_none_when_no_devices_are_available(mocked_device_coun
         device_parser.parse_gpu_ids(gpus)
 
 
+@mock.patch.dict(
+    os.environ, {
+        "CUDA_VISIBLE_DEVICES": "0",
+        "LOCAL_RANK": "1",
+        "GROUP_RANK": "1",
+        "RANK": "3",
+        "WORLD_SIZE": "4",
+        "LOCAL_WORLD_SIZE": "2",
+    }
+)
+@mock.patch('torch.cuda.device_count', return_value=1)
+@pytest.mark.parametrize("gpus", [[0, 1, 2], 2, '0'])
+def test_torchelastic_gpu_parsing(mocked_device_count, gpus):
+    """
+    Ensure when using torchelastic and nproc_per_node is set to the default of 1 per GPU device
+    That we omit sanitizing the gpus as only one of the GPUs is visible.
+    """
+    trainer = Trainer(gpus=gpus)
+    assert isinstance(trainer.accelerator_connector.cluster_environment, TorchElasticEnvironment)
+    assert trainer.accelerator_connector.parallel_device_ids == device_parser.parse_gpu_ids(gpus)
+    assert trainer.gpus == gpus
+
+
 @RunIf(min_gpus=1)
 def test_single_gpu_batch_parse():
     trainer = Trainer(gpus=1)
@@ -331,25 +355,3 @@ def test_non_blocking():
     with patch.object(batch, 'to', wraps=batch.to) as mocked:
         batch = trainer.accelerator.batch_to_device(batch, torch.device('cuda:0'))
         mocked.assert_called_with(torch.device('cuda', 0))
-
-
-@mock.patch.dict(
-    os.environ, {
-        "CUDA_VISIBLE_DEVICES": "0",
-        "LOCAL_RANK": "1",
-        "GROUP_RANK": "1",
-        "RANK": "3",
-        "WORLD_SIZE": "4",
-        "LOCAL_WORLD_SIZE": "2",
-    }
-)
-@mock.patch('torch.cuda.device_count', return_value=1)
-@pytest.mark.parametrize("gpus", [[0, 1, 2], 2, '0'])
-def test_torchelastic_gpu_parsing(mocked_device_count, gpus):
-    """
-    Ensure when using torchelastic and nproc_per_node is set to the default of 1 per GPU device
-    That we omit sanitizing the gpus as only one of the GPUs is visible.
-    """
-    trainer = Trainer(gpus=gpus)
-    assert trainer.accelerator_connector.parallel_device_ids == device_parser.parse_gpu_ids(gpus)
-    assert trainer.gpus == gpus


### PR DESCRIPTION
## What does this PR do?

When using torchelastic, I noticed that `nproc_per_node` is set to one per gpu device (so if there was 8 GPUs, there are 8 processes) that only see the individual GPU. This means each process sees one GPU at GPU ID 0.

This PR skips sanitising the total GPUs when using torchelastic + one visible GPU with multi-gpu setups, assuming torchelastic has created processes.

cc @ananthsub @awaelchli 

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
