### PR TITLE
Add property to skip restoring optimizers and schedulers via plugin (DeepSpeed Checkpointing Fix 2/n) 

### DIFF
--- a/pytorch_lightning/plugins/training_type/training_type_plugin.py
+++ b/pytorch_lightning/plugins/training_type/training_type_plugin.py
@@ -246,6 +246,14 @@ class TrainingTypePlugin(Plugin, ABC):
         """
         return False
 
+    @property
+    def lightning_restore_optimizer_and_schedulers(self) -> bool:
+        """
+        Override to disable Lightning restoring optimizers/schedulers.
+        This is useful for plugins which manage restoring optimizers/schedulers.
+        """
+        return True
+
     def update_global_step(self, total_batch_idx: int, current_global_step: int) -> int:
         """
         Provide a hook to count optimizer step calls.

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -221,7 +221,10 @@ class CheckpointConnector:
 
     def restore_optimizers_and_schedulers(self) -> None:
         """Restores the optimizers and learning rate scheduler states from the pre-loaded checkpoint."""
-        if not self._loaded_checkpoint:
+        if (
+            not self._loaded_checkpoint
+            or not self.trainer.training_type_plugin.lightning_restore_optimizer_and_schedulers
+        ):
             return
 
         # validation

--- a/tests/plugins/test_custom_plugin.py
+++ b/tests/plugins/test_custom_plugin.py
@@ -11,8 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+from typing import Any, Mapping
+
+import pytest
+import torch
+
 from pytorch_lightning import Trainer
-from pytorch_lightning.plugins import DDPPlugin
+from pytorch_lightning.plugins import DDPPlugin, SingleDevicePlugin
 from tests.helpers import BoringModel
 from tests.helpers.runif import RunIf
 
@@ -33,3 +39,31 @@ def test_sync_batchnorm_set(tmpdir):
     trainer = Trainer(max_epochs=1, plugins=[plugin], default_root_dir=tmpdir, sync_batchnorm=True)
     trainer.fit(model)
     assert plugin.sync_batchnorm is True
+
+
+@pytest.mark.parametrize("restore_optimizer_and_schedulers", [True, False])
+def test_plugin_lightning_restore_optimizer_and_schedulers(tmpdir, restore_optimizer_and_schedulers):
+    class TestPlugin(SingleDevicePlugin):
+        load_optimizer_state_dict_called = False
+
+        @property
+        def lightning_restore_optimizer_and_schedulers(self) -> bool:
+            return restore_optimizer_and_schedulers
+
+        def load_optimizer_state_dict(self, checkpoint: Mapping[str, Any]) -> None:
+            self.load_optimizer_state_dict_called = True
+
+    # create ckpt to resume from
+    checkpoint_path = os.path.join(tmpdir, "model.ckpt")
+    model = BoringModel()
+    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=True)
+    trainer.fit(model)
+    trainer.save_checkpoint(checkpoint_path)
+
+    model = BoringModel()
+    plugin = TestPlugin(torch.device("cpu"))
+    trainer = Trainer(
+        default_root_dir=tmpdir, fast_dev_run=True, plugins=plugin, resume_from_checkpoint=checkpoint_path
+    )
+    trainer.fit(model)
+    assert plugin.load_optimizer_state_dict_called == restore_optimizer_and_schedulers


### PR DESCRIPTION
## What does this PR do?

Related to #8397

This PR adds a new property to skip optimizer/schedulers loading via the checkpoint connector, which for DeepSpeed is managed by the engine itself. The alternative was to move the loading logic into the plugin however this breaks the responsibility a bit for all other plugins that do not need this additional logic to be moved into the training type plugin.

Eventually, I'd like to see the actual loading logic end up inside the CheckpointPlugin, as described in https://github.com/PyTorchLightning/pytorch-lightning/issues/8118 to give the plugin a bit more control in the future.

CHANGELOG to be added in #8397 

cc @awaelchli @tchaton 

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)
<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
