### PR TITLE
Added support for log_model='best_and_last' option in wandb logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 
+- Added support for `log_model=best_and_last` option in `pytorch_lightning.loggers.WandbLogger`.
+
+
 - Register `ShardedTensor` state dict hooks in `LightningModule.__init__` if the pytorch version supports `ShardedTensor` ([#8944](https://github.com/PyTorchLightning/pytorch-lightning/pull/8944))
 
 

--- a/tests/loggers/test_wandb.py
+++ b/tests/loggers/test_wandb.py
@@ -213,7 +213,7 @@ def test_wandb_log_model(wandb, tmpdir):
         type="model",
         metadata={
             "score": None,
-            "original_filename": "epoch=1-step=5-v3.ckpt",
+            "original_filename": "epoch=1-step=5-v4.ckpt",
             "ModelCheckpoint": {
                 "monitor": None,
                 "mode": "min",

--- a/tests/loggers/test_wandb.py
+++ b/tests/loggers/test_wandb.py
@@ -176,6 +176,16 @@ def test_wandb_log_model(wandb, tmpdir):
     trainer.fit(model)
     assert wandb.init().log_artifact.call_count == 2
 
+    # test log_model='best_and_last'
+    wandb.init().log_artifact.reset_mock()
+    wandb.init.reset_mock()
+    logger = WandbLogger(log_model="best_and_last")
+    logger.experiment.id = "1"
+    logger.experiment.project_name.return_value = "project"
+    trainer = Trainer(default_root_dir=tmpdir, logger=logger, max_epochs=2, limit_train_batches=3, limit_val_batches=3)
+    trainer.fit(model)
+    assert wandb.init().log_artifact.call_count == 2
+
     # test log_model=False
     wandb.init().log_artifact.reset_mock()
     wandb.init.reset_mock()


### PR DESCRIPTION
## What does this PR do?

<!--
As a followup of the discussion https://github.com/PyTorchLightning/pytorch-lightning/discussions/9342#discussioncomment-1289699

Currently, the Weights and Biases logger is able to log checkpoints as artifacts either at the end of training or during training (any time a new checkpoint is created by the ModelCheckpoint callback). This feature can be controlled with the `log_model` flag, where `log_model=True` means to log at the end of training, and `log_model=all` means to log all checkpoints during training. However, the latter option can blow up the artifacts storage as many checkpoints can be saved, which is undesirable especially when using [wandb local ](https://github.com/wandb/local)

Thus, I added a `log_model=best_and_last` option, which keeps only the best and the last checkpoints in the wandb artifacts storage. Previous artifacts versions are automatically deleted.

No extra dependencies are required. Only wandb.

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [v] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [v] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [v] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [v] Did you make sure to **update the documentation** with your changes? (if necessary)
- [v] Did you write any **new necessary tests**? (not for typos and docs)
- [v] Did you verify new and **existing tests pass** locally with your changes?
- [v] Did you list all the **breaking changes** introduced by this pull request?
- [v] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun? yup :)

Make sure you had fun coding 🙃
