### PR TITLE
[CI/Tests] Fix Pytorch 1.10 autocast failing tests

### DIFF
--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -87,7 +87,7 @@ _OMEGACONF_AVAILABLE = _module_available("omegaconf")
 _POPTORCH_AVAILABLE = _module_available("poptorch")
 _RICH_AVAILABLE = _module_available("rich")
 _TORCH_CPU_AMP_AVAILABLE = _compare_version(
-    "torch", operator.ge, "1.10.0dev20210501"
+    "torch", operator.ge, "1.10.dev20210902"
 )  # todo: swap to 1.10.0 once released
 _TORCH_BFLOAT_AVAILABLE = _compare_version(
     "torch", operator.ge, "1.10.0.dev20210902"

--- a/tests/models/test_amp.py
+++ b/tests/models/test_amp.py
@@ -184,10 +184,13 @@ def test_amp_gpu_ddp_slurm_managed(tmpdir):
 
 
 @pytest.mark.skipif(torch.cuda.is_available(), reason="test is restricted only on CPU")
-def test_cpu_model_with_amp(tmpdir):
-    """Make sure model trains on CPU."""
-    with pytest.raises(MisconfigurationException, match="AMP is only available on GPU"):
-        Trainer(precision=16)
+@RunIf(max_torch="1.9")
+@pytest.mark.parametrize("precision", [16, "bf16"])
+def test_cpu_model_with_amp(tmpdir, precision):
+    """Make sure exception is thrown on CPU when precision 16 is enabled on PyTorch 1.9 and lower."""
+
+    with pytest.raises(MisconfigurationException, match="AMP is only available on GPU for PyTorch 1.9"):
+        Trainer(precision=precision)
 
 
 @mock.patch("pytorch_lightning.plugins.precision.apex_amp.ApexMixedPrecisionPlugin.backward")


### PR DESCRIPTION
## What does this PR do?

The signature for CPU autocast has also changed, hence we need to update the requirements check to the same as bfloat16. I've also updated a test which seems I missed in the initial integration!

Related https://github.com/PyTorchLightning/pytorch-lightning/issues/9280

cc @daniellepintz 

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
