### PR TITLE
Modify name and version handling for logger collection

### DIFF
--- a/pytorch_lightning/loggers/base.py
+++ b/pytorch_lightning/loggers/base.py
@@ -410,6 +410,10 @@ class LoggerCollection(LightningLoggerBase):
         for logger in self._logger_iterable:
             logger.close()
 
+    @staticmethod
+    def all_equal(x):
+        return all(el == x[0] for el in x)
+
     @property
     def save_dir(self) -> Optional[str]:
         # Checkpoints should be saved to default / chosen location when using multiple loggers
@@ -417,11 +421,19 @@ class LoggerCollection(LightningLoggerBase):
 
     @property
     def name(self) -> str:
-        return "_".join(str(logger.name) for logger in self._logger_iterable)
+        names = (str(logger.name) for logger in self._logger_iterable)
+        if all_equal(names):
+            return names[0]
+        else:
+            return "_".join(names)
 
     @property
     def version(self) -> str:
-        return "_".join(str(logger.version) for logger in self._logger_iterable)
+        versions = (str(logger.version) for logger in self._logger_iterable)
+        if all_equal(versions):
+            return int(versions[0]) if versions[0].isdigit() else versions[0]
+        else:
+            return "_".join(versions)
 
 
 class DummyExperiment:


### PR DESCRIPTION
## What does this PR do?

Fixes #9097

This pull request is meant to simplify how `LoggerCollection` decides and shares `name` and `version` information when multiple loggers are used. When the loggers use the same version (the expected case), then only that version is returned (possibly as an integer) so that can be used by other machinery such as callbacks (e.g. `ModelCheckpoint`).

This should make it easier to get all of the items written to disk in a consistently versioned location for a given iteration/version of training.

### Does your PR introduce any breaking changes? If yes, please list them.

No breaking changes.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
