### PR TITLE
[WIP] Fix current_epoch value on training end

### DIFF
--- a/pytorch_lightning/loops/base.py
+++ b/pytorch_lightning/loops/base.py
@@ -46,8 +46,6 @@ class Loop(ABC):
     """
 
     def __init__(self) -> None:
-        # TODO: replace by progress tracking
-        self.iteration_count: int = 0
         self.restarting = False
         self._trainer: Optional["pl.Trainer"] = None
 
@@ -110,7 +108,6 @@ class Loop(ABC):
                 self.on_advance_start(*args, **kwargs)
                 self.advance(*args, **kwargs)
                 self.on_advance_end()
-                self.iteration_count += 1
                 self.restarting = False
             except StopIteration:
                 break

--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -47,7 +47,6 @@ class TrainingBatchLoop(Loop):
         self.accumulated_loss: Optional[Tensor] = None
         self.batch_outputs: Optional[List[List[STEP_OUTPUT]]] = None
         self.running_loss: TensorRunningAccum = TensorRunningAccum(window_length=20)
-        self.batch_idx: int = 0
         self.split_idx: Optional[int] = None
         self.optim_progress = OptimizationProgress()
 
@@ -105,7 +104,6 @@ class TrainingBatchLoop(Loop):
     def reset(self) -> None:
         """Resets the loop state"""
         self._hiddens = None
-        self.batch_idx = 0
         self.batch_outputs = [[] for _ in range(len(self.trainer.optimizers))]
 
     def on_run_start(self, batch: Any, batch_idx: int, dataloader_idx: int):
@@ -129,7 +127,6 @@ class TrainingBatchLoop(Loop):
         """
         void(batch, dataloader_idx)
         split_idx, split_batch = self._remaining_splits.pop(0)
-        self.batch_idx = batch_idx
         self.split_idx = split_idx
 
         # let logger connector extract current batch size
@@ -181,7 +178,7 @@ class TrainingBatchLoop(Loop):
         result = AttributeDict()
         closure = self._make_closure(split_batch, batch_idx, opt_idx, optimizer, self._hiddens, result)
 
-        if self.should_accumulate():
+        if self.trainer.fit_loop.should_accumulate():
             # For gradient accumulation
 
             # -------------------
@@ -444,27 +441,6 @@ class TrainingBatchLoop(Loop):
         )
         return grad_norm_dict
 
-    def _accumulated_batches_reached(self) -> bool:
-        """Determine if accumulation will be finished by the end of the current batch."""
-        # FIXME(@awaelchli): use progress tracking of batches instead of manual batch_idx
-        return (self.batch_idx + 1) % self.trainer.accumulate_grad_batches == 0
-
-    def _num_training_batches_reached(self, is_last_batch: bool = False) -> bool:
-        """Checks whether sufficient training batches have been processed.
-
-        Args:
-            is_last_batch: Whether the current batch is the last one
-        """
-        # FIXME(@awaelchli): use progress tracking of batches instead of manual batch_idx
-        return (self.batch_idx + 1) == self.trainer.num_training_batches or is_last_batch
-
-    def should_accumulate(self) -> bool:
-        """Checks if the optimizer step should be performed or gradients should be accumulated for the current step."""
-        # checks if backward or backward + optimizer step (via closure)
-        accumulation_done = self._accumulated_batches_reached()
-        is_final_batch = self._num_training_batches_reached()
-        return not (accumulation_done or is_final_batch)
-
     def _tbptt_split_batch(self, batch: Any) -> List[Any]:
         """Splits a single batch into a list of sequence steps for tbptt.
 
@@ -585,7 +561,7 @@ class TrainingBatchLoop(Loop):
         else:
             result.closure_loss = self.trainer.accelerator.backward(result.closure_loss, optimizer, *args, **kwargs)
 
-        if not self.should_accumulate():
+        if not self.trainer.fit_loop.should_accumulate():
             # track gradients
             grad_norm_dict = self._track_and_norm_grad(optimizer=optimizer)
             if grad_norm_dict:

--- a/pytorch_lightning/loops/dataloader/evaluation_loop.py
+++ b/pytorch_lightning/loops/dataloader/evaluation_loop.py
@@ -142,8 +142,8 @@ class EvaluationLoop(DataLoaderLoop):
         # hook
         self.on_evaluation_end()
 
-        # save predictions to disk
-        self.epoch_loop.predictions.to_disk()
+        if self.predictions is not None:
+            self.predictions.to_disk()
 
         # enable train mode again
         self.on_evaluation_model_train()

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -216,6 +216,10 @@ class FitLoop(Loop):
 
     def on_run_end(self) -> None:
         """Calls the ``on_train_end`` hook"""
+        # necessary until restoring mid-epoch is fully supported
+        if not self.done:
+            self.current_epoch += 1
+
         self.trainer.call_hook("on_train_end")
 
         # todo: TPU 8 cores hangs in flush with TensorBoard. Might do for all loggers.

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -216,13 +216,6 @@ class FitLoop(Loop):
 
     def on_run_end(self) -> None:
         """Calls the ``on_train_end`` hook"""
-        # NOTE: the iteration_count/current_epoch is already incremented
-        # Lightning today does not increment the current epoch at the last epoch run in Trainer.fit
-        # To simulate that current behavior, we decrement here.
-        # TODO: must be fixed by https://github.com/PyTorchLightning/pytorch-lightning/issues/5007
-        self.current_epoch -= 1
-
-        # hook
         self.trainer.call_hook("on_train_end")
 
         # todo: TPU 8 cores hangs in flush with TensorBoard. Might do for all loggers.

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -69,7 +69,7 @@ class FitLoop(Loop):
     @property
     def batch_idx(self) -> int:
         """Returns the number of batches already run within this epoch"""
-        return self.epoch_loop.batch_progress.current.ready - 1
+        return self.epoch_loop.batch_idx
 
     @property
     def split_idx(self) -> int:
@@ -236,7 +236,7 @@ class FitLoop(Loop):
 
     def should_accumulate(self) -> bool:
         """Whether the gradients should be accumulated"""
-        return self.epoch_loop.batch_loop.should_accumulate()
+        return self.epoch_loop._should_accumulate()
 
     def teardown(self) -> None:
         self.epoch_loop.teardown()

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -326,12 +326,7 @@ class CheckpointConnector:
         # dump epoch/global_step/pytorch-lightning_version
         current_epoch = self.trainer.current_epoch
         global_step = self.trainer.global_step
-        has_reached_max_steps = self.trainer.max_steps and self.trainer.max_steps <= global_step
-
         global_step += 1
-        if not has_reached_max_steps:
-            current_epoch += 1
-
         model = self.trainer.lightning_module
 
         checkpoint = {

--- a/tests/callbacks/test_early_stopping.py
+++ b/tests/callbacks/test_early_stopping.py
@@ -75,7 +75,7 @@ def test_resume_early_stopping_from_checkpoint(tmpdir):
     # ensure state is persisted properly
     checkpoint = torch.load(checkpoint_filepath)
     # the checkpoint saves "epoch + 1"
-    early_stop_callback_state = early_stop_callback.saved_states[checkpoint["epoch"] - 1]
+    early_stop_callback_state = early_stop_callback.saved_states[checkpoint["epoch"]]
     assert checkpoint["callbacks"][type(early_stop_callback)] == early_stop_callback_state
 
     # ensure state is reloaded properly (assertion in the callback)
@@ -137,7 +137,7 @@ def test_early_stopping_patience(tmpdir, loss_values: list, patience: int, expec
         progress_bar_refresh_rate=0,
     )
     trainer.fit(model)
-    assert trainer.current_epoch == expected_stop_epoch
+    assert trainer.current_epoch - 1 == expected_stop_epoch
 
 
 @pytest.mark.parametrize("validation_step_none", [True, False])
@@ -173,7 +173,7 @@ def test_early_stopping_patience_train(
         progress_bar_refresh_rate=0,
     )
     trainer.fit(model)
-    assert trainer.current_epoch == expected_stop_epoch
+    assert trainer.current_epoch - 1 == expected_stop_epoch
 
 
 def test_pickling(tmpdir):
@@ -224,7 +224,7 @@ def test_early_stopping_thresholds(tmpdir, stopping_threshold, divergence_thesho
     )
     trainer = Trainer(default_root_dir=tmpdir, callbacks=[early_stopping], overfit_batches=0.20, max_epochs=20)
     trainer.fit(model)
-    assert trainer.current_epoch == expected_epoch, "early_stopping failed"
+    assert trainer.current_epoch - 1 == expected_epoch, "early_stopping failed"
 
 
 @pytest.mark.parametrize("stop_value", [torch.tensor(np.inf), torch.tensor(np.nan)])
@@ -242,7 +242,7 @@ def test_early_stopping_on_non_finite_monitor(tmpdir, stop_value):
     early_stopping = EarlyStopping(monitor="val_loss", check_finite=True)
     trainer = Trainer(default_root_dir=tmpdir, callbacks=[early_stopping], overfit_batches=0.20, max_epochs=10)
     trainer.fit(model)
-    assert trainer.current_epoch == expected_stop_epoch
+    assert trainer.current_epoch - 1 == expected_stop_epoch
     assert early_stopping.stopped_epoch == expected_stop_epoch
 
 
@@ -370,7 +370,7 @@ class EarlyStoppingModel(BoringModel):
         self._epoch_end()
 
     def on_train_end(self) -> None:
-        assert self.trainer.current_epoch == self.expected_end_epoch, "Early Stopping Failed"
+        assert self.trainer.current_epoch - 1 == self.expected_end_epoch, "Early Stopping Failed"
 
 
 _ES_CHECK = dict(check_on_train_epoch_end=True)

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -855,7 +855,8 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
     ckpt_last_epoch = torch.load(path_last_epoch)
     ckpt_last = torch.load(path_last)
 
-    assert ckpt_last_epoch["epoch"] == ckpt_last["epoch"]
+    # `last.ckpt` has its epoch counter increased by 1 in `on_run_end` as we consider the epoch to be over
+    assert ckpt_last_epoch["epoch"] == ckpt_last["epoch"] - 1
     assert ckpt_last_epoch["global_step"] == ckpt_last["global_step"]
 
     ch_type = type(model_checkpoint)
@@ -953,18 +954,16 @@ def test_checkpoint_repeated_strategy_extended(tmpdir):
         def validation_epoch_end(self, *_):
             ...
 
-    def assert_trainer_init(trainer):
-        assert trainer.global_step == 0
-        assert trainer.current_epoch == 0
-
     def get_last_checkpoint(ckpt_dir):
-        last = ckpt_dir.listdir(sort=True)[-1]
+        ckpts = ckpt_dir.listdir(sort=True)
+        print(ckpts)
+        last = ckpts[-1]
         return str(last)
 
     def assert_checkpoint_content(ckpt_dir):
-        chk = pl_load(get_last_checkpoint(ckpt_dir))
-        assert chk["epoch"] == epochs
-        assert chk["global_step"] == 4
+        ckpt = pl_load(get_last_checkpoint(ckpt_dir))
+        assert ckpt["epoch"] == epochs
+        assert ckpt["global_step"] == 4
 
     def assert_checkpoint_log_dir(idx):
         lightning_logs = tmpdir / "lightning_logs"
@@ -983,22 +982,22 @@ def test_checkpoint_repeated_strategy_extended(tmpdir):
         limit_val_batches=3,
         limit_test_batches=4,
         callbacks=[checkpoint_cb],
+        progress_bar_refresh_rate=0,
     )
     trainer = pl.Trainer(**trainer_config)
-    assert_trainer_init(trainer)
 
     model = ExtendedBoringModel()
     trainer.fit(model)
     assert trainer.global_step == epochs * limit_train_batches
-    assert trainer.current_epoch == epochs - 1
+    assert trainer.current_epoch == epochs
     assert_checkpoint_log_dir(0)
     assert_checkpoint_content(ckpt_dir)
 
-    trainer.validate(model)
-    assert trainer.current_epoch == epochs - 1
+    trainer.validate(model, verbose=False)
+    assert trainer.current_epoch == epochs
 
-    trainer.test(model)
-    assert trainer.current_epoch == epochs - 1
+    trainer.test(model, verbose=False)
+    assert trainer.current_epoch == epochs
 
     for idx in range(1, 5):
         chk = get_last_checkpoint(ckpt_dir)
@@ -1007,11 +1006,9 @@ def test_checkpoint_repeated_strategy_extended(tmpdir):
         # load from checkpoint
         trainer_config["callbacks"] = [ModelCheckpoint(dirpath=ckpt_dir, save_top_k=-1)]
         trainer = pl.Trainer(**trainer_config, resume_from_checkpoint=chk)
-        assert_trainer_init(trainer)
-
         model = ExtendedBoringModel()
 
-        trainer.test(model)
+        trainer.test(model, verbose=False)
         # resume_from_checkpoint is resumed when calling `.fit`
         assert trainer.global_step == 0
         assert trainer.current_epoch == 0
@@ -1021,7 +1018,7 @@ def test_checkpoint_repeated_strategy_extended(tmpdir):
         assert trainer.current_epoch == epochs
         assert_checkpoint_log_dir(idx)
 
-        trainer.validate(model)
+        trainer.validate(model, verbose=False)
         assert trainer.global_step == epochs * limit_train_batches
         assert trainer.current_epoch == epochs
 

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -855,8 +855,7 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
     ckpt_last_epoch = torch.load(path_last_epoch)
     ckpt_last = torch.load(path_last)
 
-    # `last.ckpt` has its epoch counter increased by 1 in `on_run_end` as we consider the epoch to be over
-    assert ckpt_last_epoch["epoch"] == ckpt_last["epoch"] - 1
+    assert ckpt_last_epoch["epoch"] == ckpt_last["epoch"]
     assert ckpt_last_epoch["global_step"] == ckpt_last["global_step"]
 
     ch_type = type(model_checkpoint)
@@ -948,16 +947,18 @@ def test_checkpoint_repeated_strategy_extended(tmpdir):
         def validation_epoch_end(self, *_):
             ...
 
+    def assert_trainer_init(trainer):
+        assert trainer.global_step == 0
+        assert trainer.current_epoch == 0
+
     def get_last_checkpoint(ckpt_dir):
-        ckpts = ckpt_dir.listdir(sort=True)
-        print(ckpts)
-        last = ckpts[-1]
+        last = ckpt_dir.listdir(sort=True)[-1]
         return str(last)
 
     def assert_checkpoint_content(ckpt_dir):
-        ckpt = pl_load(get_last_checkpoint(ckpt_dir))
-        assert ckpt["epoch"] == epochs
-        assert ckpt["global_step"] == 4
+        chk = pl_load(get_last_checkpoint(ckpt_dir))
+        assert chk["epoch"] == epochs
+        assert chk["global_step"] == 4
 
     def assert_checkpoint_log_dir(idx):
         lightning_logs = tmpdir / "lightning_logs"
@@ -976,22 +977,22 @@ def test_checkpoint_repeated_strategy_extended(tmpdir):
         limit_val_batches=3,
         limit_test_batches=4,
         callbacks=[checkpoint_cb],
-        progress_bar_refresh_rate=0,
     )
     trainer = pl.Trainer(**trainer_config)
+    assert_trainer_init(trainer)
 
     model = ExtendedBoringModel()
     trainer.fit(model)
     assert trainer.global_step == epochs * limit_train_batches
-    assert trainer.current_epoch == epochs
+    assert trainer.current_epoch == epochs - 1
     assert_checkpoint_log_dir(0)
     assert_checkpoint_content(ckpt_dir)
 
-    trainer.validate(model, verbose=False)
-    assert trainer.current_epoch == epochs
+    trainer.validate(model)
+    assert trainer.current_epoch == epochs - 1
 
-    trainer.test(model, verbose=False)
-    assert trainer.current_epoch == epochs
+    trainer.test(model)
+    assert trainer.current_epoch == epochs - 1
 
     for idx in range(1, 5):
         chk = get_last_checkpoint(ckpt_dir)
@@ -1000,9 +1001,11 @@ def test_checkpoint_repeated_strategy_extended(tmpdir):
         # load from checkpoint
         trainer_config["callbacks"] = [ModelCheckpoint(dirpath=ckpt_dir, save_top_k=-1)]
         trainer = pl.Trainer(**trainer_config, resume_from_checkpoint=chk)
+        assert_trainer_init(trainer)
+
         model = ExtendedBoringModel()
 
-        trainer.test(model, verbose=False)
+        trainer.test(model)
         # resume_from_checkpoint is resumed when calling `.fit`
         assert trainer.global_step == 0
         assert trainer.current_epoch == 0
@@ -1012,7 +1015,7 @@ def test_checkpoint_repeated_strategy_extended(tmpdir):
         assert trainer.current_epoch == epochs
         assert_checkpoint_log_dir(idx)
 
-        trainer.validate(model, verbose=False)
+        trainer.validate(model)
         assert trainer.global_step == epochs * limit_train_batches
         assert trainer.current_epoch == epochs
 

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -145,7 +145,7 @@ def test_model_checkpoint_score_and_ckpt(
         assert math.isclose(score, expected_score, rel_tol=1e-4)
 
         chk = pl_load(os.path.join(checkpoint.dirpath, expected_filename))
-        assert chk["epoch"] == epoch + 1
+        assert chk["epoch"] == epoch
         assert chk["global_step"] == limit_train_batches * (epoch + 1)
 
         mc_specific_data = chk["callbacks"][type(checkpoint)]
@@ -254,7 +254,7 @@ def test_model_checkpoint_score_and_ckpt_val_check_interval(
         assert math.isclose(score, expected_score, rel_tol=1e-4)
 
         chk = pl_load(os.path.join(checkpoint.dirpath, expected_filename))
-        assert chk["epoch"] == epoch + 1
+        assert chk["epoch"] == epoch
         epoch_num = epoch + duplicated
         expected_global_step = per_val_train_batches * (global_ix + 1) + (leftover_train_batches * epoch_num)
         assert chk["global_step"] == expected_global_step

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -1208,7 +1208,7 @@ def test_ckpt_version_after_rerun_same_trainer(tmpdir):
     trainer.fit_loop.max_epochs = 4
     trainer.fit(BoringModel())
 
-    ckpt_range = range(mc.STARTING_VERSION, trainer.max_epochs + mc.STARTING_VERSION)
+    ckpt_range = range(mc.STARTING_VERSION, trainer.max_epochs + mc.STARTING_VERSION - 1)
     expected = {"test.ckpt", *(f"test-v{i}.ckpt" for i in ckpt_range)}
     # check best_k_models state
     assert {Path(f).name for f in mc.best_k_models} == expected

--- a/tests/loops/test_loops.py
+++ b/tests/loops/test_loops.py
@@ -100,6 +100,7 @@ def test_loop_restore():
     class Simple(Loop):
         def __init__(self, dataset: Iterator):
             super().__init__()
+            self.iteration_count = 0
             self.dataset = dataset
 
         @property
@@ -126,6 +127,9 @@ def test_loop_restore():
                 raise CustomException
 
             self.outputs.append(value)
+
+        def on_advance_end(self) -> None:
+            self.iteration_count += 1
 
         def state_dict(self) -> Dict:
             return {"iteration_count": self.iteration_count, "outputs": self.outputs}

--- a/tests/models/test_restore.py
+++ b/tests/models/test_restore.py
@@ -127,6 +127,61 @@ def test_model_properties_resume_from_checkpoint(tmpdir):
     trainer.fit(model)
 
 
+def test_correct_step_and_epoch(tmpdir):
+
+    class TestModel(BoringModel):
+
+        def on_pretrain_routine_end(self) -> None:
+            assert self.trainer.global_step == 5  # TODO(@carmocca): should be 4
+
+    model = BoringModel()
+    trainer = Trainer(default_root_dir=tmpdir, max_epochs=2, limit_train_batches=2)
+    assert trainer.current_epoch == 0
+    assert trainer.global_step == 0
+
+    trainer.fit(model)
+    assert trainer.current_epoch == 2
+    assert trainer.global_step == 4
+
+    ckpt = str(tmpdir / "model.ckpt")
+    trainer.save_checkpoint(ckpt)
+    assert torch.load(ckpt)["global_step"] == 5  # TODO(@carmocca): should be 4
+
+    trainer = Trainer(default_root_dir=tmpdir, resume_from_checkpoint=ckpt, max_epochs=4, limit_train_batches=2)
+    # the ckpt state is not loaded at this point
+    assert trainer.current_epoch == 0
+    assert trainer.global_step == 0
+
+    trainer.fit(TestModel())
+    assert trainer.current_epoch == 4
+    assert trainer.global_step == 7  # TODO(@carmocca): should be 8
+
+
+def test_fit_twice(tmpdir):
+    epochs = []
+
+    class TestModel(BoringModel):
+
+        def on_train_epoch_end(self, *_):
+            epochs.append(self.current_epoch)
+
+    trainer = Trainer(
+        max_epochs=2,
+        limit_train_batches=1,
+        limit_val_batches=1,
+        default_root_dir=tmpdir,
+        checkpoint_callback=False,
+        logger=False,
+        weights_summary=None,
+        progress_bar_refresh_rate=0,
+    )
+    trainer.fit(TestModel())
+    trainer.fit_loop.max_epochs = 4
+    trainer.fit(TestModel())
+
+    assert epochs == list(range(4))
+
+
 def test_try_resume_from_non_existing_checkpoint(tmpdir):
     """Test that trying to resume from non-existing `resume_from_checkpoint` fails with an error."""
     model = BoringModel()


### PR DESCRIPTION
# Blocked by #8477 and enabling restoring the ckpt progress tracking state by default.

## What does this PR do?



Fixes #5007
Part of #7406 

### Does your PR introduce any breaking changes? If yes, please list them.

With this PR, a `Trainer(max_epochs=1, limit_train_batches=1)` which saves a checkpoint`on_train_epoch_end` will have the `current_epoch=0, global_step=1` values saved. This is because we consider `on_train_epoch_end` to be part of the epoch itself:

```python
for epoch in epochs:
  ...
  on_train_epoch_end()
  epoch_count++
on_train_end()
```

`current_epoch` is now increased by 1 when training is over.
This means that if a model is run for 3 epochs (0, 1, 2), `trainer.current_epoch` will return `3`.
This is consistent with the fact that a new trainer returns `trainer.current_epoch == 0`, as in, the 0-th (first) epoch needs to run.
This will be breaking for anybody accessing the `trainer.current_epoch` attribute after `fit` is finished

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)
<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

🤪 
