### PR TITLE
Support post-localSGD in Lightning DDP plugin

### DIFF
--- a/pytorch_lightning/plugins/training_type/ddp.py
+++ b/pytorch_lightning/plugins/training_type/ddp.py
@@ -23,20 +23,21 @@ from pathlib import Path
 from time import sleep
 from typing import Any, Dict, List, Optional, Union
 
-import __main__
 import numpy as np
 import torch
 import torch.distributed
-from torch.nn.parallel.distributed import DistributedDataParallel
 
+from pytorch_lightning.core.optimizer import LightningOptimizer
 from pytorch_lightning.distributed import LightningDistributed
 from pytorch_lightning.overrides import LightningDistributedModule
 from pytorch_lightning.overrides.distributed import prepare_for_backward
 from pytorch_lightning.plugins.environments.cluster_environment import ClusterEnvironment
 from pytorch_lightning.plugins.io.checkpoint_plugin import CheckpointIO
 from pytorch_lightning.plugins.training_type.parallel import ParallelPlugin
+from pytorch_lightning.trainer.states import TrainerFn
 from pytorch_lightning.utilities import (
     _HYDRA_AVAILABLE,
+    _IS_WINDOWS,
     _TORCH_GREATER_EQUAL_1_7,
     _TORCH_GREATER_EQUAL_1_8,
     _TORCH_GREATER_EQUAL_1_9,
@@ -52,12 +53,23 @@ from pytorch_lightning.utilities.distributed import (
 )
 from pytorch_lightning.utilities.exceptions import DeadlockDetectedException, MisconfigurationException
 from pytorch_lightning.utilities.seed import reset_seed
+from torch.nn.parallel.distributed import DistributedDataParallel
+
+import __main__
+
+if not _IS_WINDOWS and _TORCH_GREATER_EQUAL_1_9:
+    from torch.distributed.optim import DistributedOptimizer
+    from torch.distributed.optim import PostLocalSGDOptimizer
+    from torch.distributed.optim import ZeroRedundancyOptimizer
 
 if _HYDRA_AVAILABLE:
     from hydra.core.hydra_config import HydraConfig
     from hydra.utils import get_original_cwd, to_absolute_path
 if _TORCH_GREATER_EQUAL_1_8:
-    from pytorch_lightning.utilities.distributed import register_ddp_comm_hook
+    from pytorch_lightning.utilities.distributed import register_ddp_comm_hook	
+if _TORCH_GREATER_EQUAL_1_9:
+    import torch.distributed.algorithms.ddp_comm_hooks.post_localSGD_hook as post_localSGD
+    import torch.distributed.algorithms.model_averaging.averagers as averagers
 
 log = logging.getLogger(__name__)
 
@@ -83,6 +95,7 @@ class DDPPlugin(ParallelPlugin):
         ddp_comm_state: Optional[object] = None,
         ddp_comm_hook: Optional[callable] = None,
         ddp_comm_wrapper: Optional[callable] = None,
+        model_averaging_period: Optional[int] = None,
         **kwargs: Union[Any, Dict[str, Any]],
     ) -> None:
         super().__init__(
@@ -111,6 +124,7 @@ class DDPPlugin(ParallelPlugin):
         self._ddp_comm_state = ddp_comm_state
         self._ddp_comm_hook = ddp_comm_hook
         self._ddp_comm_wrapper = ddp_comm_wrapper
+        self._model_averaging_period = model_averaging_period
         self._pids: Optional[List[int]] = None
         self._sync_dir: Optional[str] = None
         self.set_world_ranks()
@@ -303,6 +317,45 @@ class DDPPlugin(ParallelPlugin):
                 ddp_comm_hook=self._ddp_comm_hook,
                 ddp_comm_wrapper=self._ddp_comm_wrapper,
             )
+
+            # Post-localSDG is only available after 1.9, and `torch.distributed.optim` package currently is not available on Windows.
+            if (
+                not _IS_WINDOWS
+                and _TORCH_GREATER_EQUAL_1_9
+                and isinstance(self._ddp_comm_state, post_localSGD.PostLocalSGDState)
+                and self.lightning_module.trainer.state.fn == TrainerFn.FITTING
+            ):
+                self._reinit_optimizers_with_post_localSGD(self._ddp_comm_state.start_localSGD_iter)
+
+    def _reinit_optimizers_with_post_localSGD(self, warmup_steps: int):
+        optimizers = self.lightning_module.trainer.optimizers
+        if self._model_averaging_period is None:
+            rank_zero_warn("Post-localSGD algorithm is used, but model averaging period is not provided to DDP plugin. Set this period as 16.")
+            self._model_averaging_period = 16
+        averager = averagers.PeriodicModelAverager(period=self._model_averaging_period, warmup_steps=warmup_steps)
+        for x, optimizer in enumerate(optimizers):
+            if isinstance(optimizer, LightningOptimizer):
+                optimizer = optimizer._optimizer
+
+            if (
+                isinstance(optimizer, DistributedOptimizer)
+                or isinstance(optimizer, ZeroRedundancyOptimizer)
+            ):
+                raise ValueError("Cannot wrap a distributed optimizer of type {} by PostLocalSGDOptimizer.".format(optimizer.__name__))
+
+            if not isinstance(optimizer, PostLocalSGDOptimizer):
+                optim_class = type(optimizer)
+                post_localSGD_optimizer = PostLocalSGDOptimizer(
+                    params=self.model.parameters(),
+                    optimizer_class=optim_class,
+                    averager=averager,
+                    **optimizer.defaults,
+                )
+                optimizers[x] = post_localSGD_optimizer
+                del optimizer
+        trainer = self.lightning_module.trainer
+        trainer.optimizers = optimizers
+        trainer.convert_to_lightning_optimizers()
 
     def configure_ddp(self):
         self.pre_configure_ddp()

--- a/pytorch_lightning/utilities/__init__.py
+++ b/pytorch_lightning/utilities/__init__.py
@@ -38,6 +38,7 @@ from pytorch_lightning.utilities.imports import (  # noqa: F401
     _HYDRA_EXPERIMENTAL_AVAILABLE,
     _IPU_AVAILABLE,
     _IS_INTERACTIVE,
+    _IS_WINDOWS,
     _JSONARGPARSE_AVAILABLE,
     _module_available,
     _NATIVE_AMP_AVAILABLE,

--- a/pytorch_lightning/utilities/distributed.py
+++ b/pytorch_lightning/utilities/distributed.py
@@ -283,12 +283,14 @@ def register_ddp_comm_hook(
 
     .. warning ::
         DDP communication wrapper needs pytorch version at least 1.9.0
+        Post-localSGD hook needs pytorch version at least 1.9.0
 
     Example:
 
         from torch.distributed.algorithms.ddp_comm_hooks import (
             default_hooks as default,
             powerSGD_hook as powerSGD,
+            post_localSGD_hook as post_localSGD,
         )
 
         # fp16_compress_hook for compress gradients
@@ -306,6 +308,18 @@ def register_ddp_comm_hook(
                 start_powerSGD_iter=5000,
             ),
             ddp_comm_hook=powerSGD.powerSGD_hook,
+        )
+
+        # post_localSGD_hook
+        subgroup, _ = torch.distributed.new_subgroups()
+        register_comm_hook(
+            model=ddp_model,
+            state=post_localSGD.PostLocalSGDState(
+                process_group=None,
+                subgroup=subgroup,
+                start_localSGD_iter=1_000,
+            ),
+            ddp_comm_hook=post_localSGD.post_localSGD_hook,
         )
 
         # fp16_compress_wrapper combined with other communication hook


### PR DESCRIPTION
Integrate a new feature post-localSGD from PyTorch Distributed into Lightning. We have seen good speedup on our benchmark with parity on accuracy.

Proposal: https://github.com/pytorch/pytorch/issues/59699

This PR has already been reviewed by @ananthsub and his teammates in FB internally.

**Usage:**
To enable post-localSGD, expect the user to provide two args:
1. A DDP comm hook (`post_localSGD.post_localSGD_hook`), which is constructed by `_ddp_comm_hook` and `_ddp_comm_state` in DDP plugin;
2. A new optional field, `_model_averaging_period`. The default value is set as 16 if post-localSGD hook is specified but no model averaging period is provided.

**Requirements:**
1. PyTorch Version >= 1.9.0
2. not _IS_WINDOWS