### PR TITLE
Single-process multi-node CPU training

### DIFF
--- a/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -769,7 +769,11 @@ class AcceleratorConnector:
                     "`accelerator='ddp_cpu'` is not supported on TPU machines. "
                     "Learn more: https://github.com/PyTorchLightning/pytorch-lightning/issues/7810"
                 )
-            self._distrib_type = DistributedType.DDP_SPAWN
+            if self.num_processes == 1 or (self.num_nodes > 1 and self.num_processes is None):
+                self._distrib_type = DistributedType.DDP
+                self.num_processes = 1
+            else:
+                self._distrib_type = DistributedType.DDP_SPAWN
             if self.num_gpus > 0:
                 rank_zero_warn(
                     "You requested one or more GPUs, but set the backend to `ddp_cpu`. Training will not use GPUs."


### PR DESCRIPTION


## What does this PR do?

Whenever a model is small, it is not necessarily useful to use a GPU. However, one might still benefit from distributing computations for model training across nodes -- especially when you consider that containers are also "nodes".

This PR sets `DistributedType.DDP` instead of `DistributedType.DDP_SPAWN` whenever `DistributedType.DDP_CPU` is set and only a single process or a single process per node is used.

### Does your PR introduce any breaking changes? If yes, please list them.

- Minor breaking change: whenever one requests a `num_nodes > 1` and does not explicitly set `num_processes` on the `Trainer`, `num_processes` now defaults to 1 and `DistributedType.DDP` is used. Before, `num_processes` was set to `os.cpu_count()` and `DistributedType.DDP_SPAWN` was used. However, it is unlikely that people rely on that behavior.

One could decide to keep the old behavior, however, I would argue that it is far more likely to only want a single process when distributing across nodes (think containers).

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified