### PR TITLE
Return the `default_root_dir` as the `log_dir` when the logger is a `LoggerCollection`

### DIFF
--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -227,7 +227,7 @@ class TrainerProperties(ABC):
         elif isinstance(self.logger, TensorBoardLogger):
             dirpath = self.logger.log_dir
         else:
-            dirpath = getattr(self.logger, 'save_dir')
+            dirpath = self.logger.save_dir
 
         # e.g. when the logger is a LoggerCollection
         if (dirpath is None):

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -229,10 +229,6 @@ class TrainerProperties(ABC):
         else:
             dirpath = self.logger.save_dir
 
-        # e.g. when the logger is a LoggerCollection
-        if (dirpath is None):
-            dirpath = self.default_root_dir
-
         if isinstance(self.logger, LoggerCollection) and dirpath is None:
             dirpath = self.default_root_dir
 

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -28,6 +28,7 @@ from pytorch_lightning.callbacks.base import Callback
 from pytorch_lightning.callbacks.prediction_writer import BasePredictionWriter
 from pytorch_lightning.core.optimizer import LightningOptimizer
 from pytorch_lightning.loggers import LightningLoggerBase
+from pytorch_lightning.loggers.base import LoggerCollection
 from pytorch_lightning.loggers.tensorboard import TensorBoardLogger
 from pytorch_lightning.loops.dataloader.evaluation_loop import EvaluationLoop
 from pytorch_lightning.loops.fit_loop import FitLoop
@@ -221,10 +222,10 @@ class TrainerProperties(ABC):
 
     @property
     def log_dir(self) -> Optional[str]:
-        if self.logger is None:
+        if self.logger is None or isinstance(self.logger, LoggerCollection):
             dirpath = self.default_root_dir
         elif isinstance(self.logger, TensorBoardLogger):
-            dirpath = getattr(self.logger, 'log_dir')
+            dirpath = self.logger.log_dir
         else:
             dirpath = getattr(self.logger, 'save_dir')
 

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -222,7 +222,7 @@ class TrainerProperties(ABC):
 
     @property
     def log_dir(self) -> Optional[str]:
-        if self.logger is None or isinstance(self.logger, LoggerCollection):
+        if self.logger is None:
             dirpath = self.default_root_dir
         elif isinstance(self.logger, TensorBoardLogger):
             dirpath = self.logger.log_dir
@@ -231,6 +231,9 @@ class TrainerProperties(ABC):
 
         # e.g. when the logger is a LoggerCollection
         if (dirpath is None):
+            dirpath = self.default_root_dir
+
+        if isinstance(self.logger, LoggerCollection) and dirpath is None:
             dirpath = self.default_root_dir
 
         dirpath = self.accelerator.broadcast(dirpath)

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -223,8 +223,14 @@ class TrainerProperties(ABC):
     def log_dir(self) -> Optional[str]:
         if self.logger is None:
             dirpath = self.default_root_dir
+        elif isinstance(self.logger, TensorBoardLogger):
+            dirpath = getattr(self.logger, 'log_dir')
         else:
-            dirpath = getattr(self.logger, 'log_dir' if isinstance(self.logger, TensorBoardLogger) else 'save_dir')
+            dirpath = getattr(self.logger, 'save_dir')
+
+        # e.g. when the logger is a LoggerCollection
+        if(dirpath is None):
+            dirpath = self.default_root_dir
 
         dirpath = self.accelerator.broadcast(dirpath)
         return dirpath

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -229,7 +229,7 @@ class TrainerProperties(ABC):
             dirpath = getattr(self.logger, 'save_dir')
 
         # e.g. when the logger is a LoggerCollection
-        if(dirpath is None):
+        if (dirpath is None):
             dirpath = self.default_root_dir
 
         dirpath = self.accelerator.broadcast(dirpath)

--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -226,11 +226,10 @@ class TrainerProperties(ABC):
             dirpath = self.default_root_dir
         elif isinstance(self.logger, TensorBoardLogger):
             dirpath = self.logger.log_dir
+        elif isinstance(self.logger, LoggerCollection):
+            dirpath = self.default_root_dir
         else:
             dirpath = self.logger.save_dir
-
-        if isinstance(self.logger, LoggerCollection) and dirpath is None:
-            dirpath = self.default_root_dir
 
         dirpath = self.accelerator.broadcast(dirpath)
         return dirpath

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -225,7 +225,9 @@ class Trainer(
             limit_predict_batches: How much of prediction dataset to check (float = fraction, int = num_batches)
 
             logger: Logger (or iterable collection of loggers) for experiment tracking. A ``True`` value uses
-                the default ``TensorBoardLogger``. ``False`` will disable logging.
+                the default ``TensorBoardLogger``. ``False`` will disable logging. If multiple loggers are
+                provided, local files (checkpoints, profiler traces, etc.) are saved in ``default_root_dir``
+                rather than in the ``log_dir`` of any of the individual loggers.
 
             log_gpu_memory: None, 'min_max', 'all'. Might slow performance
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -226,8 +226,9 @@ class Trainer(
 
             logger: Logger (or iterable collection of loggers) for experiment tracking. A ``True`` value uses
                 the default ``TensorBoardLogger``. ``False`` will disable logging. If multiple loggers are
-                provided, local files (checkpoints, profiler traces, etc.) are saved in ``default_root_dir``
-                rather than in the ``log_dir`` of any of the individual loggers.
+                provided and the `save_dir` property of that logger is not set, local files (checkpoints, 
+                profiler traces, etc.) are saved in ``default_root_dir`` rather than in the ``log_dir`` of any 
+                of the individual loggers.
 
             log_gpu_memory: None, 'min_max', 'all'. Might slow performance
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -226,8 +226,8 @@ class Trainer(
 
             logger: Logger (or iterable collection of loggers) for experiment tracking. A ``True`` value uses
                 the default ``TensorBoardLogger``. ``False`` will disable logging. If multiple loggers are
-                provided and the `save_dir` property of that logger is not set, local files (checkpoints, 
-                profiler traces, etc.) are saved in ``default_root_dir`` rather than in the ``log_dir`` of any 
+                provided and the `save_dir` property of that logger is not set, local files (checkpoints,
+                profiler traces, etc.) are saved in ``default_root_dir`` rather than in the ``log_dir`` of any
                 of the individual loggers.
 
             log_gpu_memory: None, 'min_max', 'all'. Might slow performance

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -23,6 +23,7 @@ import torch
 from packaging.version import Version
 
 from pytorch_lightning import Callback, Trainer
+from pytorch_lightning.loggers.base import LoggerCollection
 from pytorch_lightning.loggers.tensorboard import TensorBoardLogger
 from pytorch_lightning.profiler import AdvancedProfiler, PassThroughProfiler, PyTorchProfiler, SimpleProfiler
 from pytorch_lightning.profiler.pytorch import RegisterRecordFunction

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -432,7 +432,7 @@ def test_pytorch_profiler_nested(tmpdir):
     assert events_name == expected, (events_name, torch.__version__, platform.system())
 
 
-def test_pytorch_profiler_loggercollection(tmpdir):
+def test_pytorch_profiler_logger_collection(tmpdir):
     """
     Tests whether the PyTorch profiler is able to write its trace locally when
     the Trainer's logger is an instance of LoggerCollection. See issue #8157.
@@ -456,6 +456,8 @@ def test_pytorch_profiler_loggercollection(tmpdir):
         limit_train_batches=5,  # it takes a while for the warning to appear
         max_epochs=1,
     )
+
+    assert isinstance(trainer.logger, LoggerCollection)
 
     trainer.fit(model)
 

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -454,14 +454,12 @@ def test_pytorch_profiler_logger_collection(tmpdir):
         default_root_dir=tmpdir,
         profiler="pytorch",
         logger=logger,
-        limit_train_batches=5,  # it takes a while for the warning to appear
+        limit_train_batches=5,
         max_epochs=1,
     )
 
     assert isinstance(trainer.logger, LoggerCollection)
-
     trainer.fit(model)
-
     assert look_for_trace(tmpdir)
 
 

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -15,7 +15,6 @@ import logging
 import os
 import platform
 import time
-import warnings
 from copy import deepcopy
 
 import numpy as np

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -438,9 +438,9 @@ def test_pytorch_profiler_loggercollection(tmpdir):
     the Trainer's logger is an instance of LoggerCollection. See issue #8157.
     """
 
-    def look_for_trace(dir):
+    def look_for_trace(trace_dir):
         """ Determines if a directory contains a PyTorch trace """
-        return any(("trace.json" in filename for filename in os.listdir(dir)))
+        return any(("trace.json" in filename for filename in os.listdir(trace_dir)))
 
     # Sanity check
     assert not look_for_trace(tmpdir)

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -441,7 +441,7 @@ def test_pytorch_profiler_logger_collection(tmpdir):
 
     def look_for_trace(trace_dir):
         """ Determines if a directory contains a PyTorch trace """
-        return any(("trace.json" in filename for filename in os.listdir(trace_dir)))
+        return any("trace.json" in filename for filename in os.listdir(trace_dir))
 
     # Sanity check
     assert not look_for_trace(tmpdir)

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -435,7 +435,7 @@ def test_pytorch_profiler_nested(tmpdir):
 
 def test_pytorch_profiler_loggercollection(tmpdir):
     """
-    Tests whether the PyTorch profiler is able to write its trace locally when 
+    Tests whether the PyTorch profiler is able to write its trace locally when
     the Trainer's logger is an instance of LoggerCollection
     """
     model = BoringModel()
@@ -452,7 +452,7 @@ def test_pytorch_profiler_loggercollection(tmpdir):
 
     with warnings.catch_warnings(record=True) as warnings_list:
         trainer.fit(model)
-        msg = "failed to export trace" 
+        msg = "failed to export trace"
         assert all((msg not in str(w.message) for w in warnings_list))
 
 

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -24,9 +24,9 @@ import torch
 from packaging.version import Version
 
 from pytorch_lightning import Callback, Trainer
+from pytorch_lightning.loggers.tensorboard import TensorBoardLogger
 from pytorch_lightning.profiler import AdvancedProfiler, PassThroughProfiler, PyTorchProfiler, SimpleProfiler
 from pytorch_lightning.profiler.pytorch import RegisterRecordFunction
-from pytorch_lightning.loggers.tensorboard import TensorBoardLogger
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.imports import _KINETO_AVAILABLE
 from tests.helpers import BoringModel
@@ -432,25 +432,25 @@ def test_pytorch_profiler_nested(tmpdir):
 
     assert events_name == expected, (events_name, torch.__version__, platform.system())
 
+
 def test_pytorch_profiler_loggercollection(tmpdir):
     model = BoringModel()
 
     # Wrap the logger in a list so it becomes a LoggerCollection
-    logger = [
-        TensorBoardLogger(save_dir=tmpdir)
-    ]
+    logger = [TensorBoardLogger(save_dir=tmpdir)]
     trainer = Trainer(
         default_root_dir=tmpdir,
         profiler="pytorch",
         logger=logger,
-        limit_train_batches=5, # it takes a while for the warning to appear
+        limit_train_batches=5,  # it takes a while for the warning to appear
         max_epochs=1,
     )
 
     with warnings.catch_warnings(record=True) as l:
         trainer.fit(model)
-        msg = "failed to export trace" 
+        msg = "failed to export trace"
         assert all([msg not in str(w.message) for w in l])
+
 
 @RunIf(min_gpus=1, special=True)
 def test_pytorch_profiler_nested_emit_nvtx(tmpdir):

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -434,6 +434,10 @@ def test_pytorch_profiler_nested(tmpdir):
 
 
 def test_pytorch_profiler_loggercollection(tmpdir):
+    """
+    Tests whether the PyTorch profiler is able to write its trace locally when 
+    the Trainer's logger is an instance of LoggerCollection
+    """
     model = BoringModel()
 
     # Wrap the logger in a list so it becomes a LoggerCollection
@@ -446,10 +450,10 @@ def test_pytorch_profiler_loggercollection(tmpdir):
         max_epochs=1,
     )
 
-    with warnings.catch_warnings(record=True) as l:
+    with warnings.catch_warnings(record=True) as warnings_list:
         trainer.fit(model)
-        msg = "failed to export trace"
-        assert all([msg not in str(w.message) for w in l])
+        msg = "failed to export trace" 
+        assert all((msg not in str(w.message) for w in warnings_list))
 
 
 @RunIf(min_gpus=1, special=True)

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -438,6 +438,7 @@ def test_pytorch_profiler_loggercollection(tmpdir):
     Tests whether the PyTorch profiler is able to write its trace locally when
     the Trainer's logger is an instance of LoggerCollection. See issue #8157.
     """
+
     def look_for_trace(dir):
         """ Determines if a directory contains a PyTorch trace """
         return any(("trace.json" in filename for filename in os.listdir(dir)))
@@ -458,7 +459,7 @@ def test_pytorch_profiler_loggercollection(tmpdir):
     )
 
     trainer.fit(model)
-    
+
     assert look_for_trace(tmpdir)
 
 

--- a/tests/trainer/properties/log_dir.py
+++ b/tests/trainer/properties/log_dir.py
@@ -15,7 +15,7 @@ import os
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
-from pytorch_lightning.loggers import TensorBoardLogger
+from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
 from tests.helpers.boring_model import BoringModel
 
 
@@ -142,7 +142,7 @@ def test_logdir_custom_logger(tmpdir):
     assert trainer.log_dir == expected
 
 
-def test_logdir_loggercollection(tmpdir):
+def test_logdir_logger_collection(tmpdir):
     """
     Tests that the logdir equals the default_root_dir when the logger is a
     LoggerCollection
@@ -157,6 +157,7 @@ def test_logdir_loggercollection(tmpdir):
         logger=[TensorBoardLogger(save_dir=tmpdir, name='custom_logs')]
     )
 
+    assert isinstance(trainer.logger, LoggerCollection)
     assert trainer.log_dir == expected
     trainer.fit(model)
     assert trainer.log_dir == expected

--- a/tests/trainer/properties/log_dir.py
+++ b/tests/trainer/properties/log_dir.py
@@ -144,14 +144,16 @@ def test_logdir_custom_logger(tmpdir):
 
 def test_logdir_logger_collection(tmpdir):
     """Tests that the logdir equals the default_root_dir when the logger is a LoggerCollection"""
-    expected = tmpdir
-    model = TestModel(expected)
-
+    default_root_dir = tmpdir / "default_root_dir"
+    save_dir = tmpdir / "save_dir"
+    model = TestModel(default_root_dir)
     trainer = Trainer(
-        default_root_dir=tmpdir, max_steps=2, logger=[TensorBoardLogger(save_dir=tmpdir, name='custom_logs')]
+        default_root_dir=default_root_dir,
+        max_steps=2,
+        logger=[TensorBoardLogger(save_dir=save_dir, name='custom_logs')]
     )
-
     assert isinstance(trainer.logger, LoggerCollection)
-    assert trainer.log_dir == expected
+    assert trainer.log_dir == default_root_dir
+
     trainer.fit(model)
-    assert trainer.log_dir == expected
+    assert trainer.log_dir == default_root_dir

--- a/tests/trainer/properties/log_dir.py
+++ b/tests/trainer/properties/log_dir.py
@@ -143,10 +143,7 @@ def test_logdir_custom_logger(tmpdir):
 
 
 def test_logdir_logger_collection(tmpdir):
-    """
-    Tests that the logdir equals the default_root_dir when the logger is a
-    LoggerCollection
-    """
+    """Tests that the logdir equals the default_root_dir when the logger is a LoggerCollection"""
     expected = tmpdir
     model = TestModel(expected)
 

--- a/tests/trainer/properties/log_dir.py
+++ b/tests/trainer/properties/log_dir.py
@@ -150,7 +150,6 @@ def test_logdir_logger_collection(tmpdir):
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_steps=2,
-        callbacks=[ModelCheckpoint(dirpath=tmpdir)],
         logger=[TensorBoardLogger(save_dir=tmpdir, name='custom_logs')]
     )
 

--- a/tests/trainer/properties/log_dir.py
+++ b/tests/trainer/properties/log_dir.py
@@ -140,3 +140,24 @@ def test_logdir_custom_logger(tmpdir):
     assert trainer.log_dir == expected
     trainer.fit(model)
     assert trainer.log_dir == expected
+
+
+def test_logdir_loggercollection(tmpdir):
+    """ 
+    Tests that the logdir equals the default_root_dir when the logger is a 
+    LoggerCollection 
+    """
+    expected = tmpdir
+    model = TestModel(expected)
+
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=2,
+        callbacks=[ModelCheckpoint(dirpath=tmpdir)],
+        logger=[TensorBoardLogger(save_dir=tmpdir, name='custom_logs')]
+    )
+
+    assert trainer.log_dir == expected
+    trainer.fit(model)
+    assert trainer.log_dir == expected
+

--- a/tests/trainer/properties/log_dir.py
+++ b/tests/trainer/properties/log_dir.py
@@ -143,9 +143,9 @@ def test_logdir_custom_logger(tmpdir):
 
 
 def test_logdir_loggercollection(tmpdir):
-    """ 
-    Tests that the logdir equals the default_root_dir when the logger is a 
-    LoggerCollection 
+    """
+    Tests that the logdir equals the default_root_dir when the logger is a
+    LoggerCollection
     """
     expected = tmpdir
     model = TestModel(expected)
@@ -160,4 +160,3 @@ def test_logdir_loggercollection(tmpdir):
     assert trainer.log_dir == expected
     trainer.fit(model)
     assert trainer.log_dir == expected
-

--- a/tests/trainer/properties/log_dir.py
+++ b/tests/trainer/properties/log_dir.py
@@ -148,9 +148,7 @@ def test_logdir_logger_collection(tmpdir):
     model = TestModel(expected)
 
     trainer = Trainer(
-        default_root_dir=tmpdir,
-        max_steps=2,
-        logger=[TensorBoardLogger(save_dir=tmpdir, name='custom_logs')]
+        default_root_dir=tmpdir, max_steps=2, logger=[TensorBoardLogger(save_dir=tmpdir, name='custom_logs')]
     )
 
     assert isinstance(trainer.logger, LoggerCollection)


### PR DESCRIPTION
## What does this PR do?

Fixes a bug whereby the PyTorch profiler would fail to write to a local file when the `Trainer`'s logger is a `LoggerCollection`. 

Fixes #8157

The way I see it, there are three ways to go about this:

1. Change the `save_dir` property of the LoggerCollection to the `default_root_dir` of the `Trainer`
2. What I did here
3. Some more complex fix, arguably the most natural, where the profiler traces are written to the `save_dir` of each constituent logger.

The first would probably break code that relies on the property being `None` to set defaults. The third, since the Lightning wrapper around the PyTorch profiler relies on PyTorch functions that expect a single path, is probably prohibitively complex.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Make sure you had fun coding 🙃
