### PR TITLE
Avoid Pillow 8.3.0 due to errors with numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # the default package dependencies
 
+pillow!=8.3.0  # TODO: Delete line after https://github.com/python-pillow/Pillow/issues/5571
 numpy>=1.17.2
 torch>=1.4
 future>=0.17.1  # required for builtins in setup.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # the default package dependencies
 
-pillow!=8.3.0  # TODO: Delete line after https://github.com/python-pillow/Pillow/issues/5571
 numpy>=1.17.2
 torch>=1.4
 future>=0.17.1  # required for builtins in setup.py
@@ -12,3 +11,4 @@ torchmetrics>=0.4.0
 pyDeprecate==0.3.1
 packaging>=17.0
 typing-extensions  # TypedDict support for python<3.8
+pillow!=8.3.0  # TODO: delete line after https://github.com/python-pillow/Pillow/issues/5571


### PR DESCRIPTION
## What does this PR do?

```python
        img = torch.from_numpy(
>           np.array(pic, mode_to_nptype.get(pic.mode, np.uint8), copy=True)
        )
E       TypeError: __array__() takes 1 positional argument but 2 were given

/opt/hostedtoolcache/Python/3.8.10/x64/lib/python3.8/site-packages/torchvision/transforms/functional.py:129: TypeError
```

https://github.com/python-pillow/Pillow/issues/5571

## Before submitting
- [n/a] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes? (if necessary)
- [n/a] Did you write any new necessary tests? (not for typos and docs)
- [n/a] Did you verify new and existing tests pass locally with your changes?
- [n/a] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified