### PR TITLE
resurface lost ddp info message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,6 +308,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Pass the `stage` argument of `Callback.{setup,teardown}` as a keyword ([#7973](https://github.com/PyTorchLightning/pytorch-lightning/pull/7973))
 
 
+- Fixed a DDP info message that was never shown ([#8111](https://github.com/PyTorchLightning/pytorch-lightning/pull/8111))
+
 
 ## [1.3.7] - 2021-06-22
 

--- a/pytorch_lightning/plugins/training_type/ddp.py
+++ b/pytorch_lightning/plugins/training_type/ddp.py
@@ -37,7 +37,7 @@ from pytorch_lightning.utilities import (
     rank_zero_deprecation,
     rank_zero_warn,
 )
-from pytorch_lightning.utilities.distributed import rank_zero_only, ReduceOp, sync_ddp_if_available
+from pytorch_lightning.utilities.distributed import rank_zero_only, ReduceOp, sync_ddp_if_available, rank_zero_info
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.seed import reset_seed
 
@@ -233,13 +233,6 @@ class DDPPlugin(ParallelPlugin):
         # where to store ip_table
         self.init_ddp_connection()
 
-        # on world_size=0 let everyone know training is starting
-        if self.is_global_zero and not torch.distributed.is_initialized():
-            log.info("-" * 100)
-            log.info(f"distributed_backend={self.distributed_backend}")
-            log.info(f"All DDP processes registered. Starting ddp with {self.world_size} processes")
-            log.info("-" * 100)
-
         # set the ranks and devices
         self.dist.rank = self.global_rank
         self.dist.device = self.root_device
@@ -307,6 +300,12 @@ class DDPPlugin(ParallelPlugin):
         if not torch.distributed.is_initialized():
             log.info(f"initializing ddp: GLOBAL_RANK: {global_rank}, MEMBER: {global_rank + 1}/{world_size}")
             torch_distrib.init_process_group(self.torch_distributed_backend, rank=global_rank, world_size=world_size)
+
+            # on rank=0 let everyone know training is starting
+            rank_zero_info("-" * 100)
+            rank_zero_info(f"distributed_backend={self.distributed_backend}")
+            rank_zero_info(f"All DDP processes registered. Starting ddp with {self.world_size} processes")
+            rank_zero_info("-" * 100)
 
     def pre_dispatch(self):
         # move the model to the correct device

--- a/pytorch_lightning/plugins/training_type/ddp.py
+++ b/pytorch_lightning/plugins/training_type/ddp.py
@@ -302,10 +302,10 @@ class DDPPlugin(ParallelPlugin):
             torch_distrib.init_process_group(self.torch_distributed_backend, rank=global_rank, world_size=world_size)
 
             # on rank=0 let everyone know training is starting
-            rank_zero_info("-" * 100)
-            rank_zero_info(f"distributed_backend={self.distributed_backend}")
-            rank_zero_info(f"All DDP processes registered. Starting ddp with {self.world_size} processes")
-            rank_zero_info("-" * 100)
+            rank_zero_info(("-" * 100,
+            f"distributed_backend={self.distributed_backend}", 
+            f"All DDP processes registered. Starting ddp with {self.world_size} processes",
+            "-" * 100))
 
     def pre_dispatch(self):
         # move the model to the correct device

--- a/pytorch_lightning/plugins/training_type/ddp.py
+++ b/pytorch_lightning/plugins/training_type/ddp.py
@@ -304,7 +304,7 @@ class DDPPlugin(ParallelPlugin):
             # on rank=0 let everyone know training is starting
             rank_zero_info((
                 "-" * 100, f"distributed_backend={self.distributed_backend}",
-                f"All DDP processes registered. Starting ddp with {self.world_size} processes", "-" * 100
+                f"All DDP processes registered. Starting ddp with {self.world_size} processes", "-" * 100,
             ))
 
     def pre_dispatch(self):

--- a/pytorch_lightning/plugins/training_type/ddp.py
+++ b/pytorch_lightning/plugins/training_type/ddp.py
@@ -302,12 +302,12 @@ class DDPPlugin(ParallelPlugin):
             torch_distrib.init_process_group(self.torch_distributed_backend, rank=global_rank, world_size=world_size)
 
             # on rank=0 let everyone know training is starting
-            rank_zero_info((
-                "-" * 100,
-                f"distributed_backend={self.distributed_backend}",
-                f"All DDP processes registered. Starting ddp with {self.world_size} processes",
-                "-" * 100,
-            ))
+            rank_zero_info(
+                f"{'-' * 100}\n"
+                f"distributed_backend={self.torch_distributed_backend}\n"
+                f"All DDP processes registered. Starting ddp with {self.world_size} processes\n"
+                f"{'-' * 100}\n"
+            )
 
     def pre_dispatch(self):
         # move the model to the correct device

--- a/pytorch_lightning/plugins/training_type/ddp.py
+++ b/pytorch_lightning/plugins/training_type/ddp.py
@@ -302,10 +302,10 @@ class DDPPlugin(ParallelPlugin):
             torch_distrib.init_process_group(self.torch_distributed_backend, rank=global_rank, world_size=world_size)
 
             # on rank=0 let everyone know training is starting
-            rank_zero_info(("-" * 100,
-            f"distributed_backend={self.distributed_backend}", 
-            f"All DDP processes registered. Starting ddp with {self.world_size} processes",
-            "-" * 100))
+            rank_zero_info((
+                "-" * 100, f"distributed_backend={self.distributed_backend}",
+                f"All DDP processes registered. Starting ddp with {self.world_size} processes", "-" * 100
+            ))
 
     def pre_dispatch(self):
         # move the model to the correct device

--- a/pytorch_lightning/plugins/training_type/ddp.py
+++ b/pytorch_lightning/plugins/training_type/ddp.py
@@ -303,8 +303,10 @@ class DDPPlugin(ParallelPlugin):
 
             # on rank=0 let everyone know training is starting
             rank_zero_info((
-                "-" * 100, f"distributed_backend={self.distributed_backend}",
-                f"All DDP processes registered. Starting ddp with {self.world_size} processes", "-" * 100,
+                "-" * 100,
+                f"distributed_backend={self.distributed_backend}",
+                f"All DDP processes registered. Starting ddp with {self.world_size} processes",
+                "-" * 100,
             ))
 
     def pre_dispatch(self):

--- a/pytorch_lightning/plugins/training_type/ddp_spawn.py
+++ b/pytorch_lightning/plugins/training_type/ddp_spawn.py
@@ -261,9 +261,9 @@ class DDPSpawnPlugin(ParallelPlugin):
             torch_distrib.init_process_group(self.torch_distributed_backend, rank=global_rank, world_size=world_size)
 
             # on rank=0 let everyone know training is starting
-            rank_zero_info("-" * 100, 
-            f"distributed_backend={self.distributed_backend}", 
-            f"All DDP processes registered. Starting ddp with {self.world_size} processes", 
+            rank_zero_info("-" * 100,
+            f"distributed_backend={self.distributed_backend}",
+            f"All DDP processes registered. Starting ddp with {self.world_size} processes",
             "-" * 100,))
 
     def determine_ddp_device_ids(self):

--- a/pytorch_lightning/plugins/training_type/ddp_spawn.py
+++ b/pytorch_lightning/plugins/training_type/ddp_spawn.py
@@ -261,12 +261,12 @@ class DDPSpawnPlugin(ParallelPlugin):
             torch_distrib.init_process_group(self.torch_distributed_backend, rank=global_rank, world_size=world_size)
 
             # on rank=0 let everyone know training is starting
-            rank_zero_info((
-                "-" * 100,
-                f"distributed_backend={self.distributed_backend}",
-                f"All DDP processes registered. Starting ddp with {self.world_size} processes",
-                "-" * 100,
-            ))
+            rank_zero_info(
+                f"{'-' * 100}\n"
+                f"distributed_backend={self.torch_distributed_backend}\n"
+                f"All DDP processes registered. Starting ddp with {self.world_size} processes\n"
+                f"{'-' * 100}\n"
+            )
 
     def determine_ddp_device_ids(self):
         if self.root_device.type == "cpu":

--- a/pytorch_lightning/plugins/training_type/ddp_spawn.py
+++ b/pytorch_lightning/plugins/training_type/ddp_spawn.py
@@ -261,10 +261,10 @@ class DDPSpawnPlugin(ParallelPlugin):
             torch_distrib.init_process_group(self.torch_distributed_backend, rank=global_rank, world_size=world_size)
 
             # on rank=0 let everyone know training is starting
-            rank_zero_info("-" * 100)
-            rank_zero_info(f"distributed_backend={self.distributed_backend}")
-            rank_zero_info(f"All DDP processes registered. Starting ddp with {self.world_size} processes")
-            rank_zero_info("-" * 100)
+            rank_zero_info("-" * 100, 
+            f"distributed_backend={self.distributed_backend}", 
+            f"All DDP processes registered. Starting ddp with {self.world_size} processes", 
+            "-" * 100,))
 
     def determine_ddp_device_ids(self):
         if self.root_device.type == "cpu":

--- a/pytorch_lightning/plugins/training_type/ddp_spawn.py
+++ b/pytorch_lightning/plugins/training_type/ddp_spawn.py
@@ -261,10 +261,12 @@ class DDPSpawnPlugin(ParallelPlugin):
             torch_distrib.init_process_group(self.torch_distributed_backend, rank=global_rank, world_size=world_size)
 
             # on rank=0 let everyone know training is starting
-            rank_zero_info("-" * 100,
-            f"distributed_backend={self.distributed_backend}",
-            f"All DDP processes registered. Starting ddp with {self.world_size} processes",
-            "-" * 100,))
+            rank_zero_info((
+                "-" * 100,
+                f"distributed_backend={self.distributed_backend}",
+                f"All DDP processes registered. Starting ddp with {self.world_size} processes",
+                "-" * 100,
+            ))
 
     def determine_ddp_device_ids(self):
         if self.root_device.type == "cpu":


### PR DESCRIPTION
## What does this PR do?

The following message disappeared from Lightning:

```
----------------------------------------------------------------------------------------------------
distributed_backend=ddp
All DDP processes registered. Starting ddp with 2 processes
----------------------------------------------------------------------------------------------------
```

The condition for printing it was mistakenly `if not torch.distributed.is_initialized`, which would never be true since right before that we initialized the backend. 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃
