### PR TITLE
Hotfix Patch Release v1.3.7post0 [full merge, no squash]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+
 ## [1.3.7] - 2021-06-22
 
 - Fixed a bug where skipping an optimizer while using amp causes amp to trigger an assertion error ([#7975](https://github.com/PyTorchLightning/pytorch-lightning/pull/7975))
@@ -11,6 +12,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed setting a `DistributedSampler` when using a distributed plugin in a custom accelerator ([#7814](https://github.com/PyTorchLightning/pytorch-lightning/pull/7814))
 - Improved `PyTorchProfiler` chrome traces names ([#8009](https://github.com/PyTorchLightning/pytorch-lightning/pull/8009))
 - Fixed moving the best score to device in `EarlyStopping` callback for TPU devices ([#7959](https://github.com/PyTorchLightning/pytorch-lightning/pull/7959))
+- Fixed backward compatibility of moved functions `rank_zero_warn` and `rank_zero_deprecation` ([#8085](https://github.com/PyTorchLightning/pytorch-lightning/pull/8085))
+
 
 ## [1.3.6] - 2021-06-15
 

--- a/pytorch_lightning/__about__.py
+++ b/pytorch_lightning/__about__.py
@@ -1,7 +1,7 @@
 import time
 
 _this_year = time.strftime("%Y")
-__version__ = '1.3.7'
+__version__ = '1.3.7post0'
 __author__ = 'William Falcon et al.'
 __author_email__ = 'waf2107@columbia.edu'
 __license__ = 'Apache-2.0'

--- a/pytorch_lightning/utilities/distributed.py
+++ b/pytorch_lightning/utilities/distributed.py
@@ -65,6 +65,24 @@ def _get_rank() -> int:
 rank_zero_only.rank = getattr(rank_zero_only, 'rank', _get_rank())
 
 
+def rank_zero_warn(*args, stacklevel: int = 5, **kwargs):
+    from pytorch_lightning.utilities.warnings import rank_zero_deprecation, rank_zero_warn
+    rank_zero_deprecation(
+        '`pytorch_lightning.utilities.distributed.rank_zero_warn` has been moved to'
+        ' `pytorch_lightning.utilities.rank_zero_warn` in v1.3.7 and will be removed in v1.6'
+    )
+    return rank_zero_warn(*args, stacklevel=stacklevel, **kwargs)
+
+
+def rank_zero_deprecation(*args, stacklevel: int = 5, **kwargs):
+    from pytorch_lightning.utilities.warnings import rank_zero_deprecation
+    rank_zero_deprecation(
+        '`pytorch_lightning.utilities.distributed.rank_zero_deprecation` has been moved to'
+        ' `pytorch_lightning.utilities.rank_zero_deprecation` in v1.3.7 and will be removed in v1.6'
+    )
+    return rank_zero_deprecation(*args, stacklevel=stacklevel, **kwargs)
+
+
 def _info(*args, stacklevel: int = 2, **kwargs):
     if python_version() >= "3.8.0":
         kwargs['stacklevel'] = stacklevel


### PR DESCRIPTION
## What does this PR do?

`rank_zero_warn` and `rank_zero_deprecation` got moved out of `utilities.distributed`, but this broke back compatibility. 
PR #8085 fixes this and now we will include it in the bug release branch to unblock flash users.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃
