### PR TITLE
Remove deprecated property `ModelCheckpoint.period` in favor of `ModelCheckpoint.every_n_epochs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Removed deprecated property `Trainer.running_sanity_check` in favor of `Trainer.sanity_checking` ([#9209](https://github.com/PyTorchLightning/pytorch-lightning/pull/9209))
 
+
+- Removed deprecated property `ModelCheckpoint.period` in favor of `ModelCheckpoint.every_n_epochs` ([#9213](https://github.com/PyTorchLightning/pytorch-lightning/pull/9213))
+
 ### Fixed
 
 - Fixed save/load/resume from checkpoint for DeepSpeed Plugin (

--- a/docs/source/common/weights_loading.rst
+++ b/docs/source/common/weights_loading.rst
@@ -71,7 +71,7 @@ You can customize the checkpointing behavior to monitor any quantity of your tra
     # 4. Add your callback to the callbacks list
     trainer = Trainer(callbacks=[checkpoint_callback])
 
-You can also control more advanced options, like `save_top_k`, to save the best k models and the `mode` of the monitored quantity (min/max), `save_weights_only` or `period` to set the interval of epochs between checkpoints, to avoid slowdowns.
+You can also control more advanced options, like `save_top_k`, to save the best k models and the `mode` of the monitored quantity (min/max), `save_weights_only` or `every_n_epochs` to set the interval of epochs between checkpoints, to avoid slowdowns.
 
 .. testcode::
 

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -90,7 +90,7 @@ class ModelCheckpoint(Callback):
             the quantity monitored will be saved.
             if ``save_top_k == 0``, no models are saved.
             if ``save_top_k == -1``, all models are saved.
-            Please note that the monitors are checked every ``period`` epochs.
+            Please note that the monitors are checked every ``every_n_epochs`` epochs.
             if ``save_top_k >= 2`` and the callback is called multiple
             times inside an epoch, the name of the saved file will be
             appended with a version count starting with ``v1``.
@@ -124,12 +124,6 @@ class ModelCheckpoint(Callback):
             where both values for ``every_n_epochs`` and ``check_val_every_n_epoch`` evenly divide E.
         save_on_train_epoch_end: Whether to run checkpointing at the end of the training epoch.
             If this is ``False``, then the check runs at the end of the validation.
-        period: Interval (number of epochs) between checkpoints.
-
-            .. warning::
-               This argument has been deprecated in v1.3 and will be removed in v1.5.
-
-            Use ``every_n_epochs`` instead.
         every_n_val_epochs: Number of epochs between checkpoints.
 
             .. warning::
@@ -222,7 +216,6 @@ class ModelCheckpoint(Callback):
         train_time_interval: Optional[timedelta] = None,
         every_n_epochs: Optional[int] = None,
         save_on_train_epoch_end: Optional[bool] = None,
-        period: Optional[int] = None,
         every_n_val_epochs: Optional[int] = None,
     ):
         super().__init__()
@@ -251,7 +244,7 @@ class ModelCheckpoint(Callback):
 
         self.__init_monitor_mode(mode)
         self.__init_ckpt_dir(dirpath, filename)
-        self.__init_triggers(every_n_train_steps, every_n_epochs, train_time_interval, period)
+        self.__init_triggers(every_n_train_steps, every_n_epochs, train_time_interval)
         self.__validate_init_configuration()
 
     @property
@@ -474,7 +467,6 @@ class ModelCheckpoint(Callback):
         every_n_train_steps: Optional[int],
         every_n_epochs: Optional[int],
         train_time_interval: Optional[timedelta],
-        period: Optional[int],
     ) -> None:
 
         # Default to running once after each validation epoch if neither
@@ -491,30 +483,9 @@ class ModelCheckpoint(Callback):
         self._every_n_epochs: int = every_n_epochs
         self._every_n_train_steps: int = every_n_train_steps
 
-        # period takes precedence over every_n_epochs for backwards compatibility
-        if period is not None:
-            rank_zero_deprecation(
-                "Argument `period` in `ModelCheckpoint` is deprecated in v1.3 and will be removed in v1.5."
-                " Please use `every_n_epochs` instead."
-            )
-            self._every_n_epochs = period
-        self._period = self._every_n_epochs
-
     @property
-    def period(self) -> Optional[int]:
-        rank_zero_deprecation(
-            "Property `period` in `ModelCheckpoint` is deprecated in v1.3 and will be removed in v1.5."
-            " Please use `every_n_epochs` instead."
-        )
-        return self._period
-
-    @period.setter
-    def period(self, value: Optional[int]) -> None:
-        rank_zero_deprecation(
-            "Property `period` in `ModelCheckpoint` is deprecated in v1.3 and will be removed in v1.5."
-            " Please use `every_n_epochs` instead."
-        )
-        self._period = value
+    def every_n_epochs(self) -> Optional[int]:
+        return self._every_n_epochs
 
     def _del_model(self, trainer: "pl.Trainer", filepath: str) -> None:
         if trainer.should_rank_save_checkpoint and self._fs.exists(filepath):

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -568,8 +568,7 @@ def test_invalid_trigger_combination(tmpdir):
 
 def test_none_every_n_train_steps_val_epochs(tmpdir):
     checkpoint_callback = ModelCheckpoint(dirpath=tmpdir)
-    assert checkpoint_callback.period == 1
-    assert checkpoint_callback._every_n_epochs == 1
+    assert checkpoint_callback.every_n_epochs == 1
     assert checkpoint_callback._every_n_train_steps == 0
 
 
@@ -607,55 +606,12 @@ def test_model_checkpoint_save_last_none_monitor(tmpdir, caplog):
     assert set(os.listdir(tmpdir)) == set(expected)
 
 
-@pytest.mark.parametrize("period", list(range(4)))
-def test_model_checkpoint_period(tmpdir, period: int):
-    model = LogInTwoMethods()
-    epochs = 5
-    checkpoint_callback = ModelCheckpoint(dirpath=tmpdir, filename="{epoch}", save_top_k=-1, period=period)
-    trainer = Trainer(
-        default_root_dir=tmpdir,
-        callbacks=[checkpoint_callback],
-        max_epochs=epochs,
-        limit_train_batches=1,
-        limit_val_batches=1,
-        logger=False,
-    )
-    trainer.fit(model)
-
-    # check that the correct ckpts were created
-    expected = [f"epoch={e}.ckpt" for e in range(epochs) if not (e + 1) % period] if period > 0 else []
-    assert set(os.listdir(tmpdir)) == set(expected)
-
-
 @pytest.mark.parametrize("every_n_epochs", list(range(4)))
 def test_model_checkpoint_every_n_epochs(tmpdir, every_n_epochs):
     model = LogInTwoMethods()
     epochs = 5
     checkpoint_callback = ModelCheckpoint(
         dirpath=tmpdir, filename="{epoch}", save_top_k=-1, every_n_epochs=every_n_epochs
-    )
-    trainer = Trainer(
-        default_root_dir=tmpdir,
-        callbacks=[checkpoint_callback],
-        max_epochs=epochs,
-        limit_train_batches=1,
-        limit_val_batches=1,
-        logger=False,
-    )
-    trainer.fit(model)
-
-    # check that the correct ckpts were created
-    expected = [f"epoch={e}.ckpt" for e in range(epochs) if not (e + 1) % every_n_epochs] if every_n_epochs > 0 else []
-    assert set(os.listdir(tmpdir)) == set(expected)
-
-
-@pytest.mark.parametrize("every_n_epochs", list(range(4)))
-def test_model_checkpoint_every_n_epochs_and_period(tmpdir, every_n_epochs):
-    """Tests that if period is set, it takes precedence over every_n_epochs for backwards compatibility."""
-    model = LogInTwoMethods()
-    epochs = 5
-    checkpoint_callback = ModelCheckpoint(
-        dirpath=tmpdir, filename="{epoch}", save_top_k=-1, every_n_epochs=(2 * every_n_epochs), period=every_n_epochs
     )
     trainer = Trainer(
         default_root_dir=tmpdir,

--- a/tests/deprecated_api/test_remove_1-5.py
+++ b/tests/deprecated_api/test_remove_1-5.py
@@ -31,13 +31,6 @@ def test_v1_5_0_running_sanity_check():
         assert not trainer.running_sanity_check
 
 
-def test_v1_5_0_model_checkpoint_period(tmpdir):
-    with no_warning_call(DeprecationWarning):
-        ModelCheckpoint(dirpath=tmpdir)
-    with pytest.deprecated_call(match="is deprecated in v1.3 and will be removed in v1.5"):
-        ModelCheckpoint(dirpath=tmpdir, period=1)
-
-
 @pytest.mark.parametrize("cls", (BaseProfiler, SimpleProfiler, AdvancedProfiler, PyTorchProfiler))
 def test_v1_5_0_profiler_output_filename(tmpdir, cls):
     filepath = str(tmpdir / "test.txt")


### PR DESCRIPTION
## What does this PR do?

Removal of `ModelCheckpoint.period` in favor of `ModelCheckpoint.every_n_epochs` as scheduled for 1.5

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
