### PR TITLE
[Bugfix] Fix location of `unscale` in mixed precision plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
+## [unreleased] - 2021-??-??
+
+- Moved the gradient unscaling in `NativeMixedPrecisionPlugin` from `pre_optimizer_step` to `post_backward` ([#9606](https://github.com/PyTorchLightning/pytorch-lightning/pull/9606))
+- Fixed gradient unscaling being called too late, causing gradient clipping and gradient norm tracking to be applied incorrectly ([#9606](https://github.com/PyTorchLightning/pytorch-lightning/pull/9606))
+
+
 ## [1.4.8] - 2021-09-22
 
 - Fixed error reporting in DDP process reconciliation when processes are launched by an external agent (#9389)
 - Added PL_RECONCILE_PROCESS environment variable to enable process reconciliation regardless of cluster environment settings (#9389)
 - Fixed `add_argparse_args` raising `TypeError` when args are typed as `typing.Generic` in Python 3.6 ([#9554](https://github.com/PyTorchLightning/pytorch-lightning/pull/9554))
 - Fixed back-compatibility for saving hyperparameters from a single container and inferring its argument name by reverting [#9125](https://github.com/PyTorchLightning/pytorch-lightning/pull/9125) ([#9642](https://github.com/PyTorchLightning/pytorch-lightning/pull/9642))
+
 
 ## [1.4.7] - 2021-09-14
 

--- a/pytorch_lightning/accelerators/accelerator.py
+++ b/pytorch_lightning/accelerators/accelerator.py
@@ -264,7 +264,7 @@ class Accelerator:
         """
         return self.training_type_plugin.validation_step_end(output)
 
-    def backward(self, closure_loss: Tensor, *args: Any, **kwargs: Any) -> Tensor:
+    def backward(self, closure_loss: Tensor, optimizer: torch.optim.Optimizer, *args: Any, **kwargs: Any) -> Tensor:
         """Forwards backward-calls to the precision plugin.
 
         Args:
@@ -273,9 +273,9 @@ class Accelerator:
         self.training_type_plugin.pre_backward(closure_loss)
         closure_loss = self.precision_plugin.pre_backward(self.lightning_module, closure_loss)
 
-        self.precision_plugin.backward(self.lightning_module, closure_loss, *args, **kwargs)
+        self.precision_plugin.backward(self.lightning_module, closure_loss, optimizer, *args, **kwargs)
 
-        closure_loss = self.precision_plugin.post_backward(self.lightning_module, closure_loss)
+        closure_loss = self.precision_plugin.post_backward(self.lightning_module, closure_loss, optimizer)
         self.training_type_plugin.post_backward(closure_loss)
 
         return closure_loss

--- a/pytorch_lightning/plugins/precision/native_amp.py
+++ b/pytorch_lightning/plugins/precision/native_amp.py
@@ -71,10 +71,9 @@ class NativeMixedPrecisionPlugin(MixedPrecisionPlugin):
     ) -> torch.Tensor:
         ret_val = super().post_backward(model, closure_loss, optimizer)
         # unscale here to have it inside the closure before the grad tracking and clipping
-        if model.automatic_optimization and not model.trainer.fit_loop._should_accumulate():
+        if model.automatic_optimization and not model.trainer.fit_loop.should_accumulate():
             self.scaler.unscale_(optimizer)
         return ret_val
-
 
     @contextmanager
     def train_step_context(self) -> Generator[None, None, None]:

--- a/pytorch_lightning/plugins/precision/native_amp.py
+++ b/pytorch_lightning/plugins/precision/native_amp.py
@@ -56,6 +56,8 @@ class NativeMixedPrecisionPlugin(MixedPrecisionPlugin):
             )
         result = lambda_closure()  # native amp does not support closures
         if not model.automatic_optimization:
+            # unscale in manual optimization as user does not rely on lightning
+            # to call backward, but does call LightningOptimizer.step
             self.scaler.unscale_(optimizer)
         super().pre_optimizer_step(model, optimizer, optimizer_idx, lambda_closure, **kwargs)
         skipped_backward = result is None

--- a/pytorch_lightning/plugins/precision/precision_plugin.py
+++ b/pytorch_lightning/plugins/precision/precision_plugin.py
@@ -79,8 +79,10 @@ class PrecisionPlugin(Plugin, CheckpointHooks):
         else:
             closure_loss.backward(*args, **kwargs)
 
-    def post_backward(self, model: "pl.LightningModule", closure_loss: Tensor) -> Tensor:
-        """Run after precision plugin executes backward
+    def post_backward(
+        self, model: "pl.LightningModule", closure_loss: Tensor, optimizer: torch.optim.Optimizer
+    ) -> Tensor:
+        """Run after precision plugin executes backward.
 
         Args:
             model: the model to be optimized
@@ -89,6 +91,7 @@ class PrecisionPlugin(Plugin, CheckpointHooks):
         # once backward has been applied, release graph
         closure_loss = closure_loss.detach()
         model.trainer.call_hook("on_after_backward")
+
         return closure_loss
 
     def pre_optimizer_step(

--- a/tests/plugins/test_amp_plugins.py
+++ b/tests/plugins/test_amp_plugins.py
@@ -188,7 +188,7 @@ class GradientUnscaleNativeAMPPlugin(NativeMixedPrecisionPlugin):
 
         # norm_after unscale should be smaller by scaling factor greater than 1
         if not (torch.isinf(norm_before) or torch.isnan(norm_before)):
-            assert norm_after < norm_before
+            assert norm_after < norm_before * 10
             # during initial phase of finding the appropriate scaling, AMP skips optimizer steps that have
             # non-finite gradients; we count and assert that we had at least one finite gradient here
             self._was_scaled_finite += 1

--- a/tests/plugins/test_amp_plugins.py
+++ b/tests/plugins/test_amp_plugins.py
@@ -19,6 +19,7 @@ import pytest
 import torch
 
 from pytorch_lightning import seed_everything, Trainer
+from pytorch_lightning.core.optimizer import LightningOptimizer
 from pytorch_lightning.plugins import ApexMixedPrecisionPlugin, NativeMixedPrecisionPlugin
 from pytorch_lightning.plugins.precision import MixedPrecisionPlugin
 from tests.helpers import BoringModel
@@ -180,6 +181,7 @@ class GradientUnscaleNativeAMPPlugin(NativeMixedPrecisionPlugin):
     _was_scaled_finite = 0
 
     def post_backward(self, model, closure_loss, optimizer) -> torch.Tensor:
+        assert not isinstance(optimizer, LightningOptimizer)
         norm_before = torch.nn.utils.clip_grad_norm_(model.parameters(), 2)
         ret_val = super().post_backward(model, closure_loss, optimizer)
         norm_after = torch.nn.utils.clip_grad_norm_(model.parameters(), 2)


### PR DESCRIPTION
## What does this PR do?

Fixes #9599, #9330, #9205, #9694

Unscale was called after gradnorm tracking and gradient clipping. Moving it to a different hook in the plugins should fix that.

Alternative solution would be to move gradient tracking and clipping. Finding a solution that works for all plugin combinations might be difficult though.

Probably same purpose as #9287

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->
`None`

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃

**Please don't merge before review from @carmocca** 
