### PR TITLE
added callable option to logging

### DIFF
--- a/pytorch_lightning/trainer/connectors/logger_connector/result.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/result.py
@@ -88,7 +88,8 @@ class _Metadata:
     @reduce_fx.setter
     def reduce_fx(self, reduce_fx: Union[str, Callable]) -> None:
         error = (
-            "Only `self.log(..., reduce_fx={min,max,mean,sum})` are currently supported."
+            "Only `self.log(..., reduce_fx={'min','max','mean','sum'})`"
+            " or `self.log(..., reduce_fx=Callable)` are currently supported."
             " Please, open an issue in `https://github.com/PyTorchLightning/pytorch-lightning/issues`."
             f" Found: {reduce_fx}"
         )
@@ -100,6 +101,8 @@ class _Metadata:
             if reduce_fx not in ("min", "max", "mean", "sum"):
                 raise MisconfigurationException(error)
             self._reduce_fx = getattr(torch, reduce_fx)
+        elif isinstance(reduce_fx, Callable):
+            self._reduce_fx = reduce_fx
         elif self.is_custom_reduction:
             raise MisconfigurationException(error)
 


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/8894
@tchaton 
Where Logging fails when passing a callable as a reduce_fx with the following exception:

```
# Somewhere in training_step, being nanmean a function
        self.log_dict({"loss": loss}, prog_bar = True, reduce_fx = nanmean)
```

```
pytorch_lightning.utilities.exceptions.MisconfigurationException: Only `self.log(..., reduce_fx={min,max,mean,sum})` are currently supported. Please, open an issue in `https://github.com/PyTorchLightning/pytorch-lightning/issues`. Found: <function nanmean at 0x7fa4b394a9e0>
```

I modified the error message to state that there is a callable option (which was already stated in the typing of the function) and added an instance where the callable is used.