### PR TITLE
Fix an import deprecation warning

### DIFF
--- a/pytorch_lightning/accelerators/ipu.py
+++ b/pytorch_lightning/accelerators/ipu.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from collections import Callable
+from collections.abc import Callable
 from typing import Any
 
 from torch.optim import Optimizer

--- a/pytorch_lightning/accelerators/ipu.py
+++ b/pytorch_lightning/accelerators/ipu.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from collections.abc import Callable
-from typing import Any
+from typing import Any, Callable
 
 from torch.optim import Optimizer
 


### PR DESCRIPTION
## What does this PR do?

Fix an import deprecation warning (collections -> collections.abc). Similar to https://github.com/PyTorchLightning/pytorch-lightning/pull/3110.

The warning this addresses is:
```
DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  from collections import Callable
``` 