### PR TITLE
Fix references for `ResultCollection.extra` and improve `str` and `repr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Saved checkpoints will no longer use the type of a `Callback` as the key to avoid issues with unpickling ([#6886](https://github.com/PyTorchLightning/pytorch-lightning/pull/6886))
 
 
--
+- Improved string conversion for `ResultCollection` ([#8622](https://github.com/PyTorchLightning/pytorch-lightning/pull/8622))
 
 
 -
@@ -74,7 +74,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
--
+- Fixed references for `ResultCollection.extra` ([#8622](https://github.com/PyTorchLightning/pytorch-lightning/pull/8622))
 
 
 -

--- a/tests/core/test_metric_result_integration.py
+++ b/tests/core/test_metric_result_integration.py
@@ -132,12 +132,27 @@ def test_result_metric_integration():
 
         assert epoch_log == {"b": cumulative_sum, "a_epoch": cumulative_sum}
 
+    result.minimize = torch.tensor(1.0)
+    result.extra = {}
     assert str(result) == (
-        "ResultCollection(True, cpu, {"
+        "ResultCollection("
+        "minimize=1.0, "
+        "{"
         "'h.a': ResultMetric('a', value=DummyMetric()), "
         "'h.b': ResultMetric('b', value=DummyMetric()), "
         "'h.c': ResultMetric('c', value=DummyMetric())"
         "})"
+    )
+    assert repr(result) == (
+        "{"
+        "True, "
+        "device(type='cpu'), "
+        "minimize=tensor(1.), "
+        "{'h.a': ResultMetric('a', value=DummyMetric()), "
+        "'h.b': ResultMetric('b', value=DummyMetric()), "
+        "'h.c': ResultMetric('c', value=DummyMetric()), "
+        "'_extra': {}}"
+        "}"
     )
 
 
@@ -332,3 +347,9 @@ def test_lightning_module_logging_result_collection(tmpdir, device):
         gpus=1 if device == "cuda" else 0,
     )
     trainer.fit(model)
+
+
+def test_result_collection_extra_reference():
+    """Unit-test to check that the `extra` dict reference is properly set."""
+    rc = ResultCollection(True)
+    assert rc.extra is rc["_extra"]


### PR DESCRIPTION
## What does this PR do?

Fixes an issue where the `ResultCollection.extra` return dict was not set back to the object in the default case.

Also improve its string representations.

Found while debugging #8613

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)
<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified