### PR TITLE
add `_is_fresh_start_epoch` attribute to fit_loop to avoid reload dl twice when training starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -359,6 +359,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Fixed `add_argparse_args` raising `TypeError` when args are typed as `typing.Generic` in Python 3.6 ([#9554](https://github.com/PyTorchLightning/pytorch-lightning/pull/9554))
 
+- Fixed `train_dataloader` is loaded twice when resuming from checkpoint during fit loop ([#9614](https://github.com/PyTorchLightning/pytorch-lightning/pull/9614))
 
 ## [1.4.7] - 2021-09-14
 

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -47,6 +47,7 @@ class FitLoop(Loop):
         self.epoch_progress = Progress()
         # caches the loaded dataloader state until dataloader objects are available
         self._dataloader_state_dict: Dict[str, Any] = {}
+        self.is_fresh_start_epoch: bool = False
 
     @property
     def current_epoch(self) -> int:
@@ -188,8 +189,9 @@ class FitLoop(Loop):
         model = self.trainer.lightning_module
 
         # reset train dataloader
-        if self.current_epoch != 0 and self.trainer._should_reload_dl_epoch:
+        if not self._is_fresh_start_epoch and self.trainer._should_reload_dl_epoch:
             self.trainer.reset_train_dataloader(model)
+        self._is_fresh_start_epoch = False
 
         if self._dataloader_state_dict:
             self.trainer.train_dataloader.load_state_dict(self._dataloader_state_dict)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1164,6 +1164,12 @@ class Trainer(
 
         self.reset_train_val_dataloaders(model)
 
+        # fresh start epoch can be under following situations:
+        # 1) fit loop's current_epoch = 0
+        # 2) fit loop's current_epoch != 0, but trainer.fit() is called again,
+        # either with new dl/dm, or resuming from checkpoint
+        self.fit_loop._is_fresh_start_epoch = True
+
         self.fit_loop.trainer = self
         self.fit_loop.run()
 


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #9502 

This PR aims to fix the bug mentioned in issue #9502. 
During fit loop, train_dataloader is loaded twice when resuming from checkpoint. This underlying behavior does not meet user's expectation. 
There are two options to fix this issue:
- **Option 1** (implemented in this PR): introduce an attribute `_is_fresh_start_epoch` in fit_loop to track if a new fit_loop is called. `_is_fresh_start_epoch` can be `True` when 
1. Trainer. fit(model), current_epoch = 0
2. Trainer.fit(model, dm), current_epoch != 0 but new dataloader/datamoudle is provided
3. trainer=Trainer(resume_from_checkpoint=ckpt), Trainer.fit(), current_epoch!=0 but Trainer.fit() resumes from checkpoint

- **Option 2**: remove `self.reset_train_val_dataloaders(model)` in `Trainer._run_train()` and set the reload logics in corresponding loops. When I worked on this option, I found a lot of other underlying assumptions:
1. `self.num_training_batches = 0` in `trainer._setup_on_init()`. This value should be initialized as `self.num_training_batches = float('inf')`, otherwise, if we remove dataloader reloading in `Trainer._run_train()` before calling fit_loop.run(), the `skip` flag from `fit_loop` will be true. which makes `fit_loop` falsely stops. 
2. we allow users to call `trainer.fit()` multiple times with different dataloaders. removing dataloader reloading in `Trainer._run_train()`, it marks `fit_loop` unable to continue fitting with new data. In this sense, we still need  attribute `_is_fresh_start_epoch` mentioned in Option 1. 
3. `reset_val_dataloader()` is called before fit_loop officially starts. Sometimes it's called if sanity_check is enabled. naively removing `self.reset_train_val_dataloaders(model)` in `Trainer._run_train()` breaks a lot of tests since our usage and assumption of loading `val_dataloder()` changed. As mentioned in issue #8738, it's better to provide more gradually control of reloading train and val dataloader seperately. 

In summary, this PR adopts the **option 1** to quickly fix this bug. In the next step, let's complete issue #8738 and then refactor dataloader reloading. 
 
### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [X] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [X] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [X] Did you write any **new necessary tests**? (not for typos and docs)
- [X] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
