### PR TITLE
Support `DataLoader`s with missing arguments in `replace_sampler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,6 +328,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added private `prevent_trainer_and_dataloaders_deepcopy` context manager on the `LightningModule` ([#8472](https://github.com/PyTorchLightning/pytorch-lightning/pull/8472))
 
 
+- Improved error messages in `replace_sampler` when the `DataLoader` attributes are not included in the signature or the signature is missing optional arguments ([#8519](https://github.com/PyTorchLightning/pytorch-lightning/pull/8519))
+
+
 - Moved `DeviceDtypeModuleMixin` and `HyperparametersMixin` mixin to `core` ([#8396](https://github.com/PyTorchLightning/pytorch-lightning/pull/8396))
 
 
@@ -520,6 +523,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 - Fixed `ModelPruning` callback `on_save_checkpoint` to avoid making a `deepcopy` potentially leading to OOM ([#8472](https://github.com/PyTorchLightning/pytorch-lightning/pull/8472))
+
+
+- Fixed the sampler replacement logic for `DataLoader`s which do not define all `DataLoader` attributes as `__init__` parameters ([#8519](https://github.com/PyTorchLightning/pytorch-lightning/pull/8519))
 
 
 - Fixed DeepSpeed Windows support ([#8488](https://github.com/PyTorchLightning/pytorch-lightning/pull/8488))

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -215,7 +215,7 @@ class TrainerDataLoadingMixin(ABC):
                 missing_kwargs = sorted(missing_kwargs)
                 dataloader_cls_name = dataloader.__class__.__name__
                 raise MisconfigurationException(
-                    f"Trying to inject `DistributedSampler` into the `{dataloader_cls_name}` `DataLoader`. "
+                    f"Trying to inject `DistributedSampler` into the `{dataloader_cls_name}` instance. "
                     "This would fail as it doesn't expose all its attributes in the `__init__` signature. "
                     f"The missing arguments are {missing_kwargs}. "
                     f"HINT: If you wrote the `{dataloader_cls_name}` class, add the `__init__` arguments or "

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -192,8 +192,9 @@ class TrainerDataLoadingMixin(ABC):
         # compute the symmetric difference separately, if `**kwargs` are present, we ignore the dataloader kwargs
         has_variadic_kwargs = any(p.kind == p.VAR_KEYWORD for p in params.values())
         missing_kwargs = set() if has_variadic_kwargs else (dl_kwargs.keys() - params.keys())
-        # compute any extra custom non-dataloader arguments
-        missing_kwargs.update(params.keys() - dl_kwargs.keys() - {'args', 'kwargs'})
+        if type(dataloader) is not DataLoader:
+            # compute any extra custom non-dataloader arguments
+            missing_kwargs.update(params.keys() - dl_kwargs.keys() - {'args', 'kwargs'})
         if missing_kwargs:
             missing_kwargs = sorted(missing_kwargs)
             dataloader_cls_name = dataloader.__class__.__name__

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -199,7 +199,7 @@ class TrainerDataLoadingMixin(ABC):
             required_args = sorted(required_args)
             dataloader_cls_name = dataloader.__class__.__name__
             raise MisconfigurationException(
-                f"Trying to inject `DistributedSampler` into the `{dataloader_cls_name}` `DataLoader`. "
+                f"Trying to inject `DistributedSampler` into the `{dataloader_cls_name}` instance. "
                 "This would fail as some of the `__init__` arguments are not available as instance attributes. "
                 f"The missing attributes are {required_args}. "
                 f"HINT: If you wrote the `{dataloader_cls_name}` class, define `self.missing_arg_name` or "

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -175,6 +175,7 @@ class TrainerDataLoadingMixin(ABC):
     def replace_sampler(self, dataloader: DataLoader, sampler, mode: Optional[RunningStage] = None) -> DataLoader:
         # get the dataloader instance attributes
         attrs = {k: v for k, v in vars(dataloader).items() if not k.startswith("_")}
+        attrs['multiprocessing_context'] = dataloader.multiprocessing_context
 
         # get the dataloader instance `__init__` parameters
         params = dict(inspect.signature(dataloader.__init__).parameters)

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -171,6 +171,9 @@ class TrainerDataLoadingMixin(ABC):
         }
 
     def replace_sampler(self, dataloader: DataLoader, sampler, mode: Optional[RunningStage] = None) -> DataLoader:
+        if not isinstance(dataloader, DataLoader):
+            raise ValueError(f'The dataloader {dataloader} needs to subclass `torch.utils.data.DataLoader`')
+
         # get the dataloader instance attributes
         attrs = {k: v for k, v in vars(dataloader).items() if not k.startswith("_")}
         # not part of `vars`

--- a/tests/trainer/test_data_loading.py
+++ b/tests/trainer/test_data_loading.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
 from re import escape
 
 import pytest
@@ -19,9 +20,13 @@ from torch.utils.data.sampler import BatchSampler, Sampler, SequentialSampler
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
+from pytorch_lightning.utilities.imports import _TORCH_GREATER_EQUAL_1_7
 from tests.helpers import BoringModel, RandomDataset
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32" and not _TORCH_GREATER_EQUAL_1_7, reason="Bad `torch.distributed` support on Windows"
+)
 @pytest.mark.parametrize('mode', (1, 2))
 def test_replace_distributed_sampler(tmpdir, mode):
 

--- a/tests/trainer/test_data_loading.py
+++ b/tests/trainer/test_data_loading.py
@@ -121,6 +121,12 @@ def test_dataloader_warnings(num_workers):
         trainer.fit(TestModel(), dl)
 
 
+def test_replace_sampler_raises():
+    trainer = Trainer()
+    with pytest.raises(ValueError, match="needs to subclass `torch.utils.data.DataLoader"):
+        trainer.replace_sampler(object(), object(), mode='fit')  # noqa:
+
+
 def test_dataloaders_with_missing_keyword_arguments():
     trainer = Trainer()
     ds = RandomDataset(10, 20)

--- a/tests/trainer/test_data_loading.py
+++ b/tests/trainer/test_data_loading.py
@@ -124,7 +124,7 @@ def test_dataloader_warnings(num_workers):
 def test_replace_sampler_raises():
     trainer = Trainer()
     with pytest.raises(ValueError, match="needs to subclass `torch.utils.data.DataLoader"):
-        trainer.replace_sampler(object(), object(), mode='fit')  # noqa:
+        trainer.replace_sampler(object(), object(), mode='fit')  # noqa
 
 
 def test_dataloaders_with_missing_keyword_arguments():

--- a/tests/trainer/test_data_loading.py
+++ b/tests/trainer/test_data_loading.py
@@ -15,75 +15,71 @@ from re import escape
 
 import pytest
 from torch.utils.data import DataLoader, DistributedSampler
-from torch.utils.data.sampler import BatchSampler, SequentialSampler
+from torch.utils.data.sampler import BatchSampler, Sampler, SequentialSampler
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.helpers import BoringModel, RandomDataset
 
 
-class IndexedRandomDataset(RandomDataset):
-
-    def __getitem__(self, index):
-        return self.data[index]
-
-
-class CustomDataLoader(DataLoader):
-
-    def __init__(self, num_features, dataset, *args, **kwargs):
-        self.num_features = num_features
-        super().__init__(dataset, *args, **kwargs)
-
-
-class FailureCustomDataLoader(DataLoader):
-
-    def __init__(self, num_features, dataset, *args, **kwargs):
-        super().__init__(dataset, *args, **kwargs)
-
-
-class CustomBatchSampler(BatchSampler):
-    pass
-
-
-class TestModel(BoringModel):
-
-    def __init__(self, numbers_test_dataloaders, mode):
-        super().__init__()
-        self._numbers_test_dataloaders = numbers_test_dataloaders
-        self._mode = mode
-
-    def test_step(self, batch, batch_idx, dataloader_idx=None):
-        return super().test_step(batch, batch_idx)
-
-    def on_test_start(self) -> None:
-        dataloader = self.trainer.test_dataloaders[0]
-        assert isinstance(dataloader, CustomDataLoader)
-        assert dataloader.batch_size is None
-
-        batch_sampler = dataloader.batch_sampler
-        assert isinstance(batch_sampler, CustomBatchSampler)
-        assert batch_sampler.batch_size == 1
-        assert batch_sampler.drop_last
-        assert isinstance(batch_sampler.sampler, DistributedSampler)
-
-    def create_dataset(self):
-        dataset = IndexedRandomDataset(32, 64)
-        batch_sampler = None
-        batch_size = 2
-        if self._mode == 2:
-            batch_size = 1
-            batch_sampler = CustomBatchSampler(SequentialSampler(dataset), batch_size=batch_size, drop_last=True)
-            dataloader_cls = CustomDataLoader
-        else:
-            dataloader_cls = FailureCustomDataLoader
-        return dataloader_cls(32, dataset, batch_size=batch_size, batch_sampler=batch_sampler)
-
-    def test_dataloader(self):
-        return [self.create_dataset()] * self._numbers_test_dataloaders
-
-
 @pytest.mark.parametrize('mode', (1, 2))
 def test_replace_distributed_sampler(tmpdir, mode):
+
+    class IndexedRandomDataset(RandomDataset):
+
+        def __getitem__(self, index):
+            return self.data[index]
+
+    class CustomDataLoader(DataLoader):
+
+        def __init__(self, num_features, dataset, *args, **kwargs):
+            self.num_features = num_features
+            super().__init__(dataset, *args, **kwargs)
+
+    class FailureCustomDataLoader(DataLoader):
+
+        def __init__(self, num_features, dataset, *args, **kwargs):
+            super().__init__(dataset, *args, **kwargs)
+
+    class CustomBatchSampler(BatchSampler):
+        pass
+
+    class TestModel(BoringModel):
+
+        def __init__(self, numbers_test_dataloaders, mode):
+            super().__init__()
+            self._numbers_test_dataloaders = numbers_test_dataloaders
+            self._mode = mode
+
+        def test_step(self, batch, batch_idx, dataloader_idx=None):
+            return super().test_step(batch, batch_idx)
+
+        def on_test_start(self) -> None:
+            dataloader = self.trainer.test_dataloaders[0]
+            assert isinstance(dataloader, CustomDataLoader)
+            assert dataloader.batch_size is None
+
+            batch_sampler = dataloader.batch_sampler
+            assert isinstance(batch_sampler, CustomBatchSampler)
+            assert batch_sampler.batch_size == 1
+            assert batch_sampler.drop_last
+            assert isinstance(batch_sampler.sampler, DistributedSampler)
+
+        def create_dataset(self):
+            dataset = IndexedRandomDataset(32, 64)
+            batch_sampler = None
+            batch_size = 2
+            if self._mode == 2:
+                batch_size = 1
+                batch_sampler = CustomBatchSampler(SequentialSampler(dataset), batch_size=batch_size, drop_last=True)
+                dataloader_cls = CustomDataLoader
+            else:
+                dataloader_cls = FailureCustomDataLoader
+            return dataloader_cls(32, dataset, batch_size=batch_size, batch_sampler=batch_sampler)
+
+        def test_dataloader(self):
+            return [self.create_dataset()] * self._numbers_test_dataloaders
+
     model = TestModel(2, mode)
     model.test_epoch_end = None
 
@@ -91,7 +87,7 @@ def test_replace_distributed_sampler(tmpdir, mode):
         default_root_dir=tmpdir, limit_test_batches=2, plugins="ddp_find_unused_parameters_false", num_processes=1
     )
     if mode == 1:
-        match = escape("Missing arguments are ['num_features']")
+        match = escape("missing attributes are ['num_features']")
         with pytest.raises(MisconfigurationException, match=match):
             trainer.test(model)
     else:
@@ -131,10 +127,10 @@ def test_dataloaders_with_missing_keyword_arguments():
 
     loader = TestDataLoader(ds)
     sampler = SequentialSampler(ds)
-    match = escape("['batch_sampler', 'sampler', 'shuffle']")
+    match = escape("missing arguments are ['batch_sampler', 'sampler', 'shuffle']")
     with pytest.raises(MisconfigurationException, match=match):
         trainer.replace_sampler(loader, sampler, mode='fit')
-    match = escape("['batch_sampler', 'batch_size', 'drop_last', 'sampler', 'shuffle']")
+    match = escape("missing arguments are ['batch_sampler', 'batch_size', 'drop_last', 'sampler', 'shuffle']")
     with pytest.raises(MisconfigurationException, match=match):
         trainer.replace_sampler(loader, sampler, mode='predict')
 
@@ -166,10 +162,25 @@ def test_dataloaders_with_missing_keyword_arguments():
 
     loader = TestDataLoader(1, ds)
     sampler = SequentialSampler(ds)
-    match = escape("['batch_sampler', 'sampler']")
+    match = escape("missing arguments are ['batch_sampler', 'sampler']")
     with pytest.raises(MisconfigurationException, match=match):
         trainer.replace_sampler(loader, sampler, mode='fit')
-    match = escape("['batch_sampler', 'batch_size', 'drop_last', 'sampler']")
+    match = escape("missing arguments are ['batch_sampler', 'batch_size', 'drop_last', 'sampler']")
+    with pytest.raises(MisconfigurationException, match=match):
+        trainer.replace_sampler(loader, sampler, mode='predict')
+
+    class TestDataLoader(DataLoader):
+
+        def __init__(self, num_feat, dataset, **kwargs):
+            self.feat_num = num_feat
+            super().__init__(dataset)
+
+    loader = TestDataLoader(1, ds)
+    sampler = SequentialSampler(ds)
+    match = escape("missing attributes are ['num_feat']")
+    with pytest.raises(MisconfigurationException, match=match):
+        trainer.replace_sampler(loader, sampler, mode='fit')
+    match = escape("missing attributes are ['num_feat']")
     with pytest.raises(MisconfigurationException, match=match):
         trainer.replace_sampler(loader, sampler, mode='predict')
 
@@ -182,3 +193,57 @@ def test_replace_sampler_with_multiprocessing_context():
     trainer = Trainer()
     new_data_loader = trainer.replace_sampler(train, SequentialSampler(train.dataset))
     assert new_data_loader.multiprocessing_context == train.multiprocessing_context
+
+
+def test_dataloader_reinit_for_subclass():
+
+    class CustomDataLoader(DataLoader):
+
+        def __init__(
+            self,
+            dataset,
+            batch_size=1,
+            shuffle=False,
+            sampler=None,
+            batch_sampler=None,
+            num_workers=0,
+            collate_fn=None,
+            pin_memory=False,
+            drop_last=False,
+            timeout=0,
+            worker_init_fn=None,
+            dummy_kwarg=None,
+        ):
+            super().__init__(
+                dataset, batch_size, shuffle, sampler, batch_sampler, num_workers, collate_fn, pin_memory, drop_last,
+                timeout, worker_init_fn
+            )
+            self.dummy_kwarg = dummy_kwarg
+
+    trainer = Trainer(num_processes=1, accelerator='ddp_cpu')
+
+    class CustomDummyObj:
+        sampler = None
+
+    result = trainer.auto_add_sampler(CustomDummyObj(), shuffle=True)
+    assert isinstance(result, CustomDummyObj), "Wrongly reinstantiated data loader"
+
+    dataset = list(range(10))
+    result = trainer.auto_add_sampler(CustomDataLoader(dataset), shuffle=True)
+    assert isinstance(result, DataLoader)
+    assert isinstance(result, CustomDataLoader)
+    assert result.dummy_kwarg is None
+
+    # Shuffled DataLoader should also work
+    result = trainer.auto_add_sampler(CustomDataLoader(dataset, shuffle=True), shuffle=True)
+    assert isinstance(result, DataLoader)
+    assert isinstance(result, CustomDataLoader)
+    assert result.dummy_kwarg is None
+
+    class CustomSampler(Sampler):
+        pass
+
+    # Should raise an error if existing sampler is being replaced
+    dataloader = CustomDataLoader(dataset, sampler=CustomSampler(dataset))
+    with pytest.raises(MisconfigurationException, match='will be replaced  by `DistributedSampler`'):
+        trainer.auto_add_sampler(dataloader, shuffle=True)

--- a/tests/trainer/test_data_loading.py
+++ b/tests/trainer/test_data_loading.py
@@ -146,8 +146,8 @@ def test_dataloaders_with_missing_keyword_arguments():
 
     class TestDataLoader(DataLoader):
 
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
+        def __init__(self, *foo, **bar):
+            super().__init__(*foo, **bar)
 
     loader = TestDataLoader(ds)
     sampler = SequentialSampler(ds)

--- a/tests/trainer/test_data_loading.py
+++ b/tests/trainer/test_data_loading.py
@@ -219,6 +219,7 @@ def test_dataloader_reinit_for_subclass():
                 timeout, worker_init_fn
             )
             self.dummy_kwarg = dummy_kwarg
+            self.something_unrelated = 1
 
     trainer = Trainer(num_processes=1, accelerator='ddp_cpu')
 

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -21,7 +21,6 @@ import torch
 from torch.utils.data.dataloader import DataLoader
 from torch.utils.data.dataset import Dataset, IterableDataset, Subset
 from torch.utils.data.distributed import DistributedSampler
-from torch.utils.data.sampler import SequentialSampler
 
 import tests.helpers.pipelines as tpipes
 from pytorch_lightning import Callback, seed_everything, Trainer
@@ -1544,23 +1543,6 @@ def test_dataloaders_reset_and_attach(tmpdir):
     # 2nd predict
     trainer.predict(model, dataloaders=dataloader_1)
     assert trainer.predict_dataloaders[0] is dataloader_1
-
-
-def test_replace_sampler_with_multiprocessing_context(tmpdir):
-    """
-    This test verifies that replace_sampler conserves multiprocessing context
-    """
-    train = RandomDataset(32, 64)
-    context = 'spawn'
-    train = DataLoader(train, batch_size=32, num_workers=2, multiprocessing_context=context, shuffle=True)
-    trainer = Trainer(
-        max_epochs=1,
-        progress_bar_refresh_rate=20,
-        overfit_batches=5,
-    )
-
-    new_data_loader = trainer.replace_sampler(train, SequentialSampler(train.dataset))
-    assert (new_data_loader.multiprocessing_context == train.multiprocessing_context)
 
 
 @pytest.mark.parametrize('multiple_trainloader_mode', ["min_size", "max_size_cycle"])


### PR DESCRIPTION
## What does this PR do?

Passing a `DataLoader` that did not define all the `vars(DataLoader)` arguments produced an error. For example:

```python
    dataloader = type(dataloader)(**dl_args)
TypeError: __init__() got an unexpected keyword argument 'generator'
```

(`dataloader.generator` exists but `generator` is not in this custom DataLoader `__init__` signature)

This is not ideal as we should not error in this case if the existing attribute name is the default one. In this case, passing it should be optional.

Additionally, the error message is not clear about the problem.

This PR fixes it by rewriting the `replace_sampler` function and improving our coverage for this.

Additional improvements:
- Setting `*args, **kwargs` with different names is now allowed.

Fixes #8518

### Does your PR introduce any breaking changes? If yes, please list them.

No

## Before submitting
- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)
- [x] Did you list all the **breaking changes** introduced by this pull request?

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

