### PR TITLE
Use `searchsorted` over `argmax`

### DIFF
--- a/pytorch_lightning/loops/batch/training_batch_loop.py
+++ b/pytorch_lightning/loops/batch/training_batch_loop.py
@@ -191,5 +191,5 @@ class TrainingBatchLoop(Loop):
         current_place_in_loop = batch_idx % optimizers_loop_length
 
         # find optimzier index by looking for the first {item > current_place} in the cumsum list
-        opt_idx = int(np.argmax(self.optimizer_freq_cumsum > current_place_in_loop))
+        opt_idx = np.searchsorted(self.optimizer_freq_cumsum, current_place_in_loop, side="right")
         return [(opt_idx, self.trainer.optimizers[opt_idx])]


### PR DESCRIPTION
## What does this PR do?

since `freq_cumsum` will be sorted, this is more efficient.
ref: https://stackoverflow.com/a/48360950

Part of #9581

just in case we have ~10^6 optimizers 😂 

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified