### PR TITLE
scheduled removal of BaseProfiler.output_filename in favor of dirpath…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Removed deprecated property `Trainer.running_sanity_check` in favor of `Trainer.sanity_checking` ([#9209](https://github.com/PyTorchLightning/pytorch-lightning/pull/9209))
 
+
+- Removed deprecated `BaseProfiler.output_filename` arg from it and its descendents in favor of `dirpath` and `filename` ([#9214](https://github.com/PyTorchLightning/pytorch-lightning/pull/9214))
+
 ### Fixed
 
 - Fixed save/load/resume from checkpoint for DeepSpeed Plugin (

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,7 +241,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed deprecated property `Trainer.running_sanity_check` in favor of `Trainer.sanity_checking` ([#9209](https://github.com/PyTorchLightning/pytorch-lightning/pull/9209))
 
 
-- Removed deprecated `BaseProfiler.output_filename` arg from it and its descendents in favor of `dirpath` and `filename` ([#9214](https://github.com/PyTorchLightning/pytorch-lightning/pull/9214))
+- Removed deprecated `BaseProfiler.output_filename` arg from it and its descendants in favor of `dirpath` and `filename` ([#9214](https://github.com/PyTorchLightning/pytorch-lightning/pull/9214))
 
 ### Fixed
 

--- a/pytorch_lightning/profiler/__init__.py
+++ b/pytorch_lightning/profiler/__init__.py
@@ -67,7 +67,7 @@ This option uses Python's cProfiler_ to provide a report of time spent on *each*
     trainer = Trainer(..., profiler=profiler)
 
 The profiler's results will be printed at the completion of a training `fit()`. This profiler
-report can be quite long, so you can also specify an `output_filename` to save the report instead
+report can be quite long, so you can also specify a `dirpath` and `filename` to save the report instead
 of logging it to the output in your terminal. The output below shows the profiling for the action
 `get_train_batch`.
 

--- a/pytorch_lightning/profiler/advanced.py
+++ b/pytorch_lightning/profiler/advanced.py
@@ -36,7 +36,6 @@ class AdvancedProfiler(BaseProfiler):
         dirpath: Optional[Union[str, Path]] = None,
         filename: Optional[str] = None,
         line_count_restriction: float = 1.0,
-        output_filename: Optional[str] = None,
     ) -> None:
         """
         Args:
@@ -55,7 +54,7 @@ class AdvancedProfiler(BaseProfiler):
             ValueError:
                 If you attempt to stop recording an action which was never started.
         """
-        super().__init__(dirpath=dirpath, filename=filename, output_filename=output_filename)
+        super().__init__(dirpath=dirpath, filename=filename)
         self.profiled_actions: Dict[str, cProfile.Profile] = {}
         self.line_count_restriction = line_count_restriction
 

--- a/pytorch_lightning/profiler/base.py
+++ b/pytorch_lightning/profiler/base.py
@@ -19,7 +19,6 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, Iterable, Optional, TextIO, Union
 
-from pytorch_lightning.utilities import rank_zero_deprecation
 from pytorch_lightning.utilities.cloud_io import get_filesystem
 
 log = logging.getLogger(__name__)

--- a/pytorch_lightning/profiler/base.py
+++ b/pytorch_lightning/profiler/base.py
@@ -58,18 +58,9 @@ class BaseProfiler(AbstractProfiler):
         self,
         dirpath: Optional[Union[str, Path]] = None,
         filename: Optional[str] = None,
-        output_filename: Optional[str] = None,
     ) -> None:
         self.dirpath = dirpath
         self.filename = filename
-        if output_filename is not None:
-            rank_zero_deprecation(
-                "`Profiler` signature has changed in v1.3. The `output_filename` parameter has been removed in"
-                " favor of `dirpath` and `filename`. Support for the old signature will be removed in v1.5"
-            )
-            filepath = Path(output_filename)
-            self.dirpath = filepath.parent
-            self.filename = filepath.stem
 
         self._output_file: Optional[TextIO] = None
         self._write_stream: Optional[Callable] = None

--- a/pytorch_lightning/profiler/pytorch.py
+++ b/pytorch_lightning/profiler/pytorch.py
@@ -222,7 +222,6 @@ class PyTorchProfiler(BaseProfiler):
         sort_by_key: Optional[str] = None,
         record_functions: Set[str] = None,
         record_module_names: bool = True,
-        output_filename: Optional[str] = None,
         **profiler_kwargs: Any,
     ) -> None:
         """
@@ -274,7 +273,7 @@ class PyTorchProfiler(BaseProfiler):
                 If arg ``schedule`` is not a ``Callable``.
                 If arg ``schedule`` does not return a ``torch.profiler.ProfilerAction``.
         """
-        super().__init__(dirpath=dirpath, filename=filename, output_filename=output_filename)
+        super().__init__(dirpath=dirpath, filename=filename)
 
         self._group_by_input_shapes = group_by_input_shapes and profiler_kwargs.get("record_shapes", False)
         self._emit_nvtx = emit_nvtx

--- a/pytorch_lightning/profiler/simple.py
+++ b/pytorch_lightning/profiler/simple.py
@@ -37,7 +37,6 @@ class SimpleProfiler(BaseProfiler):
         dirpath: Optional[Union[str, Path]] = None,
         filename: Optional[str] = None,
         extended: bool = True,
-        output_filename: Optional[str] = None,
     ) -> None:
         """
         Args:
@@ -53,7 +52,7 @@ class SimpleProfiler(BaseProfiler):
                 If you attempt to start an action which has already started, or
                 if you attempt to stop recording an action which was never started.
         """
-        super().__init__(dirpath=dirpath, filename=filename, output_filename=output_filename)
+        super().__init__(dirpath=dirpath, filename=filename)
         self.current_actions: Dict[str, float] = {}
         self.recorded_durations = defaultdict(list)
         self.extended = extended

--- a/pytorch_lightning/profiler/xla.py
+++ b/pytorch_lightning/profiler/xla.py
@@ -69,7 +69,7 @@ class XLAProfiler(BaseProfiler):
         This Profiler will help you debug and optimize training workload performance
         for your models using Cloud TPU performance tools.
         """
-        super().__init__(dirpath=None, filename=None, output_filename=None)
+        super().__init__(dirpath=None, filename=None)
         self.port = port
         self._recording_map: Dict = {}
         self._step_recoding_map: Dict = {}

--- a/tests/deprecated_api/test_remove_1-5.py
+++ b/tests/deprecated_api/test_remove_1-5.py
@@ -32,15 +32,6 @@ def test_v1_5_0_model_checkpoint_period(tmpdir):
         ModelCheckpoint(dirpath=tmpdir, period=1)
 
 
-@pytest.mark.parametrize("cls", (BaseProfiler, SimpleProfiler, AdvancedProfiler, PyTorchProfiler))
-def test_v1_5_0_profiler_output_filename(tmpdir, cls):
-    filepath = str(tmpdir / "test.txt")
-    with pytest.deprecated_call(match="`output_filename` parameter has been removed"):
-        profiler = cls(output_filename=filepath)
-    assert profiler.dirpath == tmpdir
-    assert profiler.filename == "test"
-
-
 def test_v1_5_0_auto_move_data():
     with pytest.deprecated_call(match="deprecated in v1.3 and will be removed in v1.5.*was applied to `bar`"):
 

--- a/tests/deprecated_api/test_remove_1-5.py
+++ b/tests/deprecated_api/test_remove_1-5.py
@@ -18,7 +18,6 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.core.decorators import auto_move_data
 from pytorch_lightning.plugins import DeepSpeedPlugin
-from pytorch_lightning.profiler import AdvancedProfiler, BaseProfiler, PyTorchProfiler, SimpleProfiler
 from tests.deprecated_api import no_deprecated_call
 from tests.helpers import BoringDataModule, BoringModel
 from tests.helpers.runif import RunIf


### PR DESCRIPTION
… and filename

Removes BaseProfiler.output_filename from that class and its descendants in favor of dirpath and filename as scheduled for 1.5

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
