### PR TITLE
Remove `InternalDebugger.track_event`

### DIFF
--- a/pytorch_lightning/utilities/debugging.py
+++ b/pytorch_lightning/utilities/debugging.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import time
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -43,32 +42,11 @@ class InternalDebugger:
     def __init__(self, trainer: "pl.Trainer") -> None:
         self.enabled = os.environ.get("PL_DEV_DEBUG", "0") == "1"
         self.trainer = trainer
-        self.events: List[Dict[str, Any]] = []
         self.saved_lr_scheduler_updates: List[Dict[str, Union[int, float, str, torch.Tensor, None]]] = []
         self.train_dataloader_calls: List[Dict[str, Any]] = []
         self.val_dataloader_calls: List[Dict[str, Any]] = []
         self.test_dataloader_calls: List[Dict[str, Any]] = []
         self.dataloader_sequence_calls: List[Dict[str, Any]] = []
-
-    @enabled_only
-    def track_event(
-        self,
-        evt_type: str,
-        evt_value: Any = None,
-        global_rank: Optional[int] = None,
-        local_rank: Optional[int] = None,
-        comment: str = "",
-    ) -> None:
-        self.events.append(
-            {
-                "timestamp": time.time(),
-                "event": evt_type,
-                "value": evt_value,
-                "global_rank": global_rank,
-                "local_rank": local_rank,
-                "comment": comment,
-            }
-        )
 
     @enabled_only
     def track_load_dataloader_call(self, name: str, dataloaders: List[DataLoader]) -> None:


### PR DESCRIPTION
## What does this PR do?

Part of #9661 

This one is unused.

### Does your PR introduce any breaking changes? If yes, please list them.

Removes `InternalDebugger.track_event`

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified