### PR TITLE
Allow --gpus=None in argparse

### DIFF
--- a/pytorch_lightning/utilities/argparse.py
+++ b/pytorch_lightning/utilities/argparse.py
@@ -285,8 +285,10 @@ def _parse_args_from_docstring(docstring: str) -> Dict[str, str]:
     return parsed
 
 
-def _gpus_allowed_type(x: str) -> Union[int, str]:
-    if "," in x:
+def _gpus_allowed_type(x: str) -> Union[int, str, None]:
+    if x.lower() == "none":
+        return None
+    elif "," in x:
         return str(x)
     return int(x)
 

--- a/tests/utilities/test_argparse.py
+++ b/tests/utilities/test_argparse.py
@@ -210,6 +210,7 @@ def test_add_argparse_args_no_argument_group():
 def test_gpus_allowed_type():
     assert _gpus_allowed_type("1,2") == "1,2"
     assert _gpus_allowed_type("1") == 1
+    assert _gpus_allowed_type("None") is None
 
 
 def test_int_or_float_type():


### PR DESCRIPTION
## What does this PR do?

This is a minor change that allows for the user to specify `--gpus=None` on the command line.

I hade an issue here describing the modifivation for the change.  #8823

Not sure if a CHANGELOG entry is  needed for this level of change. I did add a corresponding test though. 

## Did you have fun?

Of course I had fun! Who doesn't enjoy orchestrating complex dances of subatomic particles‽