### PR TITLE
Allow disabling automatic stopping after max_steps or max_epochs

### DIFF
--- a/docs/source/common/trainer.rst
+++ b/docs/source/common/trainer.rst
@@ -907,6 +907,9 @@ Stop training once this number of epochs is reached
     # default used by the Trainer
     trainer = Trainer(max_epochs=1000)
 
+If both ``max_epochs`` and ``max_steps`` aren't specified, ``max_epochs`` will default to ``1000``.
+To disable this default, you can set one (or both) of ``max_epochs`` or ``max_steps`` to be ``-1``.
+
 min_epochs
 ^^^^^^^^^^
 
@@ -946,6 +949,10 @@ Training will stop if max_steps or max_epochs have reached (earliest).
 
     # Stop after 100 steps
     trainer = Trainer(max_steps=100)
+
+If ``max_steps`` is not specified, ``max_epochs`` will be used instead (and ``max_epochs`` defaults to
+``1000`` if ``max_epochs`` is not specified). To disable this default, you can set one (or both) of ``max_steps`` or
+``max_epochs`` to be ``-1``.
 
 min_steps
 ^^^^^^^^^

--- a/docs/source/common/trainer.rst
+++ b/docs/source/common/trainer.rst
@@ -908,7 +908,7 @@ Stop training once this number of epochs is reached
     trainer = Trainer(max_epochs=1000)
 
 If both ``max_epochs`` and ``max_steps`` aren't specified, ``max_epochs`` will default to ``1000``.
-To disable this default, set ``max_epochs = -1``.
+To enable infinite training, set ``max_epochs = -1``.
 
 min_epochs
 ^^^^^^^^^^

--- a/docs/source/common/trainer.rst
+++ b/docs/source/common/trainer.rst
@@ -908,7 +908,7 @@ Stop training once this number of epochs is reached
     trainer = Trainer(max_epochs=1000)
 
 If both ``max_epochs`` and ``max_steps`` aren't specified, ``max_epochs`` will default to ``1000``.
-To disable this default, you can set one (or both) of ``max_epochs`` or ``max_steps`` to be ``-1``.
+To disable this default, set ``max_epochs = -1``.
 
 min_epochs
 ^^^^^^^^^^
@@ -951,8 +951,7 @@ Training will stop if max_steps or max_epochs have reached (earliest).
     trainer = Trainer(max_steps=100)
 
 If ``max_steps`` is not specified, ``max_epochs`` will be used instead (and ``max_epochs`` defaults to
-``1000`` if ``max_epochs`` is not specified). To disable this default, you can set one (or both) of ``max_steps`` or
-``max_epochs`` to be ``-1``.
+``1000`` if ``max_epochs`` is not specified). To disable this default, set ``max_steps = -1``.
 
 min_steps
 ^^^^^^^^^

--- a/pytorch_lightning/loops/epoch/training_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/training_epoch_loop.py
@@ -39,9 +39,7 @@ class TrainingEpochLoop(loops.Loop):
         self.min_steps: int = min_steps
 
         if max_steps and max_steps < -1:
-            raise MisconfigurationException(
-                f"`max_steps` must be a positive integer or -1. You passed in {max_steps}."
-            )
+            raise MisconfigurationException(f"`max_steps` must be a positive integer or -1. You passed in {max_steps}.")
         self.max_steps: int = max_steps
 
         self.global_step: int = 0

--- a/pytorch_lightning/loops/epoch/training_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/training_epoch_loop.py
@@ -37,6 +37,11 @@ class TrainingEpochLoop(loops.Loop):
     def __init__(self, min_steps: int, max_steps: int):
         super().__init__()
         self.min_steps: int = min_steps
+
+        if max_steps and max_steps < -1:
+            raise MisconfigurationException(
+                f"`max_steps` must be a positive integer or -1. You passed in {max_steps}."
+            )
         self.max_steps: int = max_steps
 
         self.global_step: int = 0

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -37,7 +37,7 @@ class FitLoop(Loop):
 
     def __init__(self, min_epochs: Optional[int] = None, max_epochs: Optional[int] = None):
         super().__init__()
-         # Allow max_epochs or max_steps to be zero, since this will be handled by fit_loop.done
+        # Allow max_epochs or max_steps to be zero, since this will be handled by fit_loop.done
         if max_epochs and max_epochs < -1:
             raise MisconfigurationException(
                 f"`max_epochs` must be a positive integer or -1. You passed in {max_epochs}."
@@ -106,9 +106,7 @@ class FitLoop(Loop):
     def max_steps(self, value: int) -> None:
         """Sets the maximum number of steps (forwards to epoch_loop)"""
         if value and value < -1:
-            raise MisconfigurationException(
-                f"`max_steps` must be a positive integer or -1. You passed in {value}."
-            )
+            raise MisconfigurationException(f"`max_steps` must be a positive integer or -1. You passed in {value}.")
 
         # TODO(@awaelchli): This setter is required by debugging connector (fast dev run), should be avoided
         self.epoch_loop.max_steps = value

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -132,8 +132,8 @@ class FitLoop(Loop):
         or if the maximum number of steps or epochs is reached.
         """
         # TODO(@awaelchli): Move track steps inside training loop and move part of these condition inside training loop
-        stop_steps = self.max_steps not in [None, -1] and self.global_step >= self.max_steps
-        stop_epochs = self.max_epochs not in [None, -1] and self.current_epoch >= self.max_epochs
+        stop_steps = self.max_steps not in (None, -1) and self.global_step >= self.max_steps
+        stop_epochs = self.max_epochs not in (None, -1) and self.current_epoch >= self.max_epochs
 
         should_stop = False
         if self.trainer.should_stop:

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -105,10 +105,9 @@ class FitLoop(Loop):
     @max_steps.setter
     def max_steps(self, value: int) -> None:
         """Sets the maximum number of steps (forwards to epoch_loop)"""
+        # TODO(@awaelchli): This setter is required by debugging connector (fast dev run), should be avoided
         if value and value < -1:
             raise MisconfigurationException(f"`max_steps` must be a positive integer or -1. You passed in {value}.")
-
-        # TODO(@awaelchli): This setter is required by debugging connector (fast dev run), should be avoided
         self.epoch_loop.max_steps = value
 
     @property

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -21,6 +21,7 @@ from pytorch_lightning.loops.epoch import TrainingEpochLoop
 from pytorch_lightning.trainer.connectors.logger_connector.result import ResultCollection
 from pytorch_lightning.trainer.progress import Progress
 from pytorch_lightning.trainer.supporters import TensorRunningAccum
+from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 log = logging.getLogger(__name__)
 
@@ -36,6 +37,12 @@ class FitLoop(Loop):
 
     def __init__(self, min_epochs: Optional[int] = None, max_epochs: Optional[int] = None):
         super().__init__()
+         # Allow max_epochs or max_steps to be zero, since this will be handled by fit_loop.done
+        if max_epochs and max_epochs < -1:
+            raise MisconfigurationException(
+                f"`max_epochs` must be a positive integer or -1. You passed in {max_epochs}."
+            )
+
         self.max_epochs = max_epochs
         self.min_epochs = min_epochs
         self.epoch_loop: Optional[TrainingEpochLoop] = None
@@ -98,6 +105,11 @@ class FitLoop(Loop):
     @max_steps.setter
     def max_steps(self, value: int) -> None:
         """Sets the maximum number of steps (forwards to epoch_loop)"""
+        if value and value < -1:
+            raise MisconfigurationException(
+                f"`max_steps` must be a positive integer or -1. You passed in {value}."
+            )
+
         # TODO(@awaelchli): This setter is required by debugging connector (fast dev run), should be avoided
         self.epoch_loop.max_steps = value
 

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -132,8 +132,7 @@ class FitLoop(Loop):
         or if the maximum number of steps or epochs is reached.
         """
         if self.max_epochs < 0 and self.max_steps is None:
-            # If max_epochs is negative and self.max_steps isn't specified,
-            # disable automatic stopping
+            # If max_epochs is negative and max_steps is not defined, disable automatic stopping
             return False
 
         # TODO(@awaelchli): Move track steps inside training loop and move part of these condition inside training loop

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -130,7 +130,7 @@ class FitLoop(Loop):
         be used for checking whether max_epochs or max_steps is enabled.
 
         Args:
-            max_value (Optional[int]): the value to check
+            max_value: the value to check
 
         Returns:
             bool: whether the limit for this value should be enabled

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -124,6 +124,19 @@ class FitLoop(Loop):
             return self.epoch_loop.val_loop._results
         raise RuntimeError("`FitLoop._results` property isn't defined. Accessed outside of scope")
 
+    @staticmethod
+    def _is_max_limit_enabled(max_value: Optional[int]) -> bool:
+        """Checks whether the max_value is enabled. This can
+        be used for checking whether max_epochs or max_steps is enabled.
+
+        Args:
+            max_value (Optional[int]): the value to check
+
+        Returns:
+            bool: whether the limit for this value should be enabled
+        """
+        return max_value not in [None, -1]
+
     @property
     def done(self) -> bool:
         """Evaluates when to leave the loop.
@@ -132,8 +145,8 @@ class FitLoop(Loop):
         or if the maximum number of steps or epochs is reached.
         """
         # TODO(@awaelchli): Move track steps inside training loop and move part of these condition inside training loop
-        stop_steps = self.max_steps not in (None, -1) and self.global_step >= self.max_steps
-        stop_epochs = self.max_epochs not in (None, -1) and self.current_epoch >= self.max_epochs
+        stop_steps = FitLoop._is_max_limit_enabled(self.max_steps) and self.global_step >= self.max_steps
+        stop_epochs = FitLoop._is_max_limit_enabled(self.max_epochs) and self.current_epoch >= self.max_epochs
 
         should_stop = False
         if self.trainer.should_stop:

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -133,7 +133,7 @@ class FitLoop(Loop):
             max_value: the value to check
 
         Returns:
-            bool: whether the limit for this value should be enabled
+            whether the limit for this value should be enabled
         """
         return max_value not in [None, -1]
 

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -131,6 +131,11 @@ class FitLoop(Loop):
         Returns True if trainer.should_stop was set (e.g. by early stopping)
         or if the maximum number of steps or epochs is reached.
         """
+        if self.max_epochs < 0 and self.max_steps is None:
+            # If max_epochs is negative and self.max_steps isn't specified,
+            # disable automatic stopping
+            return False
+
         # TODO(@awaelchli): Move track steps inside training loop and move part of these condition inside training loop
         stop_steps = self.max_steps is not None and self.global_step >= self.max_steps
         stop_epochs = self.max_epochs is not None and self.current_epoch >= self.max_epochs

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -135,7 +135,7 @@ class FitLoop(Loop):
         Returns:
             whether the limit for this value should be enabled
         """
-        return max_value not in [None, -1]
+        return max_value not in (None, -1)
 
     @property
     def done(self) -> bool:

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -131,13 +131,9 @@ class FitLoop(Loop):
         Returns True if trainer.should_stop was set (e.g. by early stopping)
         or if the maximum number of steps or epochs is reached.
         """
-        if self.max_epochs < 0 and self.max_steps is None:
-            # If max_epochs is negative and max_steps is not defined, disable automatic stopping
-            return False
-
         # TODO(@awaelchli): Move track steps inside training loop and move part of these condition inside training loop
-        stop_steps = self.max_steps is not None and self.global_step >= self.max_steps
-        stop_epochs = self.max_epochs is not None and self.current_epoch >= self.max_epochs
+        stop_steps = self.max_steps not in [None, -1] and self.global_step >= self.max_steps
+        stop_epochs = self.max_epochs not in [None, -1] and self.current_epoch >= self.max_epochs
 
         should_stop = False
         if self.trainer.should_stop:

--- a/pytorch_lightning/trainer/configuration_validator.py
+++ b/pytorch_lightning/trainer/configuration_validator.py
@@ -91,12 +91,12 @@ class ConfigValidator:
             )
 
         # Allow max_epochs or max_steps to be zero, since this will be handled by fit_loop.done
-        if trainer.max_epochs and (trainer.max_epochs < -1 or isinstance(trainer.max_epochs, float)):
+        if trainer.max_epochs and (trainer.max_epochs < -1 or not isinstance(trainer.max_epochs, int)):
             raise MisconfigurationException(
                 f"`max_epochs` must be a positive integer or -1. You passed in {trainer.max_epochs}."
             )
 
-        if trainer.max_steps and (trainer.max_steps < -1 or isinstance(trainer.max_steps, float)):
+        if trainer.max_steps and (trainer.max_steps < -1 or not isinstance(trainer.max_steps, int)):
             raise MisconfigurationException(
                 f"`max_steps` must be a positive integer or -1. You passed in {trainer.max_steps}."
             )

--- a/pytorch_lightning/trainer/configuration_validator.py
+++ b/pytorch_lightning/trainer/configuration_validator.py
@@ -90,6 +90,18 @@ class ConfigValidator:
                 "(rather, they are called on every optimization step)."
             )
 
+        # Allow max_epochs or max_steps to be zero, since this will be handled by fit_loop.done 
+        if trainer.max_epochs < -1 or isinstance(trainer.max_epochs, float):
+            raise MisconfigurationException(
+                f"`max_epochs` must be a positive integer or -1. You passed in {trainer.max_epochs}."
+            )
+
+        if trainer.max_steps < -1 or isinstance(trainer.max_steps, float):
+            raise MisconfigurationException(
+                f"`max_steps` must be a positive integer or -1. You passed in {trainer.max_steps}."
+            )
+        
+
     def __verify_eval_loop_configuration(self, model: "pl.LightningModule", stage: str) -> None:
         loader_name = f"{stage}_dataloader"
         step_name = "validation_step" if stage == "val" else "test_step"

--- a/pytorch_lightning/trainer/configuration_validator.py
+++ b/pytorch_lightning/trainer/configuration_validator.py
@@ -90,13 +90,17 @@ class ConfigValidator:
                 "(rather, they are called on every optimization step)."
             )
 
-        # Allow max_epochs or max_steps to be zero, since this will be handled by fit_loop.done
-        if trainer.max_epochs < -1 or isinstance(trainer.max_epochs, float):
+         # Allow max_epochs or max_steps to be zero, since this will be handled by fit_loop.done
+        if trainer.max_epochs and (
+            trainer.max_epochs < -1 or isinstance(trainer.max_epochs, float)
+        ):
             raise MisconfigurationException(
                 f"`max_epochs` must be a positive integer or -1. You passed in {trainer.max_epochs}."
             )
 
-        if trainer.max_steps < -1 or isinstance(trainer.max_steps, float):
+        if trainer.max_steps and (
+            trainer.max_steps < -1 or isinstance(trainer.max_steps, float)
+        ):
             raise MisconfigurationException(
                 f"`max_steps` must be a positive integer or -1. You passed in {trainer.max_steps}."
             )

--- a/pytorch_lightning/trainer/configuration_validator.py
+++ b/pytorch_lightning/trainer/configuration_validator.py
@@ -91,12 +91,12 @@ class ConfigValidator:
             )
 
         # Allow max_epochs or max_steps to be zero, since this will be handled by fit_loop.done
-        if trainer.max_epochs and (trainer.max_epochs < -1 or not isinstance(trainer.max_epochs, int)):
+        if trainer.max_epochs and trainer.max_epochs < -1:
             raise MisconfigurationException(
                 f"`max_epochs` must be a positive integer or -1. You passed in {trainer.max_epochs}."
             )
 
-        if trainer.max_steps and (trainer.max_steps < -1 or not isinstance(trainer.max_steps, int)):
+        if trainer.max_steps and trainer.max_steps < -1:
             raise MisconfigurationException(
                 f"`max_steps` must be a positive integer or -1. You passed in {trainer.max_steps}."
             )

--- a/pytorch_lightning/trainer/configuration_validator.py
+++ b/pytorch_lightning/trainer/configuration_validator.py
@@ -90,7 +90,7 @@ class ConfigValidator:
                 "(rather, they are called on every optimization step)."
             )
 
-        # Allow max_epochs or max_steps to be zero, since this will be handled by fit_loop.done 
+        # Allow max_epochs or max_steps to be zero, since this will be handled by fit_loop.done
         if trainer.max_epochs < -1 or isinstance(trainer.max_epochs, float):
             raise MisconfigurationException(
                 f"`max_epochs` must be a positive integer or -1. You passed in {trainer.max_epochs}."
@@ -100,7 +100,6 @@ class ConfigValidator:
             raise MisconfigurationException(
                 f"`max_steps` must be a positive integer or -1. You passed in {trainer.max_steps}."
             )
-        
 
     def __verify_eval_loop_configuration(self, model: "pl.LightningModule", stage: str) -> None:
         loader_name = f"{stage}_dataloader"

--- a/pytorch_lightning/trainer/configuration_validator.py
+++ b/pytorch_lightning/trainer/configuration_validator.py
@@ -90,17 +90,6 @@ class ConfigValidator:
                 "(rather, they are called on every optimization step)."
             )
 
-        # Allow max_epochs or max_steps to be zero, since this will be handled by fit_loop.done
-        if trainer.max_epochs and trainer.max_epochs < -1:
-            raise MisconfigurationException(
-                f"`max_epochs` must be a positive integer or -1. You passed in {trainer.max_epochs}."
-            )
-
-        if trainer.max_steps and trainer.max_steps < -1:
-            raise MisconfigurationException(
-                f"`max_steps` must be a positive integer or -1. You passed in {trainer.max_steps}."
-            )
-
     def __verify_eval_loop_configuration(self, model: "pl.LightningModule", stage: str) -> None:
         loader_name = f"{stage}_dataloader"
         step_name = "validation_step" if stage == "val" else "test_step"

--- a/pytorch_lightning/trainer/configuration_validator.py
+++ b/pytorch_lightning/trainer/configuration_validator.py
@@ -90,17 +90,13 @@ class ConfigValidator:
                 "(rather, they are called on every optimization step)."
             )
 
-         # Allow max_epochs or max_steps to be zero, since this will be handled by fit_loop.done
-        if trainer.max_epochs and (
-            trainer.max_epochs < -1 or isinstance(trainer.max_epochs, float)
-        ):
+        # Allow max_epochs or max_steps to be zero, since this will be handled by fit_loop.done
+        if trainer.max_epochs and (trainer.max_epochs < -1 or isinstance(trainer.max_epochs, float)):
             raise MisconfigurationException(
                 f"`max_epochs` must be a positive integer or -1. You passed in {trainer.max_epochs}."
             )
 
-        if trainer.max_steps and (
-            trainer.max_steps < -1 or isinstance(trainer.max_steps, float)
-        ):
+        if trainer.max_steps and (trainer.max_steps < -1 or isinstance(trainer.max_steps, float)):
             raise MisconfigurationException(
                 f"`max_steps` must be a positive integer or -1. You passed in {trainer.max_steps}."
             )

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -21,6 +21,7 @@ import torch
 from torchmetrics import Metric
 
 import pytorch_lightning as pl
+from pytorch_lightning.loops.fit_loop import FitLoop
 from pytorch_lightning.utilities import _OMEGACONF_AVAILABLE, rank_zero_deprecation, rank_zero_info, rank_zero_warn
 from pytorch_lightning.utilities.cloud_io import atomic_save, get_filesystem
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
@@ -190,7 +191,7 @@ class CheckpointConnector:
         self.trainer.fit_loop.current_epoch = self._loaded_checkpoint["epoch"]
 
         # crash if max_epochs is lower then the current epoch from the checkpoint
-        if self.trainer.max_epochs not in (None, -1) and self.trainer.current_epoch > self.trainer.max_epochs:
+        if FitLoop._is_max_limit_enabled(self.max_epochs) and self.trainer.current_epoch > self.trainer.max_epochs:
             raise MisconfigurationException(
                 f"You restored a checkpoint with current_epoch={self.trainer.current_epoch},"
                 f" but you have set Trainer(max_epochs={self.trainer.max_epochs})."

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -191,7 +191,10 @@ class CheckpointConnector:
         self.trainer.fit_loop.current_epoch = self._loaded_checkpoint["epoch"]
 
         # crash if max_epochs is lower then the current epoch from the checkpoint
-        if FitLoop._is_max_limit_enabled(self.trainer.max_epochs) and self.trainer.current_epoch > self.trainer.max_epochs:
+        if (
+            FitLoop._is_max_limit_enabled(self.trainer.max_epochs)
+            and self.trainer.current_epoch > self.trainer.max_epochs
+        ):
             raise MisconfigurationException(
                 f"You restored a checkpoint with current_epoch={self.trainer.current_epoch},"
                 f" but you have set Trainer(max_epochs={self.trainer.max_epochs})."

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -191,7 +191,7 @@ class CheckpointConnector:
         self.trainer.fit_loop.current_epoch = self._loaded_checkpoint["epoch"]
 
         # crash if max_epochs is lower then the current epoch from the checkpoint
-        if FitLoop._is_max_limit_enabled(self.max_epochs) and self.trainer.current_epoch > self.trainer.max_epochs:
+        if FitLoop._is_max_limit_enabled(self.trainer.max_epochs) and self.trainer.current_epoch > self.trainer.max_epochs:
             raise MisconfigurationException(
                 f"You restored a checkpoint with current_epoch={self.trainer.current_epoch},"
                 f" but you have set Trainer(max_epochs={self.trainer.max_epochs})."

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -190,7 +190,7 @@ class CheckpointConnector:
         self.trainer.fit_loop.current_epoch = self._loaded_checkpoint["epoch"]
 
         # crash if max_epochs is lower then the current epoch from the checkpoint
-        if self.trainer.max_epochs is not None and self.trainer.current_epoch > self.trainer.max_epochs:
+        if self.trainer.max_epochs not in (None, -1) and self.trainer.current_epoch > self.trainer.max_epochs:
             raise MisconfigurationException(
                 f"You restored a checkpoint with current_epoch={self.trainer.current_epoch},"
                 f" but you have set Trainer(max_epochs={self.trainer.max_epochs})."

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -262,7 +262,7 @@ class Trainer(
 
             max_epochs: Stop training once this number of epochs is reached. Disabled by default (None).
                 If both max_epochs and max_steps are not specified, defaults to ``max_epochs = 1000``.
-                To disable this default, set ``max_epochs = -1``.
+                To enable infinite training, set ``max_epochs = -1``.
 
             min_epochs: Force training for at least these many epochs. Disabled by default (None).
                 If both min_epochs and min_steps are not specified, defaults to ``min_epochs = 1``.

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -261,16 +261,15 @@ class Trainer(
                 Can be used on CPU, GPU or TPUs.
 
             max_epochs: Stop training once this number of epochs is reached. Disabled by default (None).
-                If both max_epochs and max_steps are not specified, defaults to ``max_epochs`` = 1000.
-                To disable automatic stopping, you can set ``max_epochs = -1`` and set ``max_steps`` as ``None``
-                or ``-1``. Note that if the the ``max_time`` limit is specified, it will still be observed.
+                If both max_epochs and max_steps are not specified, defaults to ``max_epochs = 1000``.
+                To disable this default, set ``max_epochs = -1``.
 
             min_epochs: Force training for at least these many epochs. Disabled by default (None).
-                If both min_epochs and min_steps are not specified, defaults to ``min_epochs`` = 1.
+                If both min_epochs and min_steps are not specified, defaults to ``min_epochs = 1``.
 
             max_steps: Stop training after this number of steps. Disabled by default (None). If ``max_steps = None``
-                and ``max_epochs = None``, will default to ``max_epochs = 1000``. To disable automatic stopping,
-                you can set ``max_steps = -1`` and set ``max_epochs`` as ``None`` or ``-1``.
+                and ``max_epochs = None``, will default to ``max_epochs = 1000``. To disable this default, set
+                ``max_steps`` to ``-1``.
 
             min_steps: Force training for at least these number of steps. Disabled by default (None).
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -269,7 +269,7 @@ class Trainer(
                 If both min_epochs and min_steps are not specified, defaults to ``min_epochs`` = 1.
 
             max_steps: Stop training after this number of steps. Disabled by default (None). If ``max_steps = None``
-                and ``max_epochs = None``, will default to ``max_epochs = 1000``. To disable automatic stopping, 
+                and ``max_epochs = None``, will default to ``max_epochs = 1000``. To disable automatic stopping,
                 you can set ``max_steps = -1`` and set ``max_epochs`` as ``None`` or ``-1``.
 
             min_steps: Force training for at least these number of steps. Disabled by default (None).

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -262,6 +262,7 @@ class Trainer(
 
             max_epochs: Stop training once this number of epochs is reached. Disabled by default (None).
                 If both max_epochs and max_steps are not specified, defaults to ``max_epochs`` = 1000.
+                To disable automatic stopping, specify a negative integer (and leave max_steps = None).
 
             min_epochs: Force training for at least these many epochs. Disabled by default (None).
                 If both min_epochs and min_steps are not specified, defaults to ``min_epochs`` = 1.

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -269,8 +269,8 @@ class Trainer(
                 If both min_epochs and min_steps are not specified, defaults to ``min_epochs`` = 1.
 
             max_steps: Stop training after this number of steps. Disabled by default (None). If ``max_steps = None``
-                and ``max_epochs = None``, will default to ``max_epochs = 1000``. To override this
-                behavior, see ``max_epochs``.
+                and ``max_epochs = None``, will default to ``max_epochs = 1000``. To disable automatic stopping, 
+                you can set ``max_steps = -1`` and set ``max_epochs`` as ``None`` or ``-1``.
 
             min_steps: Force training for at least these number of steps. Disabled by default (None).
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -262,12 +262,15 @@ class Trainer(
 
             max_epochs: Stop training once this number of epochs is reached. Disabled by default (None).
                 If both max_epochs and max_steps are not specified, defaults to ``max_epochs`` = 1000.
-                To disable automatic stopping, specify a negative integer (and leave max_steps = None).
+                To disable automatic stopping, you can set ``max_epochs = -1`` and set ``max_steps`` as ``None``
+                or ``-1``. Note that if the the ``max_time`` limit is specified, it will still be observed.
 
             min_epochs: Force training for at least these many epochs. Disabled by default (None).
                 If both min_epochs and min_steps are not specified, defaults to ``min_epochs`` = 1.
 
-            max_steps: Stop training after this number of steps. Disabled by default (None).
+            max_steps: Stop training after this number of steps. Disabled by default (None). If ``max_steps = None``
+                and ``max_epochs = None``, will default to ``max_epochs = 1000``. To override this
+                behavior, see ``max_epochs``.
 
             min_steps: Force training for at least these number of steps. Disabled by default (None).
 
@@ -375,6 +378,7 @@ class Trainer(
         self.slurm_connector = SLURMConnector(self)
         self.tuner = Tuner(self)
 
+        # max_epochs won't default to 1000 if max_steps/max_time are specified (including being set to -1).
         fit_loop = FitLoop(
             min_epochs=(1 if (min_epochs is None and min_steps is None and max_time is None) else min_epochs),
             max_epochs=(1000 if (max_epochs is None and max_steps is None and max_time is None) else max_epochs),

--- a/tests/callbacks/test_timer.py
+++ b/tests/callbacks/test_timer.py
@@ -47,6 +47,13 @@ def test_trainer_flag(caplog):
     assert trainer.max_epochs is None
     assert trainer.max_steps is None
 
+    # Make sure max_time still honored even if max_epochs == -1
+    trainer = Trainer(max_time=dict(seconds=10), max_epochs=-1)
+    with pytest.raises(SystemExit):
+        trainer.fit(TestModel())
+    timer = [c for c in trainer.callbacks if isinstance(c, Timer)][0]
+    assert timer._duration == 10
+
 
 @pytest.mark.parametrize(
     "duration,expected",

--- a/tests/callbacks/test_timer.py
+++ b/tests/callbacks/test_timer.py
@@ -67,17 +67,13 @@ def test_trainer_flag(caplog):
 )
 def test_timer_parse_duration(duration, expected):
     timer = Timer(duration=duration)
-    assert (timer.time_remaining() == expected is None) or (
-        timer.time_remaining() == expected.total_seconds()
-    )
+    assert (timer.time_remaining() == expected is None) or (timer.time_remaining() == expected.total_seconds())
 
 
 def test_timer_interval_choice():
     Timer(duration=timedelta(), interval="step")
     Timer(duration=timedelta(), interval="epoch")
-    with pytest.raises(
-        MisconfigurationException, match="Unsupported parameter value"
-    ):
+    with pytest.raises(MisconfigurationException, match="Unsupported parameter value"):
         Timer(duration=timedelta(), interval="invalid")
 
 
@@ -116,9 +112,7 @@ def test_timer_stops_training(tmpdir, caplog):
     duration = timedelta(milliseconds=100)
     timer = Timer(duration=duration)
 
-    trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1000, callbacks=[timer]
-    )
+    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1000, callbacks=[timer])
     with caplog.at_level(logging.INFO):
         trainer.fit(model)
     assert trainer.global_step > 1

--- a/tests/callbacks/test_timer.py
+++ b/tests/callbacks/test_timer.py
@@ -48,7 +48,7 @@ def test_trainer_flag(caplog):
         trainer.fit(TestModel())
     timer = [c for c in trainer.callbacks if isinstance(c, Timer)][0]
     assert timer._duration == 1
-    assert trainer.max_epochs is None
+    assert trainer.max_epochs == -1
     assert trainer.max_steps is None
 
 
@@ -58,19 +58,26 @@ def test_trainer_flag(caplog):
         (None, None),
         ("00:00:00:22", timedelta(seconds=22)),
         ("12:34:56:65", timedelta(days=12, hours=34, minutes=56, seconds=65)),
-        (timedelta(weeks=52, milliseconds=1), timedelta(weeks=52, milliseconds=1)),
+        (
+            timedelta(weeks=52, milliseconds=1),
+            timedelta(weeks=52, milliseconds=1),
+        ),
         (dict(weeks=52, days=1), timedelta(weeks=52, days=1)),
     ],
 )
 def test_timer_parse_duration(duration, expected):
     timer = Timer(duration=duration)
-    assert (timer.time_remaining() == expected is None) or (timer.time_remaining() == expected.total_seconds())
+    assert (timer.time_remaining() == expected is None) or (
+        timer.time_remaining() == expected.total_seconds()
+    )
 
 
 def test_timer_interval_choice():
     Timer(duration=timedelta(), interval="step")
     Timer(duration=timedelta(), interval="epoch")
-    with pytest.raises(MisconfigurationException, match="Unsupported parameter value"):
+    with pytest.raises(
+        MisconfigurationException, match="Unsupported parameter value"
+    ):
         Timer(duration=timedelta(), interval="invalid")
 
 
@@ -109,7 +116,9 @@ def test_timer_stops_training(tmpdir, caplog):
     duration = timedelta(milliseconds=100)
     timer = Timer(duration=duration)
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1000, callbacks=[timer])
+    trainer = Trainer(
+        default_root_dir=tmpdir, max_epochs=1000, callbacks=[timer]
+    )
     with caplog.at_level(logging.INFO):
         trainer.fit(model)
     assert trainer.global_step > 1
@@ -141,7 +150,12 @@ def test_timer_duration_min_steps_override(tmpdir, min_steps, min_epochs):
     model = BoringModel()
     duration = timedelta(0)
     timer = Timer(duration=duration)
-    trainer = Trainer(default_root_dir=tmpdir, callbacks=[timer], min_steps=min_steps, min_epochs=min_epochs)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        callbacks=[timer],
+        min_steps=min_steps,
+        min_epochs=min_epochs,
+    )
     trainer.fit(model)
     if min_epochs:
         assert trainer.current_epoch >= min_epochs - 1
@@ -157,7 +171,11 @@ def test_timer_resume_training(tmpdir):
     checkpoint_callback = ModelCheckpoint(dirpath=tmpdir, save_top_k=-1)
 
     # initial training
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=100, callbacks=[timer, checkpoint_callback])
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=100,
+        callbacks=[timer, checkpoint_callback],
+    )
     trainer.fit(model)
     assert not timer._offset
     assert timer.time_remaining() <= 0

--- a/tests/callbacks/test_timer.py
+++ b/tests/callbacks/test_timer.py
@@ -58,10 +58,7 @@ def test_trainer_flag(caplog):
         (None, None),
         ("00:00:00:22", timedelta(seconds=22)),
         ("12:34:56:65", timedelta(days=12, hours=34, minutes=56, seconds=65)),
-        (
-            timedelta(weeks=52, milliseconds=1),
-            timedelta(weeks=52, milliseconds=1),
-        ),
+        (timedelta(weeks=52, milliseconds=1), timedelta(weeks=52, milliseconds=1)),
         (dict(weeks=52, days=1), timedelta(weeks=52, days=1)),
     ],
 )
@@ -144,12 +141,7 @@ def test_timer_duration_min_steps_override(tmpdir, min_steps, min_epochs):
     model = BoringModel()
     duration = timedelta(0)
     timer = Timer(duration=duration)
-    trainer = Trainer(
-        default_root_dir=tmpdir,
-        callbacks=[timer],
-        min_steps=min_steps,
-        min_epochs=min_epochs,
-    )
+    trainer = Trainer(default_root_dir=tmpdir, callbacks=[timer], min_steps=min_steps, min_epochs=min_epochs)
     trainer.fit(model)
     if min_epochs:
         assert trainer.current_epoch >= min_epochs - 1

--- a/tests/callbacks/test_timer.py
+++ b/tests/callbacks/test_timer.py
@@ -42,17 +42,14 @@ def test_trainer_flag(caplog):
         trainer.fit(TestModel())
     assert "callbacks list already contains a Timer" in caplog.text
 
-    seconds = 1
-    trainer = Trainer(max_time=dict(seconds=seconds))
-    assert trainer.max_epochs is None
-    assert trainer.max_steps is None
-
     # Make sure max_time still honored even if max_epochs == -1
     trainer = Trainer(max_time=dict(seconds=1), max_epochs=-1)
     with pytest.raises(SystemExit):
         trainer.fit(TestModel())
     timer = [c for c in trainer.callbacks if isinstance(c, Timer)][0]
     assert timer._duration == 1
+    assert trainer.max_epochs is None
+    assert trainer.max_steps is None
 
 
 @pytest.mark.parametrize(

--- a/tests/callbacks/test_timer.py
+++ b/tests/callbacks/test_timer.py
@@ -48,11 +48,11 @@ def test_trainer_flag(caplog):
     assert trainer.max_steps is None
 
     # Make sure max_time still honored even if max_epochs == -1
-    trainer = Trainer(max_time=dict(seconds=10), max_epochs=-1)
+    trainer = Trainer(max_time=dict(seconds=1), max_epochs=-1)
     with pytest.raises(SystemExit):
         trainer.fit(TestModel())
     timer = [c for c in trainer.callbacks if isinstance(c, Timer)][0]
-    assert timer._duration == 10
+    assert timer._duration == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -491,6 +491,29 @@ def test_trainer_max_steps_and_epochs(tmpdir):
     assert trainer.global_step == num_train_samples * trainer.max_epochs
     assert trainer.current_epoch == trainer.max_epochs - 1, "Model did not stop at max_epochs"
 
+    # if max_steps is positive and max_epochs is negative, use max_steps
+    trainer_kwargs["max_epochs"] = -1
+    trainer_kwargs["max_steps"] = 3 * 2 * num_train_samples
+    trainer = Trainer(**trainer_kwargs)
+    trainer.fit(model)
+
+    assert trainer.state.finished, f"Training failed with {trainer.state}"
+    assert trainer.global_step == 3 * 2 * num_train_samples
+
+    # if max_steps is 0 and max_epochs is negative, use max_steps
+    trainer_kwargs["max_epochs"] = -5
+    trainer_kwargs["max_steps"] = 0
+    trainer = Trainer(**trainer_kwargs)
+    trainer.fit(model)
+
+    assert trainer.state.finished, f"Training failed with {trainer.state}"
+    assert trainer.global_step == 0
+
+    # allow specifying max_epochs < 0 and max_steps = None
+    trainer_kwargs["max_epochs"] = -100
+    trainer_kwargs["max_steps"] = None
+    trainer = Trainer(**trainer_kwargs)
+
 
 def test_trainer_min_steps_and_epochs(tmpdir):
     """Verify model trains according to specified min steps"""

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -516,6 +516,7 @@ def test_trainer_max_steps_and_epochs_validation(max_epochs, max_steps, incorrec
     ):
         trainer = Trainer(max_epochs=max_epochs, max_steps=max_steps)
 
+
 @pytest.mark.parametrize(
     "max_epochs,max_steps,is_done,correct_trainer_epochs",
     [

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -533,12 +533,7 @@ def test_trainer_max_steps_and_epochs_validation(max_epochs, max_steps, incorrec
         (0, -1, True, 0),
     ],
 )
-def test_trainer_max_steps_and_epochs_fit_loop_done(
-    max_epochs,
-    max_steps,
-    is_done,
-    correct_trainer_epochs
-):
+def test_trainer_max_steps_and_epochs_fit_loop_done(max_epochs, max_steps, is_done, correct_trainer_epochs):
     trainer = Trainer(max_epochs=max_epochs, max_steps=max_steps)
 
     assert trainer.max_epochs == correct_trainer_epochs
@@ -548,6 +543,7 @@ def test_trainer_max_steps_and_epochs_fit_loop_done(
     # Make sure there is no timer
     timer_callbacks = [c for c in trainer.callbacks if isinstance(c, Timer)]
     assert len(timer_callbacks) == 0
+
 
 def test_trainer_min_steps_and_epochs(tmpdir):
     """Verify model trains according to specified min steps"""

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -493,12 +493,12 @@ def test_trainer_max_steps_and_epochs(tmpdir):
 
     # if max_steps is positive and max_epochs is negative, use max_steps
     trainer_kwargs["max_epochs"] = -1
-    trainer_kwargs["max_steps"] = 3 * 2 * num_train_samples
+    trainer_kwargs["max_steps"] = 3
     trainer = Trainer(**trainer_kwargs)
     trainer.fit(model)
 
     assert trainer.state.finished, f"Training failed with {trainer.state}"
-    assert trainer.global_step == 3 * 2 * num_train_samples
+    assert trainer.global_step == 3
 
 
 @pytest.mark.parametrize(

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -514,7 +514,7 @@ def test_trainer_max_steps_and_epochs_validation(max_epochs, max_steps, incorrec
         MisconfigurationException,
         match=f"`{incorrect_variable}` must be a positive integer or -1. You passed in {incorrect_value}",
     ):
-        trainer = Trainer(max_epochs=max_epochs, max_steps=max_steps)
+        Trainer(max_epochs=max_epochs, max_steps=max_steps)
 
 
 @pytest.mark.parametrize(

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -500,6 +500,7 @@ def test_trainer_max_steps_and_epochs(tmpdir):
     assert trainer.state.finished, f"Training failed with {trainer.state}"
     assert trainer.global_step == 3 * 2 * num_train_samples
 
+
 @pytest.mark.parametrize(
     "max_epochs,max_steps,incorrect_variable,incorrect_value",
     [
@@ -509,9 +510,7 @@ def test_trainer_max_steps_and_epochs(tmpdir):
         (1, 0.5, "max_steps", -2),
     ],
 )
-def test_trainer_max_steps_and_epochs_validation(
-    max_epochs, max_steps, incorrect_variable, incorrect_value
-):
+def test_trainer_max_steps_and_epochs_validation(max_epochs, max_steps, incorrect_variable, incorrect_value):
     """Don't allow max_epochs or max_steps to be less than -1 or a float"""
     with pytest.raises(
         MisconfigurationException,
@@ -534,9 +533,7 @@ def test_trainer_max_steps_and_epochs_validation(
         (0, -1, True),
     ],
 )
-def test_trainer_max_steps_and_epochs_fit_loop_done(
-    max_epochs, max_steps, is_done
-):
+def test_trainer_max_steps_and_epochs_fit_loop_done(max_epochs, max_steps, is_done):
     trainer = Trainer(max_epochs=max_epochs, max_steps=max_steps)
 
     assert trainer.max_epochs == max_epochs

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -505,9 +505,7 @@ def test_trainer_max_steps_and_epochs(tmpdir):
     "max_epochs,max_steps,incorrect_variable,incorrect_value",
     [
         (-100, None, "max_epochs", -100),
-        (1.5, None, "max_epochs", 1.5),
         (1, -2, "max_steps", -2),
-        (1, 0.5, "max_steps", -2),
     ],
 )
 def test_trainer_max_steps_and_epochs_validation(max_epochs, max_steps, incorrect_variable, incorrect_value):
@@ -516,7 +514,14 @@ def test_trainer_max_steps_and_epochs_validation(max_epochs, max_steps, incorrec
         MisconfigurationException,
         match=f"`{incorrect_variable}` must be a positive integer or -1. You passed in {incorrect_value}",
     ):
-        trainer = Trainer(max_epochs=max_epochs, max_steps=max_steps)
+        trainer = Trainer(
+            max_epochs=max_epochs,
+            max_steps=max_steps,
+            limit_val_batches=0,
+            limit_train_batches=2,
+        )
+        model = EvalModelTemplate()
+        trainer.fit(model)
 
 
 @pytest.mark.parametrize(

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -520,7 +520,7 @@ def test_trainer_max_steps_and_epochs_validation(max_epochs, max_steps, incorrec
             limit_val_batches=0,
             limit_train_batches=2,
         )
-        model = EvalModelTemplate()
+        model = BoringModel()
         trainer.fit(model)
 
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -514,15 +514,7 @@ def test_trainer_max_steps_and_epochs_validation(max_epochs, max_steps, incorrec
         MisconfigurationException,
         match=f"`{incorrect_variable}` must be a positive integer or -1. You passed in {incorrect_value}",
     ):
-        trainer = Trainer(
-            max_epochs=max_epochs,
-            max_steps=max_steps,
-            limit_val_batches=0,
-            limit_train_batches=2,
-        )
-        model = BoringModel()
-        trainer.fit(model)
-
+        trainer = Trainer(max_epochs=max_epochs, max_steps=max_steps)
 
 @pytest.mark.parametrize(
     "max_epochs,max_steps,is_done,correct_trainer_epochs",


### PR DESCRIPTION
## What does this PR do?
Adds the ability to disable automatic stopping by passing `max_epochs < 0` and leaving `max_steps = None`.

Fixes #8818

### Does your PR introduce any breaking changes? If yes, please list them.
None

## Before submitting

- [✅] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [✅] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [✅] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [✅] Did you make sure to **update the documentation** with your changes? (if necessary)
- [] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [✅] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [✅] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
![oh-yes](https://user-images.githubusercontent.com/18071029/129282255-89e5bc4e-855d-4a57-86fb-923e1536e224.gif)

