### PR TITLE
remove checkpoint tracking from internal debugger

### DIFF
--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -493,9 +493,6 @@ class ModelCheckpoint(Callback):
             log.debug(f"Removed checkpoint: {filepath}")
 
     def _save_model(self, trainer: "pl.Trainer", filepath: str) -> None:
-        # in debugging, track when we save checkpoints
-        trainer.dev_debugger.track_checkpointing_history(filepath)
-
         # make paths
         if trainer.should_rank_save_checkpoint:
             self._fs.makedirs(os.path.dirname(filepath), exist_ok=True)

--- a/pytorch_lightning/utilities/debugging.py
+++ b/pytorch_lightning/utilities/debugging.py
@@ -44,7 +44,6 @@ class InternalDebugger:
         self.enabled = os.environ.get("PL_DEV_DEBUG", "0") == "1"
         self.trainer = trainer
         self.early_stopping_history: List[Dict[str, Any]] = []
-        self.checkpoint_callback_history: List[Dict[str, Any]] = []
         self.events: List[Dict[str, Any]] = []
         self.saved_lr_scheduler_updates: List[Dict[str, Union[int, float, str, torch.Tensor, None]]] = []
         self.train_dataloader_calls: List[Dict[str, Any]] = []

--- a/pytorch_lightning/utilities/debugging.py
+++ b/pytorch_lightning/utilities/debugging.py
@@ -139,15 +139,3 @@ class InternalDebugger:
             "patience": callback.wait_count,
         }
         self.early_stopping_history.append(debug_dict)
-
-    @enabled_only
-    def track_checkpointing_history(self, filepath: str) -> None:
-        cb = self.trainer.checkpoint_callback
-        debug_dict = {
-            "epoch": self.trainer.current_epoch,
-            "global_step": self.trainer.global_step,
-            "monitor": cb.monitor if cb is not None else None,
-            "rank": self.trainer.global_rank,
-            "filepath": filepath,
-        }
-        self.checkpoint_callback_history.append(debug_dict)

--- a/tests/checkpointing/test_checkpoint_callback_frequency.py
+++ b/tests/checkpointing/test_checkpoint_callback_frequency.py
@@ -26,9 +26,9 @@ from tests.helpers.runif import RunIf
 def test_checkpoint_callback_disabled(tmpdir):
     # no callback
     trainer = Trainer(max_epochs=3, checkpoint_callback=False)
-    assert not any(isinstance(c, ModelCheckpoint) for c in trainer.callbacks)
+    assert not trainer.checkpoint_callbacks
     trainer.fit(BoringModel())
-    assert not any(isinstance(c, ModelCheckpoint) for c in trainer.callbacks)
+    assert not trainer.checkpoint_callbacks
 
 
 @mock.patch("torch.save")

--- a/tests/checkpointing/test_checkpoint_callback_frequency.py
+++ b/tests/checkpointing/test_checkpoint_callback_frequency.py
@@ -17,34 +17,18 @@ from unittest import mock
 import pytest
 import torch
 
-from pytorch_lightning import callbacks, seed_everything, Trainer
+from pytorch_lightning import callbacks, Trainer
+from pytorch_lightning.callbacks import ModelCheckpoint
 from tests.helpers import BoringModel
 from tests.helpers.runif import RunIf
 
 
-@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
-def test_mc_called(tmpdir):
-    seed_everything(1234)
-
-    # -----------------
-    # TRAIN LOOP ONLY
-    # -----------------
-    train_step_only_model = BoringModel()
-    train_step_only_model.validation_step = None
-
+def test_checkpoint_callback_disabled(tmpdir):
     # no callback
     trainer = Trainer(max_epochs=3, checkpoint_callback=False)
-    trainer.fit(train_step_only_model)
-    assert len(trainer.dev_debugger.checkpoint_callback_history) == 0
-
-    # -----------------
-    # TRAIN + VAL LOOP ONLY
-    # -----------------
-    val_train_model = BoringModel()
-    # no callback
-    trainer = Trainer(max_epochs=3, checkpoint_callback=False)
-    trainer.fit(val_train_model)
-    assert len(trainer.dev_debugger.checkpoint_callback_history) == 0
+    assert not any(isinstance(c, ModelCheckpoint) for c in trainer.callbacks)
+    trainer.fit(BoringModel())
+    assert not any(isinstance(c, ModelCheckpoint) for c in trainer.callbacks)
 
 
 @mock.patch("torch.save")

--- a/tests/checkpointing/test_checkpoint_callback_frequency.py
+++ b/tests/checkpointing/test_checkpoint_callback_frequency.py
@@ -18,7 +18,6 @@ import pytest
 import torch
 
 from pytorch_lightning import callbacks, Trainer
-from pytorch_lightning.callbacks import ModelCheckpoint
 from tests.helpers import BoringModel
 from tests.helpers.runif import RunIf
 

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -23,7 +23,7 @@ from logging import INFO
 from pathlib import Path
 from typing import Union
 from unittest import mock
-from unittest.mock import Mock, patch, call, MagicMock
+from unittest.mock import call, MagicMock, Mock, patch
 
 import cloudpickle
 import pytest

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -773,8 +773,6 @@ def test_default_checkpoint_behavior(tmpdir):
         results = trainer.test()
 
     assert len(results) == 1
-    assert save_mock.call_count == 3
-
     save_dir = tmpdir / "lightning_logs" / "version_0" / "checkpoints"
     save_mock.assert_has_calls(
         [
@@ -783,9 +781,7 @@ def test_default_checkpoint_behavior(tmpdir):
             call(trainer, save_dir / "epoch=2-step=14.ckpt"),
         ]
     )
-
-    # make sure the checkpoint we saved has the metric in the name
-    ckpts = os.listdir(os.path.join(tmpdir, "lightning_logs", "version_0", "checkpoints"))
+    ckpts = os.listdir(save_dir)
     assert len(ckpts) == 1
     assert ckpts[0] == "epoch=2-step=14.ckpt"
 

--- a/tests/trainer/flags/test_fast_dev_run.py
+++ b/tests/trainer/flags/test_fast_dev_run.py
@@ -1,5 +1,6 @@
 import os
 from unittest import mock
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -67,6 +68,7 @@ def test_callbacks_and_logger_not_called_with_fastdevrun(tmpdir, fast_dev_run):
             return super().test_step(batch, batch_idx)
 
     checkpoint_callback = ModelCheckpoint()
+    checkpoint_callback.save_checkpoint = Mock()
     early_stopping_callback = EarlyStopping()
     trainer_config = dict(
         default_root_dir=tmpdir,
@@ -97,8 +99,8 @@ def test_callbacks_and_logger_not_called_with_fastdevrun(tmpdir, fast_dev_run):
 
         # checkpoint callback should not have been called with fast_dev_run
         assert trainer.checkpoint_callback == checkpoint_callback
+        checkpoint_callback.save_checkpoint.assert_not_called()
         assert not os.path.exists(checkpoint_callback.dirpath)
-        assert len(trainer.dev_debugger.checkpoint_callback_history) == 0
 
         # early stopping should not have been called with fast_dev_run
         assert trainer.early_stopping_callback == early_stopping_callback


### PR DESCRIPTION
## What does this PR do?

Follow up to #9188 

Replaces the calls to the internal dev debugger in the model checkpoint. Tests are updated to cover what the "debugger" offered for tracking the calls inside the callback.
This is just one step towards removing the InternalDebugger completely in favor of proper unit testing.

### Does your PR introduce any breaking changes? If yes, please list them.

No, the "InternalDebugger" is internal as the name suggests.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


