### PR TITLE
Move plateau schedulers epoch update to the training epoch loop

### DIFF
--- a/pytorch_lightning/loops/epoch/training_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/training_epoch_loop.py
@@ -221,6 +221,8 @@ class TrainingEpochLoop(loops.Loop):
         self.trainer.call_hook('on_epoch_end')
         self.trainer.logger_connector.on_epoch_end()
 
+        self.update_lr_schedulers('epoch', update_plateau_schedulers=True)
+
         epoch_output = self._epoch_output
         # free memory
         self._epoch_output = None

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -233,8 +233,6 @@ class FitLoop(Loop):
         if self.epoch_loop.batches_seen == 0:
             return
 
-        self.epoch_loop.update_lr_schedulers('epoch', update_plateau_schedulers=True)
-
         did_train_only = not self.trainer.enable_validation or self.epoch_loop.val_loop.skip
         if did_train_only:
             self.global_step -= 1


### PR DESCRIPTION
## What does this PR do?

Move to epoch-level update to the `ReduceLROnPlateau` schedulers the appropriate loop. No logic changed as the end of the `on_run_end` hook of the `TrainingEpochLoop` runs right before the start of the `on_advance_end` in the `FitLoop`

Part of #8362

### Does your PR introduce any breaking changes ? If yes, please list them.

None

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [n/a] Did you make sure to update the documentation with your changes? (if necessary)
- [n/a] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [n/a] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)
- [x] Did you list all the breaking changes introduced by this pull request?

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified