### PR TITLE
Fix broadcast for Windows minimal

### DIFF
--- a/pytorch_lightning/distributed/dist.py
+++ b/pytorch_lightning/distributed/dist.py
@@ -24,7 +24,7 @@ class LightningDistributed:
         self.device = device
 
     def broadcast(self, obj: Any, group=_group.WORLD):
-        # always wrap into a list so list can be brodcasted.
+        # always wrap into a list so it can be broadcasted.
         obj = [obj]
 
         if self.rank != 0:

--- a/pytorch_lightning/overrides/torch_distributed.py
+++ b/pytorch_lightning/overrides/torch_distributed.py
@@ -88,7 +88,14 @@ def _broadcast_object_list(object_list, src=0, group=None):
             object_list[i] = _tensor_to_object(obj_view, obj_size)
 
 
-if _TORCH_GREATER_EQUAL_1_8 and torch.distributed.is_available():
+if not torch.distributed.is_available():
+    # avoid failures on early PyTorch versions for Windows where
+    # not all functions used in `broadcast_object_list` are available.
+    def _broadcast_noop(obj, *_, **__):
+        return obj
+
+    broadcast_object_list = _broadcast_noop
+elif _TORCH_GREATER_EQUAL_1_8:
     from torch.distributed.distributed_c10d import broadcast_object_list
 else:
     broadcast_object_list = _broadcast_object_list


### PR DESCRIPTION
## What does this PR do?

Hot-fix for master. Broken in #8017 

Avoids:

```python
D:\a\pytorch-lightning\pytorch-lightning\pytorch_lightning\accelerators\accelerator.py:409: in broadcast
    return self.training_type_plugin.broadcast(obj, src)
D:\a\pytorch-lightning\pytorch-lightning\pytorch_lightning\plugins\training_type\ddp.py:362: in broadcast
    return self.dist.broadcast(obj)
D:\a\pytorch-lightning\pytorch-lightning\pytorch_lightning\distributed\dist.py:33: in broadcast
    broadcast_object_list(obj, 0, group=group or _group.WORLD)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

object_list = ['C:\\Users\\runneradmin\\AppData\\Local\\Temp\\pytest-of-test_user\\pytest-0\\test_cli_ddp_spawn_save_config3\\lightning_logs\\version_0']
src = 0, group = None

    def _broadcast_object_list(object_list, src=0, group=None):
        if _rank_not_in_group(group):
            return
    
>       my_rank = get_rank()
E       NameError: name 'get_rank' is not defined
```

Closes #8330 

## Before submitting
- [n/a] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes? (if necessary)
- [n/a] Did you write any new necessary tests? (not for typos and docs)
- [n/a] Did you verify new and existing tests pass locally with your changes?
- [n/a] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)
- [x] Did you list all the breaking changes introduced by this pull request?

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified