### PR TITLE
[WIP] Remove `TrainingEpochLoop.is_last_batch`

### DIFF
--- a/pytorch_lightning/trainer/properties.py
+++ b/pytorch_lightning/trainer/properties.py
@@ -545,7 +545,7 @@ class TrainerProperties(ABC):
 
     @property
     def is_last_batch(self) -> bool:
-        return self.fit_loop.epoch_loop.is_last_batch
+        return self.fit_loop.epoch_loop._num_training_batches_reached()
 
     @property
     def fit_loop(self) -> FitLoop:

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -242,9 +242,8 @@ def test_gradient_accumulation_scheduling_last_batch(tmpdir, accumulate_grad_bat
 
         def on_train_batch_end(self, outputs, batch, batch_idx, *_):
             end_state_dict = self.state_dict()
-            is_last_batch = (batch_idx + 1) == self.trainer.num_training_batches
 
-            if is_last_batch or self.opt_step_called:
+            if self.trainer.is_last_batch or self.opt_step_called:
                 assert self.check(self.start_state_dict, end_state_dict, equal=False)
             else:
                 assert self.check(self.start_state_dict, end_state_dict)


### PR DESCRIPTION
## What does this PR do?

Removes the `is_last_batch` attribute which is not necessary anymore.

### Does your PR introduce any breaking changes? If yes, please list them.

The attribute has been removed in the `TrainingEpochLoop`, but kept in Trainer properties.

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified