### PR TITLE
Remove `torch >= 1.6` checks

### DIFF
--- a/pytorch_lightning/callbacks/finetuning.py
+++ b/pytorch_lightning/callbacks/finetuning.py
@@ -68,7 +68,7 @@ class BaseFinetuning(Callback):
 
             def freeze_before_training(self, pl_module):
                 # freeze any module you want
-                # Here, we are freezing ``feature_extractor``
+                # Here, we are freezing `feature_extractor`
                 self.freeze(pl_module.feature_extractor)
 
             def finetune_function(self, pl_module, current_epoch, optimizer, optimizer_idx):

--- a/pytorch_lightning/callbacks/stochastic_weight_avg.py
+++ b/pytorch_lightning/callbacks/stochastic_weight_avg.py
@@ -20,15 +20,13 @@ from typing import Callable, Optional, Union
 
 import torch
 from torch import nn
+from torch.optim.swa_utils import SWALR
 
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks.base import Callback
 from pytorch_lightning.trainer.optimizers import _get_default_scheduler_config
-from pytorch_lightning.utilities import _TORCH_GREATER_EQUAL_1_6, rank_zero_info, rank_zero_warn
+from pytorch_lightning.utilities import rank_zero_info, rank_zero_warn
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-
-if _TORCH_GREATER_EQUAL_1_6:
-    from torch.optim.swa_utils import SWALR
 
 _AVG_FN = Callable[[torch.Tensor, torch.Tensor, torch.LongTensor], torch.FloatTensor]
 

--- a/pytorch_lightning/loops/dataloader/prediction_loop.py
+++ b/pytorch_lightning/loops/dataloader/prediction_loop.py
@@ -29,14 +29,14 @@ class PredictionLoop(DataLoaderLoop):
 
     @return_predictions.setter
     def return_predictions(self, return_predictions: Optional[bool] = None) -> None:
-        # ``DDPSpawnPlugin`` plugins and derivate don't support return predictions.
+        # `DDPSpawnPlugin` plugins and derivatives don't support return predictions.
         is_ddp_spawn = isinstance(self.trainer.training_type_plugin, DDPSpawnPlugin)
         if return_predictions and is_ddp_spawn:
             raise MisconfigurationException(
                 "`return_predictions` should be set to `False` when using the `DDPSpawnPlugin` or children class. "
                 f"Found {return_predictions} with training_type_plugin {type(self.trainer.training_type_plugin)}."
             )
-        # For non ``DDPSpawnPlugin`` plugin, the `return_predictions` is True by default unless user decide otherwise.
+        # For non `DDPSpawnPlugin` plugin, the `return_predictions` is True by default unless user decide otherwise.
         self._return_predictions = not is_ddp_spawn if return_predictions is None else return_predictions
 
     @property

--- a/pytorch_lightning/overrides/base.py
+++ b/pytorch_lightning/overrides/base.py
@@ -84,9 +84,9 @@ class _LightningModuleWrapperBase(DeviceDtypeModuleMixin, torch.nn.Module):
             output = self.module.training_step(*inputs, **kwargs)
 
             # In manual_optimization, we need to prevent DDP reducer as
-            # it is done manually in ``LightningModule.manual_backward``
+            # it is done manually in `LightningModule.manual_backward`
             # `require_backward_grad_sync` will be reset in the
-            # ddp_plugin ``post_training_step`` hook
+            # ddp_plugin `post_training_step` hook
             if not lightning_module.automatic_optimization:
                 trainer.model.require_backward_grad_sync = False
         elif trainer and trainer.testing:

--- a/pytorch_lightning/overrides/torch_distributed.py
+++ b/pytorch_lightning/overrides/torch_distributed.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 if torch.distributed.is_available():
     from torch.distributed import Backend, broadcast, get_backend, get_rank, GroupMember
 
-# The code underneath is taken from PyTorch ``torch/distributed/distributed_c10d.py``
+# The code underneath is taken from PyTorch `torch/distributed/distributed_c10d.py`
 # and enable broadcasting for PyTorch 1.6 and lower.
 
 

--- a/pytorch_lightning/plugins/training_type/ddp.py
+++ b/pytorch_lightning/plugins/training_type/ddp.py
@@ -279,7 +279,7 @@ class DDPPlugin(ParallelPlugin):
         # when not all parameter backward hooks are fired by the autograd engine even if require_grad is set to True.
         # This flag does come with a performance hit, so it is suggested to disable in cases where it is possible.
         self._ddp_kwargs["find_unused_parameters"] = self._ddp_kwargs.get("find_unused_parameters", True)
-        # todo: PyTorch 1.7.0 DDP introduces ``self.reducer._rebuild_buckets()`` breaking manual_optimization
+        # todo: PyTorch 1.7.0 DDP introduces `self.reducer._rebuild_buckets()` breaking manual_optimization
         if _TORCH_GREATER_EQUAL_1_7 and not self.lightning_module.automatic_optimization and not self._ddp_kwargs.get(
             "find_unused_parameters", False
         ):

--- a/pytorch_lightning/plugins/training_type/ddp_spawn.py
+++ b/pytorch_lightning/plugins/training_type/ddp_spawn.py
@@ -224,7 +224,7 @@ class DDPSpawnPlugin(ParallelPlugin):
         # when not all parameter backward hooks are fired by the autograd engine even if require_grad is set to True.
         # This flag does come with a performance hit, so it is suggested to disable in cases where it is possible.
         self._ddp_kwargs["find_unused_parameters"] = self._ddp_kwargs.get("find_unused_parameters", True)
-        # todo: PyTorch 1.7.0 DDP introduces ``self.reducer._rebuild_buckets()`` breaking manual_optimization
+        # todo: PyTorch 1.7.0 DDP introduces `self.reducer._rebuild_buckets()` breaking manual_optimization
         if _TORCH_GREATER_EQUAL_1_7 and not self.lightning_module.automatic_optimization and not self._ddp_kwargs.get(
             "find_unused_parameters", False
         ):

--- a/pytorch_lightning/profiler/xla.py
+++ b/pytorch_lightning/profiler/xla.py
@@ -27,7 +27,7 @@ help you with the Cloud TPU setup with the required installations
 >> tensorboard --logdir ./tensorboard --port 9001
 
 You could view the TensorBoard output at http://localhost:9001 on your local machine, and then open the
-``PROFILE`` plugn from the top right dropdown or open http://localhost:9001/#profile
+``PROFILE`` plugin from the top right dropdown or open http://localhost:9001/#profile
 
 2. Once the code you'd like to profile is running, click on ``CAPTURE PROFILE`` button. You could enter
 ``localhost:9012`` (default port for XLA Profiler) as the Profile Service URL. Then, you could enter

--- a/pytorch_lightning/trainer/data_loading.py
+++ b/pytorch_lightning/trainer/data_loading.py
@@ -28,7 +28,7 @@ from pytorch_lightning.overrides.distributed import IndexBatchSamplerWrapper, Un
 from pytorch_lightning.trainer.connectors.accelerator_connector import AcceleratorConnector
 from pytorch_lightning.trainer.states import RunningStage
 from pytorch_lightning.trainer.supporters import CombinedLoader
-from pytorch_lightning.utilities import _TORCH_GREATER_EQUAL_1_6, rank_zero_warn
+from pytorch_lightning.utilities import rank_zero_warn
 from pytorch_lightning.utilities.apply_func import apply_to_collection
 from pytorch_lightning.utilities.auto_restart import _sampler_metadata_collate
 from pytorch_lightning.utilities.data import has_iterable_dataset, has_len
@@ -222,8 +222,7 @@ class TrainerDataLoadingMixin(ABC):
     ) -> DistributedSampler:
         kwargs = self.distributed_sampler_kwargs
         kwargs["shuffle"] = shuffle and not self.overfit_batches
-        if _TORCH_GREATER_EQUAL_1_6:
-            kwargs.setdefault("seed", int(os.getenv("PL_GLOBAL_SEED", 0)))
+        kwargs.setdefault("seed", int(os.getenv("PL_GLOBAL_SEED", 0)))
         cls = UnrepeatedDistributedSampler if mode == RunningStage.PREDICTING else DistributedSampler
         sampler = cls(dataloader.dataset, **kwargs)
         return sampler

--- a/pytorch_lightning/trainer/supporters.py
+++ b/pytorch_lightning/trainer/supporters.py
@@ -406,14 +406,14 @@ class CombinedLoader(object):
 
     def load_state_dict(self, state_dict):
         # store the samplers state.
-        # They would be reloaded once the ``CombinedIterator`` as been created
+        # They would be reloaded once the `CombinedIterator` as been created
         # and the workers are created.
         self._loaders_iter_state_dict = state_dict
 
         def mock_reset_fn(self, *_, **__):
             pass
 
-        # mock reset call, so we can rotate the ``_worker_queue_idx_cycle`` to failed worker
+        # mock reset call, so we can rotate the `_worker_queue_idx_cycle` to failed worker
         # and get the first batch from it
         _MultiProcessingDataLoaderIter._original_reset = _MultiProcessingDataLoaderIter._reset
         _MultiProcessingDataLoaderIter._reset = mock_reset_fn
@@ -426,11 +426,11 @@ class CombinedLoader(object):
 
         def create_loader_iters(dataloader: DataLoader, state_dict: DataLoaderDict):
             if isinstance(dataloader.dataset, CaptureIterableDataset):
-                # provide the ``state_dict`` to the ``CaptureIterableDataset``
-                # as it is responsible for passing down the state to associated ``FastForwardSampler``
+                # provide the `state_dict` to the `CaptureIterableDataset`
+                # as it is responsible for passing down the state to associated `FastForwardSampler`
                 dataloader.dataset.load_state_dict(state_dict)
             else:
-                # for ``Mapping-based`` dataset, the ``fast_forward_sampler`` was attached
+                # for `Mapping-based` dataset, the `fast_forward_sampler` was attached
                 # on the dataloader for simplicity
                 dataloader.fast_forward_sampler.load_state_dict(state_dict)
 
@@ -444,8 +444,8 @@ class CombinedLoader(object):
                 iterator._sampler_state_dict = [state_dict]
             return iterator
 
-        # apply the ``create_loader_iters`` on the collection of ``DataLoader / Iterator``.
-        # each ``Iterator``` was created from the ``DataLoader``.
+        # apply the `create_loader_iters` on the collection of `DataLoader / Iterator`.
+        # each `Iterator` was created from the `DataLoader`.
         iterator._loader_iters = apply_to_collections(
             self.loaders, self._loaders_iter_state_dict, (DataLoader, DataLoaderDict), create_loader_iters
         )
@@ -477,7 +477,7 @@ class CombinedLoader(object):
         Create and return an iterator, `CombinedLoaderIterator`, for the combined loader.
         """
 
-        # prevent ``NotImplementedError`` from PyTorch:
+        # prevent `NotImplementedError` from PyTorch:
         # https://github.com/pytorch/pytorch/blob/v1.9.0/torch/utils/data/dataloader.py#L541
         def __getstate__patch__(*_):
             return {}
@@ -562,12 +562,12 @@ class CombinedLoaderIterator(object):
             if not _fault_tolerant_enabled():
                 return batch
             # when fault tolerant is enabled, the iterator will return
-            # ``FastForwardSampler`` state_dict metadata
+            # `FastForwardSampler` state_dict metadata
             # along side with the user data.
             # the metadata are extracted and store directly on the iterator
-            # to simplify the collection on ``state_dict`` call.
+            # to simplify the collection on `state_dict` call.
             batch, samplers_state_dict = CaptureIterableDataset.extract_samplers_state_dict_from_batch(batch)
-            # store the ``sampler_state_dict`` on the iterator
+            # store the `sampler_state_dict` on the iterator
             CaptureIterableDataset.store_samplers_state_dict(iterator, samplers_state_dict)
             return batch
 

--- a/pytorch_lightning/utilities/__init__.py
+++ b/pytorch_lightning/utilities/__init__.py
@@ -42,7 +42,6 @@ from pytorch_lightning.utilities.imports import (  # noqa: F401
     _NATIVE_AMP_AVAILABLE,
     _OMEGACONF_AVAILABLE,
     _POPTORCH_AVAILABLE,
-    _TORCH_GREATER_EQUAL_1_6,
     _TORCH_GREATER_EQUAL_1_7,
     _TORCH_GREATER_EQUAL_1_8,
     _TORCH_GREATER_EQUAL_1_9,

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -248,7 +248,7 @@ def move_data_to_device(batch: Any, device: torch.device):
         data_output = data.to(device, **kwargs)
         if data_output is not None:
             return data_output
-        # user wrongly implemented the ``TransferableDataType`` and forgot to return ``self``.
+        # user wrongly implemented the `TransferableDataType` and forgot to return `self`.
         return data
 
     dtype = (TransferableDataType, Batch) if _TORCHTEXT_AVAILABLE else TransferableDataType

--- a/pytorch_lightning/utilities/auto_restart.py
+++ b/pytorch_lightning/utilities/auto_restart.py
@@ -116,7 +116,7 @@ class FastForwardSampler(Sampler):
         If the ``state_dict`` contains multiple states, it means there were multiple workers.
         The state will be cached and fully reloaded (fast-forward) the first time :meth:`__iter__` is called.
         """
-        # as workers aren't available, the ``state_dict``` is cached until workers are made available.
+        # as workers aren't available, the `state_dict` is cached until workers are made available.
         if len(state_dict) > 1 and not workers_initialized:
             self._cached_state_dict = deepcopy(state_dict)
             self.restarting = True
@@ -163,8 +163,8 @@ class CaptureIterableDataset(IterableDataset):
         # create a dictionary of generator present within the dataset attributes
         dataset_sampler_generators = {k: v for k, v in dataset_dict.items() if isinstance(v, (Generator, Iterator))}
 
-        # iterate over the generator. If a generator was created from a ``Sampler```,
-        # it will be wrapped into a ``FastForwardSampler``.
+        # iterate over the generator. If a generator was created from a `Sampler`,
+        # it will be wrapped into a `FastForwardSampler`.
         for (generator_attr_name, generator) in dataset_sampler_generators.items():
 
             if isinstance(generator, Sampler):
@@ -184,17 +184,17 @@ class CaptureIterableDataset(IterableDataset):
             # validate the base generator name matches a sampler name.
             if is_legacy or any(sampler_name == generator_name for sampler_name in samplers_names):
 
-                # wrap the generator into a ``FastForwardSampler``
+                # wrap the generator into a `FastForwardSampler`
                 sampler = FastForwardSampler(generator, attr_name=generator_attr_name)
 
-                # if ``CaptureIterableDataset`` was available, the sampler should reload its own state.
+                # if `CaptureIterableDataset` was available, the sampler should reload its own state.
                 if self._state_dict is not None:
                     sampler.load_state_dict(self._state_dict[generator_attr_name])
 
                 # store the samplers
                 self.samplers[generator_attr_name] = sampler
 
-                # replace generator with the generator from the ``FastForwardSampler``.
+                # replace generator with the generator from the `FastForwardSampler`.
                 dataset_dict[generator_attr_name] = iter(sampler)
 
     def reset_on_epoch(self) -> None:
@@ -205,7 +205,7 @@ class CaptureIterableDataset(IterableDataset):
         # if the dataset contained samplers, they will be transformers into generators
         self.iter_data = iter(self.dataset)
 
-        # wrap any generator associated to a Sampler into a ``FastForwardSampler``.
+        # wrap any generator associated to a Sampler into a `FastForwardSampler`.
         self._wrap_generator_samplers()
         return self
 
@@ -304,11 +304,11 @@ def _cycle_to_next_worker_and_reset(dataloader: DataLoader, state_dict: Dict[str
     iter_dataloader = iter(dataloader)
     # get current num workers
     num_workers = getattr(iter_dataloader, "_num_workers", 0)
-    # as ``state_dict``` are workers dependent, Lightning doesn't support changing
-    # the ``num_workers`` for fault tolerant training
+    # as `state_dict` are workers dependent, Lightning doesn't support changing
+    # the `num_workers` for fault tolerant training
     if state_dict["num_workers"] != num_workers:
         raise MisconfigurationException(
-            f"The provided ``num_workers`` {num_workers} doesn't match the one used "
+            f"The provided `num_workers` {num_workers} doesn't match the one used "
             f"while generating the checkpoint: {state_dict['num_workers']}"
         )
     # when using multiple workers, we will cycle back the worker queue idx to
@@ -370,7 +370,7 @@ def _find_current_worker(iterator: Iterator) -> Dict[str, Optional[int]]:
         next_worker = (next(iterator._worker_queue_idx_cycle)) % num_workers
         # get the current worker from next one
         previous_worker = (next_worker - 1) % num_workers
-        # reset back the ``worker_queue_idx`` to current one, so we can keep
+        # reset back the `worker_queue_idx` to current one, so we can keep
         # going without perturbation.
         while next(iterator._worker_queue_idx_cycle) != previous_worker:
             pass

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -101,13 +101,9 @@ else:
     _IPU_AVAILABLE = False
 
 
-def _fault_tolerant_enabled():
-    env_var = os.getenv("PL_FAULT_TOLERANT_TRAINING", "0") == "1"
-    # the ``reset`` function from ``_MultiProcessingDataLoaderIter``
-    # was introduced in PyTorch 1.7 and we need to mock for Fault Tolerant
-    # Support for earlier version will be added later on.
-    if env_var and not _TORCH_GREATER_EQUAL_1_7:
-        from pytorch_lightning.utilities.exceptions import MisconfigurationException
-        raise MisconfigurationException(f'Restart is only supported with torch >= 1.7.0. Found {torch.__version__}')
-
-    return env_var
+def _fault_tolerant_enabled() -> bool:
+    """
+    EXPERIMENTAL
+    the `reset` function from `_MultiProcessingDataLoaderIter` was introduced in PyTorch 1.7 but we need to mock it.
+    """
+    return _TORCH_GREATER_EQUAL_1_7 and bool(os.getenv("PL_FAULT_TOLERANT_TRAINING", False))

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -64,7 +64,6 @@ def _compare_version(package: str, op, version) -> bool:
 
 _IS_WINDOWS = platform.system() == "Windows"
 _IS_INTERACTIVE = hasattr(sys, "ps1")  # https://stackoverflow.com/a/64523765
-_TORCH_GREATER_EQUAL_1_6 = _compare_version("torch", operator.ge, "1.6.0")
 _TORCH_GREATER_EQUAL_1_7 = _compare_version("torch", operator.ge, "1.7.0")
 _TORCH_GREATER_EQUAL_1_8 = _compare_version("torch", operator.ge, "1.8.0")
 _TORCH_GREATER_EQUAL_1_8_1 = _compare_version("torch", operator.ge, "1.8.1")
@@ -73,7 +72,7 @@ _TORCH_GREATER_EQUAL_1_9 = _compare_version("torch", operator.ge, "1.9.0")
 _APEX_AVAILABLE = _module_available("apex.amp")
 _BOLTS_AVAILABLE = _module_available('pl_bolts')
 _DEEPSPEED_AVAILABLE = _module_available('deepspeed')
-_FAIRSCALE_AVAILABLE = _TORCH_GREATER_EQUAL_1_6 and not _IS_WINDOWS and _module_available('fairscale.nn')
+_FAIRSCALE_AVAILABLE = not _IS_WINDOWS and _module_available('fairscale.nn')
 _FAIRSCALE_OSS_FP16_BROADCAST_AVAILABLE = _FAIRSCALE_AVAILABLE and _compare_version("fairscale", operator.ge, "0.3.3")
 _FAIRSCALE_FULLY_SHARDED_AVAILABLE = _FAIRSCALE_AVAILABLE and _compare_version("fairscale", operator.ge, "0.3.4")
 _GROUP_AVAILABLE = not _IS_WINDOWS and _module_available('torch.distributed.group')

--- a/tests/callbacks/test_stochastic_weight_avg.py
+++ b/tests/callbacks/test_stochastic_weight_avg.py
@@ -17,99 +17,97 @@ from unittest import mock
 import pytest
 import torch
 from torch import nn
+from torch.optim.swa_utils import SWALR
 from torch.utils.data import DataLoader
 
 from pytorch_lightning import LightningModule, Trainer
 from pytorch_lightning.accelerators import Accelerator
+from pytorch_lightning.callbacks import StochasticWeightAveraging
 from pytorch_lightning.plugins import DDPSpawnPlugin
 from pytorch_lightning.trainer.connectors.data_connector import _PatchDataLoader
-from pytorch_lightning.utilities import _TORCH_GREATER_EQUAL_1_6
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.helpers.boring_model import BoringModel, RandomDataset, RandomIterableDataset
 from tests.helpers.runif import RunIf
 
-if _TORCH_GREATER_EQUAL_1_6:
-    from torch.optim.swa_utils import SWALR
 
-    from pytorch_lightning.callbacks import StochasticWeightAveraging
+class SwaTestModel(BoringModel):
 
-    class SwaTestModel(BoringModel):
+    def __init__(self, batchnorm: bool = True, interval: str = "epoch", iterable_dataset: bool = False):
+        super().__init__()
+        layers = [nn.Linear(32, 32)]
+        if batchnorm:
+            layers.append(nn.BatchNorm1d(32))
+        layers += [nn.ReLU(), nn.Linear(32, 2)]
+        self.layer = nn.Sequential(*layers)
+        self.interval = interval
+        self.iterable_dataset = iterable_dataset
 
-        def __init__(self, batchnorm: bool = True, interval: str = "epoch", iterable_dataset: bool = False):
-            super().__init__()
-            layers = [nn.Linear(32, 32)]
-            if batchnorm:
-                layers.append(nn.BatchNorm1d(32))
-            layers += [nn.ReLU(), nn.Linear(32, 2)]
-            self.layer = nn.Sequential(*layers)
-            self.interval = interval
-            self.iterable_dataset = iterable_dataset
+    def training_step(self, batch, batch_idx):
+        output = self.forward(batch)
+        loss = self.loss(batch, output)
+        return {"loss": loss}
 
-        def training_step(self, batch, batch_idx):
-            output = self.forward(batch)
-            loss = self.loss(batch, output)
-            return {"loss": loss}
+    def train_dataloader(self):
 
-        def train_dataloader(self):
+        dset_cls = RandomIterableDataset if self.iterable_dataset else RandomDataset
+        dset = dset_cls(32, 64)
 
-            dset_cls = RandomIterableDataset if self.iterable_dataset else RandomDataset
-            dset = dset_cls(32, 64)
+        return DataLoader(dset, batch_size=2)
 
-            return DataLoader(dset, batch_size=2)
-
-        def configure_optimizers(self):
-            optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
-            return {
-                "optimizer": optimizer,
-                "lr_scheduler": {
-                    "scheduler": torch.optim.lr_scheduler.StepLR(optimizer, step_size=1),
-                    "interval": self.interval,
-                }
+    def configure_optimizers(self):
+        optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
+        return {
+            "optimizer": optimizer,
+            "lr_scheduler": {
+                "scheduler": torch.optim.lr_scheduler.StepLR(optimizer, step_size=1),
+                "interval": self.interval,
             }
+        }
 
-    class SwaTestCallback(StochasticWeightAveraging):
-        update_parameters_calls: int = 0
-        transfer_weights_calls: int = 0
 
-        def update_parameters(self, *args, **kwargs):
-            self.update_parameters_calls += 1
-            return StochasticWeightAveraging.update_parameters(*args, **kwargs)
+class SwaTestCallback(StochasticWeightAveraging):
+    update_parameters_calls: int = 0
+    transfer_weights_calls: int = 0
 
-        def transfer_weights(self, *args, **kwargs):
-            self.transfer_weights_calls += 1
-            return StochasticWeightAveraging.transfer_weights(*args, **kwargs)
+    def update_parameters(self, *args, **kwargs):
+        self.update_parameters_calls += 1
+        return StochasticWeightAveraging.update_parameters(*args, **kwargs)
 
-        def on_train_epoch_start(self, trainer, *args):
-            super().on_train_epoch_start(trainer, *args)
-            assert trainer.fit_loop._skip_backward == (trainer.current_epoch > self.swa_end)
-            if self.swa_start <= trainer.current_epoch:
-                assert isinstance(trainer.lr_schedulers[0]["scheduler"], SWALR)
-                assert trainer.lr_schedulers[0]["interval"] == "epoch"
-                assert trainer.lr_schedulers[0]["frequency"] == 1
+    def transfer_weights(self, *args, **kwargs):
+        self.transfer_weights_calls += 1
+        return StochasticWeightAveraging.transfer_weights(*args, **kwargs)
 
-        def on_train_epoch_end(self, trainer, *args):
-            super().on_train_epoch_end(trainer, *args)
-            if self.swa_start <= trainer.current_epoch <= self.swa_end:
-                swa_epoch = trainer.current_epoch - self.swa_start
-                assert self.n_averaged == swa_epoch + 1
-            elif trainer.current_epoch > self.swa_end:
-                assert self.n_averaged == self._max_epochs - self.swa_start
+    def on_train_epoch_start(self, trainer, *args):
+        super().on_train_epoch_start(trainer, *args)
+        assert trainer.fit_loop._skip_backward == (trainer.current_epoch > self.swa_end)
+        if self.swa_start <= trainer.current_epoch:
+            assert isinstance(trainer.lr_schedulers[0]["scheduler"], SWALR)
+            assert trainer.lr_schedulers[0]["interval"] == "epoch"
+            assert trainer.lr_schedulers[0]["frequency"] == 1
 
-        def on_train_end(self, trainer, pl_module):
-            super().on_train_end(trainer, pl_module)
+    def on_train_epoch_end(self, trainer, *args):
+        super().on_train_epoch_end(trainer, *args)
+        if self.swa_start <= trainer.current_epoch <= self.swa_end:
+            swa_epoch = trainer.current_epoch - self.swa_start
+            assert self.n_averaged == swa_epoch + 1
+        elif trainer.current_epoch > self.swa_end:
+            assert self.n_averaged == self._max_epochs - self.swa_start
 
-            # make sure these are correctly set again
-            assert not trainer.fit_loop._skip_backward
-            assert trainer.accumulate_grad_batches == 2
-            assert trainer.num_training_batches == 5
+    def on_train_end(self, trainer, pl_module):
+        super().on_train_end(trainer, pl_module)
 
-            if not isinstance(trainer.training_type_plugin, DDPSpawnPlugin):
-                # check backward call count. the batchnorm update epoch should not backward
-                assert trainer.accelerator.backward.call_count == trainer.max_epochs * trainer.limit_train_batches
+        # make sure these are correctly set again
+        assert not trainer.fit_loop._skip_backward
+        assert trainer.accumulate_grad_batches == 2
+        assert trainer.num_training_batches == 5
 
-            # check call counts
-            assert self.update_parameters_calls == trainer.max_epochs - (self._swa_epoch_start - 1)
-            assert self.transfer_weights_calls == 1
+        if not isinstance(trainer.training_type_plugin, DDPSpawnPlugin):
+            # check backward call count. the batchnorm update epoch should not backward
+            assert trainer.accelerator.backward.call_count == trainer.max_epochs * trainer.limit_train_batches
+
+        # check call counts
+        assert self.update_parameters_calls == trainer.max_epochs - (self._swa_epoch_start - 1)
+        assert self.transfer_weights_calls == 1
 
 
 def train_with_swa(

--- a/tests/loggers/test_tensorboard.py
+++ b/tests/loggers/test_tensorboard.py
@@ -20,7 +20,6 @@ import pytest
 import torch
 import yaml
 from omegaconf import OmegaConf
-from packaging.version import Version
 from tensorboard.backend.event_processing.event_accumulator import EventAccumulator
 
 from pytorch_lightning import Trainer
@@ -60,9 +59,7 @@ def test_tensorboard_hparams_reload(tmpdir):
     event_acc = EventAccumulator(folder_path)
     event_acc.Reload()
 
-    data_pt_1_5 = b'\x12\x1b"\x04\n\x02b1"\x04\n\x02b2*\r\n\x0b\x12\thp_metric'
-    data_pt_1_6 = b'\x12\x1f"\x06\n\x02b1 \x03"\x06\n\x02b2 \x03*\r\n\x0b\x12\thp_metric'
-    hparams_data = data_pt_1_6 if Version(torch.__version__) >= Version("1.6.0") else data_pt_1_5
+    hparams_data = b'\x12\x1f"\x06\n\x02b1 \x03"\x06\n\x02b2 \x03*\r\n\x0b\x12\thp_metric'
 
     assert event_acc.summary_metadata['_hparams_/experiment'].plugin_data.plugin_name == 'hparams'
     assert event_acc.summary_metadata['_hparams_/experiment'].plugin_data.content == hparams_data

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -417,11 +417,6 @@ def test_pytorch_profiler_nested(tmpdir):
     if platform.system() == "Windows":
         expected = {'a', 'add', 'b', 'c', 'profiler::_record_function_enter', 'profiler::_record_function_exit'}
     else:
-        expected = {
-            'signed char', 'add', 'profiler::_record_function_exit', 'bool', 'char', 'profiler::_record_function_enter'
-        }
-
-    if Version(torch.__version__) >= Version("1.6.0"):
         expected = {'add', 'zeros', 'ones', 'zero_', 'b', 'fill_', 'c', 'a', 'empty'}
 
     if Version(torch.__version__) >= Version("1.7.0"):

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -26,7 +26,6 @@ from torch.utils.data.sampler import SequentialSampler
 import tests.helpers.pipelines as tpipes
 from pytorch_lightning import Callback, seed_everything, Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
-from pytorch_lightning.utilities import _TORCH_GREATER_EQUAL_1_6
 from pytorch_lightning.utilities.data import has_iterable_dataset, has_len
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.base import EvalModelTemplate
@@ -1061,22 +1060,19 @@ class DistribSamplerCallback(Callback):
         train_sampler = trainer.train_dataloader.sampler
         assert isinstance(train_sampler, DistributedSampler)
         assert train_sampler.shuffle
-        if _TORCH_GREATER_EQUAL_1_6:
-            assert train_sampler.seed == self.expected_seed[0]
+        assert train_sampler.seed == self.expected_seed[0]
 
     def on_validation_start(self, trainer, pl_module):
         val_sampler = trainer.val_dataloaders[0].sampler
         assert isinstance(val_sampler, DistributedSampler)
         assert not val_sampler.shuffle
-        if _TORCH_GREATER_EQUAL_1_6:
-            assert val_sampler.seed == self.expected_seed[1]
+        assert val_sampler.seed == self.expected_seed[1]
 
     def on_test_start(self, trainer, pl_module):
         test_sampler = trainer.test_dataloaders[0].sampler
         assert isinstance(test_sampler, DistributedSampler)
         assert not test_sampler.shuffle
-        if _TORCH_GREATER_EQUAL_1_6:
-            assert test_sampler.seed == self.expected_seed[2]
+        assert test_sampler.seed == self.expected_seed[2]
 
 
 @RunIf(min_gpus=2, skip_windows=True)

--- a/tests/utilities/test_auto_restart.py
+++ b/tests/utilities/test_auto_restart.py
@@ -47,7 +47,7 @@ from tests.helpers.runif import RunIf
 # Credit to PyTorch Team.
 # Taken from:
 # https://github.com/pytorch/pytorch/blob/3b977a0d2834d300c0301a0c6af98c8e939019ce/torch/utils/data/_utils/worker.py#L151
-# Not available in PyTorch 1.4.
+# Not available until torch 1.9.0
 def _generate_state(base_seed, worker_id):
     INIT_A = 0x43b0d7e5
     MULT_A = 0x931e8875
@@ -161,7 +161,6 @@ def test_fast_forward_on_sequential_sampler():
     assert next(batch_sampler_iter) == [6, 7, 8]
 
 
-@RunIf(min_torch="1.6.0")
 @pytest.mark.skipif(torch.cuda.is_available(), reason="todo (tchaton) Need more investigation")
 def test_fast_forward_on_random_sampler():
     """
@@ -244,7 +243,6 @@ class RangeIterableDataset(IterableDataset):
 
 @pytest.mark.skipif(torch.cuda.is_available(), reason="This test takes around 30 sec and should be skipped in Azure CI")
 @pytest.mark.parametrize("num_workers", [0, 1, 2])
-@RunIf(min_torch="1.6.0")
 def test_fast_forward_sampler_over_iterative_dataset(num_workers):
     """
     This test ensures ``FastForwardSampler`` and ``CaptureIterableDataset`` are properly being
@@ -358,7 +356,7 @@ def _test_fast_forward_sampler_with_distributed_sampler(rank, worldsize):
 
 
 @pytest.mark.skipif(torch.cuda.is_available(), reason="This test takes around 25 sec and should be skipped in Azure CI")
-@RunIf(skip_windows=True, min_torch="1.6.0")
+@RunIf(skip_windows=True)
 def test_fast_forward_sampler_with_distributed_sampler():
     """Make sure result logging works with DDP"""
     tutils.set_random_master_port()
@@ -628,13 +626,12 @@ def _test_fast_forward_sampler_with_distributed_sampler_and_iterative_dataset(ra
 
 
 @pytest.mark.skipif(torch.cuda.is_available(), reason="This test takes around 45 sec and should be skipped in Azure CI")
-@RunIf(min_torch="1.6.0")
 def test_fast_forward_sampler_iterative_dataset():
     _test_fast_forward_sampler_with_distributed_sampler_and_iterative_dataset(0, 1)
 
 
 @pytest.mark.skipif(torch.cuda.is_available(), reason="This test takes around 55 sec and should be skipped in Azure CI")
-@RunIf(skip_windows=True, min_torch="1.6.0")
+@RunIf(skip_windows=True)
 def test_fast_forward_sampler_with_distributed_sampler_and_iterative_dataset():
     """Make sure result logging works with DDP"""
     tutils.set_random_master_port()
@@ -645,7 +642,7 @@ def test_fast_forward_sampler_with_distributed_sampler_and_iterative_dataset():
 
 
 @mock.patch.dict(os.environ, {'PL_FAULT_TOLERANT_TRAINING': "1"})
-@RunIf(max_torch="1.6")
+@RunIf(min_torch="1.7")
 def test_fault_tolerant_not_supported():
     with pytest.raises(MisconfigurationException, match="Restart is only supported with torch >= 1.7.0."):
         _fault_tolerant_enabled()

--- a/tests/utilities/test_auto_restart.py
+++ b/tests/utilities/test_auto_restart.py
@@ -40,7 +40,6 @@ from pytorch_lightning.utilities.auto_restart import (
 )
 from pytorch_lightning.utilities.enums import AutoRestartBatchKeys
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities.imports import _fault_tolerant_enabled
 from tests.helpers.runif import RunIf
 
 
@@ -639,13 +638,6 @@ def test_fast_forward_sampler_with_distributed_sampler_and_iterative_dataset():
     mp.spawn(
         _test_fast_forward_sampler_with_distributed_sampler_and_iterative_dataset, args=(worldsize, ), nprocs=worldsize
     )
-
-
-@mock.patch.dict(os.environ, {'PL_FAULT_TOLERANT_TRAINING': "1"})
-@RunIf(min_torch="1.7")
-def test_fault_tolerant_not_supported():
-    with pytest.raises(MisconfigurationException, match="Restart is only supported with torch >= 1.7.0."):
-        _fault_tolerant_enabled()
 
 
 def create_iterable_dataset(batch_size, num_workers, attr_name="iter_sampler"):


### PR DESCRIPTION
## What does this PR do?

1.6 is our minimum supported version now so this is redundant.

Follow up to #8288, this was missed

Also cleans some typos

### Does your PR introduce any breaking changes ? If yes, please list them.

No

## Before submitting
- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [n/a] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)
- [x] Did you list all the **breaking changes** introduced by this pull request?

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified