### PR TITLE
Make Plugins Proxies after transfering ownership

### DIFF
--- a/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -118,9 +118,9 @@ class AcceleratorConnector(object):
         self.amp_level = amp_level
         self.is_slurm_managing_tasks = False
 
-        self._precision_plugin: Union[None, PrecisionPlugin, ProxyType[PrecisionPlugin]] = None
-        self._training_type_plugin: Union[None, TrainingTypePlugin, ProxyType[TrainingTypePlugin]] = None
-        self._cluster_environment: Union[None, ClusterEnvironment, ProxyType[ClusterEnvironment]] = None
+        self._precision_plugin: Union[None, PrecisionPlugin, ProxyType] = None
+        self._training_type_plugin: Union[None, TrainingTypePlugin, ProxyType] = None
+        self._cluster_environment: Union[None, ClusterEnvironment, ProxyType] = None
 
         plugins = plugins if plugins is not None else []
 
@@ -226,13 +226,13 @@ class AcceleratorConnector(object):
         self._cluster_environment = cluster_environment or self.select_cluster_environment()
 
     @property
-    def precision_plugin(self) -> Union[PrecisionPlugin, ProxyType[PrecisionPlugin]]:
+    def precision_plugin(self) -> Union[PrecisionPlugin, ProxyType]:
         if self._precision_plugin is None:
             self._precision_plugin = self.select_precision_plugin()
         return self._precision_plugin
 
     @property
-    def training_type_plugin(self) -> Union[TrainingTypePlugin, ProxyType[TrainingTypePlugin]]:
+    def training_type_plugin(self) -> Union[TrainingTypePlugin, ProxyType]:
         if self._training_type_plugin_resolved:
             # avoid calling `resolve_training_type_plugin` multiple times
             return self._training_type_plugin
@@ -244,7 +244,7 @@ class AcceleratorConnector(object):
         return self._training_type_plugin
 
     @property
-    def cluster_environment(self) -> Union[ClusterEnvironment, ProxyType[ClusterEnvironment]]:
+    def cluster_environment(self) -> Union[ClusterEnvironment, ProxyType]:
         if self._cluster_environment is None:
             self._cluster_environment = self.select_cluster_environment()
         return self._cluster_environment

--- a/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -499,6 +499,7 @@ class AcceleratorConnector(object):
                 training_type.num_processes = len(self.parallel_devices)
 
         if hasattr(training_type, 'cluster_environment') and getattr(training_type, 'cluster_environment') is None:
+            # transfer ownership of the cluster environment to the training type
             training_type.cluster_environment = self.cluster_environment
             self._cluster_environment = proxy(self.cluster_environment)
 
@@ -537,6 +538,7 @@ class AcceleratorConnector(object):
             training_type_plugin=self.training_type_plugin,
             precision_plugin=self.precision_plugin,
         )
+        # transfer ownership of the plugins to the accelerator
         self._training_type_plugin = proxy(self.training_type_plugin)
         self._precision_plugin = proxy(self.precision_plugin)
 

--- a/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -118,9 +118,9 @@ class AcceleratorConnector(object):
         self.amp_level = amp_level
         self.is_slurm_managing_tasks = False
 
-        self._precision_plugin: Optional[Union[PrecisionPlugin, ProxyType[PrecisionPlugin]] = None
-        self._training_type_plugin: Optional[TrainingTypePlugin, ProxyType[TrainingTypePlugin]] = None
-        self._cluster_environment: Optional[ClusterEnvironment, ProxyType[ClusterEnvironment]] = None
+        self._precision_plugin: Union[None, PrecisionPlugin, ProxyType[PrecisionPlugin]] = None
+        self._training_type_plugin: Union[None, TrainingTypePlugin, ProxyType[TrainingTypePlugin]] = None
+        self._cluster_environment: Union[None, ClusterEnvironment, ProxyType[ClusterEnvironment]] = None
 
         plugins = plugins if plugins is not None else []
 

--- a/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -539,7 +539,7 @@ class AcceleratorConnector(object):
         )
         self._training_type_plugin = proxy(self.training_type_plugin)
         self._precision_plugin = proxy(self.precision_plugin)
-        
+
         return accelerator
 
     def select_cluster_environment(self) -> ClusterEnvironment:

--- a/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -15,7 +15,7 @@
 import logging
 import os
 from typing import List, Optional, Sequence, Union
-from weakref import proxy, ProxyType
+from weakref import proxy
 
 import torch
 
@@ -118,9 +118,9 @@ class AcceleratorConnector(object):
         self.amp_level = amp_level
         self.is_slurm_managing_tasks = False
 
-        self._precision_plugin: Union[None, PrecisionPlugin, ProxyType] = None
-        self._training_type_plugin: Union[None, TrainingTypePlugin, ProxyType] = None
-        self._cluster_environment: Union[None, ClusterEnvironment, ProxyType] = None
+        self._precision_plugin: Optional[PrecisionPlugin] = None
+        self._training_type_plugin: Optional[TrainingTypePlugin] = None
+        self._cluster_environment: Optional[ClusterEnvironment] = None
 
         plugins = plugins if plugins is not None else []
 
@@ -226,13 +226,13 @@ class AcceleratorConnector(object):
         self._cluster_environment = cluster_environment or self.select_cluster_environment()
 
     @property
-    def precision_plugin(self) -> Union[PrecisionPlugin, ProxyType]:
+    def precision_plugin(self) -> PrecisionPlugin:
         if self._precision_plugin is None:
             self._precision_plugin = self.select_precision_plugin()
         return self._precision_plugin
 
     @property
-    def training_type_plugin(self) -> Union[TrainingTypePlugin, ProxyType]:
+    def training_type_plugin(self) -> TrainingTypePlugin:
         if self._training_type_plugin_resolved:
             # avoid calling `resolve_training_type_plugin` multiple times
             return self._training_type_plugin
@@ -244,7 +244,7 @@ class AcceleratorConnector(object):
         return self._training_type_plugin
 
     @property
-    def cluster_environment(self) -> Union[ClusterEnvironment, ProxyType]:
+    def cluster_environment(self) -> ClusterEnvironment:
         if self._cluster_environment is None:
             self._cluster_environment = self.select_cluster_environment()
         return self._cluster_environment

--- a/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -539,6 +539,8 @@ class AcceleratorConnector(object):
         )
         self._training_type_plugin = proxy(self.training_type_plugin)
         self._precision_plugin = proxy(self.precision_plugin)
+        
+        return accelerator
 
     def select_cluster_environment(self) -> ClusterEnvironment:
         if self._cluster_environment is not None:


### PR DESCRIPTION
## What does this PR do?

Based on @carmocca s finding, this PR makes the plugins a proxy in the accelerator connector after moving the ownership to the accelerator.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [n/a] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
