### PR TITLE
remove calls to internal dev debugger in training- and eval loop

### DIFF
--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -272,10 +272,6 @@ class TrainingBatchLoop(Loop):
         def backward_fn(loss: Tensor):
             self.backward(loss, optimizer, opt_idx)
 
-            # when in dev debugging track the losses
-            # TODO: remove dev debugger tracking loss history
-            self.trainer.dev_debugger.track_train_loss_history(batch_idx, loss)
-
             # check if loss or model weights are nan
             if self.trainer.terminate_on_nan:
                 check_finite_loss(self.trainer.lightning_module, loss)

--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -226,7 +226,7 @@ class TrainingBatchLoop(Loop):
         other functions such as `backward` and `zero_grad`.
         """
         step_fn = self._make_step_fn(split_batch, batch_idx, opt_idx, hiddens)
-        backward_fn = self._make_backward_fn(batch_idx, optimizer, opt_idx)
+        backward_fn = self._make_backward_fn(optimizer, opt_idx)
         zero_grad_fn = self._make_zero_grad_fn(batch_idx, opt_idx, optimizer)
 
         return Closure(
@@ -258,12 +258,7 @@ class TrainingBatchLoop(Loop):
         ):
             return zero_grad_fn
 
-    def _make_backward_fn(
-        self,
-        batch_idx: int,
-        optimizer: Optimizer,
-        opt_idx: int,
-    ) -> Optional[Callable[[Tensor], Tensor]]:
+    def _make_backward_fn(self, optimizer: Optimizer, opt_idx: int) -> Optional[Callable[[Tensor], Tensor]]:
         """
         Build a `backward` function that handles back-propagation through the output produced by the `training_step`
         function. Returns ``None`` in the case backward needs to be skipped, e.g., when manual optimization is on.

--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -207,7 +207,6 @@ class TrainingBatchLoop(Loop):
             # if no result, user decided to skip optimization
             # otherwise update running loss + reset accumulated loss
             self._update_running_loss(result.loss)
-            self._process_closure_result(result)
 
         # untoggle model params
         self._run_optimization_end(opt_idx)
@@ -275,19 +274,6 @@ class TrainingBatchLoop(Loop):
 
         if not self._skip_backward and self.trainer.lightning_module.automatic_optimization:
             return backward_fn
-
-    def _process_closure_result(self, opt_closure_result: Optional[ClosureResult]) -> None:
-        """Checks if the closure results is finite and optionally breaks if it is not
-
-        Args:
-            opt_closure_result: the result of the train step wrapped in an attribute dict
-        """
-        if not opt_closure_result:
-            return
-
-        # check if loss or model weights are nan
-        if self.trainer.terminate_on_nan:
-            check_finite_loss(self.trainer.lightning_module, opt_closure_result.loss)
 
     def _training_step(
         self, split_batch: Any, batch_idx: int, opt_idx: int, hiddens: Tensor

--- a/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
@@ -200,9 +200,6 @@ class EvaluationEpochLoop(Loop):
 
         self.trainer.logger_connector.on_batch_end()
 
-        # track debug metrics
-        self.trainer.dev_debugger.track_eval_loss_history(batch_idx, dataloader_idx, output)
-
     def _build_kwargs(self, batch: Any, batch_idx: int, dataloader_idx: int) -> Dict[str, Union[Any, int]]:
         """Helper function to build the arguments for the current step
 

--- a/pytorch_lightning/utilities/debugging.py
+++ b/pytorch_lightning/utilities/debugging.py
@@ -14,7 +14,6 @@
 
 import os
 import time
-from collections import Counter
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -44,9 +43,6 @@ class InternalDebugger:
     def __init__(self, trainer: "pl.Trainer") -> None:
         self.enabled = os.environ.get("PL_DEV_DEBUG", "0") == "1"
         self.trainer = trainer
-        self.saved_train_losses: List[Dict[str, Any]] = []
-        self.saved_val_losses: List[Dict[str, Any]] = []
-        self.saved_test_losses: List[Dict[str, Any]] = []
         self.early_stopping_history: List[Dict[str, Any]] = []
         self.checkpoint_callback_history: List[Dict[str, Any]] = []
         self.events: List[Dict[str, Any]] = []
@@ -108,11 +104,6 @@ class InternalDebugger:
             self.test_dataloader_calls.append(values)
 
     @enabled_only
-    def track_train_loss_history(self, batch_idx: int, loss: torch.Tensor) -> None:
-        loss_dict = {"batch_idx": batch_idx, "epoch": self.trainer.current_epoch, "loss": loss.detach().clone()}
-        self.saved_train_losses.append(loss_dict)
-
-    @enabled_only
     def track_lr_schedulers_update(
         self,
         batch_idx: int,
@@ -134,21 +125,6 @@ class InternalDebugger:
             "new_lr": new_lr,
         }
         self.saved_lr_scheduler_updates.append(loss_dict)
-
-    @enabled_only
-    def track_eval_loss_history(self, batch_idx: int, dataloader_idx: int, output: torch.Tensor) -> None:
-        loss_dict = {
-            "sanity_check": self.trainer.sanity_checking,
-            "dataloader_idx": dataloader_idx,
-            "batch_idx": batch_idx,
-            "epoch": self.trainer.current_epoch,
-            "output": output,
-        }
-
-        if self.trainer.testing:
-            self.saved_test_losses.append(loss_dict)
-        else:
-            self.saved_val_losses.append(loss_dict)
 
     @enabled_only
     def track_early_stopping_history(
@@ -175,24 +151,3 @@ class InternalDebugger:
             "filepath": filepath,
         }
         self.checkpoint_callback_history.append(debug_dict)
-
-    @property
-    def num_seen_sanity_check_batches(self) -> int:
-        count = sum(1 for x in self.saved_val_losses if x["sanity_check"])
-        return count
-
-    @property
-    def num_seen_val_check_batches(self) -> Counter:
-        counts: Counter = Counter()
-        for x in self.saved_val_losses:
-            if not x["sanity_check"]:
-                counts.update({x["dataloader_idx"]: 1})
-        return counts
-
-    @property
-    def num_seen_test_check_batches(self) -> Counter:
-        counts: Counter = Counter()
-        for x in self.saved_test_losses:
-            if not x["sanity_check"]:
-                counts.update({x["dataloader_idx"]: 1})
-        return counts

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -446,7 +446,6 @@ def test_dataloaders_with_limit_percent_batches(tmpdir, limit_train_batches, lim
 @pytest.mark.parametrize(
     ["limit_train_batches", "limit_val_batches", "limit_test_batches"], [(0, 0, 0), (1, 2, 3), (1, 2, 1e50)]
 )
-@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_dataloaders_with_limit_num_batches(tmpdir, limit_train_batches, limit_val_batches, limit_test_batches):
     """Verify num_batches for train, val & test dataloaders passed with batch limit as number"""
 
@@ -465,50 +464,38 @@ def test_dataloaders_with_limit_num_batches(tmpdir, limit_train_batches, limit_v
         limit_train_batches=limit_train_batches,
         limit_val_batches=limit_val_batches,
         limit_test_batches=limit_test_batches,
+        num_sanity_val_steps=0,
     )
-    trainer.fit(model)
 
-    # -------------------------------------------
-    # MAKE SURE THE TRAINER SET THE CORRECT VALUES
-    # -------------------------------------------
-    assert trainer.num_training_batches == limit_train_batches
-    assert trainer.num_val_batches == [limit_val_batches] * len(trainer.val_dataloaders)
-    trainer.test(model)
+    with patch.object(
+        trainer.fit_loop.epoch_loop.val_loop.epoch_loop,
+        "evaluation_step",
+        wraps=trainer.fit_loop.epoch_loop.val_loop.epoch_loop.evaluation_step,
+    ) as mocked:
+        trainer.fit(model)
+        assert trainer.num_training_batches == limit_train_batches
+        assert trainer.num_val_batches == [limit_val_batches] * len(trainer.val_dataloaders)
+        assert mocked.call_count == limit_val_batches * len(trainer.val_dataloaders)
 
-    # when the limit is greater than the number of test batches it should be the num in loaders
-    test_dataloader_lengths = [len(x) for x in model.test_dataloader()]
-    if limit_test_batches > 1e10:
-        assert trainer.num_test_batches == test_dataloader_lengths
-    else:
-        assert trainer.num_test_batches == [limit_test_batches] * len(trainer.test_dataloaders)
-
-    # -------------------------------------------
-    # make sure we actually saw the expected num of batches
-    # -------------------------------------------
-    num_val_dataloaders = len(model.val_dataloader())
-    num_test_dataloaders = len(model.test_dataloader())
-    if limit_train_batches > 0:
-
-        # make sure val batches are as expected
-        assert len(trainer.dev_debugger.num_seen_val_check_batches) == num_val_dataloaders
-        for dataloader_idx, num_batches in trainer.dev_debugger.num_seen_val_check_batches.items():
-            assert num_batches == limit_val_batches
-
-        # make sure test batches are as expected
-        assert len(trainer.dev_debugger.num_seen_test_check_batches) == num_test_dataloaders
-        for dataloader_idx, num_batches in trainer.dev_debugger.num_seen_test_check_batches.items():
-            if limit_test_batches > 1e10:
-                assert num_batches == test_dataloader_lengths[dataloader_idx]
-            else:
-                assert num_batches == limit_test_batches
+    with patch.object(
+        trainer.test_loop.epoch_loop,
+        "evaluation_step",
+        wraps=trainer.test_loop.epoch_loop.evaluation_step,
+    ) as mocked:
+        trainer.test(model)
+        test_dataloader_lengths = [len(x) for x in model.test_dataloader()]
+        if limit_test_batches > 1e10:
+            # when the limit is greater than the number of test batches it should be the num in loaders
+            assert trainer.num_test_batches == test_dataloader_lengths
+            assert mocked.call_count == sum(test_dataloader_lengths)
+        else:
+            assert trainer.num_test_batches == [limit_test_batches] * len(trainer.test_dataloaders)
+            assert mocked.call_count == limit_test_batches * len(trainer.test_dataloaders)
 
 
-@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 @pytest.mark.parametrize("fast_dev_run", [True, 1, 3, -1, "temp"])
 def test_dataloaders_with_fast_dev_run(tmpdir, fast_dev_run):
-    """
-    Verify num_batches for train, val & test dataloaders passed with fast_dev_run
-    """
+    """Verify num_batches for train, val & test dataloaders passed with fast_dev_run"""
     model = EvalModelTemplate()
     model.val_dataloader = model.val_dataloader__multiple_mixed_length
     model.test_dataloader = model.test_dataloader__multiple_mixed_length
@@ -550,10 +537,6 @@ def test_dataloaders_with_fast_dev_run(tmpdir, fast_dev_run):
 
         trainer.test(model)
         assert trainer.num_test_batches == [fast_dev_run] * len(trainer.test_dataloaders)
-
-        # verify sanity check batches match as expected
-        num_val_dataloaders = len(model.val_dataloader())
-        assert trainer.dev_debugger.num_seen_sanity_check_batches == trainer.num_sanity_val_steps * num_val_dataloaders
 
 
 @pytest.mark.parametrize("ckpt_path", [None, "best", "specific"])


### PR DESCRIPTION
## What does this PR do?

Replaces the calls to the internal dev debugger in the loops. Tests are updated to cover what the "debugger" offered for tracking the calls inside the loops. 
This is just one step towards removing the `InternalDebugger` completely, and to make loops more easily extensible.



## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃
