### PR TITLE
remove lr scheduler tracking from internal debugger

### DIFF
--- a/pytorch_lightning/trainer/connectors/optimizer_connector.py
+++ b/pytorch_lightning/trainer/connectors/optimizer_connector.py
@@ -79,27 +79,11 @@ class OptimizerConnector:
                             RuntimeWarning,
                         )
                         continue
+
                 # update LR
-                old_lr = lr_scheduler["scheduler"].optimizer.param_groups[0]["lr"]
-
                 self.trainer.fit_loop.epoch_loop.scheduler_progress.increment_ready()
-
                 if lr_scheduler["reduce_on_plateau"]:
                     lr_scheduler["scheduler"].step(monitor_val)
                 else:
                     lr_scheduler["scheduler"].step()
-
-                new_lr = lr_scheduler["scheduler"].optimizer.param_groups[0]["lr"]
-
                 self.trainer.fit_loop.epoch_loop.scheduler_progress.increment_completed()
-
-                if self.trainer.dev_debugger.enabled:
-                    self.trainer.dev_debugger.track_lr_schedulers_update(
-                        self.trainer.fit_loop.batch_idx,
-                        interval,
-                        scheduler_idx,
-                        old_lr,
-                        new_lr,
-                        monitor_key=monitor_key,
-                        monitor_val=monitor_val,
-                    )

--- a/pytorch_lightning/utilities/debugging.py
+++ b/pytorch_lightning/utilities/debugging.py
@@ -15,7 +15,7 @@
 import os
 import time
 from functools import wraps
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional
 
 import torch
 from torch.utils.data import DataLoader
@@ -46,7 +46,6 @@ class InternalDebugger:
         self.early_stopping_history: List[Dict[str, Any]] = []
         self.checkpoint_callback_history: List[Dict[str, Any]] = []
         self.events: List[Dict[str, Any]] = []
-        self.saved_lr_scheduler_updates: List[Dict[str, Union[int, float, str, torch.Tensor, None]]] = []
         self.train_dataloader_calls: List[Dict[str, Any]] = []
         self.val_dataloader_calls: List[Dict[str, Any]] = []
         self.test_dataloader_calls: List[Dict[str, Any]] = []
@@ -102,29 +101,6 @@ class InternalDebugger:
             self.val_dataloader_calls.append(values)
         elif "test" in name:
             self.test_dataloader_calls.append(values)
-
-    @enabled_only
-    def track_lr_schedulers_update(
-        self,
-        batch_idx: int,
-        interval: int,
-        scheduler_idx: int,
-        old_lr: float,
-        new_lr: float,
-        monitor_key: Optional[str] = None,
-        monitor_val: Optional[torch.Tensor] = None,
-    ) -> None:
-        loss_dict = {
-            "batch_idx": batch_idx,
-            "interval": interval,
-            "scheduler_idx": scheduler_idx,
-            "epoch": self.trainer.current_epoch,
-            "monitor_key": monitor_key,
-            "monitor_val": monitor_val,
-            "old_lr": old_lr,
-            "new_lr": new_lr,
-        }
-        self.saved_lr_scheduler_updates.append(loss_dict)
 
     @enabled_only
     def track_early_stopping_history(

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -143,9 +143,7 @@ def test_model_checkpoint_score_and_ckpt(
     assert trainer.state.finished, f"Training failed with {trainer.state}"
 
     ckpt_files = list(Path(tmpdir).glob("*.ckpt"))
-    lr_scheduler_debug = trainer.dev_debugger.saved_lr_scheduler_updates
     assert len(ckpt_files) == len(model.scores) == max_epochs
-    assert len(lr_scheduler_debug) == max_epochs
 
     for epoch in range(max_epochs):
         score = model.scores[epoch]
@@ -171,9 +169,6 @@ def test_model_checkpoint_score_and_ckpt(
             # checkpoint is saved after updating lr_scheduler states
             assert actual_step_count == epoch + 2  # step_count starts at 1
             assert actual_lr == lr * gamma ** (epoch + 1)
-
-        assert lr_scheduler_debug[epoch]["monitor_val"] == (score if reduce_lr_on_plateau else None)
-        assert lr_scheduler_debug[epoch]["monitor_key"] == (monitor if reduce_lr_on_plateau else None)
 
 
 @mock.patch.dict(os.environ, {"PL_DEV_DEBUG": "1"})
@@ -246,10 +241,8 @@ def test_model_checkpoint_score_and_ckpt_val_check_interval(
     assert trainer.state.finished, f"Training failed with {trainer.state}"
 
     ckpt_files = list(Path(tmpdir).glob("*.ckpt"))
-    lr_scheduler_debug = trainer.dev_debugger.saved_lr_scheduler_updates
 
     assert len(ckpt_files) == len(model.scores) == per_epoch_val_checks * max_epochs
-    assert len(lr_scheduler_debug) == max_epochs
 
     def _make_assertions(epoch, ix, version=""):
         global_ix = ix + per_epoch_val_checks * epoch
@@ -289,10 +282,7 @@ def test_model_checkpoint_score_and_ckpt_val_check_interval(
 
     for epoch in range(max_epochs):
         for i in range(per_epoch_val_checks):
-            score = _make_assertions(epoch, i)
-
-        assert lr_scheduler_debug[epoch]["monitor_val"] == (score if reduce_lr_on_plateau else None)
-        assert lr_scheduler_debug[epoch]["monitor_key"] == (monitor if reduce_lr_on_plateau else None)
+            _make_assertions(epoch, i)
 
 
 @pytest.mark.parametrize("save_top_k", [-1, 0, 1, 2])


### PR DESCRIPTION
## What does this PR do?

Follow up to #9188, #9326

Replaces the calls to the internal dev debugger in the optimizer connector. Tests are updated to cover what the "debugger" offered for tracking the calls inside the learning scheduler tracking.
This is just one step towards removing the InternalDebugger completely in favor of proper unit testing.

TODO: 
- update tests

### Does your PR introduce any breaking changes? If yes, please list them.

No, the "InternalDebugger" is internal as the name suggests.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃



Make sure you had fun coding 🙃
