### PR TITLE
fix missing call to untoggle_optimizer when accumulating gradients 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -354,6 +354,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed passing a custom `DDPPlugin` when choosing `accelerator="ddp_cpu"` for the accelerator ([#6208](https://github.com/PyTorchLightning/pytorch-lightning/pull/6208))
 
 
+- Fixed missing call to `LightningModule.untoggle_optimizer` in training loop when running gradient accumulation with multiple optimizers ([#8284](https://github.com/PyTorchLightning/pytorch-lightning/pull/8284))
+
+
 ## [1.3.8] - 2021-07-01
 
 ### Fixed

--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -190,7 +190,8 @@ class TrainingBatchLoop(Loop):
                 result = self._training_step(split_batch, batch_idx, opt_idx, self._hiddens)
 
         if result:
-            # update running loss + reset accumulated loss
+            # if no result, user decided to skip optimization
+            # otherwise update running loss + reset accumulated loss
             self._update_running_loss(result.loss)
             self._process_closure_result(result)
 

--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -178,6 +178,10 @@ class TrainingBatchLoop(Loop):
             with self.block_ddp_sync_behaviour():
                 closure()
 
+            if self.trainer.lightning_module.automatic_optimization and len(self.trainer.optimizers) > 1:
+                # revert back to previous state
+                self.trainer.lightning_module.untoggle_optimizer(opt_idx)
+
         # ------------------------------
         # BACKWARD PASS
         # ------------------------------

--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -130,7 +130,6 @@ class TrainingBatchLoop(Loop):
 
         if self.trainer.lightning_module.automatic_optimization:
             for opt_idx, optimizer in self.get_active_optimizers(batch_idx):
-                # assert self.trainer.lightning_module.layer.weight.requires_grad
                 result = self._run_optimization(batch_idx, split_batch, opt_idx, optimizer)
                 if result:
                     self.batch_outputs[opt_idx].append(result.training_step_output)

--- a/tests/core/test_lightning_module.py
+++ b/tests/core/test_lightning_module.py
@@ -197,7 +197,7 @@ def test_toggle_untoggle_2_optimizers_no_shared_parameters(tmpdir):
         max_epochs=1,
         default_root_dir=tmpdir,
         limit_train_batches=8,
-        accumulate_grad_batches=1,
+        accumulate_grad_batches=2,
         limit_val_batches=0,
     )
     trainer.fit(model)
@@ -331,7 +331,7 @@ def test_toggle_untoggle_3_optimizers_shared_parameters(tmpdir):
         max_epochs=1,
         default_root_dir=tmpdir,
         limit_train_batches=8,
-        accumulate_grad_batches=1,
+        accumulate_grad_batches=2,
     )
 
     trainer.fit(model)


### PR DESCRIPTION
## What does this PR do?

Fixes  #8281

The training loop toggles the optimizers in case there are mutliple, and untoggles after the optimizer step is completed.
However, the untoggle is missing during the accumulation phase, and it is certainly necessary.

Every `toggle_optimizer()` call needs a matching `untoggle_optimizer()` call.

Test fails on master


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃
