### PR TITLE
Improvements and changes to progress tracking dataclasses

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,7 +36,6 @@
 
 # Specifics
 /pytorch_lightning/trainer/connectors/logger_connector @tchaton @carmocca
-/pytorch_lightning/trainer/progress.py  @tchaton @awaelchli @carmocca
 
 # Metrics
 /pytorch_lightning/metrics/             @SkafteNicki @ananyahjha93 @justusschock

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,6 +36,7 @@
 
 # Specifics
 /pytorch_lightning/trainer/connectors/logger_connector @tchaton @carmocca
+/pytorch_lightning/trainer/progress.py  @tchaton @awaelchli @carmocca
 
 # Metrics
 /pytorch_lightning/metrics/             @SkafteNicki @ananyahjha93 @justusschock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added support for checkpointing based on a provided time interval during training ([#7515](https://github.com/PyTorchLightning/pytorch-lightning/pull/7515))
 
 
-- Added dataclasses for progress tracking (
-    [#6603](https://github.com/PyTorchLightning/pytorch-lightning/pull/6603),
-    [#7574](https://github.com/PyTorchLightning/pytorch-lightning/pull/7574))
+- Progress tracking
+  * Added dataclasses for progress tracking ([#6603](https://github.com/PyTorchLightning/pytorch-lightning/pull/6603), [#7574](https://github.com/PyTorchLightning/pytorch-lightning/pull/7574))
 
 
 - Added support for passing a `LightningDataModule` positionally as the second argument to `trainer.{validate,test,predict}` ([#7431](https://github.com/PyTorchLightning/pytorch-lightning/pull/7431))
@@ -85,10 +84,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fault-tolerant training
     * Add `{,load_}state_dict` to `ResultCollection` ([#7948](https://github.com/PyTorchLightning/pytorch-lightning/pull/7948))
-    * Checkpoint the loop results ([#7966](https://github.com/PyTorchLightning/pytorch-lightning/pull/7966))
 
 
 - Add `rank_zero_only` to `LightningModule.log` function ([#7966](https://github.com/PyTorchLightning/pytorch-lightning/pull/7966))
+
+
+- Add `metric_attribute` to `LightningModule.log` function ([#7966](https://github.com/PyTorchLightning/pytorch-lightning/pull/7966))
 
 
 - Added a warning if `Trainer(log_every_n_steps)` is a value too high for the training dataloader ([#7734](https://github.com/PyTorchLightning/pytorch-lightning/pull/7734))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 - Progress tracking
-  * Added dataclasses for progress tracking ([#6603](https://github.com/PyTorchLightning/pytorch-lightning/pull/6603), [#7574](https://github.com/PyTorchLightning/pytorch-lightning/pull/7574))
+  * Added dataclasses for progress tracking ([#6603](https://github.com/PyTorchLightning/pytorch-lightning/pull/6603), [#7574](https://github.com/PyTorchLightning/pytorch-lightning/pull/7574), [#8140](https://github.com/PyTorchLightning/pytorch-lightning/pull/8140))
+  * Add `{,load_}state_dict` to the progress tracking dataclasses ([#8140](https://github.com/PyTorchLightning/pytorch-lightning/pull/8140))
 
 
 - Added support for passing a `LightningDataModule` positionally as the second argument to `trainer.{validate,test,predict}` ([#7431](https://github.com/PyTorchLightning/pytorch-lightning/pull/7431))

--- a/pytorch_lightning/trainer/progress.py
+++ b/pytorch_lightning/trainer/progress.py
@@ -11,12 +11,31 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Optional
 
 
 @dataclass
-class Tracker:
+class _DataclassStateDictMixin:
+
+    def __getstate__(self) -> dict:
+        return asdict(self)
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+
+    def state_dict(self) -> dict:
+        return self.__getstate__()
+
+    @classmethod
+    def load_state_dict(cls, state_dict: dict) -> "_DataclassStateDictMixin":
+        obj = cls()
+        obj.__setstate__(state_dict)
+        return obj
+
+
+@dataclass
+class Tracker(_DataclassStateDictMixin):
     """
     Track an event's progress.
 
@@ -28,6 +47,7 @@ class Tracker:
 
     Attributes set to ``None`` are treated as unused and are restricted.
     """
+
     ready: Optional[int] = 0
     started: Optional[int] = 0
     processed: Optional[int] = 0
@@ -55,7 +75,7 @@ class Tracker:
 
 
 @dataclass
-class Progress:
+class Progress(_DataclassStateDictMixin):
     """
     Track aggregated and current progress.
 
@@ -63,6 +83,7 @@ class Progress:
         total: Intended to track the total progress of an event
         current: Intended to track the current progress of an event
     """
+
     total: Tracker = field(default_factory=Tracker)
     current: Tracker = field(default_factory=Tracker)
 
@@ -91,35 +112,70 @@ class Progress:
         self.current.completed += 1
 
     @classmethod
-    def from_defaults(cls, **kwargs: Optional[int]) -> 'Progress':
+    def from_defaults(cls, **kwargs: Optional[int]) -> "Progress":
         return cls(total=Tracker(**kwargs), current=Tracker(**kwargs))
+
+    def __setstate__(self, state: dict) -> None:
+        self.total.__setstate__(state["total"])
+        self.current.__setstate__(state["current"])
+
+
+class BatchProgress(Progress):
+    """
+    Tracks the batch progress
+
+    Args:
+        total: Tracks the total epoch progress
+        current: Tracks the current epoch progress
+    """
 
 
 @dataclass
-class LoopProgress:
+class EpochProgress(Progress):
     """
-    Track loop progress during execution.
-
+    Tracks the epoch progress
     These counters are local to a trainer rank. By default, they are not globally synced across all ranks.
 
     Args:
-        epoch: Tracks epochs progress.
+        total: Tracks the total epoch progress
+        current: Tracks the current epoch progress
         batch: Tracks batch progress.
     """
-    epoch: Progress = field(default_factory=Progress)
-    batch: Progress = field(default_factory=Progress)
 
-    def increment_epoch_completed(self) -> None:
-        self.epoch.increment_completed()
-        self.reset_on_epoch()
+    batch: BatchProgress = field(default_factory=BatchProgress)
 
     def reset_on_epoch(self) -> None:
         self.batch.current.reset()
-        self.epoch.current.reset()
+
+    def __setstate__(self, state: dict) -> None:
+        super().__setstate__(state)
+        self.batch.__setstate__(state["batch"])
 
 
 @dataclass
-class OptimizationProgress:
+class OptimizerProgress(_DataclassStateDictMixin):
+    """
+    Track optimizer progress.
+
+    Args:
+        step: Tracks ``optimizer.step`` calls.
+        zero_grad: Tracks ``optimizer.zero_grad`` calls.
+    """
+
+    step: Progress = field(default_factory=lambda: Progress.from_defaults(processed=None))
+    zero_grad: Progress = field(default_factory=lambda: Progress.from_defaults(processed=None))
+
+    def reset_on_epoch(self) -> None:
+        self.step.current.reset()
+        self.zero_grad.current.reset()
+
+    def __setstate__(self, state: dict) -> None:
+        self.step.__setstate__(state["step"])
+        self.zero_grad.__setstate__(state["zero_grad"])
+
+
+@dataclass
+class OptimizationProgress(_DataclassStateDictMixin):
     """
     Track optimization progress.
 
@@ -127,54 +183,86 @@ class OptimizationProgress:
         optimizer: Tracks optimizer progress.
         scheduler: Tracks scheduler progress.
     """
-    optimizer: Progress = Progress.from_defaults(processed=None)
-    scheduler: Progress = Progress.from_defaults(started=None, processed=None)
-    zero_grad: Progress = Progress.from_defaults(processed=None)
+
+    # TODO: support for multiple optimizers
+    optimizer: OptimizerProgress = field(default_factory=OptimizerProgress)
+    scheduler: Progress = field(default_factory=lambda: Progress.from_defaults(started=None, processed=None))
 
     @property
     def optimizer_steps(self) -> int:
-        return self.optimizer.total.completed
+        return self.optimizer.step.total.completed
 
     @property
     def scheduler_steps(self) -> int:
         return self.scheduler.total.completed
 
+    def reset_on_epoch(self) -> None:
+        self.optimizer.reset_on_epoch()
+        self.scheduler.current.reset()
+
+    def __setstate__(self, state: dict) -> None:
+        self.optimizer.__setstate__(state["optimizer"])
+        self.scheduler.__setstate__(state["scheduler"])
+
 
 @dataclass
-class TrainingProgress(Progress):
+class EpochLoopProgress(_DataclassStateDictMixin):
     """
-    Extends ``Progress`` with training specific attributes
+    Tracks epoch loop progress.
+    These counters are local to a trainer rank. By default, they are not globally synced across all ranks.
 
     Args:
-        optimization: Tracks optimization progress
+        epoch: Tracks epochs progress.
     """
-    optimization: OptimizationProgress = field(default_factory=OptimizationProgress)
 
+    epoch: EpochProgress = field(default_factory=EpochProgress)
 
-@dataclass
-class TrainingLoopProgress(LoopProgress):
-    epoch: TrainingProgress = field(default_factory=TrainingProgress)
+    def increment_epoch_completed(self) -> None:
+        self.epoch.increment_completed()
+        self.reset_on_epoch()
 
     def reset_on_epoch(self) -> None:
-        # override to avoid resetting `epoch.current`
-        self.batch.current.reset()
+        self.epoch.reset_on_epoch()
+        self.epoch.current.reset()
+
+    def __setstate__(self, state: dict) -> None:
+        self.epoch.__setstate__(state["epoch"])
 
 
 @dataclass
-class FitLoopProgress:
-    train: TrainingLoopProgress = field(default_factory=TrainingLoopProgress)
-    val: LoopProgress = field(default_factory=LoopProgress)
+class TrainingEpochProgress(EpochProgress):
+    """
+    Extends ``EpochProgress`` with training specific attributes
+
+    Args:
+        total: Tracks the total epoch progress.
+        current: Tracks the current epoch progress.
+        batch: Tracks batch progress.
+        optim: Tracks optimization progress.
+        val: Tracks validation_loop progress.
+    """
+
+    optim: OptimizationProgress = field(default_factory=OptimizationProgress)
+    val: EpochLoopProgress = field(default_factory=EpochLoopProgress)
+
+    def __setstate__(self, state: dict) -> None:
+        super().__setstate__(state)
+        self.optim.__setstate__(state["optim"])
+        self.val.__setstate__(state["val"])
 
 
 @dataclass
-class LoopState:
+class FitLoopProgress(EpochLoopProgress):
     """
-    Basic dataclass to track loop progress across trainer functions during trainer execution.
+    Extends ``EpochLoopProgress`` with fit specific attributes
 
-    This class will be removed and these attributes will live in each loop.
+    Args:
+        epoch: Tracks epochs progress.
     """
 
-    fit: FitLoopProgress = field(default_factory=FitLoopProgress)
-    val: LoopProgress = field(default_factory=LoopProgress)
-    test: LoopProgress = field(default_factory=LoopProgress)
-    predict: LoopProgress = field(default_factory=LoopProgress)
+    epoch: TrainingEpochProgress = field(default_factory=TrainingEpochProgress)
+
+    def reset_on_epoch(self) -> None:
+        # do not reset `epoch.current` as it should track the number of epochs this `fit` call
+        self.epoch.reset_on_epoch()
+        self.epoch.optim.reset_on_epoch()

--- a/pytorch_lightning/trainer/progress.py
+++ b/pytorch_lightning/trainer/progress.py
@@ -28,7 +28,7 @@ class _DataclassStateDictMixin:
         return self.__getstate__()
 
     @classmethod
-    def load_state_dict(cls, state_dict: dict) -> "_DataclassStateDictMixin":
+    def from_state_dict(cls, state_dict: dict) -> "_DataclassStateDictMixin":
         obj = cls()
         obj.__setstate__(state_dict)
         return obj

--- a/tests/trainer/test_progress.py
+++ b/tests/trainer/test_progress.py
@@ -191,7 +191,7 @@ def test_fit_loop_progress_serialization():
         }
     }
     # yapf: enable
-    new_loop = FitLoopProgress.load_state_dict(state_dict)
+    new_loop = FitLoopProgress.from_state_dict(state_dict)
     assert fit_loop == new_loop
 
 
@@ -214,5 +214,5 @@ def test_epoch_loop_progress_serialization():
         }
     }
     # yapf: enable
-    new_loop = EpochLoopProgress.load_state_dict(state_dict)
+    new_loop = EpochLoopProgress.from_state_dict(state_dict)
     assert loop == new_loop

--- a/tests/trainer/test_progress.py
+++ b/tests/trainer/test_progress.py
@@ -13,7 +13,15 @@
 # limitations under the License.
 import pytest
 
-from pytorch_lightning.trainer.progress import LoopProgress, Progress, Tracker
+from pytorch_lightning.trainer.progress import (
+    BatchProgress,
+    EpochLoopProgress,
+    EpochProgress,
+    FitLoopProgress,
+    OptimizerProgress,
+    Progress,
+    Tracker,
+)
 
 
 def test_progress_geattr_setattr():
@@ -60,51 +68,151 @@ def test_base_progress_from_defaults():
     assert actual == expected
 
 
-def test_loop_progress_increment_epoch():
-    p = LoopProgress()
+def test_epoch_loop_progress_increment_epoch():
+    p = EpochLoopProgress()
     p.increment_epoch_completed()
     p.increment_epoch_completed()
     assert p.epoch.total == Tracker(completed=2)
     assert p.epoch.current == Tracker()
-    assert p.batch.current == Tracker()
+    assert p.epoch.batch.current == Tracker()
 
 
-def test_loop_progress_increment_sequence():
-    """ Test sequences for incrementing batches reads and epochs. """
-    p = LoopProgress(batch=Progress(total=Tracker(started=None)))
+def test_epoch_loop_progress_increment_sequence():
+    """Test sequences for incrementing batches reads and epochs."""
+    batch = BatchProgress(total=Tracker(started=None))
+    epoch = EpochProgress(batch=batch)
+    loop = EpochLoopProgress(epoch=epoch)
 
-    p.batch.increment_ready()
-    assert p.batch.total == Tracker(ready=1, started=None)
-    assert p.batch.current == Tracker(ready=1)
+    batch.increment_ready()
+    assert batch.total == Tracker(ready=1, started=None)
+    assert batch.current == Tracker(ready=1)
 
-    p.batch.increment_started()
-    assert p.batch.total == Tracker(ready=1, started=None)
-    assert p.batch.current == Tracker(ready=1)
+    batch.increment_started()
+    assert batch.total == Tracker(ready=1, started=None)
+    assert batch.current == Tracker(ready=1)
 
-    p.batch.increment_processed()
-    assert p.batch.total == Tracker(ready=1, started=None, processed=1)
-    assert p.batch.current == Tracker(ready=1, processed=1)
+    batch.increment_processed()
+    assert batch.total == Tracker(ready=1, started=None, processed=1)
+    assert batch.current == Tracker(ready=1, processed=1)
 
-    p.batch.increment_completed()
-    assert p.batch.total == Tracker(ready=1, started=None, processed=1, completed=1)
-    assert p.batch.current == Tracker(ready=1, processed=1, completed=1)
+    batch.increment_completed()
+    assert batch.total == Tracker(ready=1, started=None, processed=1, completed=1)
+    assert batch.current == Tracker(ready=1, processed=1, completed=1)
 
-    assert p.epoch.total == Tracker()
-    assert p.epoch.current == Tracker()
-    p.increment_epoch_completed()
-    assert p.batch.total == Tracker(ready=1, started=None, processed=1, completed=1)
-    assert p.batch.current == Tracker()
-    assert p.epoch.total == Tracker(completed=1)
-    assert p.epoch.current == Tracker()
+    assert epoch.total == Tracker()
+    assert epoch.current == Tracker()
+    loop.increment_epoch_completed()
+    assert batch.total == Tracker(ready=1, started=None, processed=1, completed=1)
+    assert batch.current == Tracker()
+    assert epoch.total == Tracker(completed=1)
+    assert epoch.current == Tracker()
 
-    p.batch.increment_ready()
-    assert p.batch.total == Tracker(ready=2, started=None, processed=1, completed=1)
-    assert p.batch.current == Tracker(ready=1)
-    assert p.epoch.total == Tracker(completed=1)
-    assert p.epoch.current == Tracker()
+    batch.increment_ready()
+    assert batch.total == Tracker(ready=2, started=None, processed=1, completed=1)
+    assert batch.current == Tracker(ready=1)
+    assert epoch.total == Tracker(completed=1)
+    assert epoch.current == Tracker()
 
-    p.reset_on_epoch()
-    assert p.batch.total == Tracker(ready=2, started=None, processed=1, completed=1)
-    assert p.batch.current == Tracker()
-    assert p.epoch.total == Tracker(completed=1)
-    assert p.epoch.current == Tracker()
+    loop.reset_on_epoch()
+    assert batch.total == Tracker(ready=2, started=None, processed=1, completed=1)
+    assert batch.current == Tracker()
+    assert epoch.total == Tracker(completed=1)
+    assert epoch.current == Tracker()
+
+
+def test_optimizer_progress_default_factory():
+    """
+    Ensure that the defaults are created appropiately. If `default_factory` was not used, the default would
+    be shared between instances.
+    """
+    p1 = OptimizerProgress()
+    p2 = OptimizerProgress()
+    p1.step.increment_completed()
+    assert p1.step.total.completed == p1.step.current.completed
+    assert p1.step.total.completed == 1
+    assert p2.step.total.completed == 0
+
+
+def test_fit_loop_progress_serialization():
+    fit_loop = FitLoopProgress()
+    state_dict = fit_loop.state_dict()
+    # yapf: disable
+    assert state_dict == {
+        'epoch': {
+            # number of epochs across `fit` calls
+            'total': {'completed': 0, 'processed': 0, 'ready': 0, 'started': 0},
+            # number of epochs this `fit` call
+            'current': {'completed': 0, 'processed': 0, 'ready': 0, 'started': 0},
+            'batch': {
+                # number of batches across `fit` calls
+                'total': {'completed': 0, 'processed': 0, 'ready': 0, 'started': 0},
+                # number of batches this epoch
+                'current': {'completed': 0, 'processed': 0, 'ready': 0, 'started': 0},
+            },
+            # `fit` optimization progress
+            'optim': {
+                # optimizers progress
+                'optimizer': {
+                    'step': {
+                        # `optimizer.step` calls across `fit` calls
+                        'total': {'completed': 0, 'processed': None, 'ready': 0, 'started': 0},
+                        # `optimizer.step` calls this epoch
+                        'current': {'completed': 0, 'processed': None, 'ready': 0, 'started': 0},
+                    },
+                    'zero_grad': {
+                        # `optimizer.zero_grad` calls across `fit` calls
+                        'total': {'completed': 0, 'processed': None, 'ready': 0, 'started': 0},
+                        # `optimizer.zero_grad` calls this epoch
+                        'current': {'completed': 0, 'processed': None, 'ready': 0, 'started': 0},
+                    },
+                },
+                'scheduler': {
+                    # `scheduler.step` calls across `fit` calls
+                    'total': {'completed': 0, 'processed': None, 'ready': 0, 'started': None},
+                    # `scheduler.step` calls this epoch
+                    'current': {'completed': 0, 'processed': None, 'ready': 0, 'started': None},
+                },
+            },
+            # `fit` validation progress
+            'val': {
+                'epoch': {
+                    # number of `validation` calls across `fit` calls
+                    'total': {'completed': 0, 'processed': 0, 'ready': 0, 'started': 0},
+                    # number of `validation` calls this `fit` call
+                    'current': {'completed': 0, 'processed': 0, 'ready': 0, 'started': 0},
+                    'batch': {
+                        # number of batches across `fit` `validation` calls
+                        'total': {'completed': 0, 'processed': 0, 'ready': 0, 'started': 0},
+                        # number of batches this `fit` `validation` call
+                        'current': {'completed': 0, 'processed': 0, 'ready': 0, 'started': 0},
+                    },
+                }
+            },
+        }
+    }
+    # yapf: enable
+    new_loop = FitLoopProgress.load_state_dict(state_dict)
+    assert fit_loop == new_loop
+
+
+def test_epoch_loop_progress_serialization():
+    loop = EpochLoopProgress()
+    state_dict = loop.state_dict()
+    # yapf: disable
+    assert state_dict == {
+        'epoch': {
+            # number of times `validate` has been called
+            'total': {'completed': 0, 'processed': 0, 'ready': 0, 'started': 0},
+            # either 0 or 1 as `max_epochs` does not apply to the `validate` loop
+            'current': {'completed': 0, 'processed': 0, 'ready': 0, 'started': 0},
+            'batch': {
+                # number of batches across `validate` calls
+                'total': {'completed': 0, 'processed': 0, 'ready': 0, 'started': 0},
+                # number of batches this `validate` call
+                'current': {'completed': 0, 'processed': 0, 'ready': 0, 'started': 0},
+            },
+        }
+    }
+    # yapf: enable
+    new_loop = EpochLoopProgress.load_state_dict(state_dict)
+    assert loop == new_loop


### PR DESCRIPTION
## What does this PR do?

- Move the batch attributes inside the epoch progress. This follows the structure in the loops where the batch loop is an attribute in the epoch loop. This makes it easier for users to compose custom progress dataclasses and connect them across loops.
- Implement `{,from_}state_dict` for all dataclasses
- Follows the structure in https://github.com/PyTorchLightning/pytorch-lightning/pull/8120

Necessary to unblock https://github.com/PyTorchLightning/pytorch-lightning/pull/7976

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified