### PR TITLE
Unpin Pillow after the 8.3.1 release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,3 @@ torchmetrics>=0.4.0
 pyDeprecate==0.3.1
 packaging>=17.0
 typing-extensions  # TypedDict support for python<3.8
-pillow!=8.3.0  # TODO: delete line after https://github.com/python-pillow/Pillow/issues/5571


### PR DESCRIPTION
## What does this PR do?

Pillow 8.3.0 was banned to avoid breaking our CI. But now that it's fixed (a new version was released), we can remove it.

We don't use Pillow directly so it's the responsibility of our dependencies to keep the ban.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified