### PR TITLE
guard against None in pytorch get_xla_supported_devices

### DIFF
--- a/pytorch_lightning/utilities/xla_device.py
+++ b/pytorch_lightning/utilities/xla_device.py
@@ -72,7 +72,8 @@ class XLADeviceUtils:
         # `xm.get_xla_supported_devices("TPU")` won't be possible.
         if xm.xrt_world_size() > 1:
             return True
-        return len(xm.get_xla_supported_devices("TPU")) > 0
+        tpus = xm.get_xla_supported_devices("TPU")
+        return False if tpus is None else len(tpus) > 0
 
     @staticmethod
     def xla_available() -> bool:


### PR DESCRIPTION
## What does this PR do?
Guard against `None` when checking if TPU's are available. This happens (e.g.) if you use google's standard deep learning containers on CPU only machines.

Fixes #9552 

### Does your PR introduce any breaking changes? If yes, please list them.
None

## Before submitting

- [x ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)


## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
