### PR TITLE
Remove unnecessary `TrainingEpochLoop` return

### DIFF
--- a/pytorch_lightning/loops/epoch/training_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/training_epoch_loop.py
@@ -196,15 +196,11 @@ class TrainingEpochLoop(loops.Loop):
         # inform logger the batch loop has finished
         self.trainer.logger_connector.epoch_end_reached()
 
-        # prepare epoch output
-        processed_outputs = self._prepare_outputs(self._epoch_output, batch_mode=False)
-        # free memory
-        self._epoch_output = None
-
         # get the model and call model.training_epoch_end
         model = self.trainer.lightning_module
-
         if is_overridden("training_epoch_end", model):
+            processed_outputs = self._prepare_outputs(self._epoch_output, batch_mode=False)
+
             # run training_epoch_end
             # refresh the result for custom logging at the epoch level
             model._current_fx_name = "training_epoch_end"
@@ -217,6 +213,8 @@ class TrainingEpochLoop(loops.Loop):
                     "training_epoch_end expects a return of None. "
                     "HINT: remove the return statement in training_epoch_end"
                 )
+        # free memory
+        self._epoch_output = None
 
         self.trainer.fit_loop.epoch_progress.increment_processed()
 

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -200,11 +200,7 @@ class FitLoop(Loop):
         data_fetcher = self.trainer.data_connector.get_profiled_dataloader(dataloader)
 
         with self.trainer.profiler.profile("run_training_epoch"):
-            # run train epoch
-            epoch_output = self.epoch_loop.run(data_fetcher)
-
-            if epoch_output is None:
-                return
+            self.epoch_loop.run(data_fetcher)
 
             # the global step is manually decreased here due to backwards compatibility with existing loggers
             # as they expect that the same step is used when logging epoch end metrics even when the batch loop has

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -869,7 +869,7 @@ def test_warning_with_iterable_dataset_and_len(tmpdir):
 
 
 def test_iterable_dataset_stop_iteration_at_epoch_beginning():
-    """Test that the training loop skips execution if the iterator is empty from the start."""
+    """Test that the training loop skips execution if the iterator is empty from an epoch."""
 
     class RandomDataset(IterableDataset):
         def __init__(self, gen):
@@ -896,6 +896,24 @@ def test_iterable_dataset_stop_iteration_at_epoch_beginning():
     )
     trainer.fit(model)
     assert trainer.global_step == 2
+    assert trainer.current_epoch == 1
+
+
+def test_iterable_dataset_stop_iteration_at_start():
+    """Test that the training loop skips execution if the iterator is empty."""
+
+    class RandomDataset(IterableDataset):
+        def __iter__(self):
+            return iter(self.gen())
+
+        def gen(self):
+            yield from []
+
+    model = BoringModel()
+    train_dataloader = DataLoader(RandomDataset(), batch_size=2)
+    trainer = Trainer(default_root_dir=os.getcwd(), max_epochs=2)
+    trainer.fit(model, train_dataloader=train_dataloader)
+    assert trainer.global_step == 0
     assert trainer.current_epoch == 1
 
 


### PR DESCRIPTION
## What does this PR do?

We were returning the `training_epoch_end` input as the output of `TrainingEpochLoop`, I believe this is legacy and no longer necessary. Let's see what CI thinks

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [n/a] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified