### PR TITLE
Make device and dtype required in `apply_func`

### DIFF
--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -23,7 +23,6 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 import numpy as np
 import torch
 
-from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.imports import _compare_version, _TORCHTEXT_AVAILABLE
 
 if _TORCHTEXT_AVAILABLE:
@@ -36,22 +35,16 @@ else:
 
 
 def to_dtype_tensor(
-    value: Union[int, float, List[Union[int, float]]],
-    dtype: Optional[torch.dtype] = None,
-    device: Union[str, torch.device] = None,
+    value: Union[int, float, List[Union[int, float]]], dtype: torch.dtype, device: Union[str, torch.device]
 ) -> torch.Tensor:
-    if device is None:
-        raise MisconfigurationException("device (torch.device) should be provided.")
     return torch.tensor(value, dtype=dtype, device=device)
 
 
-def from_numpy(value: np.ndarray, device: Union[str, torch.device] = None) -> torch.Tensor:
-    if device is None:
-        raise MisconfigurationException("device (torch.device) should be provided.")
+def from_numpy(value: np.ndarray, device: Union[str, torch.device]) -> torch.Tensor:
     return torch.from_numpy(value).to(device)
 
 
-CONVERSION_DTYPES: List[Tuple[Any, Callable[[Any], torch.Tensor]]] = [
+CONVERSION_DTYPES: List[Tuple[Any, Callable[[Any, Any], torch.Tensor]]] = [
     # bool -> uint8 as bool -> torch.bool triggers RuntimeError: Unsupported data type for NCCL process group
     (bool, partial(to_dtype_tensor, dtype=torch.uint8)),
     (int, partial(to_dtype_tensor, dtype=torch.int)),
@@ -276,9 +269,6 @@ def move_data_to_device(batch: Any, device: Union[str, torch.device]) -> Any:
 
 
 def convert_to_tensors(data: Any, device: Union[str, torch.device]) -> Any:
-    if device is None:
-        raise MisconfigurationException("`torch.device` should be provided.")
-
     for src_dtype, conversion_func in CONVERSION_DTYPES:
         data = apply_to_collection(data, src_dtype, conversion_func, device=device)
 


### PR DESCRIPTION
## What does this PR do?

This PR imposes `device` and `dtype` arguments to be required arguments.
Fixes #9147 

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)


## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
