### PR TITLE
revert #9125 / fix back-compatibility with saving hparams as a whole container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,6 +366,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed gradient accumulation for `DDPShardedPlugin` ([#9122](https://github.com/PyTorchLightning/pytorch-lightning/pull/9122))
 
 
+- Fixed back-compatibility for saving hyperparameters from a single container and inferring its argument name by reverting [#9125](https://github.com/PyTorchLightning/pytorch-lightning/pull/9125) ([#9642](https://github.com/PyTorchLightning/pytorch-lightning/pull/9642))
+
+
 ## [1.4.7] - 2021-09-14
 
 - Fixed logging of nan parameters ([#9364](https://github.com/PyTorchLightning/pytorch-lightning/pull/9364))

--- a/pytorch_lightning/utilities/parsing.py
+++ b/pytorch_lightning/utilities/parsing.py
@@ -22,11 +22,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Type, Union
 from typing_extensions import Literal
 
 import pytorch_lightning as pl
-from pytorch_lightning.utilities import _OMEGACONF_AVAILABLE
 from pytorch_lightning.utilities.warnings import rank_zero_warn
-
-if _OMEGACONF_AVAILABLE:
-    from omegaconf.dictconfig import DictConfig
 
 
 def str_to_bool_or_str(val: str) -> Union[str, bool]:
@@ -205,57 +201,46 @@ def save_hyperparameters(
     obj: Any, *args: Any, ignore: Optional[Union[Sequence[str], str]] = None, frame: Optional[types.FrameType] = None
 ) -> None:
     """See :meth:`~pytorch_lightning.LightningModule.save_hyperparameters`"""
-    hparams_container_types = [Namespace, dict]
-    if _OMEGACONF_AVAILABLE:
-        hparams_container_types.append(DictConfig)
-    # empty container
+
     if len(args) == 1 and not isinstance(args, str) and not args[0]:
+        # args[0] is an empty container
         return
-    # container
-    elif len(args) == 1 and isinstance(args[0], tuple(hparams_container_types)):
-        hp = args[0]
-        obj._hparams_name = "hparams"
-        obj._set_hparams(hp)
-        obj._hparams_initial = copy.deepcopy(obj._hparams)
-        return
-    # non-container args parsing
+
+    if not frame:
+        current_frame = inspect.currentframe()
+        # inspect.currentframe() return type is Optional[types.FrameType]: current_frame.f_back called only if available
+        if current_frame:
+            frame = current_frame.f_back
+    if not isinstance(frame, types.FrameType):
+        raise AttributeError("There is no `frame` available while being required.")
+
+    if is_dataclass(obj):
+        init_args = {f.name: getattr(obj, f.name) for f in fields(obj)}
     else:
-        if not frame:
-            current_frame = inspect.currentframe()
-            # inspect.currentframe() return type is Optional[types.FrameType]
-            # current_frame.f_back called only if available
-            if current_frame:
-                frame = current_frame.f_back
-        if not isinstance(frame, types.FrameType):
-            raise AttributeError("There is no `frame` available while being required.")
+        init_args = get_init_args(frame)
+    assert init_args, "failed to inspect the obj init"
 
-        if is_dataclass(obj):
-            init_args = {f.name: getattr(obj, f.name) for f in fields(obj)}
+    if ignore is not None:
+        if isinstance(ignore, str):
+            ignore = [ignore]
+        if isinstance(ignore, (list, tuple)):
+            ignore = [arg for arg in ignore if isinstance(arg, str)]
+        init_args = {k: v for k, v in init_args.items() if k not in ignore}
+
+    if not args:
+        # take all arguments
+        hp = init_args
+        obj._hparams_name = "kwargs" if hp else None
+    else:
+        # take only listed arguments in `save_hparams`
+        isx_non_str = [i for i, arg in enumerate(args) if not isinstance(arg, str)]
+        if len(isx_non_str) == 1:
+            hp = args[isx_non_str[0]]
+            cand_names = [k for k, v in init_args.items() if v == hp]
+            obj._hparams_name = cand_names[0] if cand_names else None
         else:
-            init_args = get_init_args(frame)
-        assert init_args, f"failed to inspect the obj init - {frame}"
-
-        if ignore is not None:
-            if isinstance(ignore, str):
-                ignore = [ignore]
-            if isinstance(ignore, (list, tuple, set)):
-                ignore = [arg for arg in ignore if isinstance(arg, str)]
-            init_args = {k: v for k, v in init_args.items() if k not in ignore}
-
-        if not args:
-            # take all arguments
-            hp = init_args
-            obj._hparams_name = "kwargs" if hp else None
-        else:
-            # take only listed arguments in `save_hparams`
-            isx_non_str = [i for i, arg in enumerate(args) if not isinstance(arg, str)]
-            if len(isx_non_str) == 1:
-                hp = args[isx_non_str[0]]
-                cand_names = [k for k, v in init_args.items() if v == hp]
-                obj._hparams_name = cand_names[0] if cand_names else None
-            else:
-                hp = {arg: init_args[arg] for arg in args if isinstance(arg, str)}
-                obj._hparams_name = "kwargs"
+            hp = {arg: init_args[arg] for arg in args if isinstance(arg, str)}
+            obj._hparams_name = "kwargs"
 
     # `hparams` are expected here
     if hp:

--- a/tests/models/test_hparams.py
+++ b/tests/models/test_hparams.py
@@ -677,7 +677,7 @@ def test_empty_hparams_container(tmpdir):
     assert not model.hparams
 
 
-def test_hparams_name(tmpdir):
+def test_hparams_name_from_container(tmpdir):
     """Test that save_hyperparameters(container) captures the name of the argument correctly."""
     model = HparamsKwargsContainerModel(a=1, b=2)
     assert model._hparams_name is None

--- a/tests/models/test_hparams.py
+++ b/tests/models/test_hparams.py
@@ -677,6 +677,14 @@ def test_empty_hparams_container(tmpdir):
     assert not model.hparams
 
 
+def test_hparams_name(tmpdir):
+    """Test that save_hyperparameters(container) captures the name of the argument correctly."""
+    model = HparamsKwargsContainerModel(a=1, b=2)
+    assert model._hparams_name is None
+    model = HparamsNamespaceContainerModel(Namespace(a=1, b=2))
+    assert model._hparams_name == "config"
+
+
 @dataclass
 class DataClassModel(BoringModel):
 


### PR DESCRIPTION
This reverts commit 904dde7573c97245b45e477631ece989bd8c01e9, added in #9125. 

Fixes #9631

The tests added in #9125 still pass. The new test added here fails on master and asserting the behavior how it was before #9125



## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃



