### PR TITLE
[bugfix] Prevent a DDP failure using copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,7 +273,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed not setting a default value for `max_epochs` if `max_time` was specified on the `Trainer` constructor ([#9072](https://github.com/PyTorchLightning/pytorch-lightning/pull/9072))
 
+
 - Fixed the CometLogger, no longer modifies the metrics in place. Instead creates a copy of metrics before performing any operations ([#9150](https://github.com/PyTorchLightning/pytorch-lightning/pull/9150))
+
+
+- Fixed `DDP` CUDA error: initialization error due a `copy` instead of `deepcopy` on ResultCollection ([#9239](https://github.com/PyTorchLightning/pytorch-lightning/pull/9239))
+
 
 
 ## [1.4.3] - 2021-08-17

--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from copy import copy
+from copy import deepcopy
 from functools import partial
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -142,12 +142,12 @@ class TrainingBatchLoop(Loop):
 
                 result = self._run_optimization(batch_idx, split_batch, opt_idx, optimizer)
                 if result:
-                    self.batch_outputs[opt_idx].append(copy(result.result_collection))
+                    self.batch_outputs[opt_idx].append(deepcopy(result.result_collection))
         else:
             # in manual optimization, there is no looping over optimizers
             result = self._run_optimization(batch_idx, split_batch)
             if result:
-                self.batch_outputs[0].append(copy(result.result_collection))
+                self.batch_outputs[0].append(deepcopy(result.result_collection))
 
     def teardown(self) -> None:
         # release memory

--- a/pytorch_lightning/trainer/connectors/logger_connector/result.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/result.py
@@ -185,6 +185,11 @@ class ResultMetric(Metric, DeviceDtypeModuleMixin):
 
     def update(self, value: _METRIC, batch_size: torch.Tensor) -> None:
         if self.is_tensor:
+            
+            # we shouuld detach the value from the graph is provide
+            if value.grad_fn is not None:
+                value = value.detach().clone()
+
             value = value.float()
             # performance: no need to accumulate on values only logged on_step
             if self.meta.on_step and not self.meta.on_epoch:

--- a/pytorch_lightning/trainer/connectors/logger_connector/result.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/result.py
@@ -186,7 +186,7 @@ class ResultMetric(Metric, DeviceDtypeModuleMixin):
     def update(self, value: _METRIC, batch_size: torch.Tensor) -> None:
         if self.is_tensor:
             
-            # we shouuld detach the value from the graph is provide
+            # we shouuld detach the value from the autograd graph
             if value.grad_fn is not None:
                 value = value.detach().clone()
 

--- a/tests/plugins/test_ddp_plugin.py
+++ b/tests/plugins/test_ddp_plugin.py
@@ -12,15 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from unittest import mock
-
+import pytest
 import torch
 from torch.nn.parallel import DistributedDataParallel
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.plugins import DDPPlugin
-from tests.helpers.boring_model import BoringModel, RandomDataset
+from tests.helpers.boring_model import BoringModel
 from tests.helpers.runif import RunIf
-from torch.utils.data import DataLoader
 
 
 class BoringModelGPU(BoringModel):

--- a/tests/plugins/test_ddp_plugin.py
+++ b/tests/plugins/test_ddp_plugin.py
@@ -11,18 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os
 from unittest import mock
 
-import pytest
 import torch
 from torch.nn.parallel import DistributedDataParallel
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.plugins import DDPPlugin
-from pytorch_lightning.plugins.environments import LightningEnvironment
-from tests.helpers.boring_model import BoringModel
+from tests.helpers.boring_model import BoringModel, RandomDataset
 from tests.helpers.runif import RunIf
+from torch.utils.data import DataLoader
 
 
 class BoringModelGPU(BoringModel):
@@ -72,25 +70,3 @@ def test_ddp_barrier_non_consecutive_device_ids(barrier_mock, tmpdir):
     trainer = Trainer(default_root_dir=tmpdir, max_steps=1, gpus=gpus, accelerator="ddp")
     trainer.fit(model)
     barrier_mock.assert_any_call(device_ids=[gpus[trainer.local_rank]])
-
-
-@mock.patch.dict(os.environ, {"LOCAL_RANK": "1"})
-def test_incorrect_ddp_script_spawning(tmpdir):
-    """Test an error message when user accidentally instructs Lightning to spawn children processes on rank > 0."""
-
-    class WronglyImplementedEnvironment(LightningEnvironment):
-        def creates_children(self):
-            # returning false no matter what means Lightning would spawn also on ranks > 0 new processes
-            return False
-
-    model = BoringModel()
-    trainer = Trainer(
-        default_root_dir=tmpdir,
-        accelerator="ddp",
-        num_processes=2,
-        plugins=[DDPPlugin(), WronglyImplementedEnvironment()],
-    )
-    with pytest.raises(
-        RuntimeError, match="Lightning attempted to launch new distributed processes with `local_rank > 0`."
-    ):
-        trainer.fit(model)


### PR DESCRIPTION
## What does this PR do?

Fixes #8821

This error is critical as it blocks DDP. Observations:

- needs num_workers > 0
- only for ddp (spawn works)
- returning a loss has impact
- `epoch=True` breaks with any `reduce_fx`
- `step=True, sync_dist=True` breaks with `reduce_fx != "mean"`

The failure can be reproduced with this minimal repro: https://github.com/PyTorchLightning/pytorch-lightning/issues/8821#issuecomment-909283530

We believe this to be a bug upstream on PyTorch but haven't been able to easily reproduce it without Lightning.

A test hasn't been added because `pytest` seems to hang on teardown due to the `num_workers>0` requirement. Not sure why.

This would break on master.

```py
@RunIf(min_gpus=1)
def test_ddp_requires_a_deepcopy_on_training_step_output(tmpdir):

    class TestModel(BoringModel):

        def training_step(self, batch, batch_idx):
            loss = self(batch).sum()
            self.log('foo', torch.tensor(1), on_epoch=True)
            self.log('bar', torch.tensor(1), on_step=True, reduce_fx="sum", sync_dist=True)
            # a loss needs to be returned!
            return loss

        def train_dataloader(self):
            # only fails with `num_workers>0`
            return DataLoader(RandomDataset(32, 64), batch_size=2, num_workers=1)
 
    model = TestModel()
    trainer = Trainer(
        default_root_dir=tmpdir,
        gpus=1,
        accelerator='ddp',
        limit_train_batches=1,
        max_epochs=5,
        checkpoint_callback=False,
        logger=False,
    )
    trainer.fit(model)
```

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified