### PR TITLE
Deprecate DataModule properties: train_transforms, val_transforms, test_transforms, dims, and size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Deprecated `LightningModule.model_size` ([#8343](https://github.com/PyTorchLightning/pytorch-lightning/pull/8343))
 
 
-- Deprecated `DataModule` properties: `train_transforms`, `val_transforms`, `test_transforms`, `size`, `dims`
+- Deprecated `DataModule` properties: `train_transforms`, `val_transforms`, `test_transforms`, `size`, `dims` ([#8851](https://github.com/PyTorchLightning/pytorch-lightning/pull/8851))
 
 
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Deprecated `LightningModule.model_size` ([#8343](https://github.com/PyTorchLightning/pytorch-lightning/pull/8343))
 
 
--
+- Deprecated `DataModule` properties: `train_transforms`, `val_transforms`, `test_transforms`, `size`, `dims`
 
 
 -

--- a/pytorch_lightning/core/datamodule.py
+++ b/pytorch_lightning/core/datamodule.py
@@ -95,40 +95,76 @@ class LightningDataModule(CheckpointHooks, DataHooks, HyperparametersMixin):
     def train_transforms(self):
         """
         Optional transforms (or collection of transforms) you can apply to train dataset
+
+        .. deprecated:: v1.5
+            Will be removed in v1.7.0.
         """
+
+        rank_zero_deprecation(
+            "DataModule property `train_transforms` was deprecated in v1.5 and will be removed in v1.7."
+        )
         return self._train_transforms
 
     @train_transforms.setter
     def train_transforms(self, t):
+        rank_zero_deprecation(
+            "DataModule property `train_transforms` was deprecated in v1.5 and will be removed in v1.7."
+        )
         self._train_transforms = t
 
     @property
     def val_transforms(self):
         """
         Optional transforms (or collection of transforms) you can apply to validation dataset
+
+        .. deprecated:: v1.5
+            Will be removed in v1.7.0.
         """
+
+        rank_zero_deprecation(
+            "DataModule property `val_transforms` was deprecated in v1.5 and will be removed in v1.7."
+        )
         return self._val_transforms
 
     @val_transforms.setter
     def val_transforms(self, t):
+        rank_zero_deprecation(
+            "DataModule property `val_transforms` was deprecated in v1.5 and will be removed in v1.7."
+        )
         self._val_transforms = t
 
     @property
     def test_transforms(self):
         """
         Optional transforms (or collection of transforms) you can apply to test dataset
+
+        .. deprecated:: v1.5
+            Will be removed in v1.7.0.
         """
+
+        rank_zero_deprecation(
+            "DataModule property `test_transforms` was deprecated in v1.5 and will be removed in v1.7."
+        )
         return self._test_transforms
 
     @test_transforms.setter
     def test_transforms(self, t):
+        rank_zero_deprecation(
+            "DataModule property `test_transforms` was deprecated in v1.5 and will be removed in v1.7."
+        )
         self._test_transforms = t
 
     @property
     def dims(self):
         """
         A tuple describing the shape of your data. Extra functionality exposed in ``size``.
+
+        .. deprecated:: v1.5
+            Will be removed in v1.7.0.
         """
+        rank_zero_deprecation(
+            "DataModule property `dims` was deprecated in v1.5 and will be removed in v1.7."
+        )
         return self._dims
 
     @dims.setter
@@ -139,11 +175,17 @@ class LightningDataModule(CheckpointHooks, DataHooks, HyperparametersMixin):
         """
         Return the dimension of each input either as a tuple or list of tuples. You can index this
         just as you would with a torch tensor.
+
+        .. deprecated:: v1.5
+            Will be removed in v1.7.0.
         """
 
         if dim is not None:
             return self.dims[dim]
 
+        rank_zero_deprecation(
+            "DataModule property `size` was deprecated in v1.5 and will be removed in v1.7."
+        )
         return self.dims
 
     @property

--- a/pytorch_lightning/core/datamodule.py
+++ b/pytorch_lightning/core/datamodule.py
@@ -82,6 +82,8 @@ class LightningDataModule(CheckpointHooks, DataHooks, HyperparametersMixin):
             rank_zero_deprecation(
                 "DataModule property `test_transforms` was deprecated in v1.5 and will be removed in v1.7."
             )
+        if dims is not None:
+            rank_zero_deprecation("DataModule property `dims` was deprecated in v1.5 and will be removed in v1.7.")
         self._train_transforms = train_transforms
         self._val_transforms = val_transforms
         self._test_transforms = test_transforms

--- a/pytorch_lightning/core/datamodule.py
+++ b/pytorch_lightning/core/datamodule.py
@@ -70,6 +70,12 @@ class LightningDataModule(CheckpointHooks, DataHooks, HyperparametersMixin):
 
     def __init__(self, train_transforms=None, val_transforms=None, test_transforms=None, dims=None):
         super().__init__()
+        if train_transforms is not None:
+            rank_zero_deprecation("DataModule property `train_transforms` was deprecated in v1.5 and will be removed in v1.7.")
+        if val_transforms is not None:
+            rank_zero_deprecation("DataModule property `val_transforms` was deprecated in v1.5 and will be removed in v1.7.")
+        if test_transforms is not None:
+            rank_zero_deprecation("DataModule property `test_transforms` was deprecated in v1.5 and will be removed in v1.7.")
         self._train_transforms = train_transforms
         self._val_transforms = val_transforms
         self._test_transforms = test_transforms
@@ -169,6 +175,9 @@ class LightningDataModule(CheckpointHooks, DataHooks, HyperparametersMixin):
 
     @dims.setter
     def dims(self, d):
+        rank_zero_deprecation(
+            "DataModule property `dims` was deprecated in v1.5 and will be removed in v1.7."
+        )
         self._dims = d
 
     def size(self, dim=None) -> Union[Tuple, int]:

--- a/pytorch_lightning/core/datamodule.py
+++ b/pytorch_lightning/core/datamodule.py
@@ -71,11 +71,17 @@ class LightningDataModule(CheckpointHooks, DataHooks, HyperparametersMixin):
     def __init__(self, train_transforms=None, val_transforms=None, test_transforms=None, dims=None):
         super().__init__()
         if train_transforms is not None:
-            rank_zero_deprecation("DataModule property `train_transforms` was deprecated in v1.5 and will be removed in v1.7.")
+            rank_zero_deprecation(
+                "DataModule property `train_transforms` was deprecated in v1.5 and will be removed in v1.7."
+            )
         if val_transforms is not None:
-            rank_zero_deprecation("DataModule property `val_transforms` was deprecated in v1.5 and will be removed in v1.7.")
+            rank_zero_deprecation(
+                "DataModule property `val_transforms` was deprecated in v1.5 and will be removed in v1.7."
+            )
         if test_transforms is not None:
-            rank_zero_deprecation("DataModule property `test_transforms` was deprecated in v1.5 and will be removed in v1.7.")
+            rank_zero_deprecation(
+                "DataModule property `test_transforms` was deprecated in v1.5 and will be removed in v1.7."
+            )
         self._train_transforms = train_transforms
         self._val_transforms = val_transforms
         self._test_transforms = test_transforms

--- a/tests/deprecated_api/test_remove_1-7.py
+++ b/tests/deprecated_api/test_remove_1-7.py
@@ -16,7 +16,8 @@
 import pytest
 
 from tests.deprecated_api import _soft_unimport_module
-from tests.helpers import BoringModel
+from tests.helpers import BoringModel, BoringDataModule
+from tests.helpers.datamodules import MNISTDataModule
 
 
 def test_v1_7_0_deprecated_lightning_module_summarize(tmpdir):
@@ -46,3 +47,25 @@ def test_v1_7_0_deprecated_model_size():
         match="LightningModule.model_size` property was deprecated in v1.5 and will be removed in v1.7"
     ):
         _ = model.model_size
+
+
+def test_v1_7_0_datamodule_transform_properties(tmpdir):
+    dm = MNISTDataModule()
+    with pytest.deprecated_call(match=r"DataModule property `train_transforms` was deprecated in v1.5"):
+        dm.train_transforms = "a"
+    with pytest.deprecated_call(match=r"DataModule property `val_transforms` was deprecated in v1.5"):
+        dm.val_transforms = "b"
+    with pytest.deprecated_call(match=r"DataModule property `test_transforms` was deprecated in v1.5"):
+        dm.test_transforms = "c"
+
+
+def test_v1_7_0_datamodule_size_property(tmpdir):
+    dm = MNISTDataModule()
+    with pytest.deprecated_call(match=r"DataModule property `size` was deprecated in v1.5"):
+        dm.size()
+
+
+def test_v1_7_0_datamodule_dims_property(tmpdir):
+    dm = MNISTDataModule()
+    with pytest.deprecated_call(match=r"DataModule property `dims` was deprecated in v1.5"):
+        dm.dims

--- a/tests/deprecated_api/test_remove_1-7.py
+++ b/tests/deprecated_api/test_remove_1-7.py
@@ -16,7 +16,7 @@
 import pytest
 
 from tests.deprecated_api import _soft_unimport_module
-from tests.helpers import BoringDataModule, BoringModel
+from tests.helpers import BoringModel
 from tests.helpers.datamodules import MNISTDataModule
 
 

--- a/tests/deprecated_api/test_remove_1-7.py
+++ b/tests/deprecated_api/test_remove_1-7.py
@@ -15,6 +15,7 @@
 
 import pytest
 
+from pytorch_lightning import LightningDataModule
 from tests.deprecated_api import _soft_unimport_module
 from tests.helpers import BoringModel
 from tests.helpers.datamodules import MNISTDataModule
@@ -57,6 +58,12 @@ def test_v1_7_0_datamodule_transform_properties(tmpdir):
         dm.val_transforms = "b"
     with pytest.deprecated_call(match=r"DataModule property `test_transforms` was deprecated in v1.5"):
         dm.test_transforms = "c"
+    with pytest.deprecated_call(match=r"DataModule property `train_transforms` was deprecated in v1.5"):
+        _ = LightningDataModule(train_transforms="a")
+    with pytest.deprecated_call(match=r"DataModule property `val_transforms` was deprecated in v1.5"):
+        _ = LightningDataModule(val_transforms="b")
+    with pytest.deprecated_call(match=r"DataModule property `test_transforms` was deprecated in v1.5"):
+        _ = LightningDataModule(test_transforms="c")
 
 
 def test_v1_7_0_datamodule_size_property(tmpdir):
@@ -69,3 +76,5 @@ def test_v1_7_0_datamodule_dims_property(tmpdir):
     dm = MNISTDataModule()
     with pytest.deprecated_call(match=r"DataModule property `dims` was deprecated in v1.5"):
         _ = dm.dims
+    with pytest.deprecated_call(match=r"DataModule property `dims` was deprecated in v1.5"):
+        _ = LightningDataModule(dims=(1, 1, 1))

--- a/tests/deprecated_api/test_remove_1-7.py
+++ b/tests/deprecated_api/test_remove_1-7.py
@@ -68,4 +68,4 @@ def test_v1_7_0_datamodule_size_property(tmpdir):
 def test_v1_7_0_datamodule_dims_property(tmpdir):
     dm = MNISTDataModule()
     with pytest.deprecated_call(match=r"DataModule property `dims` was deprecated in v1.5"):
-        dm.dims
+        _ = dm.dims

--- a/tests/deprecated_api/test_remove_1-7.py
+++ b/tests/deprecated_api/test_remove_1-7.py
@@ -64,6 +64,8 @@ def test_v1_7_0_datamodule_transform_properties(tmpdir):
         _ = LightningDataModule(val_transforms="b")
     with pytest.deprecated_call(match=r"DataModule property `test_transforms` was deprecated in v1.5"):
         _ = LightningDataModule(test_transforms="c")
+    with pytest.deprecated_call(match=r"DataModule property `test_transforms` was deprecated in v1.5"):
+        _ = LightningDataModule(test_transforms="c", dims=(1, 1, 1))
 
 
 def test_v1_7_0_datamodule_size_property(tmpdir):


### PR DESCRIPTION
Deprecate DataModule properties: train_transforms, val_transforms, test_transforms, dums, and size

## What does this PR do?

added deprecation warnings to Datamodule methods: train_transforms, val_transforms, test_transforms, dums, and size.

as per the approach outlined in the ticket based on #7301 where the deprecation warning goes out next release and then is removed two releases later. I did not find any tests that need to be moved.

Fixes #8728 

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
