### PR TITLE
Fix typing in hparams methods

### DIFF
--- a/pytorch_lightning/core/mixins/hparams_mixin.py
+++ b/pytorch_lightning/core/mixins/hparams_mixin.py
@@ -15,7 +15,7 @@ import copy
 import inspect
 import types
 from argparse import Namespace
-from typing import MutableMapping Optional, Sequence, Union
+from typing import MutableMapping, Optional, Sequence, Union
 
 from pytorch_lightning.core.saving import ALLOWED_CONFIG_TYPES, PRIMITIVE_TYPES
 from pytorch_lightning.utilities import AttributeDict


### PR DESCRIPTION
These methods actually also support `AttributeDict`, and `MutableMapping`. And these 2 plus `dict` are all `MutableMapping`s, so I changed it to supporting all of them by changing `dict` to `MutableMapping`.