### PR TITLE
Handle the case with no queries in `GPUStatsMonitor`

### DIFF
--- a/pytorch_lightning/callbacks/gpu_stats_monitor.py
+++ b/pytorch_lightning/callbacks/gpu_stats_monitor.py
@@ -187,7 +187,7 @@ class GPUStatsMonitor(Callback):
         return [cuda_visible_devices[device_id].strip() for device_id in device_ids]
 
     def _get_gpu_stats(self, queries: List[str]) -> List[List[float]]:
-        if len(queries) == 0:
+        if not queries:
             return []
 
         """Run nvidia-smi to get the gpu stats"""

--- a/pytorch_lightning/callbacks/gpu_stats_monitor.py
+++ b/pytorch_lightning/callbacks/gpu_stats_monitor.py
@@ -187,6 +187,9 @@ class GPUStatsMonitor(Callback):
         return [cuda_visible_devices[device_id].strip() for device_id in device_ids]
 
     def _get_gpu_stats(self, queries: List[str]) -> List[List[float]]:
+        if len(queries) == 0:
+            return []
+
         """Run nvidia-smi to get the gpu stats"""
         gpu_query = ",".join(queries)
         format = "csv,nounits,noheader"

--- a/tests/callbacks/test_gpu_stats_monitor.py
+++ b/tests/callbacks/test_gpu_stats_monitor.py
@@ -69,12 +69,14 @@ def test_gpu_stats_monitor_no_queries(tmpdir):
     Test GPU stats are logged using a logger.
     """
     model = BoringModel()
-    gpu_stats = GPUStatsMonitor(memory_utilization=False,
-                                gpu_utilization=False,
-                                intra_step_time=True,
-                                inter_step_time=True,
-                                fan_speed=False,
-                                temperature=False,)
+    gpu_stats = GPUStatsMonitor(
+        memory_utilization=False,
+        gpu_utilization=False,
+        intra_step_time=True,
+        inter_step_time=True,
+        fan_speed=False,
+        temperature=False,
+    )
     logger = CSVLogger(tmpdir)
     log_every_n_steps = 2
 

--- a/tests/callbacks/test_gpu_stats_monitor.py
+++ b/tests/callbacks/test_gpu_stats_monitor.py
@@ -99,6 +99,7 @@ def test_gpu_stats_monitor_no_queries(tmpdir):
 
     def get_arg_and_value(*args, **_):
         return args[0]
+
     call_list = [get_arg_and_value(*cal[0], **cal[1]) for cal in mocked.call_args_list]
 
     for key in keys:

--- a/tests/callbacks/test_gpu_stats_monitor.py
+++ b/tests/callbacks/test_gpu_stats_monitor.py
@@ -66,7 +66,7 @@ def test_gpu_stats_monitor(tmpdir):
 @RunIf(min_gpus=1)
 def test_gpu_stats_monitor_no_queries(tmpdir):
     """
-    Test GPU stats are logged using a logger.
+    Test GPU logger doesn't fail if no "nvidia-smi" queries are to be performed.
     """
     model = BoringModel()
     gpu_stats = GPUStatsMonitor(

--- a/tests/callbacks/test_gpu_stats_monitor.py
+++ b/tests/callbacks/test_gpu_stats_monitor.py
@@ -93,6 +93,14 @@ def test_gpu_stats_monitor_no_queries(tmpdir):
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
 
+    path_csv = os.path.join(logger.log_dir, ExperimentWriter.NAME_METRICS_FILE)
+    met_data = np.genfromtxt(path_csv, delimiter=",", names=True, deletechars="", replace_space=" ")
+
+    for key in ["batch_time/intra_step (ms)", "batch_time/inter_step (ms)"]:
+        batch_time_data = met_data[key]
+        batch_time_data = batch_time_data[~np.isnan(batch_time_data)]
+        assert batch_time_data.shape[0] == trainer.global_step // log_every_n_steps
+
 
 @pytest.mark.skipif(torch.cuda.is_available(), reason="test requires CPU machine")
 def test_gpu_stats_monitor_cpu_machine(tmpdir):

--- a/tests/callbacks/test_gpu_stats_monitor.py
+++ b/tests/callbacks/test_gpu_stats_monitor.py
@@ -83,7 +83,7 @@ def test_gpu_stats_monitor_no_queries(tmpdir):
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_epochs=2,
-        limit_train_batches=7,
+        limit_train_batches=2,
         log_every_n_steps=log_every_n_steps,
         gpus=1,
         callbacks=[gpu_stats],


### PR DESCRIPTION
Call to nvidia-smi in GPUStatsMonitor would fail if there are no queries. GPUStatsMonitor can be still used to log `batch_time/intra_step (ms)` and `batch_time/inter_step (ms)`. Skipping the call to nvidia-smi also avoids unnecessary overhead.


## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
