### PR TITLE
Optimize non-empty directory warning check in model checkpoint callback

### DIFF
--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -24,8 +24,7 @@ import re
 import time
 from copy import deepcopy
 from datetime import timedelta
-from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 from weakref import proxy
 
 import numpy as np

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -617,7 +617,12 @@ class ModelCheckpoint(Callback):
             self._fs.makedirs(self.dirpath, exist_ok=True)
 
     def __check_if_dir_not_empty(self, dirpath: _PATH, trainer: "pl.Trainer") -> None:
-        if trainer.is_global_zero and self.save_top_k != 0 and self._fs.isdir(dirpath) and len(self._fs.ls(dirpath)) > 0:
+        if (
+            trainer.is_global_zero
+            and self.save_top_k != 0
+            and self._fs.isdir(dirpath)
+            and len(self._fs.ls(dirpath)) > 0
+        ):
             rank_zero_warn(f"Checkpoint directory {dirpath} exists and is not empty.")
 
     def _validate_monitor_key(self, trainer: "pl.Trainer") -> None:

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -264,7 +264,7 @@ class ModelCheckpoint(Callback):
             self._save_on_train_epoch_end = trainer.val_check_interval == 1.0 and trainer.check_val_every_n_epoch == 1
 
     def on_pretrain_routine_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
-        """When pretrain routine starts we determine the ckpt dir on the fly."""
+        """When pretrain routine starts we build the ckpt dir on the fly."""
         self.__resolve_ckpt_dir(trainer)
 
     def on_train_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -617,10 +617,9 @@ class ModelCheckpoint(Callback):
         if not trainer.fast_dev_run and trainer.should_rank_save_checkpoint:
             self._fs.makedirs(self.dirpath, exist_ok=True)
 
-    def __check_if_dir_not_empty(self, dirpath: _PATH, trainer: "pl.Trainer") -> None:
+    def __warn_if_dir_not_empty(self, dirpath: _PATH) -> None:
         if (
-            trainer.is_global_zero
-            and self.save_top_k != 0
+            self.save_top_k != 0
             and self._fs.isdir(dirpath)
             and len(self._fs.ls(dirpath)) > 0
         ):

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -618,11 +618,7 @@ class ModelCheckpoint(Callback):
             self._fs.makedirs(self.dirpath, exist_ok=True)
 
     def __warn_if_dir_not_empty(self, dirpath: _PATH) -> None:
-        if (
-            self.save_top_k != 0
-            and self._fs.isdir(dirpath)
-            and len(self._fs.ls(dirpath)) > 0
-        ):
+        if self.save_top_k != 0 and self._fs.isdir(dirpath) and len(self._fs.ls(dirpath)) > 0:
             rank_zero_warn(f"Checkpoint directory {dirpath} exists and is not empty.")
 
     def _validate_monitor_key(self, trainer: "pl.Trainer") -> None:

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -266,7 +266,8 @@ class ModelCheckpoint(Callback):
     def on_pretrain_routine_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
         """When pretrain routine starts we build the ckpt dir on the fly."""
         self.__resolve_ckpt_dir(trainer)
-        self.__check_if_dir_not_empty(self.dirpath, trainer)
+        if trainer.is_global_zero:
+            self.__warn_if_dir_not_empty(self.dirpath)
 
     def on_train_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
         self._last_time_checked = time.monotonic()

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -612,6 +612,9 @@ class ModelCheckpoint(Callback):
 
         self.dirpath = ckpt_path
 
+        if not trainer.fast_dev_run and trainer.should_rank_save_checkpoint:
+            self._fs.makedirs(self.dirpath, exist_ok=True)
+
     def _validate_monitor_key(self, trainer: "pl.Trainer") -> None:
         metrics = trainer.callback_metrics
 

--- a/pytorch_lightning/plugins/io/torch_plugin.py
+++ b/pytorch_lightning/plugins/io/torch_plugin.py
@@ -31,7 +31,10 @@ class TorchCheckpointIO(CheckpointIO):
 
     def save_checkpoint(self, checkpoint: Dict[str, Any], path: _PATH, storage_options: Optional[Any] = None) -> None:
         fs = get_filesystem(path)
-        fs.makedirs(os.path.dirname(path), exist_ok=True)
+        dirname = os.path.dirname(path)
+        if fs.isdir(dirname) and len(fs.ls(dirname)) > 0:
+            rank_zero_warn(f"Checkpoint directory {dirname} exists and is not empty.")
+        fs.makedirs(dirname, exist_ok=True)
         try:
             # write the checkpoint dictionary on the file
             atomic_save(checkpoint, path)

--- a/pytorch_lightning/plugins/io/torch_plugin.py
+++ b/pytorch_lightning/plugins/io/torch_plugin.py
@@ -26,6 +26,7 @@ from pytorch_lightning.utilities.warnings import WarningCache
 log = logging.getLogger(__name__)
 warning_cache = WarningCache()
 
+
 class TorchCheckpointIO(CheckpointIO):
     """CheckpointIO that utilizes :func:`torch.save` and :func:`torch.load` to save and load checkpoints
     respectively, common for most use cases."""

--- a/pytorch_lightning/plugins/io/torch_plugin.py
+++ b/pytorch_lightning/plugins/io/torch_plugin.py
@@ -21,9 +21,10 @@ from pytorch_lightning.utilities import rank_zero_warn
 from pytorch_lightning.utilities.cloud_io import atomic_save, get_filesystem
 from pytorch_lightning.utilities.cloud_io import load as pl_load
 from pytorch_lightning.utilities.types import _PATH
+from pytorch_lightning.utilities.warnings import WarningCache
 
 log = logging.getLogger(__name__)
-
+warning_cache = WarningCache()
 
 class TorchCheckpointIO(CheckpointIO):
     """CheckpointIO that utilizes :func:`torch.save` and :func:`torch.load` to save and load checkpoints
@@ -33,7 +34,7 @@ class TorchCheckpointIO(CheckpointIO):
         fs = get_filesystem(path)
         dirname = os.path.dirname(path)
         if fs.isdir(dirname) and len(fs.ls(dirname)) > 0:
-            rank_zero_warn(f"Checkpoint directory {dirname} exists and is not empty.")
+            warning_cache.warn(f"Checkpoint directory {dirname} exists and is not empty.")
         fs.makedirs(dirname, exist_ok=True)
         try:
             # write the checkpoint dictionary on the file

--- a/pytorch_lightning/plugins/io/torch_plugin.py
+++ b/pytorch_lightning/plugins/io/torch_plugin.py
@@ -21,10 +21,8 @@ from pytorch_lightning.utilities import rank_zero_warn
 from pytorch_lightning.utilities.cloud_io import atomic_save, get_filesystem
 from pytorch_lightning.utilities.cloud_io import load as pl_load
 from pytorch_lightning.utilities.types import _PATH
-from pytorch_lightning.utilities.warnings import WarningCache
 
 log = logging.getLogger(__name__)
-warning_cache = WarningCache()
 
 
 class TorchCheckpointIO(CheckpointIO):
@@ -33,10 +31,7 @@ class TorchCheckpointIO(CheckpointIO):
 
     def save_checkpoint(self, checkpoint: Dict[str, Any], path: _PATH, storage_options: Optional[Any] = None) -> None:
         fs = get_filesystem(path)
-        dirname = os.path.dirname(path)
-        if fs.isdir(dirname) and len(fs.ls(dirname)) > 0:
-            warning_cache.warn(f"Checkpoint directory {dirname} exists and is not empty.")
-        fs.makedirs(dirname, exist_ok=True)
+        fs.makedirs(os.path.dirname(path), exist_ok=True)
         try:
             # write the checkpoint dictionary on the file
             atomic_save(checkpoint, path)


### PR DESCRIPTION
## What does this PR do?

Along the lines of #9074, consolidate more fs calls from checkpoint callback. For non-empty directory warning:
- move to after `__resolve_ckpt_dir` 
- rank zero only

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
