### PR TITLE
insert metrics for last checkpoint

### DIFF
--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -655,7 +655,7 @@ class ModelCheckpoint(Callback):
         if not self.save_last:
             return
 
-        filepath = self._format_checkpoint_name(self.CHECKPOINT_NAME_LAST, monitor_candidates)
+        filepath = self._format_checkpoint_name(self.CHECKPOINT_NAME_LAST, monitor_candidates, auto_insert_metric_name=self.auto_insert_metric_name)
         filepath = os.path.join(self.dirpath, f"{filepath}{self.FILE_EXTENSION}")
 
         trainer.save_checkpoint(filepath, self.save_weights_only)

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -655,7 +655,9 @@ class ModelCheckpoint(Callback):
         if not self.save_last:
             return
 
-        filepath = self._format_checkpoint_name(self.CHECKPOINT_NAME_LAST, monitor_candidates, auto_insert_metric_name=self.auto_insert_metric_name)
+        filepath = self._format_checkpoint_name(
+            self.CHECKPOINT_NAME_LAST, monitor_candidates, auto_insert_metric_name=self.auto_insert_metric_name
+        )
         filepath = os.path.join(self.dirpath, f"{filepath}{self.FILE_EXTENSION}")
 
         trainer.save_checkpoint(filepath, self.save_weights_only)


### PR DESCRIPTION
Insert metrics for last checkpoint. 

When a custom CHECKPOINT_NAME_LAST is defined with metrics, they will not be filled.

e.g. with epoch = 0, step =0 and val/metric = 1.00
`CHECKPOINT_NAME_LAST = 'last_epoch={epoch:03d}-step={step}-val_metric={val/metric:.2f}'`
will result in a filename
`'last_epoch=epoch=000-step=step=0-val_metric=val/metric=1.00'`
which will then create a directory
`'last_epoch=epoch=000-step=step=0-val_metric=val`
with a checkpoint name of
`metric=1.00`

This PR fixes this issue by filling the checkpoint metrics if the user desires this.