### PR TITLE
fix "line too long" pre-commit complaints

### DIFF
--- a/pytorch_lightning/callbacks/progress.py
+++ b/pytorch_lightning/callbacks/progress.py
@@ -78,14 +78,13 @@ class ProgressBarBase(Callback):
                 self.enable = False
 
             def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx):
-                super().on_train_batch_end(trainer, pl_module, outputs, batch, batch_idx, dataloader_idx)  # important :-)
+                super().on_train_batch_end(trainer, pl_module, outputs, batch, batch_idx, dataloader_idx)  # important
                 percent = (self.train_batch_idx / self.total_train_batches) * 100
                 sys.stdout.flush()
                 sys.stdout.write(f'{percent:.01f} percent complete \r')
 
         bar = LitProgressBar()
         trainer = Trainer(callbacks=[bar])
-
     """
 
     def __init__(self):


### PR DESCRIPTION
## What does this PR do?

Pre-commit shows us annoying messages on every PR about too long lines:


![image](https://user-images.githubusercontent.com/5495193/129766382-e3bc095f-eea4-43b8-bc27-382e75953273.png)

This PR makes the pre-commit green.



## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃
