### PR TITLE
update an outdated error message in DDPPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added DeepSpeed Stage 1 support ([#8974](https://github.com/PyTorchLightning/pytorch-lightning/pull/8974))
 
 
+- Added a friendly error message when DDP attempts to spawn new distributed processes from rank > 0 ([#9005](https://github.com/PyTorchLightning/pytorch-lightning/pull/9005))
+
+
 ### Changed
 
 - Parsing of the `gpus` Trainer argument has changed: `gpus="n"` (str) no longer selects the GPU index n and instead selects the first n devices. ([#8770](https://github.com/PyTorchLightning/pytorch-lightning/pull/8770))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added DeepSpeed Stage 1 support ([#8974](https://github.com/PyTorchLightning/pytorch-lightning/pull/8974))
 
 
-- Added a friendly error message when DDP attempts to spawn new distributed processes from rank > 0 ([#9005](https://github.com/PyTorchLightning/pytorch-lightning/pull/9005))
+- Added a friendly error message when DDP attempts to spawn new distributed processes with rank > 0 ([#9005](https://github.com/PyTorchLightning/pytorch-lightning/pull/9005))
 
 
 ### Changed

--- a/pytorch_lightning/plugins/training_type/ddp.py
+++ b/pytorch_lightning/plugins/training_type/ddp.py
@@ -262,8 +262,8 @@ class DDPPlugin(ParallelPlugin):
         if self.local_rank != 0:
             raise RuntimeError(
                 "Lightning attempted to launch new distributed processes from `local_rank > 0`. This should not happen."
-                "Possible reasons: 1) LOCAL_RANK environment variable was incorrectly modified by the user,"
-                "2) `ClusterEnvironment.creates_children()` incorrectly implemented."
+                " Possible reasons: 1) LOCAL_RANK environment variable was incorrectly modified by the user,"
+                " 2) `ClusterEnvironment.creates_children()` incorrectly implemented."
             )
 
     def set_world_ranks(self) -> None:

--- a/pytorch_lightning/plugins/training_type/ddp.py
+++ b/pytorch_lightning/plugins/training_type/ddp.py
@@ -174,7 +174,6 @@ class DDPPlugin(ParallelPlugin):
 
     def _call_children_scripts(self):
         # bookkeeping of spawned processes
-        assert self.local_rank == 0
         self._check_can_spawn_children()
         self._has_spawned_children = True
 
@@ -260,10 +259,11 @@ class DDPPlugin(ParallelPlugin):
         self.dist.device = self.root_device
 
     def _check_can_spawn_children(self):
-        if self._has_spawned_children:
+        if self.local_rank != 0:
             raise RuntimeError(
-                "You tried to run `.fit` or `.test` multiple times in the same script."
-                " This is not supported in DDP mode, switch to `distributed_backend='ddp_spawn'` instead."
+                "Lightning attempted to launch new distributed processes from `local_rank > 0`. This should not happen."
+                "Possible reasons: 1) LOCAL_RANK environment variable was incorrectly modified by the user,"
+                "2) `ClusterEnvironment.creates_children()` incorrectly implemented."
             )
 
     def set_world_ranks(self) -> None:

--- a/pytorch_lightning/plugins/training_type/ddp.py
+++ b/pytorch_lightning/plugins/training_type/ddp.py
@@ -259,7 +259,7 @@ class DDPPlugin(ParallelPlugin):
     def _check_can_spawn_children(self):
         if self.local_rank != 0:
             raise RuntimeError(
-                "Lightning attempted to launch new distributed processes from `local_rank > 0`. This should not happen."
+                "Lightning attempted to launch new distributed processes with `local_rank > 0`. This should not happen."
                 " Possible reasons: 1) LOCAL_RANK environment variable was incorrectly modified by the user,"
                 " 2) `ClusterEnvironment.creates_children()` incorrectly implemented."
             )

--- a/pytorch_lightning/plugins/training_type/ddp.py
+++ b/pytorch_lightning/plugins/training_type/ddp.py
@@ -106,7 +106,6 @@ class DDPPlugin(ParallelPlugin):
         self.dist = LightningDistributed()
         self.num_processes = len(self.parallel_devices) if self.parallel_devices is not None else 0
         self._ddp_kwargs = kwargs
-        self._has_spawned_children = False
         self._task_idx = None
         self._ddp_comm_state = ddp_comm_state
         self._ddp_comm_hook = ddp_comm_hook
@@ -175,7 +174,6 @@ class DDPPlugin(ParallelPlugin):
     def _call_children_scripts(self):
         # bookkeeping of spawned processes
         self._check_can_spawn_children()
-        self._has_spawned_children = True
 
         # DDP Environment variables
         os.environ["MASTER_ADDR"] = self.cluster_environment.master_address()

--- a/tests/plugins/test_ddp_plugin.py
+++ b/tests/plugins/test_ddp_plugin.py
@@ -11,13 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from unittest import mock
 
+import pytest
 import torch
 from torch.nn.parallel import DistributedDataParallel
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.plugins import DDPPlugin
+from pytorch_lightning.plugins.environments import LightningEnvironment
 from tests.helpers.boring_model import BoringModel
 from tests.helpers.runif import RunIf
 
@@ -69,3 +72,25 @@ def test_ddp_barrier_non_consecutive_device_ids(barrier_mock, tmpdir):
     trainer = Trainer(default_root_dir=tmpdir, max_steps=1, gpus=gpus, accelerator="ddp")
     trainer.fit(model)
     barrier_mock.assert_any_call(device_ids=[gpus[trainer.local_rank]])
+
+
+@mock.patch.dict(os.environ, {"LOCAL_RANK": "1"})
+def test_incorrect_ddp_script_spawning(tmpdir):
+    """Test an error message when user accidentally instructs Lightning to spawn children processes on rank > 0."""
+
+    class WronglyImplementedEnvironment(LightningEnvironment):
+        def creates_children(self):
+            # returning false no matter what means Lightning would spawn also on ranks > 0 new processes
+            return False
+
+    model = BoringModel()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        accelerator="ddp",
+        num_processes=2,
+        plugins=[DDPPlugin(), WronglyImplementedEnvironment()],
+    )
+    with pytest.raises(
+        RuntimeError, match="Lightning attempted to launch new distributed processes from `local_rank > 0`."
+    ):
+        trainer.fit(model)

--- a/tests/plugins/test_ddp_plugin.py
+++ b/tests/plugins/test_ddp_plugin.py
@@ -91,6 +91,6 @@ def test_incorrect_ddp_script_spawning(tmpdir):
         plugins=[DDPPlugin(), WronglyImplementedEnvironment()],
     )
     with pytest.raises(
-        RuntimeError, match="Lightning attempted to launch new distributed processes from `local_rank > 0`."
+        RuntimeError, match="Lightning attempted to launch new distributed processes with `local_rank > 0`."
     ):
         trainer.fit(model)


### PR DESCRIPTION
## What does this PR do?

Fixes #8998

Replaces an outdated error message saying that fit() is not allowed to be called multiple time. 
The new error message addresses a assertion error with a friendly message with possible causes of the malfunction.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃
