### PR TITLE
Add auto_insert_metric_name to ModelCheckpoint docstring.

### DIFF
--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -98,7 +98,7 @@ class ModelCheckpoint(Callback):
             If ``save_top_k != 0``, the decision to overwrite the current save file is made
             based on either the maximization or the minimization of the monitored quantity.
             For ``'val_acc'``, this should be ``'max'``, for ``'val_loss'`` this should be ``'min'``, etc.
-        auto_insert_metric_name: When ``True`` checkpoints filename will contain the metric name.
+        auto_insert_metric_name: When ``True``, the checkpoints filenames will contain the metric name.
             For example, ``filename='checkpoint_{epoch:02d}-{acc:02d}`` with epoch 1 and acc 80 will resolve to
             ``checkpoint_epoch=01-acc=80.ckp``. Is useful to set it to ``False`` when metric names contain ``/``
             as this will result in extra folders. Default: ``True``.

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -101,7 +101,7 @@ class ModelCheckpoint(Callback):
         auto_insert_metric_name: When ``True``, the checkpoints filenames will contain the metric name.
             For example, ``filename='checkpoint_{epoch:02d}-{acc:02d}`` with epoch 1 and acc 80 will resolve to
             ``checkpoint_epoch=01-acc=80.ckp``. Is useful to set it to ``False`` when metric names contain ``/``
-            as this will result in extra folders. Default: ``True``.
+            as this will result in extra folders.
         save_weights_only: if ``True``, then only the model's weights will be
             saved (``model.save_weights(filepath)``), else the full model
             is saved (``model.save(filepath)``).

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -99,7 +99,7 @@ class ModelCheckpoint(Callback):
             based on either the maximization or the minimization of the monitored quantity.
             For ``'val_acc'``, this should be ``'max'``, for ``'val_loss'`` this should be ``'min'``, etc.
         auto_insert_metric_name: When ``True`` checkpoints filename will contain the metric name.
-            For filename ``filename='checkpoint_{epoch:02d}-{acc:02d}`` epoch 1 and acc 80 it will resolve to
+            For example, ``filename='checkpoint_{epoch:02d}-{acc:02d}`` with epoch 1 and acc 80 will resolve to
             ``checkpoint_epoch=01-acc=80.ckp``. Is useful to set it to ``False`` when metric names contain ``/``
             as this will result in extra folders. Default: ``True``.
         save_weights_only: if ``True``, then only the model's weights will be

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -100,7 +100,7 @@ class ModelCheckpoint(Callback):
             For ``'val_acc'``, this should be ``'max'``, for ``'val_loss'`` this should be ``'min'``, etc.
         auto_insert_metric_name: When ``True`` checkpoints filename will contain the metric name.
             For filename ``filename='checkpoint_{epoch:02d}-{acc:02d}`` epoch 1 and acc 80 it will resolve to
-            ``checkpoint_epoch=01-val=80.ckp``. Is useful to set it to ``False`` when metric names contain ``/``
+            ``checkpoint_epoch=01-acc=80.ckp``. Is useful to set it to ``False`` when metric names contain ``/``
             as this will result in extra folders. Default: ``True``.
         save_weights_only: if ``True``, then only the model's weights will be
             saved (``model.save_weights(filepath)``), else the full model

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -98,6 +98,10 @@ class ModelCheckpoint(Callback):
             If ``save_top_k != 0``, the decision to overwrite the current save file is made
             based on either the maximization or the minimization of the monitored quantity.
             For ``'val_acc'``, this should be ``'max'``, for ``'val_loss'`` this should be ``'min'``, etc.
+        auto_insert_metric_name: When ``True`` checkpoints filename will contain the metric name.
+            For filename ``filename='checkpoint_{epoch:02d}-{acc:02d}`` epoch 1 and acc 80 it will resolve to
+            ``checkpoint_epoch=01-val=80.ckp``. Is useful to set it to ``False`` when metric names contain ``/``
+            as this will result in extra folders. Default: ``True``.
         save_weights_only: if ``True``, then only the model's weights will be
             saved (``model.save_weights(filepath)``), else the full model
             is saved (``model.save(filepath)``).


### PR DESCRIPTION
## What does this PR do?
Hi!

Boring PR fixind docs, adds a missing parameter in the ModelCheckpoint docstring: `auto_insert_metric_name`. This metric was added on https://github.com/PyTorchLightning/pytorch-lightning/pull/6277 but the docstring was missed. I found myself in need of this parameter and didn't see anything in the docstring so I went ask in Slack and @carmocca pointed me that this parameter existed, just that it wasn't on the docs! [conversation](https://pytorch-lightning.slack.com/archives/CRBLFHY79/p1625530020434100)

The parameter is used  in code examples but lacks of any explanation https://pytorch-lightning.readthedocs.io/en/latest/extensions/generated/pytorch_lightning.callbacks.ModelCheckpoint.html#pytorch_lightning.callbacks.ModelCheckpoint. This will make it easier to understand



## Did you have fun?
Always  🙃
