### PR TITLE
Use class name in SWA info message

### DIFF
--- a/pytorch_lightning/callbacks/stochastic_weight_avg.py
+++ b/pytorch_lightning/callbacks/stochastic_weight_avg.py
@@ -195,7 +195,10 @@ class StochasticWeightAveraging(Callback):
                 scheduler_cfg = trainer.lr_schedulers[0]
                 if scheduler_cfg["interval"] != "epoch" or scheduler_cfg["frequency"] != 1:
                     rank_zero_warn(f"SWA is currently only supported every epoch. Found {scheduler_cfg}")
-                rank_zero_info(f"Swapping scheduler {scheduler_cfg['scheduler']} for {self._swa_scheduler}")
+                rank_zero_info(
+                    f"Swapping scheduler `{scheduler_cfg['scheduler'].__class__.__name__}`"
+                    f" for `{self._swa_scheduler.__class__.__name__}`"
+                )
                 trainer.lr_schedulers[0] = default_scheduler_cfg
             else:
                 trainer.lr_schedulers.append(default_scheduler_cfg)

--- a/tests/callbacks/test_stochastic_weight_avg.py
+++ b/tests/callbacks/test_stochastic_weight_avg.py
@@ -175,7 +175,7 @@ def test_swa_warns(tmpdir, caplog):
     trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=True, stochastic_weight_avg=True)
     with caplog.at_level(level=logging.INFO), pytest.warns(UserWarning, match="SWA is currently only supported"):
         trainer.fit(model)
-    assert "Swapping scheduler" in caplog.text
+    assert "Swapping scheduler `StepLR` for `SWALR`" in caplog.text
 
 
 def test_swa_raises():


### PR DESCRIPTION
## What does this PR do?

Reported in Slack

Previous:

```python
Swapping scheduler <torch.optim.lr_scheduler.ReduceLROnPlateau object at 0x7f073a59c190> for <torch.optim.swa_utils.SWALR object at 0x7f073349be20>
```

Now:

```python
Swapping scheduler `ReduceLROnPlateau` for `SWALR`
```

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [n/a] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)
<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified