### PR TITLE
sanitize arrays when logging as hyperparameters in TensorBoardLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added DeepSpeed Stage 1 support ([#8974](https://github.com/PyTorchLightning/pytorch-lightning/pull/8974))
 
 
+- Added sanitization of tensors when they get logged as hyperparameters in `TensorBoardLogger` ([#9031](https://github.com/PyTorchLightning/pytorch-lightning/pull/9031))
+
+
 ### Changed
 
 - Parsing of the `gpus` Trainer argument has changed: `gpus="n"` (str) no longer selects the GPU index n and instead selects the first n devices. ([#8770](https://github.com/PyTorchLightning/pytorch-lightning/pull/8770))

--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -21,6 +21,7 @@ import os
 from argparse import Namespace
 from typing import Any, Dict, Optional, Union
 
+import numpy as np
 import torch
 from torch.utils.tensorboard import SummaryWriter
 from torch.utils.tensorboard.summary import hparams
@@ -285,6 +286,12 @@ class TensorBoardLogger(LightningLoggerBase):
             return 0
 
         return max(existing_versions) + 1
+
+    @staticmethod
+    def _sanitize_params(params: Dict[str, Any]) -> Dict[str, Any]:
+        params = LightningLoggerBase._sanitize_params(params)
+        # logging of arrays with dimension > 1 is not supported, sanitize as string
+        return {k: str(v) for k, v in params.items() if isinstance(v, (torch.Tensor, np.ndarray)) and v.ndim > 1}
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -291,7 +291,7 @@ class TensorBoardLogger(LightningLoggerBase):
     def _sanitize_params(params: Dict[str, Any]) -> Dict[str, Any]:
         params = LightningLoggerBase._sanitize_params(params)
         # logging of arrays with dimension > 1 is not supported, sanitize as string
-        return {k: str(v) if isinstance(v, (torch.Tensor, np.ndarray)) and v.ndim > 1 else v for k, v in params.items() }
+        return {k: str(v) if isinstance(v, (torch.Tensor, np.ndarray)) and v.ndim > 1 else v for k, v in params.items()}
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -291,7 +291,7 @@ class TensorBoardLogger(LightningLoggerBase):
     def _sanitize_params(params: Dict[str, Any]) -> Dict[str, Any]:
         params = LightningLoggerBase._sanitize_params(params)
         # logging of arrays with dimension > 1 is not supported, sanitize as string
-        return {k: str(v) for k, v in params.items() if isinstance(v, (torch.Tensor, np.ndarray)) and v.ndim > 1}
+        return {k: str(v) if isinstance(v, (torch.Tensor, np.ndarray)) and v.ndim > 1 else v for k, v in params.items() }
 
     def __getstate__(self):
         state = self.__dict__.copy()

--- a/tests/loggers/test_tensorboard.py
+++ b/tests/loggers/test_tensorboard.py
@@ -179,7 +179,8 @@ def test_tensorboard_log_hyperparams(tmpdir):
         "list": [1, 2, 3],
         "namespace": Namespace(foo=Namespace(bar="buzz")),
         "layer": torch.nn.BatchNorm1d,
-        "matrix": torch.empty(2, 2, 2),
+        "tensor": torch.empty(2, 2, 2),
+        "array": np.empty([2, 2, 2]),
     }
     logger.log_hyperparams(hparams)
 
@@ -195,7 +196,8 @@ def test_tensorboard_log_hparams_and_metrics(tmpdir):
         "list": [1, 2, 3],
         "namespace": Namespace(foo=Namespace(bar="buzz")),
         "layer": torch.nn.BatchNorm1d,
-        "matrix": torch.empty(2, 2, 2),
+        "tensor": torch.empty(2, 2, 2),
+        "array": np.empty([2, 2, 2]),
     }
     metrics = {"abc": torch.tensor([0.54])}
     logger.log_hyperparams(hparams, metrics)

--- a/tests/loggers/test_tensorboard.py
+++ b/tests/loggers/test_tensorboard.py
@@ -17,6 +17,7 @@ import os
 from argparse import Namespace
 from unittest import mock
 
+import numpy as np
 import pytest
 import torch
 import yaml
@@ -178,6 +179,7 @@ def test_tensorboard_log_hyperparams(tmpdir):
         "list": [1, 2, 3],
         "namespace": Namespace(foo=Namespace(bar="buzz")),
         "layer": torch.nn.BatchNorm1d,
+        "matrix": torch.empty(2, 2, 2),
     }
     logger.log_hyperparams(hparams)
 
@@ -193,6 +195,7 @@ def test_tensorboard_log_hparams_and_metrics(tmpdir):
         "list": [1, 2, 3],
         "namespace": Namespace(foo=Namespace(bar="buzz")),
         "layer": torch.nn.BatchNorm1d,
+        "matrix": torch.empty(2, 2, 2),
     }
     metrics = {"abc": torch.tensor([0.54])}
     logger.log_hyperparams(hparams, metrics)


### PR DESCRIPTION
## What does this PR do?

Fixes #9022

TensorBoardLogger can log hyperparameters but not all types of data. It can do arrays that are 1-dimensional but anything higher-dimensional not, so we will sanitize it by converting to string as we do with other unsupported types.


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃



