### PR TITLE
Add fsspec filesystem storage options

### DIFF
--- a/pytorch_lightning/utilities/cloud_io.py
+++ b/pytorch_lightning/utilities/cloud_io.py
@@ -27,22 +27,23 @@ def load(
     map_location: Optional[
         Union[str, Callable, torch.device, Dict[Union[str, torch.device], Union[str, torch.device]]]
     ] = None,
+    **storage_options
 ) -> Any:
     if not isinstance(path_or_url, (str, Path)):
         # any sort of BytesIO or similiar
         return torch.load(path_or_url, map_location=map_location)
     if str(path_or_url).startswith("http"):
         return torch.hub.load_state_dict_from_url(str(path_or_url), map_location=map_location)
-    fs = get_filesystem(path_or_url)
+    fs = get_filesystem(path_or_url, **storage_options)
     with fs.open(path_or_url, "rb") as f:
         return torch.load(f, map_location=map_location)
 
 
-def get_filesystem(path: Union[str, Path]) -> AbstractFileSystem:
+def get_filesystem(path: Union[str, Path], **storage_options) -> AbstractFileSystem:
     path = str(path)
     if "://" in path:
         # use the fileystem from the protocol specified
-        return fsspec.filesystem(path.split(":", 1)[0])
+        return fsspec.filesystem(path.split(":", 1)[0], **storage_options)
     # use local filesystem
     return LocalFileSystem()
 


### PR DESCRIPTION
## What does this PR do?

Expose `storage_options` parameter in `get_filesystem` to configure the fsspec filesystem.

```python
def get_filesystem(path: Union[str, Path], **storage_options) -> AbstractFileSystem:
    ...
```

e.g. this would enable the use of a [minio](https://min.io/) instance.


### Does your PR introduce any breaking changes? If yes, please list them.

- It requires changing the signature of `get_filesystem`
https://github.com/PyTorchLightning/pytorch-lightning/blob/ccc83e717cd3472e10dfb6002f69054e418e73c6/pytorch_lightning/utilities/cloud_io.py#L41
- It requires changing all the internal calls to `get_filesystem` s.t. they use the correct storage options

## Before submitting

- [x] Was this **discussed** via Slack  (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)


## PR review

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified


## Discussion

I think the best way to let the fsspec filesystem be configurable is an additional parameter `storage_options`, as in the [`fsspec.filestytem` signature](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.filesystem):
```python
 fsspec.filesystem(protocol, **storage_options)
```

Thus the signature of `get_filesystem` would become:
```python
def get_filesystem(path: Union[str, Path], **storage_options) -> AbstractFileSystem:
    ...
```

This requires a new `storage_options` parameter in the `Trainer`, and the propagation of that parameter to all the `get_filesystem` calls. I count 33 matches in 14 files for "get_filesystem", thus this MR would be changing many files.

If you agree this is the best way to go I can start doing that, otherwise I am happy to hear alternative solutions!

 
@justusschock @kaushikb11 