### PR TITLE
prevent internal call to `has_prepared_data` showing a warning

### DIFF
--- a/pytorch_lightning/trainer/connectors/data_connector.py
+++ b/pytorch_lightning/trainer/connectors/data_connector.py
@@ -60,7 +60,7 @@ class DataConnector:
     def can_prepare_data(self):
         should_call_dm_prepare_data = True
         if self.trainer.datamodule is not None and is_overridden('prepare_data', self.trainer.datamodule):
-            should_call_dm_prepare_data = not self.trainer.datamodule.has_prepared_data
+            should_call_dm_prepare_data = not self.trainer.datamodule._has_prepared_data
 
         if self.trainer.prepare_data_per_node:
             return self.trainer.local_rank == 0 and should_call_dm_prepare_data


### PR DESCRIPTION
## What does this PR do?

On master, we see the following warning when using a datamodule: 

```
/Users/adrian/repositories/pytorch-lightning/pytorch_lightning/core/datamodule.py:167: LightningDeprecationWarning: DataModule property `has_prepared_data` was deprecated in v1.4 and will be removed in v1.6.
```
I believe the problem was introduced here #7657, but the warning wasn't shown for a while, cc @carmocca 

Note: only in master, 1.3.x not affected. No changelog required. 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃
