### PR TITLE
add finish method to WandbLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `state_id` property to the `Callback` base class ([#6886](https://github.com/PyTorchLightning/pytorch-lightning/pull/6886))
 
 
--
+- Added `finish()` method to `WandbLogger` for convenience to signal an experiment is over and to facilitate running several experiments in the same process ([#8617](https://github.com/PyTorchLightning/pytorch-lightning/pull/8617))
 
 
 -

--- a/pytorch_lightning/loggers/wandb.py
+++ b/pytorch_lightning/loggers/wandb.py
@@ -246,6 +246,14 @@ class WandbLogger(LightningLoggerBase):
         if self._checkpoint_callback:
             self._scan_and_log_checkpoints(self._checkpoint_callback)
 
+    def finish(self) -> None:
+        """
+        Convenience method to manually signal that the current experiment is over. It is equivalent to calling
+        :func:`wandb.finish` and allows for creating a new wandb experiment in the same process as :class:`wandb.run`
+        would be shared globally otherwise.
+        """
+        self.experiment.finish()
+
     def _scan_and_log_checkpoints(self, checkpoint_callback: "ReferenceType[ModelCheckpoint]") -> None:
         # get checkpoints to be saved with associated score
         checkpoints = {


### PR DESCRIPTION
## What does this PR do?

Adds `WandbLogger.finish()` since WandbLogger by default operates with the global wandb.run object. 
Users who want to run several experiments in the same script must manually signal `wandb.finish()`. With the addition of this convenience method, they don't have to import wandb first just to do this.

Fixes #8614

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃
