### PR TITLE
move `TrainingBatchLoop.build_kwargs` to utilities

### DIFF
--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import OrderedDict
 from contextlib import contextmanager
 from copy import copy
 from functools import partial
@@ -28,10 +27,10 @@ from pytorch_lightning.core.optimizer import LightningOptimizer
 from pytorch_lightning.loops.base import Loop
 from pytorch_lightning.loops.closure import Closure, ClosureResult
 from pytorch_lightning.loops.utilities import (
+    _build_training_step_kwargs,
     _check_training_step_output,
     _process_training_step_output,
     check_finite_loss,
-    _build_training_step_kwargs,
 )
 from pytorch_lightning.plugins import ParallelPlugin
 from pytorch_lightning.trainer.progress import OptimizationProgress
@@ -39,7 +38,6 @@ from pytorch_lightning.trainer.supporters import TensorRunningAccum
 from pytorch_lightning.utilities import AMPType, AttributeDict, DeviceType, grad_norm
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.imports import _TPU_AVAILABLE
-from pytorch_lightning.utilities.signature_utils import is_param_in_hook_signature
 from pytorch_lightning.utilities.types import STEP_OUTPUT
 from pytorch_lightning.utilities.warnings import WarningCache
 

--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -31,6 +31,7 @@ from pytorch_lightning.loops.utilities import (
     _check_training_step_output,
     _process_training_step_output,
     check_finite_loss,
+    _build_training_step_kwargs,
 )
 from pytorch_lightning.plugins import ParallelPlugin
 from pytorch_lightning.trainer.progress import OptimizationProgress
@@ -316,7 +317,9 @@ class TrainingBatchLoop(Loop):
         model_ref = self.trainer.lightning_module
 
         with self.trainer.profiler.profile("model_forward"):
-            step_kwargs = self._build_kwargs(split_batch, batch_idx, opt_idx, hiddens)
+            step_kwargs = _build_training_step_kwargs(
+                model_ref, self.trainer.optimizers, split_batch, batch_idx, opt_idx, hiddens
+            )
 
             # manually capture logged metrics
             model_ref._current_fx_name = "training_step"
@@ -540,46 +543,3 @@ class TrainingBatchLoop(Loop):
         # find optimzier index by looking for the first {item > current_place} in the cumsum list
         opt_idx = int(np.argmax(self.optimizer_freq_cumsum > current_place_in_loop))
         return [(opt_idx, self.trainer.optimizers[opt_idx])]
-
-    def _build_kwargs(self, batch: Any, batch_idx: int, opt_idx: int, hiddens: Optional[Tensor]) -> Dict[str, Any]:
-        """Builds the keyword arguments for training_step
-
-        Args:
-            batch: the batch to train on
-            batch_idx: the index of the current batch
-            opt_idx: the index of the current optimizer
-            hiddens: the hidden state of the previous RNN iteration
-
-        Returns:
-            the keyword arguments for the training step
-        """
-        # enable not needing to add opt_idx to training_step
-        step_kwargs = OrderedDict([("batch", batch)])
-
-        lightning_module = self.trainer.lightning_module
-        training_step_fx = getattr(lightning_module, "training_step")
-
-        if is_param_in_hook_signature(training_step_fx, "batch_idx", min_args=2):
-            step_kwargs["batch_idx"] = batch_idx
-
-        if len(self.trainer.optimizers) > 1:
-            has_opt_idx_in_train_step = is_param_in_hook_signature(training_step_fx, "optimizer_idx")
-            if has_opt_idx_in_train_step:
-                if not lightning_module.automatic_optimization:
-                    raise ValueError(
-                        "Your `LightningModule.training_step` signature contains an `optimizer_idx` argument but"
-                        " in manual optimization optimizers must be handled by the user. Remove the optimizer_idx"
-                        " argument or set `self.automatic_optimization = True`."
-                    )
-                step_kwargs["optimizer_idx"] = opt_idx
-            elif not has_opt_idx_in_train_step and lightning_module.automatic_optimization:
-                raise ValueError(
-                    f"Your LightningModule defines {len(self.trainer.optimizers)} optimizers but"
-                    " `training_step` is missing the `optimizer_idx` argument."
-                )
-
-        # pass hiddens if using tbptt
-        if self.trainer.lightning_module.truncated_bptt_steps > 0:
-            step_kwargs["hiddens"] = hiddens
-
-        return step_kwargs

--- a/pytorch_lightning/loops/utilities.py
+++ b/pytorch_lightning/loops/utilities.py
@@ -11,10 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from collections import OrderedDict
+from contextlib import contextmanager
+from typing import Any, Generator, Iterator, Mapping, Optional, Tuple, Sequence, Dict
 
 from typing import Any, Iterator, Mapping, Optional, Tuple
 
 import torch
+from torch import Tensor
+from torch.optim import Optimizer
 
 import pytorch_lightning as pl
 from pytorch_lightning.trainer.connectors.logger_connector.result import ResultCollection
@@ -22,6 +27,7 @@ from pytorch_lightning.utilities.apply_func import apply_to_collection
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.fetching import AbstractDataFetcher, DataLoaderIterDataFetcher
 from pytorch_lightning.utilities.finite_checks import detect_nan_parameters
+from pytorch_lightning.utilities.signature_utils import is_param_in_hook_signature
 from pytorch_lightning.utilities.types import STEP_OUTPUT
 
 
@@ -103,6 +109,58 @@ def _process_training_step_output(
     if trainer.move_metrics_to_cpu:
         results.cpu()
     return results, hiddens
+
+
+def _build_training_step_kwargs(
+    lightning_module: "pl.LightningModule",
+    optimizers: Sequence[Optimizer],
+    batch: Any,
+    batch_idx: int,
+    opt_idx: int,
+    hiddens: Optional[Tensor],
+) -> Dict[str, Any]:
+    """Builds the keyword arguments for training_step
+
+    Args:
+        lightning_module: the LightningModule with a `training_step` hook implementation
+        optimizers: the list of optimizers from the Trainer
+        batch: the batch to train on
+        batch_idx: the index of the current batch
+        opt_idx: the index of the current optimizer
+        hiddens: the hidden state of the previous RNN iteration
+
+    Returns:
+        the keyword arguments for the training step
+    """
+    # enable not needing to add opt_idx to training_step
+    step_kwargs = OrderedDict([("batch", batch)])
+
+    training_step_fx = getattr(lightning_module, "training_step")
+
+    if is_param_in_hook_signature(training_step_fx, "batch_idx", min_args=2):
+        step_kwargs["batch_idx"] = batch_idx
+
+    if len(optimizers) > 1:
+        has_opt_idx_in_train_step = is_param_in_hook_signature(training_step_fx, "optimizer_idx")
+        if has_opt_idx_in_train_step:
+            if not lightning_module.automatic_optimization:
+                raise ValueError(
+                    "Your `LightningModule.training_step` signature contains an `optimizer_idx` argument but"
+                    " in manual optimization optimizers must be handled by the user. Remove the optimizer_idx"
+                    " argument or set `self.automatic_optimization = True`."
+                )
+            step_kwargs["optimizer_idx"] = opt_idx
+        elif not has_opt_idx_in_train_step and lightning_module.automatic_optimization:
+            raise ValueError(
+                f"Your LightningModule defines {len(optimizers)} optimizers but"
+                " `training_step` is missing the `optimizer_idx` argument."
+            )
+
+    # pass hiddens if using tbptt
+    if lightning_module.truncated_bptt_steps > 0:
+        step_kwargs["hiddens"] = hiddens
+
+    return step_kwargs
 
 
 def _prepare_dataloader_iter(data_fetcher: AbstractDataFetcher, batch_idx: int) -> Iterator:

--- a/pytorch_lightning/loops/utilities.py
+++ b/pytorch_lightning/loops/utilities.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import OrderedDict
-from contextlib import contextmanager
-from typing import Any, Generator, Iterator, Mapping, Optional, Tuple, Sequence, Dict
-
-from typing import Any, Iterator, Mapping, Optional, Tuple
+from typing import Any, Dict, Iterator, Mapping, Optional, Sequence, Tuple
 
 import torch
 from torch import Tensor

--- a/pytorch_lightning/loops/utilities.py
+++ b/pytorch_lightning/loops/utilities.py
@@ -113,7 +113,7 @@ def _build_training_step_kwargs(
     optimizers: Sequence[Optimizer],
     batch: Any,
     batch_idx: int,
-    opt_idx: int,
+    opt_idx: Optional[int],
     hiddens: Optional[Tensor],
 ) -> Dict[str, Any]:
     """Builds the keyword arguments for training_step


### PR DESCRIPTION
## What does this PR do?

Part of #9191

Moves the `TrainingBatchLoop._build_kwargs` method to a function in utilities. The motivation is to avoid code duplication and share the function for automatic and manual optimization loops, which will be split up in #9191. 


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


