### PR TITLE
Sync our torchmetrics wrappers after the 0.4 release

### DIFF
--- a/pytorch_lightning/metrics/classification/f_beta.py
+++ b/pytorch_lightning/metrics/classification/f_beta.py
@@ -21,13 +21,14 @@ from pytorch_lightning.metrics.utils import deprecated_metrics, void
 
 class FBeta(_FBeta):
 
-    @deprecated_metrics(target=_FBeta)
+    @deprecated_metrics(target=_FBeta, args_mapping={"multilabel": None})
     def __init__(
         self,
         num_classes: int,
         beta: float = 1.0,
         threshold: float = 0.5,
         average: str = "micro",
+        multilabel: bool = False,
         compute_on_step: bool = True,
         dist_sync_on_step: bool = False,
         process_group: Optional[Any] = None,
@@ -38,17 +39,18 @@ class FBeta(_FBeta):
         .. deprecated::
             Use :class:`~torchmetrics.FBeta`. Will be removed in v1.5.0.
         """
-        _ = num_classes, beta, threshold, average, compute_on_step, dist_sync_on_step, process_group
+        _ = num_classes, beta, threshold, average, multilabel, compute_on_step, dist_sync_on_step, process_group
 
 
 class F1(_F1):
 
-    @deprecated_metrics(target=_F1)
+    @deprecated_metrics(target=_F1, args_mapping={"multilabel": None})
     def __init__(
         self,
         num_classes: int,
         threshold: float = 0.5,
         average: str = "micro",
+        multilabel: bool = False,
         compute_on_step: bool = True,
         dist_sync_on_step: bool = False,
         process_group: Optional[Any] = None,
@@ -59,4 +61,4 @@ class F1(_F1):
         .. deprecated::
             Use :class:`~torchmetrics.F1`. Will be removed in v1.5.0.
         """
-        void(num_classes, threshold, average, compute_on_step, dist_sync_on_step, process_group)
+        void(num_classes, threshold, average, multilabel, compute_on_step, dist_sync_on_step, process_group)

--- a/pytorch_lightning/metrics/classification/f_beta.py
+++ b/pytorch_lightning/metrics/classification/f_beta.py
@@ -28,7 +28,6 @@ class FBeta(_FBeta):
         beta: float = 1.0,
         threshold: float = 0.5,
         average: str = "micro",
-        multilabel: bool = False,
         compute_on_step: bool = True,
         dist_sync_on_step: bool = False,
         process_group: Optional[Any] = None,
@@ -39,7 +38,7 @@ class FBeta(_FBeta):
         .. deprecated::
             Use :class:`~torchmetrics.FBeta`. Will be removed in v1.5.0.
         """
-        _ = num_classes, beta, threshold, average, multilabel, compute_on_step, dist_sync_on_step, process_group
+        _ = num_classes, beta, threshold, average, compute_on_step, dist_sync_on_step, process_group
 
 
 class F1(_F1):
@@ -50,7 +49,6 @@ class F1(_F1):
         num_classes: int,
         threshold: float = 0.5,
         average: str = "micro",
-        multilabel: bool = False,
         compute_on_step: bool = True,
         dist_sync_on_step: bool = False,
         process_group: Optional[Any] = None,
@@ -61,4 +59,4 @@ class F1(_F1):
         .. deprecated::
             Use :class:`~torchmetrics.F1`. Will be removed in v1.5.0.
         """
-        void(num_classes, threshold, average, multilabel, compute_on_step, dist_sync_on_step, process_group)
+        void(num_classes, threshold, average, compute_on_step, dist_sync_on_step, process_group)

--- a/pytorch_lightning/metrics/classification/precision_recall.py
+++ b/pytorch_lightning/metrics/classification/precision_recall.py
@@ -27,11 +27,9 @@ class Precision(_Precision):
         num_classes: Optional[int] = None,
         threshold: float = 0.5,
         average: str = "micro",
-        multilabel: bool = False,
         mdmc_average: Optional[str] = None,
         ignore_index: Optional[int] = None,
         top_k: Optional[int] = None,
-        is_multiclass: Optional[bool] = None,
         compute_on_step: bool = True,
         dist_sync_on_step: bool = False,
         process_group: Optional[Any] = None,
@@ -43,7 +41,7 @@ class Precision(_Precision):
         .. deprecated::
             Use :class:`~torchmetrics.Precision`. Will be removed in v1.5.0.
         """
-        _ = num_classes, threshold, average, multilabel, mdmc_average, ignore_index, top_k, is_multiclass, \
+        _ = num_classes, threshold, average, mdmc_average, ignore_index, top_k, \
             compute_on_step, dist_sync_on_step, process_group, dist_sync_fn
 
 
@@ -55,11 +53,9 @@ class Recall(_Recall):
         num_classes: Optional[int] = None,
         threshold: float = 0.5,
         average: str = "micro",
-        multilabel: bool = False,
         mdmc_average: Optional[str] = None,
         ignore_index: Optional[int] = None,
         top_k: Optional[int] = None,
-        is_multiclass: Optional[bool] = None,
         compute_on_step: bool = True,
         dist_sync_on_step: bool = False,
         process_group: Optional[Any] = None,
@@ -72,6 +68,6 @@ class Recall(_Recall):
             Use :class:`~torchmetrics.Recall`. Will be removed in v1.5.0.
         """
         void(
-            num_classes, threshold, average, multilabel, mdmc_average, ignore_index, top_k, is_multiclass,
-            compute_on_step, dist_sync_on_step, process_group, dist_sync_fn
+            num_classes, threshold, average, mdmc_average, ignore_index, top_k, compute_on_step, dist_sync_on_step,
+            process_group, dist_sync_fn
         )

--- a/pytorch_lightning/metrics/classification/precision_recall.py
+++ b/pytorch_lightning/metrics/classification/precision_recall.py
@@ -21,15 +21,17 @@ from pytorch_lightning.metrics.utils import deprecated_metrics, void
 
 class Precision(_Precision):
 
-    @deprecated_metrics(target=_Precision)
+    @deprecated_metrics(target=_Precision, args_mapping={"multilabel": None, "is_multiclass": None})
     def __init__(
         self,
         num_classes: Optional[int] = None,
         threshold: float = 0.5,
         average: str = "micro",
+        multilabel: bool = False,
         mdmc_average: Optional[str] = None,
         ignore_index: Optional[int] = None,
         top_k: Optional[int] = None,
+        is_multiclass: Optional[bool] = None,
         compute_on_step: bool = True,
         dist_sync_on_step: bool = False,
         process_group: Optional[Any] = None,
@@ -41,21 +43,23 @@ class Precision(_Precision):
         .. deprecated::
             Use :class:`~torchmetrics.Precision`. Will be removed in v1.5.0.
         """
-        _ = num_classes, threshold, average, mdmc_average, ignore_index, top_k, \
+        _ = num_classes, threshold, average, multilabel, mdmc_average, ignore_index, top_k, is_multiclass, \
             compute_on_step, dist_sync_on_step, process_group, dist_sync_fn
 
 
 class Recall(_Recall):
 
-    @deprecated_metrics(target=_Recall)
+    @deprecated_metrics(target=_Recall, args_mapping={"multilabel": None, "is_multiclass": None})
     def __init__(
         self,
         num_classes: Optional[int] = None,
         threshold: float = 0.5,
         average: str = "micro",
+        multilabel: bool = False,
         mdmc_average: Optional[str] = None,
         ignore_index: Optional[int] = None,
         top_k: Optional[int] = None,
+        is_multiclass: Optional[bool] = None,
         compute_on_step: bool = True,
         dist_sync_on_step: bool = False,
         process_group: Optional[Any] = None,
@@ -68,6 +72,6 @@ class Recall(_Recall):
             Use :class:`~torchmetrics.Recall`. Will be removed in v1.5.0.
         """
         void(
-            num_classes, threshold, average, mdmc_average, ignore_index, top_k, compute_on_step, dist_sync_on_step,
-            process_group, dist_sync_fn
+            num_classes, threshold, average, multilabel, mdmc_average, ignore_index, top_k, is_multiclass,
+            compute_on_step, dist_sync_on_step, process_group, dist_sync_fn
         )

--- a/pytorch_lightning/metrics/classification/stat_scores.py
+++ b/pytorch_lightning/metrics/classification/stat_scores.py
@@ -29,7 +29,6 @@ class StatScores(_StatScores):
         num_classes: Optional[int] = None,
         ignore_index: Optional[int] = None,
         mdmc_reduce: Optional[str] = None,
-        is_multiclass: Optional[bool] = None,
         compute_on_step: bool = True,
         dist_sync_on_step: bool = False,
         process_group: Optional[Any] = None,
@@ -42,6 +41,6 @@ class StatScores(_StatScores):
             Use :class:`~torchmetrics.StatScores`. Will be removed in v1.5.0.
         """
         void(
-            threshold, top_k, reduce, num_classes, ignore_index, mdmc_reduce, is_multiclass, compute_on_step,
-            dist_sync_on_step, process_group, dist_sync_fn
+            threshold, top_k, reduce, num_classes, ignore_index, mdmc_reduce, compute_on_step, dist_sync_on_step,
+            process_group, dist_sync_fn
         )

--- a/pytorch_lightning/metrics/classification/stat_scores.py
+++ b/pytorch_lightning/metrics/classification/stat_scores.py
@@ -20,7 +20,7 @@ from pytorch_lightning.metrics.utils import deprecated_metrics, void
 
 class StatScores(_StatScores):
 
-    @deprecated_metrics(target=_StatScores)
+    @deprecated_metrics(target=_StatScores, args_mapping={"is_multiclass": None})
     def __init__(
         self,
         threshold: float = 0.5,
@@ -29,6 +29,7 @@ class StatScores(_StatScores):
         num_classes: Optional[int] = None,
         ignore_index: Optional[int] = None,
         mdmc_reduce: Optional[str] = None,
+        is_multiclass: Optional[bool] = None,
         compute_on_step: bool = True,
         dist_sync_on_step: bool = False,
         process_group: Optional[Any] = None,
@@ -41,6 +42,6 @@ class StatScores(_StatScores):
             Use :class:`~torchmetrics.StatScores`. Will be removed in v1.5.0.
         """
         void(
-            threshold, top_k, reduce, num_classes, ignore_index, mdmc_reduce, compute_on_step, dist_sync_on_step,
-            process_group, dist_sync_fn
+            threshold, top_k, reduce, num_classes, ignore_index, mdmc_reduce, is_multiclass, compute_on_step,
+            dist_sync_on_step, process_group, dist_sync_fn
         )

--- a/pytorch_lightning/metrics/functional/f_beta.py
+++ b/pytorch_lightning/metrics/functional/f_beta.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
 
 import torch
 from torchmetrics.functional import f1 as _f1
@@ -28,13 +27,12 @@ def fbeta(
     beta: float = 1.0,
     threshold: float = 0.5,
     average: str = "micro",
-    multilabel: Optional[bool] = None
 ) -> torch.Tensor:
     """
     .. deprecated::
         Use :func:`torchmetrics.functional.accuracy`. Will be removed in v1.5.0.
     """
-    return void(preds, target, num_classes, beta, threshold, average, multilabel)
+    return void(preds, target, num_classes, beta, threshold, average)
 
 
 @deprecated_metrics(target=_f1)
@@ -44,10 +42,9 @@ def f1(
     num_classes: int,
     threshold: float = 0.5,
     average: str = "micro",
-    multilabel: Optional[bool] = None
 ) -> torch.Tensor:
     """
     .. deprecated::
         Use :func:`torchmetrics.functional.f1`. Will be removed in v1.5.0.
     """
-    return void(preds, target, num_classes, threshold, average, multilabel)
+    return void(preds, target, num_classes, threshold, average)

--- a/pytorch_lightning/metrics/functional/f_beta.py
+++ b/pytorch_lightning/metrics/functional/f_beta.py
@@ -19,7 +19,7 @@ from torchmetrics.functional import fbeta as _fbeta
 from pytorch_lightning.metrics.utils import deprecated_metrics, void
 
 
-@deprecated_metrics(target=_fbeta)
+@deprecated_metrics(target=_fbeta, args_mapping={"multilabel": None})
 def fbeta(
     preds: torch.Tensor,
     target: torch.Tensor,
@@ -27,24 +27,26 @@ def fbeta(
     beta: float = 1.0,
     threshold: float = 0.5,
     average: str = "micro",
+    multilabel: Optional[bool] = None
 ) -> torch.Tensor:
     """
     .. deprecated::
         Use :func:`torchmetrics.functional.accuracy`. Will be removed in v1.5.0.
     """
-    return void(preds, target, num_classes, beta, threshold, average)
+    return void(preds, target, num_classes, beta, threshold, average, multilabel)
 
 
-@deprecated_metrics(target=_f1)
+@deprecated_metrics(target=_f1, args_mapping={"multilabel": None})
 def f1(
     preds: torch.Tensor,
     target: torch.Tensor,
     num_classes: int,
     threshold: float = 0.5,
     average: str = "micro",
+    multilabel: Optional[bool] = None
 ) -> torch.Tensor:
     """
     .. deprecated::
         Use :func:`torchmetrics.functional.f1`. Will be removed in v1.5.0.
     """
-    return void(preds, target, num_classes, threshold, average)
+    return void(preds, target, num_classes, threshold, average, multilabel)

--- a/pytorch_lightning/metrics/functional/f_beta.py
+++ b/pytorch_lightning/metrics/functional/f_beta.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Optional
 
 import torch
 from torchmetrics.functional import f1 as _f1

--- a/pytorch_lightning/metrics/functional/precision_recall.py
+++ b/pytorch_lightning/metrics/functional/precision_recall.py
@@ -31,13 +31,12 @@ def precision(
     num_classes: Optional[int] = None,
     threshold: float = 0.5,
     top_k: Optional[int] = None,
-    is_multiclass: Optional[bool] = None,
 ) -> torch.Tensor:
     """
     .. deprecated::
         Use :func:`torchmetrics.functional.precision`. Will be removed in v1.5.0.
     """
-    return void(preds, target, average, mdmc_average, ignore_index, num_classes, threshold, top_k, is_multiclass)
+    return void(preds, target, average, mdmc_average, ignore_index, num_classes, threshold, top_k)
 
 
 @deprecated_metrics(target=_recall)
@@ -50,13 +49,12 @@ def recall(
     num_classes: Optional[int] = None,
     threshold: float = 0.5,
     top_k: Optional[int] = None,
-    is_multiclass: Optional[bool] = None,
 ) -> torch.Tensor:
     """
     .. deprecated::
         Use :func:`torchmetrics.functional.accuracy`. Will be removed in v1.5.0.
     """
-    return void(preds, target, average, mdmc_average, ignore_index, num_classes, threshold, top_k, is_multiclass)
+    return void(preds, target, average, mdmc_average, ignore_index, num_classes, threshold, top_k)
 
 
 @deprecated_metrics(target=_precision_recall)
@@ -69,10 +67,9 @@ def precision_recall(
     num_classes: Optional[int] = None,
     threshold: float = 0.5,
     top_k: Optional[int] = None,
-    is_multiclass: Optional[bool] = None,
 ) -> torch.Tensor:
     """
     .. deprecated::
         Use :func:`torchmetrics.functional.precision_recall`. Will be removed in v1.5.0.
     """
-    return void(preds, target, average, mdmc_average, ignore_index, num_classes, threshold, top_k, is_multiclass)
+    return void(preds, target, average, mdmc_average, ignore_index, num_classes, threshold, top_k)

--- a/pytorch_lightning/metrics/functional/precision_recall.py
+++ b/pytorch_lightning/metrics/functional/precision_recall.py
@@ -21,7 +21,7 @@ from torchmetrics.functional import recall as _recall
 from pytorch_lightning.metrics.utils import deprecated_metrics, void
 
 
-@deprecated_metrics(target=_precision)
+@deprecated_metrics(target=_precision, args_mapping={"is_multiclass": None})
 def precision(
     preds: torch.Tensor,
     target: torch.Tensor,
@@ -31,15 +31,16 @@ def precision(
     num_classes: Optional[int] = None,
     threshold: float = 0.5,
     top_k: Optional[int] = None,
+    is_multiclass: Optional[bool] = None,
 ) -> torch.Tensor:
     """
     .. deprecated::
         Use :func:`torchmetrics.functional.precision`. Will be removed in v1.5.0.
     """
-    return void(preds, target, average, mdmc_average, ignore_index, num_classes, threshold, top_k)
+    return void(preds, target, average, mdmc_average, ignore_index, num_classes, threshold, top_k, is_multiclass)
 
 
-@deprecated_metrics(target=_recall)
+@deprecated_metrics(target=_recall, args_mapping={"is_multiclass": None})
 def recall(
     preds: torch.Tensor,
     target: torch.Tensor,
@@ -49,15 +50,16 @@ def recall(
     num_classes: Optional[int] = None,
     threshold: float = 0.5,
     top_k: Optional[int] = None,
+    is_multiclass: Optional[bool] = None,
 ) -> torch.Tensor:
     """
     .. deprecated::
         Use :func:`torchmetrics.functional.accuracy`. Will be removed in v1.5.0.
     """
-    return void(preds, target, average, mdmc_average, ignore_index, num_classes, threshold, top_k)
+    return void(preds, target, average, mdmc_average, ignore_index, num_classes, threshold, top_k, is_multiclass)
 
 
-@deprecated_metrics(target=_precision_recall)
+@deprecated_metrics(target=_precision_recall, args_mapping={"is_multiclass": None})
 def precision_recall(
     preds: torch.Tensor,
     target: torch.Tensor,
@@ -67,9 +69,10 @@ def precision_recall(
     num_classes: Optional[int] = None,
     threshold: float = 0.5,
     top_k: Optional[int] = None,
+    is_multiclass: Optional[bool] = None,
 ) -> torch.Tensor:
     """
     .. deprecated::
         Use :func:`torchmetrics.functional.precision_recall`. Will be removed in v1.5.0.
     """
-    return void(preds, target, average, mdmc_average, ignore_index, num_classes, threshold, top_k)
+    return void(preds, target, average, mdmc_average, ignore_index, num_classes, threshold, top_k, is_multiclass)

--- a/pytorch_lightning/metrics/functional/stat_scores.py
+++ b/pytorch_lightning/metrics/functional/stat_scores.py
@@ -19,7 +19,7 @@ from torchmetrics.functional import stat_scores as _stat_scores
 from pytorch_lightning.metrics.utils import deprecated_metrics, void
 
 
-@deprecated_metrics(target=_stat_scores)
+@deprecated_metrics(target=_stat_scores, args_mapping={"is_multiclass": None})
 def stat_scores(
     preds: torch.Tensor,
     target: torch.Tensor,
@@ -28,10 +28,11 @@ def stat_scores(
     num_classes: Optional[int] = None,
     top_k: Optional[int] = None,
     threshold: float = 0.5,
+    is_multiclass: Optional[bool] = None,
     ignore_index: Optional[int] = None,
 ) -> torch.Tensor:
     """
     .. deprecated::
         Use :func:`torchmetrics.functional.stat_scores`. Will be removed in v1.5.0.
     """
-    return void(preds, target, reduce, mdmc_reduce, num_classes, top_k, threshold, ignore_index)
+    return void(preds, target, reduce, mdmc_reduce, num_classes, top_k, threshold, is_multiclass, ignore_index)

--- a/pytorch_lightning/metrics/functional/stat_scores.py
+++ b/pytorch_lightning/metrics/functional/stat_scores.py
@@ -28,11 +28,10 @@ def stat_scores(
     num_classes: Optional[int] = None,
     top_k: Optional[int] = None,
     threshold: float = 0.5,
-    is_multiclass: Optional[bool] = None,
     ignore_index: Optional[int] = None,
 ) -> torch.Tensor:
     """
     .. deprecated::
         Use :func:`torchmetrics.functional.stat_scores`. Will be removed in v1.5.0.
     """
-    return void(preds, target, reduce, mdmc_reduce, num_classes, top_k, threshold, is_multiclass, ignore_index)
+    return void(preds, target, reduce, mdmc_reduce, num_classes, top_k, threshold, ignore_index)

--- a/pytorch_lightning/metrics/utils.py
+++ b/pytorch_lightning/metrics/utils.py
@@ -65,13 +65,13 @@ def select_topk(prob_tensor: torch.Tensor, topk: int = 1, dim: int = 1) -> torch
     return void(prob_tensor, topk, dim)
 
 
-@deprecated_metrics(target=_to_categorical, args_mapping=dict(tensor='x'))
-def to_categorical(tensor: torch.Tensor, argmax_dim: int = 1) -> torch.Tensor:
+@deprecated_metrics(target=_to_categorical)
+def to_categorical(x: torch.Tensor, argmax_dim: int = 1) -> torch.Tensor:
     """
     .. deprecated::
         Use :func:`torchmetrics.utilities.data.to_categorical`. Will be removed in v1.5.0.
     """
-    return void(tensor, argmax_dim)
+    return void(x, argmax_dim)
 
 
 @deprecated_metrics(target=_get_num_classes, skip_if=_TORCHMETRICS_GREATER_EQUAL_0_3)

--- a/pytorch_lightning/metrics/utils.py
+++ b/pytorch_lightning/metrics/utils.py
@@ -65,7 +65,7 @@ def select_topk(prob_tensor: torch.Tensor, topk: int = 1, dim: int = 1) -> torch
     return void(prob_tensor, topk, dim)
 
 
-@deprecated_metrics(target=_to_categorical)
+@deprecated_metrics(target=_to_categorical, args_mapping=dict(tensor='x'))
 def to_categorical(tensor: torch.Tensor, argmax_dim: int = 1) -> torch.Tensor:
     """
     .. deprecated::

--- a/pytorch_lightning/metrics/utils.py
+++ b/pytorch_lightning/metrics/utils.py
@@ -65,13 +65,13 @@ def select_topk(prob_tensor: torch.Tensor, topk: int = 1, dim: int = 1) -> torch
     return void(prob_tensor, topk, dim)
 
 
-@deprecated_metrics(target=_to_categorical)
-def to_categorical(x: torch.Tensor, argmax_dim: int = 1) -> torch.Tensor:
+@deprecated_metrics(target=_to_categorical, args_mapping={"tensor": "x"})
+def to_categorical(tensor: torch.Tensor, argmax_dim: int = 1) -> torch.Tensor:
     """
     .. deprecated::
         Use :func:`torchmetrics.utilities.data.to_categorical`. Will be removed in v1.5.0.
     """
-    return void(x, argmax_dim)
+    return void(tensor, argmax_dim)
 
 
 @deprecated_metrics(target=_get_num_classes, skip_if=_TORCHMETRICS_GREATER_EQUAL_0_3)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ tqdm>=4.41.0
 PyYAML>=5.1,<=5.4.1
 fsspec[http]>=2021.05.0, !=2021.06.0
 tensorboard>=2.2.0, !=2.5.0  # 2.5.0 GPU CI error: 'Couldn't build proto file into descriptor pool!'
-torchmetrics>=0.4.0rc1
+torchmetrics>=0.4.0
 pyDeprecate==0.3.1
 packaging>=17.0
 typing-extensions  # TypedDict support for python<3.8


### PR DESCRIPTION
## What does this PR do?

2 issues after the torchmetrics 0.4 release:

- `is_multi{class,label}` was removed. We can also remove it because we pin the torchmetrics version. The deprecation process was done in torchmetrics.
- The `to_categorical` argument was renamed.

Fixes the failing tests in master
There will be a separate fix for the bug-fix branch where we want to keep BC: #8206 

## Before submitting
- [n/a] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes? (if necessary)
- [n/a] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [n/a] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified