### PR TITLE
remove early stopping tracking from internal debugger

### DIFF
--- a/pytorch_lightning/callbacks/early_stopping.py
+++ b/pytorch_lightning/callbacks/early_stopping.py
@@ -206,10 +206,6 @@ class EarlyStopping(Callback):
             return
 
         current = logs.get(self.monitor)
-
-        # when in dev debugging
-        trainer.dev_debugger.track_early_stopping_history(self, current)
-
         should_stop, reason = self._evaluate_stopping_criteria(current)
 
         # stop every ddp process if any world process decides to stop

--- a/pytorch_lightning/utilities/debugging.py
+++ b/pytorch_lightning/utilities/debugging.py
@@ -43,7 +43,6 @@ class InternalDebugger:
     def __init__(self, trainer: "pl.Trainer") -> None:
         self.enabled = os.environ.get("PL_DEV_DEBUG", "0") == "1"
         self.trainer = trainer
-        self.early_stopping_history: List[Dict[str, Any]] = []
         self.checkpoint_callback_history: List[Dict[str, Any]] = []
         self.events: List[Dict[str, Any]] = []
         self.saved_lr_scheduler_updates: List[Dict[str, Union[int, float, str, torch.Tensor, None]]] = []
@@ -125,20 +124,6 @@ class InternalDebugger:
             "new_lr": new_lr,
         }
         self.saved_lr_scheduler_updates.append(loss_dict)
-
-    @enabled_only
-    def track_early_stopping_history(
-        self, callback: "pl.callbacks.early_stopping.EarlyStopping", current: torch.Tensor
-    ) -> None:
-        debug_dict = {
-            "epoch": self.trainer.current_epoch,
-            "global_step": self.trainer.global_step,
-            "rank": self.trainer.global_rank,
-            "current": current,
-            "best": callback.best_score,
-            "patience": callback.wait_count,
-        }
-        self.early_stopping_history.append(debug_dict)
 
     @enabled_only
     def track_checkpointing_history(self, filepath: str) -> None:

--- a/tests/callbacks/test_early_stopping.py
+++ b/tests/callbacks/test_early_stopping.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-import os
 import pickle
 from typing import List, Optional
 from unittest import mock

--- a/tests/trainer/flags/test_fast_dev_run.py
+++ b/tests/trainer/flags/test_fast_dev_run.py
@@ -1,5 +1,6 @@
 import os
 from unittest import mock
+from unittest.mock import Mock
 
 import pytest
 import torch
@@ -29,7 +30,6 @@ def test_skip_on_fast_dev_run_tuner(tmpdir, tuner_alg):
 
 
 @pytest.mark.parametrize("fast_dev_run", [1, 4])
-@mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
 def test_callbacks_and_logger_not_called_with_fastdevrun(tmpdir, fast_dev_run):
     """
     Test that ModelCheckpoint, EarlyStopping and Logger are turned off with fast_dev_run
@@ -68,6 +68,7 @@ def test_callbacks_and_logger_not_called_with_fastdevrun(tmpdir, fast_dev_run):
 
     checkpoint_callback = ModelCheckpoint()
     early_stopping_callback = EarlyStopping()
+    early_stopping_callback._evaluate_stopping_criteria = Mock()
     trainer_config = dict(
         default_root_dir=tmpdir,
         fast_dev_run=fast_dev_run,
@@ -102,7 +103,7 @@ def test_callbacks_and_logger_not_called_with_fastdevrun(tmpdir, fast_dev_run):
 
         # early stopping should not have been called with fast_dev_run
         assert trainer.early_stopping_callback == early_stopping_callback
-        assert len(trainer.dev_debugger.early_stopping_history) == 0
+        early_stopping_callback._evaluate_stopping_criteria.assert_not_called()
 
     train_val_step_model = FastDevRunModel()
     trainer = Trainer(**trainer_config)

--- a/tests/trainer/flags/test_fast_dev_run.py
+++ b/tests/trainer/flags/test_fast_dev_run.py
@@ -1,5 +1,4 @@
 import os
-from unittest import mock
 from unittest.mock import Mock
 
 import pytest


### PR DESCRIPTION
## What does this PR do?

Follow up to #9188, #9326

Replaces the calls to the internal dev debugger in the early stopping callback. Tests are updated to cover what the "debugger" offered for tracking the calls inside the callback.
This is just one step towards removing the InternalDebugger completely in favor of proper unit testing.

### Does your PR introduce any breaking changes? If yes, please list them.

No, the "InternalDebugger" is internal as the name suggests.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


