### PR TITLE
Type the Loop base class as generic

### DIFF
--- a/pytorch_lightning/loops/base.py
+++ b/pytorch_lightning/loops/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Generic, Optional, TypeVar
 
 from deprecate import void
 from torchmetrics import Metric
@@ -24,8 +24,10 @@ from pytorch_lightning.trainer.progress import BaseProgress, Progress
 from pytorch_lightning.utilities.apply_func import apply_to_collection
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
+T = TypeVar("T")  # the output type of `run`
 
-class Loop(ABC):
+
+class Loop(ABC, Generic[T]):
     """Basic Loops interface. All classes derived from this must implement the following properties and methods:
 
         * :attr:`done` (property): Condition to break the loop
@@ -91,7 +93,7 @@ class Loop(ABC):
             the default output value of :meth:`on_run_end`
         """
 
-    def run(self, *args: Any, **kwargs: Any) -> Optional[Any]:
+    def run(self, *args: Any, **kwargs: Any) -> T:
         """The main entry point to the loop.
 
         Will frequently check the :attr:`done` condition and calls :attr:`advance`
@@ -147,7 +149,7 @@ class Loop(ABC):
     def on_advance_end(self) -> None:
         """Hook to be called each time after :attr:`advance` is called."""
 
-    def on_run_end(self) -> Any:
+    def on_run_end(self) -> T:
         """Hook to be called at the end of the run.
 
         Its return argument is returned from :attr:`run`.

--- a/pytorch_lightning/loops/dataloader/evaluation_loop.py
+++ b/pytorch_lightning/loops/dataloader/evaluation_loop.py
@@ -18,7 +18,7 @@ from torch.utils.data.dataloader import DataLoader
 
 from pytorch_lightning.loops.dataloader import DataLoaderLoop
 from pytorch_lightning.loops.epoch import EvaluationEpochLoop
-from pytorch_lightning.trainer.connectors.logger_connector.result import ResultCollection
+from pytorch_lightning.trainer.connectors.logger_connector.result import _OUT_DICT, ResultCollection
 from pytorch_lightning.utilities.model_helpers import is_overridden
 from pytorch_lightning.utilities.types import EPOCH_OUTPUT
 
@@ -113,7 +113,7 @@ class EvaluationLoop(DataLoaderLoop):
             # indicate the loop has run
             self._has_run = True
 
-    def on_run_end(self) -> Any:
+    def on_run_end(self) -> List[_OUT_DICT]:
         """Runs the ``on_evaluation_epoch_end`` hook."""
         outputs = self.outputs
 

--- a/pytorch_lightning/loops/dataloader/prediction_loop.py
+++ b/pytorch_lightning/loops/dataloader/prediction_loop.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Sequence, Union
+from typing import Any, List, Optional, Sequence
 
 from deprecate.utils import void
 from torch.utils.data import DataLoader
@@ -94,7 +94,7 @@ class PredictionLoop(DataLoaderLoop):
         self.predictions.append(dl_predictions)
         self.epoch_batch_indices.append(dl_batch_indices)
 
-    def on_run_end(self) -> Union[List[Any], List[List[Any]]]:
+    def on_run_end(self) -> _PREDICT_OUTPUT:
         """Calls ``on_predict_epoch_end`` and ``on_predict_end`` hooks and returns results from all dataloaders."""
         results = self.on_predict_epoch_end()
         self.on_predict_end()

--- a/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
@@ -97,7 +97,7 @@ class PredictionEpochLoop(Loop):
         with self.trainer.profiler.profile("predict_step"):
             self._predict_step(batch, batch_idx, dataloader_idx)
 
-    def on_run_end(self) -> Tuple[Any, Any]:
+    def on_run_end(self) -> Tuple[List[Any], List[int]]:
         """Returns the predictions and the corresponding batch indices."""
         predictions = self.predictions
         all_batch_indices = self._all_batch_indices


### PR DESCRIPTION
## What does this PR do?

Signal that the return type of `run` is the same as the return type of `on_run_end`.

Minimal example:

```python
from dataclasses import dataclass
from typing import TypeVar, Generic

T = TypeVar("T")


class Base(Generic[T]):
    def run(self) -> T:
        return self.end()

    def end(self) -> T:
        ...


@dataclass
class Foo:
    ...


class Child(Base[Foo]):
    def end(self) -> Foo:
        ...
```

without this, when `result = self.a_loop.run(...)`, mypy doesn't know the type of `result` even if its annotated in the `on_run_end` signature.

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [n/a] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified