### PR TITLE
avoid suppressing exception in `FitLoop`

### DIFF
--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -181,8 +181,7 @@ class FitLoop(Loop):
             self.trainer.train_dataloader.load_state_dict(self._dataloader_state_dict)
             self._dataloader_state_dict = {}
 
-        # TODO: specify the possible exception
-        with suppress(Exception):
+        if callable(getattr(self.trainer.train_dataloader.sampler, "set_epoch", None)):
             # set seed for distributed sampler (enables shuffling for each epoch)
             self.trainer.train_dataloader.sampler.set_epoch(self.current_epoch)
 

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-from contextlib import suppress
 from typing import Any, Dict, Optional
 
 from pytorch_lightning.loops import Loop


### PR DESCRIPTION
## What does this PR do?

Resolves a small TODO in the FitLoop.
Not all samplers have a `set_epoch` method, hence we were suppressing an AttributeError. However, suppressing exceptions is not great because we don't know where they might come from. Instead, we should either catch and deal with the exception, or, as done here, replace it with a conditional check.

part of #7938 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


