### PR TITLE
Allow easy CLI trainer re-instantiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - `LightningCLI` additions:
   * Added `LightningCLI(run=False|True)` to choose whether to run a `Trainer` subcommand ([#8751](https://github.com/PyTorchLightning/pytorch-lightning/pull/8751))
   * Added support to call any trainer function from the `LightningCLI` via subcommands ([#7508](https://github.com/PyTorchLightning/pytorch-lightning/pull/7508))
+  * Allow easy trainer re-instantiation ([#7508](https://github.com/PyTorchLightning/pytorch-lightning/pull/9241))
 
 
 - Fault-tolerant training:

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -411,8 +411,7 @@ class LightningCLI:
             kwargs: Any custom trainer arguments.
         """
         extra_callbacks = [self._get(self.config_init, c) for c in self._parser(self.subcommand).callback_keys]
-        trainer_config = self._get(self.config_init, "trainer")
-        trainer_config.update(kwargs)
+        trainer_config = {**self._get(self.config_init, "trainer"), **kwargs}
         return self._instantiate_trainer(trainer_config, extra_callbacks)
 
     def _instantiate_trainer(self, config: Dict[str, Any], callbacks: List[Callback]) -> Trainer:

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -403,11 +403,17 @@ class LightningCLI:
         self._add_configure_optimizers_method_to_model(self.subcommand)
         self.trainer = self.instantiate_trainer()
 
-    def instantiate_trainer(self, callbacks: Optional[List[Callback]] = None) -> Trainer:
-        """Instantiates the trainer."""
-        if callbacks is None:
-            callbacks = [self._get(self.config_init, c) for c in self._parser(self.subcommand).callback_keys]
-        return self._instantiate_trainer(self._get(self.config_init, "trainer"), callbacks)
+    def instantiate_trainer(self, **kwargs: Any) -> Trainer:
+        """
+        Instantiates the trainer.
+
+        Args:
+            kwargs: Any custom trainer arguments.
+        """
+        extra_callbacks = [self._get(self.config_init, c) for c in self._parser(self.subcommand).callback_keys]
+        trainer_config = self._get(self.config_init, "trainer")
+        trainer_config.update(kwargs)
+        return self._instantiate_trainer(trainer_config, extra_callbacks)
 
     def _instantiate_trainer(self, config: Dict[str, Any], callbacks: List[Callback]) -> Trainer:
         config["callbacks"] = config["callbacks"] or []

--- a/tests/utilities/test_cli.py
+++ b/tests/utilities/test_cli.py
@@ -967,3 +967,5 @@ def test_lightning_cli_reinstantiate_trainer():
     assert {c.__class__ for c in trainer.callbacks} == {c.__class__ for c in cli.trainer.callbacks}.union(
         {TestCallback}
     )
+    # the existing config is not updated
+    assert cli.config_init["trainer"]["max_epochs"] is None

--- a/tests/utilities/test_cli.py
+++ b/tests/utilities/test_cli.py
@@ -955,13 +955,13 @@ def test_lightning_cli_parse_kwargs_with_subcommands(tmpdir):
 def test_lightning_cli_reinstantiate_trainer():
     with mock.patch("sys.argv", ["any.py"]):
         cli = LightningCLI(BoringModel, run=False)
-    cli.config_init["trainer"]["max_epochs"] = 123
+    assert cli.trainer.max_epochs == 1000
 
     class TestCallback(Callback):
         ...
 
     # make sure a new trainer can be easily created
-    trainer = cli.instantiate_trainer(callbacks=[TestCallback()])
+    trainer = cli.instantiate_trainer(max_epochs=123, callbacks=[TestCallback()])
     # the new config is used
     assert trainer.max_epochs == 123
     assert {c.__class__ for c in trainer.callbacks} == {c.__class__ for c in cli.trainer.callbacks}.union(


### PR DESCRIPTION
## What does this PR do?

Support use-case requested in Slack by @jlperla

### Does your PR introduce any breaking changes? If yes, please list them.

`instantiate_trainer` and `instantiate_classes` no longer take required arguments. This should improve the UX.

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified