### PR TITLE
Enforce that the optimizer closure is executed when `optimizer_step` is overridden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Moved `block_ddp_sync_behaviour` out of `TrainingBatchLoop` to loop utilities ([#9192](https://github.com/PyTorchLightning/pytorch-lightning/pull/9192))
 
 
+- Executing the `optimizer_closure` is now required when overriding the `optimizer_step` hook ([#9360](https://github.com/PyTorchLightning/pytorch-lightning/pull/9360))
+
+
 ### Deprecated
 
 - Deprecated `LightningModule.summarize()` in favor of `pytorch_lightning.utilities.model_summary.summarize()`

--- a/docs/source/common/optimizers.rst
+++ b/docs/source/common/optimizers.rst
@@ -443,7 +443,7 @@ For example, here step optimizer A every batch and optimizer B every 2 batches.
                 # the closure (which includes the `training_step`) will be executed by `optimizer.step`
                 optimizer.step(closure=optimizer_closure)
             else:
-                # optional: call the closure by itself to run `training_step` + `backward` without an optimizer step
+                # call the closure by itself to run `training_step` + `backward` without an optimizer step
                 optimizer_closure()
 
         # ...

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1495,15 +1495,15 @@ class LightningModule(
 
         Warning:
             If you are overriding this method, make sure that you pass the ``optimizer_closure`` parameter
-            to ``optimizer.step()`` function as shown in the examples. This ensures that
-            ``training_step()``, ``optimizer.zero_grad()``, ``backward()`` are called within the training loop.
+            to ``optimizer.step()`` function as shown in the examples.
 
         Args:
             epoch: Current epoch
             batch_idx: Index of current batch
             optimizer: A PyTorch optimizer
             optimizer_idx: If you used multiple optimizers, this indexes into that list.
-            optimizer_closure: Closure for all optimizers
+            optimizer_closure: Closure for all optimizers. This closure must be executed as it includes the
+                calls to ``training_step()``, ``optimizer.zero_grad()``, and ``backward()``.
             on_tpu: ``True`` if TPU backward is required
             using_native_amp: ``True`` if using native amp
             using_lbfgs: True if the matching optimizer is :class:`torch.optim.LBFGS`
@@ -1526,6 +1526,9 @@ class LightningModule(
                 if optimizer_idx == 1:
                     if (batch_idx + 1) % 2 == 0 :
                         optimizer.step(closure=optimizer_closure)
+                    else:
+                        # call the closure by itself to run `training_step` + `backward` without an optimizer step
+                        optimizer_closure()
 
                 # ...
                 # add as many optimizers as you want

--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -161,7 +161,7 @@ class TrainingBatchLoop(Loop):
         closure()
         result = closure.result
 
-        if result.loss:
+        if result.loss is not None:
             # if no result, user decided to skip optimization
             # otherwise update running loss + reset accumulated loss
             self._update_running_loss(result.loss)

--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -134,7 +134,7 @@ class TrainingBatchLoop(Loop):
         else:
             # in manual optimization, there is no looping over optimizers
             result = self._run_optimization(batch_idx, split_batch)
-            if result:
+            if result.result_collection is not None:
                 self.batch_outputs[0].append(deepcopy(result.result_collection))
 
     def teardown(self) -> None:
@@ -149,7 +149,7 @@ class TrainingBatchLoop(Loop):
         self,
         batch_idx: int,
         split_batch: Any,
-    ) -> Optional[ClosureResult]:
+    ) -> ClosureResult:
         """Runs closure (train step + backward) together with optimization if necessary.
 
         Args:
@@ -161,7 +161,7 @@ class TrainingBatchLoop(Loop):
         closure()
         result = closure.get_result()
 
-        if result:
+        if result.loss:
             # if no result, user decided to skip optimization
             # otherwise update running loss + reset accumulated loss
             self._update_running_loss(result.loss)

--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -159,7 +159,7 @@ class TrainingBatchLoop(Loop):
         # TODO: replace call through closure by direct call (manual optimization)
         closure = self._make_closure(split_batch, batch_idx, self._hiddens)
         closure()
-        result = closure.get_result()
+        result = closure.result
 
         if result.loss:
             # if no result, user decided to skip optimization

--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -159,7 +159,7 @@ class TrainingBatchLoop(Loop):
         # TODO: replace call through closure by direct call (manual optimization)
         closure = self._make_closure(split_batch, batch_idx, self._hiddens)
         closure()
-        result = closure.result
+        result = closure.consume_result()
 
         if result.loss is not None:
             # if no result, user decided to skip optimization

--- a/pytorch_lightning/loops/closure.py
+++ b/pytorch_lightning/loops/closure.py
@@ -64,7 +64,7 @@ class AbstractClosure(ABC):
             raise MisconfigurationException(
                 "The closure hasn't been executed."
                 " HINT: did you call `optimizer_closure()` in your `optimizer_step` hook? It could also happen because"
-                " the `optimizer.step(optimizer_closure)` call did not execute it internally"
+                " the `optimizer.step(optimizer_closure)` call did not execute it internally."
             )
         result, self._result = self._result, None  # free memory
         return result

--- a/pytorch_lightning/loops/closure.py
+++ b/pytorch_lightning/loops/closure.py
@@ -20,6 +20,7 @@ from torch import Tensor
 
 from pytorch_lightning.profiler import BaseProfiler, PassThroughProfiler
 from pytorch_lightning.trainer.connectors.logger_connector.result import ResultCollection
+from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.warnings import WarningCache
 
 
@@ -53,25 +54,29 @@ class AbstractClosure(ABC):
         super().__init__()
         self._result: Optional[ClosureResult] = None
 
-    def get_result(self) -> Optional[ClosureResult]:
+    def get_result(self) -> ClosureResult:
         """The cached result from the last time the closure was called.
 
         Once accessed, the internal reference gets reset and the consumer will have to hold on to the reference as long
         as necessary.
         """
         result = self._result
+        if self._result is None:
+            raise MisconfigurationException(
+                "The closure hasn't been executed."
+                " HINT: did you call `optimizer_closure()` in your `optimizer_step` hook?"
+            )
         self._result = None  # free memory
         return result
 
     @abstractmethod
-    def closure(self, *args: Any, **kwargs: Any) -> Optional[ClosureResult]:
+    def closure(self, *args: Any, **kwargs: Any) -> ClosureResult:
         """Implements the behavior of the closure once it is getting called."""
         pass
 
     def __call__(self, *args: Any, **kwargs: Any) -> Optional[Tensor]:
         self._result = self.closure(*args, **kwargs)
-        if self._result is not None:
-            return self._result.loss
+        return self._result.loss
 
 
 class Closure(AbstractClosure):
@@ -113,19 +118,21 @@ class Closure(AbstractClosure):
         self._zero_grad_fn = zero_grad_fn
         self._profiler = PassThroughProfiler() if profiler is None else profiler
 
-    def closure(self, *args: Any, **kwargs: Any) -> Optional[ClosureResult]:
+    def closure(self, *args: Any, **kwargs: Any) -> ClosureResult:
         with self._profiler.profile("training_step_and_backward"):
             step_output = self._step_fn()
-            step_output = ClosureResult(**step_output) if step_output else None
+            step_output = ClosureResult(**step_output) if step_output else ClosureResult(None, None, None)
 
-            if step_output is None:
-                self.warning_cache.warn("training_step returned None. If this was on purpose, ignore this warning...")
+            if step_output.closure_loss is None:
+                self.warning_cache.warn(
+                    "`training_step` returned `None`. If this was on purpose, ignore this warning..."
+                )
 
             if self._zero_grad_fn is not None:
                 with self._profiler.profile("zero_grad"):
                     self._zero_grad_fn()
 
-            if self._backward_fn is not None and step_output is not None and step_output.closure_loss is not None:
+            if self._backward_fn is not None and step_output.closure_loss is not None:
                 with self._profiler.profile("backward"):
                     step_output.closure_loss = self._backward_fn(step_output.closure_loss)
 

--- a/pytorch_lightning/loops/closure.py
+++ b/pytorch_lightning/loops/closure.py
@@ -54,19 +54,19 @@ class AbstractClosure(ABC):
         super().__init__()
         self._result: Optional[ClosureResult] = None
 
-    def get_result(self) -> ClosureResult:
+    @property
+    def result(self) -> ClosureResult:
         """The cached result from the last time the closure was called.
 
         Once accessed, the internal reference gets reset and the consumer will have to hold on to the reference as long
         as necessary.
         """
-        result = self._result
         if self._result is None:
             raise MisconfigurationException(
                 "The closure hasn't been executed."
                 " HINT: did you call `optimizer_closure()` in your `optimizer_step` hook?"
             )
-        self._result = None  # free memory
+        result, self._result = self._result, None  # free memory
         return result
 
     @abstractmethod

--- a/pytorch_lightning/loops/closure.py
+++ b/pytorch_lightning/loops/closure.py
@@ -64,7 +64,8 @@ class AbstractClosure(ABC):
         if self._result is None:
             raise MisconfigurationException(
                 "The closure hasn't been executed."
-                " HINT: did you call `optimizer_closure()` in your `optimizer_step` hook?"
+                " HINT: did you call `optimizer_closure()` in your `optimizer_step` hook? It could also happen because"
+                " the `optimizer.step(optimizer_closure)` call did not execute it internally"
             )
         result, self._result = self._result, None  # free memory
         return result

--- a/pytorch_lightning/loops/closure.py
+++ b/pytorch_lightning/loops/closure.py
@@ -54,8 +54,7 @@ class AbstractClosure(ABC):
         super().__init__()
         self._result: Optional[ClosureResult] = None
 
-    @property
-    def result(self) -> ClosureResult:
+    def consume_result(self) -> ClosureResult:
         """The cached result from the last time the closure was called.
 
         Once accessed, the internal reference gets reset and the consumer will have to hold on to the reference as long

--- a/pytorch_lightning/loops/optimizer/optimizer_loop.py
+++ b/pytorch_lightning/loops/optimizer/optimizer_loop.py
@@ -158,7 +158,7 @@ class OptimizerLoop(Loop):
         else:
             self._optimizer_step(optimizer, opt_idx, batch_idx, closure)
 
-        result = closure.result
+        result = closure.consume_result()
 
         if result.loss is not None:
             # if no result, user decided to skip optimization

--- a/pytorch_lightning/loops/optimizer/optimizer_loop.py
+++ b/pytorch_lightning/loops/optimizer/optimizer_loop.py
@@ -160,7 +160,7 @@ class OptimizerLoop(Loop):
 
         result = closure.result
 
-        if result.loss:
+        if result.loss is not None:
             # if no result, user decided to skip optimization
             # otherwise update running loss + reset accumulated loss
             # TODO: find proper way to handle updating running loss

--- a/pytorch_lightning/loops/optimizer/optimizer_loop.py
+++ b/pytorch_lightning/loops/optimizer/optimizer_loop.py
@@ -158,7 +158,7 @@ class OptimizerLoop(Loop):
         else:
             self._optimizer_step(optimizer, opt_idx, batch_idx, closure)
 
-        result = closure.get_result()
+        result = closure.result
 
         if result.loss:
             # if no result, user decided to skip optimization

--- a/pytorch_lightning/loops/optimizer/optimizer_loop.py
+++ b/pytorch_lightning/loops/optimizer/optimizer_loop.py
@@ -83,7 +83,7 @@ class OptimizerLoop(Loop):
             self._optimizers[self.optim_progress.optimizer_idx],
             self.optim_progress.optimizer_idx,
         )
-        if result:
+        if result.result_collection is not None:
             self.outputs[self.optim_progress.optimizer_idx].append(deepcopy(result.result_collection))
 
         self.optim_progress.optimizer_idx += 1
@@ -127,7 +127,7 @@ class OptimizerLoop(Loop):
         batch_idx: int,
         optimizer: torch.optim.Optimizer,
         opt_idx: int,
-    ) -> Optional[ClosureResult]:
+    ) -> ClosureResult:
         """Runs closure (train step + backward) together with optimization if necessary.
 
         Args:
@@ -160,14 +160,13 @@ class OptimizerLoop(Loop):
 
         result = closure.get_result()
 
-        if result:
+        if result.loss:
             # if no result, user decided to skip optimization
             # otherwise update running loss + reset accumulated loss
             # TODO: find proper way to handle updating running loss
             assert self.trainer.fit_loop is not None
             assert self.trainer.fit_loop.epoch_loop is not None
             assert self.trainer.fit_loop.epoch_loop.batch_loop is not None
-            assert result.loss is not None
             self.trainer.fit_loop.epoch_loop.batch_loop._update_running_loss(result.loss)
 
         # untoggle model params

--- a/tests/loops/test_closure.py
+++ b/tests/loops/test_closure.py
@@ -1,0 +1,18 @@
+import pytest
+
+from pytorch_lightning import Trainer
+from pytorch_lightning.utilities.exceptions import MisconfigurationException
+from tests.helpers import BoringModel
+
+
+def test_optimizer_step_no_closure_raises(tmpdir):
+    class TestModel(BoringModel):
+        def optimizer_step(
+            self, epoch=None, batch_idx=None, optimizer=None, optimizer_idx=None, optimizer_closure=None, **_
+        ):
+            pass
+
+    model = TestModel()
+    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=1)
+    with pytest.raises(MisconfigurationException, match="The closure hasn't been executed"):
+        trainer.fit(model)

--- a/tests/loops/test_closure.py
+++ b/tests/loops/test_closure.py
@@ -1,3 +1,16 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import pytest
 import torch
 

--- a/tests/loops/test_closure.py
+++ b/tests/loops/test_closure.py
@@ -10,6 +10,7 @@ def test_optimizer_step_no_closure_raises(tmpdir):
         def optimizer_step(
             self, epoch=None, batch_idx=None, optimizer=None, optimizer_idx=None, optimizer_closure=None, **_
         ):
+            # does not call `optimizer_closure()`
             pass
 
     model = TestModel()

--- a/tests/trainer/loops/test_training_loop_flow_scalar.py
+++ b/tests/trainer/loops/test_training_loop_flow_scalar.py
@@ -264,7 +264,7 @@ def test_train_step_no_return(tmpdir):
 
     Closure.warning_cache.clear()
 
-    with pytest.warns(UserWarning, match=r"training_step returned None.*"):
+    with pytest.warns(UserWarning, match=r"training_step` returned `None"):
         trainer.fit(model)
 
     assert model.training_step_called
@@ -276,7 +276,7 @@ def test_train_step_no_return(tmpdir):
 
     Closure.warning_cache.clear()
 
-    with no_warning_call(UserWarning, match=r"training_step returned None.*"):
+    with no_warning_call(UserWarning, match=r"training_step` returned `None"):
         trainer.fit(model)
 
 
@@ -303,7 +303,7 @@ def test_training_step_no_return_when_even(tmpdir):
 
     Closure.warning_cache.clear()
 
-    with pytest.warns(UserWarning, match=r".*training_step returned None.*"):
+    with pytest.warns(UserWarning, match=r".*training_step` returned `None.*"):
         trainer.fit(model)
 
     trainer.state.stage = RunningStage.TRAINING

--- a/tests/trainer/optimization/test_multiple_optimizers.py
+++ b/tests/trainer/optimization/test_multiple_optimizers.py
@@ -177,13 +177,21 @@ def test_custom_optimizer_step_with_multiple_optimizers(tmpdir):
                 if batch_idx % 2 == 0:
                     self.optimizer_step_called[optimizer_idx] += 1
                     optimizer.step(closure=optimizer_closure)
+                else:
+                    optimizer_closure()
 
     model = TestModel()
     model.val_dataloader = None
 
+    limit_train_batches = 4
     trainer = pl.Trainer(
-        default_root_dir=tmpdir, limit_train_batches=4, max_epochs=1, log_every_n_steps=1, weights_summary=None
+        default_root_dir=tmpdir,
+        limit_train_batches=limit_train_batches,
+        max_epochs=1,
+        log_every_n_steps=1,
+        weights_summary=None,
     )
     trainer.fit(model)
-    assert model.training_step_called == [4, 2]
-    assert model.optimizer_step_called == [4, 2]
+    assert len(model.training_step_called) == len(model.optimizer_step_called) == len(model.optimizers())
+    assert model.training_step_called == [limit_train_batches, limit_train_batches]
+    assert model.optimizer_step_called == [limit_train_batches, limit_train_batches // 2]


### PR DESCRIPTION
## What does this PR do?

Part of #9349

This has the advantage that the `ClosureResult` is no longer `Optional`.

### Does your PR introduce any breaking changes? If yes, please list them.

`optimizer_step` now requires that the closure is executed. Not doing it would skip the entire `training_step`, `zero_grad`, and `backward`. We consider this to be a bug so it's better to explicitly fail. Not doing it could also break progress tracking and fault tolerance.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified