### PR TITLE
Remove `dev_debugger.call_count`

### DIFF
--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -596,8 +596,6 @@ class TrainingBatchLoop(Loop):
             optimizer: The optimizer optimizing the gradients to call backward for
             opt_idx: the index of the current optimizer
         """
-        self.trainer.dev_debugger.track_event("backward_call")
-
         should_accumulate = self.should_accumulate()
 
         # backward can be called manually in the training loop
@@ -608,7 +606,7 @@ class TrainingBatchLoop(Loop):
                 result.closure_loss, optimizer, opt_idx, should_accumulate, *args, **kwargs
             )
 
-        if not self.should_accumulate():
+        if not should_accumulate:
             # track gradients
             grad_norm_dict = self._track_and_norm_grad(optimizer=optimizer)
             if grad_norm_dict:

--- a/pytorch_lightning/plugins/precision/apex_amp.py
+++ b/pytorch_lightning/plugins/precision/apex_amp.py
@@ -77,10 +77,6 @@ class ApexMixedPrecisionPlugin(MixedPrecisionPlugin):
         # TODO: not entirely sure, why we need this
         if model is not None and isinstance(model, pl.LightningModule):
             model.backward(closure_loss, optimizer, opt_idx, **kwargs)
-
-            # TODO: avoid dev_debugger and track these calls with mock
-            model.trainer.dev_debugger.track_event('AMP', str(AMPType.APEX))
-
         else:
             closure_loss.backward(*args, **kwargs)
 

--- a/pytorch_lightning/utilities/debugging.py
+++ b/pytorch_lightning/utilities/debugging.py
@@ -69,15 +69,6 @@ class InternalDebugger(object):
             "comment": comment,
         })
 
-    def count_events(self, evt_type: str, strict=False) -> int:
-        count = 0
-        for evt in self.events:
-            if strict and evt["event"] == evt_type:
-                count += 1
-            elif not strict and evt_type in evt["event"]:
-                count += 1
-        return count
-
     @enabled_only
     def track_load_dataloader_call(self, name, dataloaders):
         loader_counts = len(dataloaders)

--- a/tests/callbacks/test_stochastic_weight_avg.py
+++ b/tests/callbacks/test_stochastic_weight_avg.py
@@ -101,7 +101,7 @@ if _TORCH_GREATER_EQUAL_1_6:
             assert trainer.accumulate_grad_batches == 2
             assert trainer.num_training_batches == 5
 
-            # the batchnorm update epoch should not backward
+            # check backward call count. the batchnorm update epoch should not backward
             assert trainer.accelerator.backward.call_count == trainer.max_epochs * trainer.limit_train_batches
 
             # check call counts

--- a/tests/models/test_amp.py
+++ b/tests/models/test_amp.py
@@ -216,6 +216,7 @@ def test_amp_without_apex(bwd_mock, tmpdir):
     assert not bwd_mock.called
 
 
+@RunIf(min_gpus=1, amp_apex=True)
 @mock.patch('pytorch_lightning.plugins.precision.apex_amp.ApexMixedPrecisionPlugin.backward')
 def test_amp_with_apex(bwd_mock, tmpdir):
     """Check calling apex scaling in training."""

--- a/tests/models/test_amp.py
+++ b/tests/models/test_amp.py
@@ -194,8 +194,8 @@ def test_cpu_model_with_amp(tmpdir):
         Trainer(precision=16)
 
 
-@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
-def test_amp_without_apex(tmpdir):
+@mock.patch('pytorch_lightning.plugins.precision.apex_amp.ApexMixedPrecisionPlugin.backward')
+def test_amp_without_apex(bwd_mock, tmpdir):
     """Check that even with apex amp type without requesting precision=16 the amp backend is void."""
     model = BoringModel()
 
@@ -213,12 +213,11 @@ def test_amp_without_apex(tmpdir):
     assert trainer.amp_backend is None
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
-    assert trainer.dev_debugger.count_events('AMP') == 0
+    assert not bwd_mock.called
 
 
-@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
-@RunIf(min_gpus=1, amp_apex=True)
-def test_amp_with_apex(tmpdir):
+@mock.patch('pytorch_lightning.plugins.precision.apex_amp.ApexMixedPrecisionPlugin.backward')
+def test_amp_with_apex(bwd_mock, tmpdir):
     """Check calling apex scaling in training."""
 
     class CustomModel(BoringModel):
@@ -243,10 +242,10 @@ def test_amp_with_apex(tmpdir):
         amp_backend='apex',
         gpus=1,
     )
-    assert str(trainer.amp_backend) == "AMPType.APEX"
+    assert trainer.amp_backend == "apex"
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
-    assert trainer.dev_debugger.count_events('AMP') == 10
+    assert bwd_mock.call_count == 10
 
     assert isinstance(trainer.lr_schedulers[0]['scheduler'].optimizer, optim.Adam)
     assert isinstance(trainer.lr_schedulers[1]['scheduler'].optimizer, optim.SGD)

--- a/tests/models/test_amp.py
+++ b/tests/models/test_amp.py
@@ -243,7 +243,7 @@ def test_amp_with_apex(bwd_mock, tmpdir):
         amp_backend='apex',
         gpus=1,
     )
-    assert trainer.amp_backend == "apex"
+    assert str(trainer.amp_backend) == "AMPType.APEX"
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
     assert bwd_mock.call_count == 10

--- a/tests/trainer/optimization/test_manual_optimization.py
+++ b/tests/trainer/optimization/test_manual_optimization.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import collections
-import os
 from copy import deepcopy
 from unittest import mock
 from unittest.mock import ANY, call, patch
@@ -23,6 +22,7 @@ import torch.distributed as torch_distrib
 import torch.nn.functional as F
 
 from pytorch_lightning import seed_everything, Trainer
+from pytorch_lightning.accelerators import Accelerator
 from pytorch_lightning.callbacks import Callback
 from tests.helpers.boring_model import BoringModel
 from tests.helpers.runif import RunIf
@@ -65,7 +65,6 @@ class ManualOptModel(BoringModel):
         return optimizer, optimizer_2
 
 
-@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_multiple_optimizers_manual_no_return(tmpdir):
 
     class TestModel(ManualOptModel):
@@ -92,13 +91,11 @@ def test_multiple_optimizers_manual_no_return(tmpdir):
         weights_summary=None,
     )
 
-    trainer.fit(model)
+    with mock.patch.object(Accelerator, 'backward', wraps=trainer.accelerator.backward) as bwd_mock:
+        trainer.fit(model)
+    assert bwd_mock.call_count == limit_train_batches * 3
 
-    num_manual_backward_calls = 3
-    assert trainer.dev_debugger.count_events('backward_call') == limit_train_batches * num_manual_backward_calls
 
-
-@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_multiple_optimizers_manual_return(tmpdir):
 
     class TestModel(ManualOptModel):
@@ -124,13 +121,11 @@ def test_multiple_optimizers_manual_return(tmpdir):
         weights_summary=None,
     )
 
-    trainer.fit(model)
+    with mock.patch.object(Accelerator, 'backward', wraps=trainer.accelerator.backward) as bwd_mock:
+        trainer.fit(model)
+    assert bwd_mock.call_count == limit_train_batches * 3
 
-    num_manual_backward_calls = 3
-    assert trainer.dev_debugger.count_events('backward_call') == limit_train_batches * num_manual_backward_calls
 
-
-@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_multiple_optimizers_manual_log(tmpdir):
 
     class TestModel(ManualOptModel):
@@ -155,15 +150,12 @@ def test_multiple_optimizers_manual_log(tmpdir):
         weights_summary=None,
     )
 
-    trainer.fit(model)
-
-    num_manual_backward_calls = 3
-    assert trainer.dev_debugger.count_events('backward_call') == limit_train_batches * num_manual_backward_calls
-
+    with mock.patch.object(Accelerator, 'backward', wraps=trainer.accelerator.backward) as bwd_mock:
+        trainer.fit(model)
+    assert bwd_mock.call_count == limit_train_batches * 3
     assert set(trainer.logged_metrics) == {'a_step', 'a_epoch', 'epoch'}
 
 
-@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @RunIf(min_gpus=1)
 def test_multiple_optimizers_manual_native_amp(tmpdir):
     model = ManualOptModel()
@@ -181,13 +173,11 @@ def test_multiple_optimizers_manual_native_amp(tmpdir):
         gpus=1,
     )
 
-    trainer.fit(model)
+    with mock.patch.object(Accelerator, 'backward', wraps=trainer.accelerator.backward) as bwd_mock:
+        trainer.fit(model)
+    assert bwd_mock.call_count == limit_train_batches * 3
 
-    num_manual_backward_calls = 3
-    assert trainer.dev_debugger.count_events('backward_call') == limit_train_batches * num_manual_backward_calls
 
-
-@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @RunIf(min_gpus=1, amp_apex=True)
 def test_multiple_optimizers_manual_apex_no_return(tmpdir):
 
@@ -219,10 +209,9 @@ def test_multiple_optimizers_manual_apex_no_return(tmpdir):
         gpus=1
     )
 
-    trainer.fit(model)
-
-    num_manual_backward_calls = 3
-    assert trainer.dev_debugger.count_events('backward_call') == limit_train_batches * num_manual_backward_calls
+    with mock.patch.object(Accelerator, 'backward', wraps=trainer.accelerator.backward) as bwd_mock:
+        trainer.fit(model)
+    assert bwd_mock.call_count == limit_train_batches * 3
 
 
 class ManualOptimizationExtendedModel(BoringModel):
@@ -429,7 +418,6 @@ def test_manual_optimization_and_accumulated_gradient(tmpdir):
     trainer.fit(model)
 
 
-@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @RunIf(min_gpus=1)
 def test_multiple_optimizers_step(tmpdir):
     """
@@ -496,14 +484,12 @@ def test_multiple_optimizers_step(tmpdir):
         gpus=1,
     )
 
-    trainer.fit(model)
-
-    num_manual_backward_calls = 3
-    assert trainer.dev_debugger.count_events('backward_call') == limit_train_batches * num_manual_backward_calls
+    with mock.patch.object(Accelerator, 'backward', wraps=trainer.accelerator.backward) as bwd_mock:
+        trainer.fit(model)
+    assert bwd_mock.call_count == limit_train_batches * 3
     assert model.called
 
 
-@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_step_with_optimizer_closure(tmpdir):
     """
     Tests that `step` works with optimizer_closure
@@ -518,8 +504,6 @@ def test_step_with_optimizer_closure(tmpdir):
             self.automatic_optimization = False
 
         def training_step(self, batch, batch_idx):
-            # manual
-
             # make sure there are no grads
             if self.layer.weight.grad is not None:
                 assert torch.all(self.layer.weight.grad == 0)
@@ -573,13 +557,13 @@ def test_step_with_optimizer_closure(tmpdir):
         log_every_n_steps=1,
     )
 
-    trainer.fit(model)
-    assert trainer.dev_debugger.count_events('backward_call') == limit_train_batches * 2
-    assert trainer.logger_connector.progress_bar_metrics["train_loss_step"] == model._losses[-1]
-    assert trainer.logger_connector.progress_bar_metrics["train_loss_epoch"] == torch.stack(model._losses).mean()
+    with mock.patch.object(Accelerator, 'backward', wraps=trainer.accelerator.backward) as bwd_mock:
+        trainer.fit(model)
+    assert bwd_mock.call_count == limit_train_batches * 2
+    assert trainer.progress_bar_metrics["train_loss_step"] == model._losses[-1]
+    assert trainer.progress_bar_metrics["train_loss_epoch"] == torch.stack(model._losses).mean()
 
 
-@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_step_with_optimizer_closure_and_accumulated_grad(tmpdir):
     """
     Tests that `step` works with optimizer_closure and accumulated_grad
@@ -632,8 +616,9 @@ def test_step_with_optimizer_closure_and_accumulated_grad(tmpdir):
         log_every_n_steps=1,
     )
 
-    trainer.fit(model)
-    assert trainer.dev_debugger.count_events('backward_call') == limit_train_batches * 2
+    with mock.patch.object(Accelerator, 'backward', wraps=trainer.accelerator.backward) as bwd_mock:
+        trainer.fit(model)
+    assert bwd_mock.call_count == limit_train_batches * 2
 
 
 @patch("torch.optim.SGD.step")


### PR DESCRIPTION
## What does this PR do?

Delete `trainer.dev_debugger.call_count` and all its uses in our tests.

Fixes the TODOs saying to avoid these counters

Part of #8071

### Does your PR introduce any breaking changes ? If yes, please list them.

`call_count` is removed, but is internal API AFAIK.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes? (if necessary)
- [n/a] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [n/a] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)
- [x] Did you list all the breaking changes introduced by this pull request?

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified