### PR TITLE
Clear reference to training loss at the end of train step

### DIFF
--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -137,6 +137,10 @@ class TrainingBatchLoop(Loop):
             if result:
                 self.batch_outputs[0].append(deepcopy(result.result_collection))
 
+                # clear reference to this step's training loss so that it can be garbage
+                # collected before the next training step
+                trainer._results.minimize = None
+
     def teardown(self) -> None:
         # release memory
         self._remaining_splits = None

--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -137,9 +137,9 @@ class TrainingBatchLoop(Loop):
             if result:
                 self.batch_outputs[0].append(deepcopy(result.result_collection))
 
-                # clear reference to this step's training loss so that it can be garbage
-                # collected before the next training step
-                trainer._results.minimize = None
+        # clear reference to this step's training loss so that it can be garbage
+        # collected before the next training step
+        self.trainer._results.minimize = None
 
     def teardown(self) -> None:
         # release memory

--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -137,10 +137,6 @@ class TrainingBatchLoop(Loop):
             if result:
                 self.batch_outputs[0].append(deepcopy(result.result_collection))
 
-        # clear reference to this step's training loss so that it can be garbage
-        # collected before the next training step
-        self.trainer._results.minimize = None
-
     def teardown(self) -> None:
         # release memory
         self._remaining_splits = None

--- a/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -201,14 +201,17 @@ class LoggerConnector:
     """
 
     def on_train_split_start(self, batch_idx: int, split_idx: int, split_batch: Any) -> None:
+        assert self.trainer._results is not None
         # when the user requests `dataloader_iter`, we can't track the batch_size
         # and this is left to user responsibility.
         if isinstance(split_batch, pl.utilities.fetching.DataLoaderIterDataFetcher):
-            assert self.trainer._results is not None
             self.trainer._results.extract_batch_size(split_batch)
 
         self._batch_idx = batch_idx
         self._split_idx = split_idx
+
+        # clear reference to this step's training loss so that it can be garbage collected before the next training step
+        self.trainer._results.minimize = None
 
     def update_train_step_metrics(self) -> None:
         if self.trainer.fit_loop.should_accumulate() and self.trainer.lightning_module.automatic_optimization:

--- a/tests/trainer/loops/test_training_loop.py
+++ b/tests/trainer/loops/test_training_loop.py
@@ -194,6 +194,7 @@ def test_prepare_outputs(tmpdir):
 
 def test_batch_loop_releases_loss(tmpdir):
     """Test that loss/graph is released so that it can be garbage collected before the next training step"""
+
     class TestModel(BoringModel):
         def training_step(self, batch, batch_idx):
             assert self.trainer._results.minimize is None

--- a/tests/trainer/loops/test_training_loop.py
+++ b/tests/trainer/loops/test_training_loop.py
@@ -190,3 +190,14 @@ def test_prepare_outputs(tmpdir):
     trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=2)
     trainer.fit(model)
     assert model.on_train_batch_end_called == 2
+
+
+def test_batch_loop_releases_loss(tmpdir):
+    class TestModel(BoringModel):
+        def training_step(self, batch, batch_idx):
+            assert self.trainer._results.minimize is None
+            return super().training_step(batch, batch_idx)
+
+    model = TestModel()
+    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=2)
+    trainer.fit(model)

--- a/tests/trainer/loops/test_training_loop.py
+++ b/tests/trainer/loops/test_training_loop.py
@@ -193,6 +193,7 @@ def test_prepare_outputs(tmpdir):
 
 
 def test_batch_loop_releases_loss(tmpdir):
+    """Test that loss/graph is released so that it can be garbage collected before the next training step"""
     class TestModel(BoringModel):
         def training_step(self, batch, batch_idx):
             assert self.trainer._results.minimize is None


### PR DESCRIPTION
## What does this PR do?

Without clearing this reference, the loss tensor stays live through the next training
step. This can be a problem for memory intensive models that produce very deep backward
graphs such as neural ODEs. For these models, keeping the backward graph of the previous
loss in memory can lead to OOM errors in the next training step even though the step might
have succeeded if we had cleared (and thus GC'd) the previous backward graph.

Fixes #9343

### Does your PR introduce any breaking changes? If yes, please list them.

No

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified