### PR TITLE
Weekly Patch Release v1.4.9 [full merge, no squash]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed gradient unscaling being called too late, causing gradient clipping and gradient norm tracking to be applied incorrectly ([#9606](https://github.com/PyTorchLightning/pytorch-lightning/pull/9606))
 
 
+- Fixed `lr_find` to generate same results on multiple calls ([#9704](https://github.com/PyTorchLightning/pytorch-lightning/pull/9704))
+
+
 ## [1.4.8] - 2021-09-22
 
 - Fixed error reporting in DDP process reconciliation when processes are launched by an external agent (#9389)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Moved the gradient unscaling in `NativeMixedPrecisionPlugin` from `pre_optimizer_step` to `post_backward` ([#9606](https://github.com/PyTorchLightning/pytorch-lightning/pull/9606))
 - Fixed gradient unscaling being called too late, causing gradient clipping and gradient norm tracking to be applied incorrectly ([#9606](https://github.com/PyTorchLightning/pytorch-lightning/pull/9606))
-
-
 - Fixed `lr_find` to generate same results on multiple calls ([#9704](https://github.com/PyTorchLightning/pytorch-lightning/pull/9704))
+- Fixed `reset` metrics on validation epoch end ([#9717](https://github.com/PyTorchLightning/pytorch-lightning/pull/9717))
+
 
 
 ## [1.4.8] - 2021-09-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
-## [unreleased] - 2021-??-??
+## [1.4.9] - 2021-09-30
 
 - Moved the gradient unscaling in `NativeMixedPrecisionPlugin` from `pre_optimizer_step` to `post_backward` ([#9606](https://github.com/PyTorchLightning/pytorch-lightning/pull/9606))
 - Fixed gradient unscaling being called too late, causing gradient clipping and gradient norm tracking to be applied incorrectly ([#9606](https://github.com/PyTorchLightning/pytorch-lightning/pull/9606))
 - Fixed `lr_find` to generate same results on multiple calls ([#9704](https://github.com/PyTorchLightning/pytorch-lightning/pull/9704))
 - Fixed `reset` metrics on validation epoch end ([#9717](https://github.com/PyTorchLightning/pytorch-lightning/pull/9717))
-
+- Fixed input validation for `gradient_clip_val`, `gradient_clip_algorithm`, `track_grad_norm` and `terminate_on_nan` Trainer arguments ([#9595](https://github.com/PyTorchLightning/pytorch-lightning/pull/9595))
+- Reset metrics before each task starts ([#9410](https://github.com/PyTorchLightning/pytorch-lightning/pull/9410))
 
 
 ## [1.4.8] - 2021-09-22

--- a/pytorch_lightning/__about__.py
+++ b/pytorch_lightning/__about__.py
@@ -1,7 +1,7 @@
 import time
 
 _this_year = time.strftime("%Y")
-__version__ = "1.4.8"
+__version__ = "1.4.9"
 __author__ = "William Falcon et al."
 __author_email__ = "waf2107@columbia.edu"
 __license__ = "Apache-2.0"

--- a/pytorch_lightning/loops/dataloader/evaluation_loop.py
+++ b/pytorch_lightning/loops/dataloader/evaluation_loop.py
@@ -93,6 +93,7 @@ class EvaluationLoop(DataLoaderLoop):
     def on_run_start(self, *args: Any, **kwargs: Any) -> None:
         """Runs the ``on_evaluation_model_eval``, ``on_evaluation_start`` and ``on_evaluation_epoch_start`` hooks"""
         void(*args, **kwargs)
+
         # hook
         self.on_evaluation_model_eval()
         self.trainer.lightning_module.zero_grad()
@@ -208,7 +209,7 @@ class EvaluationLoop(DataLoaderLoop):
             self.trainer.profiler.describe()
 
         # reset any `torchmetrics.Metric` and the logger connector state
-        self.trainer.logger_connector.reset(metrics=True)
+        self.trainer.logger_connector.reset_results(metrics=True)
 
     def on_evaluation_epoch_start(self, *args: Any, **kwargs: Any) -> None:
         """Runs ``on_epoch_start`` and ``on_{validation/test}_epoch_start`` hooks"""

--- a/pytorch_lightning/loops/dataloader/evaluation_loop.py
+++ b/pytorch_lightning/loops/dataloader/evaluation_loop.py
@@ -208,8 +208,8 @@ class EvaluationLoop(DataLoaderLoop):
             # summarize profile results
             self.trainer.profiler.describe()
 
-        # reset any `torchmetrics.Metric` and the logger connector state
-        self.trainer.logger_connector.reset_results(metrics=True)
+        # reset the logger connector state
+        self.trainer.logger_connector.reset_results()
 
     def on_evaluation_epoch_start(self, *args: Any, **kwargs: Any) -> None:
         """Runs ``on_epoch_start`` and ``on_{validation/test}_epoch_start`` hooks"""

--- a/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -282,9 +282,9 @@ class LoggerConnector:
         self._logged_metrics = {}
         self._callback_metrics = {}
 
-    def reset_results(self, metrics: Optional[bool] = None) -> None:
+    def reset_results(self) -> None:
         if self.trainer._results is not None:
-            self.trainer._results.reset(metrics=metrics)
+            self.trainer._results.reset()
 
         self._batch_idx = None
         self._split_idx = None

--- a/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -277,13 +277,15 @@ class LoggerConnector:
             is_first_batch = self._batch_idx + self._split_idx == 0
         return is_different_fx and is_first_batch
 
-    def reset(self, metrics: Optional[bool] = None) -> None:
-        if self.trainer.sanity_checking:
-            # reset metrics
-            self._progress_bar_metrics = {}
-            self._logged_metrics = {}
-            self._callback_metrics = {}
-        self.trainer._results.reset(metrics=metrics)
+    def reset_metrics(self) -> None:
+        self._progress_bar_metrics = {}
+        self._logged_metrics = {}
+        self._callback_metrics = {}
+
+    def reset_results(self, metrics: Optional[bool] = None) -> None:
+        if self.trainer._results is not None:
+            self.trainer._results.reset(metrics=metrics)
+
         self._batch_idx = None
         self._split_idx = None
         self._current_fx = None

--- a/pytorch_lightning/trainer/connectors/training_trick_connector.py
+++ b/pytorch_lightning/trainer/connectors/training_trick_connector.py
@@ -24,25 +24,35 @@ class TrainingTricksConnector:
 
     def on_trainer_init(
         self,
-        gradient_clip_val: float,
+        gradient_clip_val: Union[int, float],
         gradient_clip_algorithm: str,
         track_grad_norm: Union[int, float, str],
         accumulate_grad_batches: Union[int, Dict[int, int], List[list]],
         truncated_bptt_steps: Optional[int],
         terminate_on_nan: bool,
     ):
-
-        self.trainer.terminate_on_nan = terminate_on_nan
+        if not isinstance(terminate_on_nan, bool):
+            raise TypeError(f"`terminate_on_nan` should be a bool, got {terminate_on_nan}.")
 
         # gradient clipping
-        if gradient_clip_algorithm not in list(GradClipAlgorithmType):
-            raise MisconfigurationException(f"gradient_clip_algorithm should be in {list(GradClipAlgorithmType)}")
-        self.trainer.gradient_clip_val = gradient_clip_val
-        self.trainer.gradient_clip_algorithm = GradClipAlgorithmType(gradient_clip_algorithm)
+        if not isinstance(gradient_clip_val, (int, float)):
+            raise TypeError(f"`gradient_clip_val` should be an int or a float. Got {gradient_clip_val}.")
+
+        if not GradClipAlgorithmType.supported_type(gradient_clip_algorithm.lower()):
+            raise MisconfigurationException(
+                f"`gradient_clip_algorithm` {gradient_clip_algorithm} is invalid. "
+                f"Allowed algorithms: {GradClipAlgorithmType.supported_types()}."
+            )
 
         # gradient norm tracking
         if not isinstance(track_grad_norm, (int, float)) and track_grad_norm != "inf":
-            raise MisconfigurationException("track_grad_norm can be an int, a float or 'inf' (infinity norm).")
+            raise MisconfigurationException(
+                f"`track_grad_norm` should be an int, a float or 'inf' (infinity norm). Got {track_grad_norm}."
+            )
+
+        self.trainer.terminate_on_nan = terminate_on_nan
+        self.trainer.gradient_clip_val = gradient_clip_val
+        self.trainer.gradient_clip_algorithm = GradClipAlgorithmType(gradient_clip_algorithm.lower())
         self.trainer.track_grad_norm = float(track_grad_norm)
 
         # accumulated grads

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -109,7 +109,7 @@ class Trainer(
         checkpoint_callback: bool = True,
         callbacks: Optional[Union[List[Callback], Callback]] = None,
         default_root_dir: Optional[str] = None,
-        gradient_clip_val: float = 0.0,
+        gradient_clip_val: Union[int, float] = 0.0,
         gradient_clip_algorithm: str = "norm",
         process_position: int = 0,
         num_nodes: int = 1,

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -903,6 +903,11 @@ class Trainer(
         # ----------------------------
         # TRAIN
         # ----------------------------
+
+        # reset logger connector
+        self.logger_connector.reset_results()
+        self.logger_connector.reset_metrics()
+
         # hook
         if self.state.fn == TrainerFn.FITTING:
             self.call_hook("on_fit_start")
@@ -1103,8 +1108,11 @@ class Trainer(
             stage = self.state.stage
             self.sanity_checking = True
 
-            # hook and callback
-            self.on_sanity_check_start()
+            # reset logger connector
+            self.logger_connector.reset_results()
+            self.logger_connector.reset_metrics()
+
+            self.call_hook("on_sanity_check_start")
 
             # reload dataloaders
             self._evaluation_loop.reload_evaluation_dataloaders()
@@ -1115,8 +1123,9 @@ class Trainer(
 
             self.on_sanity_check_end()
 
-            # reset validation metrics
-            self.logger_connector.reset()
+            # reset logger connector
+            self.logger_connector.reset_results()
+            self.logger_connector.reset_metrics()
 
             # reset the seed to what it was before sanity check
             # prevents sanity check to affect random sampling in training

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1112,7 +1112,7 @@ class Trainer(
             self.logger_connector.reset_results()
             self.logger_connector.reset_metrics()
 
-            self.call_hook("on_sanity_check_start")
+            self.on_sanity_check_start()
 
             # reload dataloaders
             self._evaluation_loop.reload_evaluation_dataloaders()

--- a/pytorch_lightning/tuner/batch_size_scaling.py
+++ b/pytorch_lightning/tuner/batch_size_scaling.py
@@ -101,6 +101,7 @@ def __scale_batch_dump_params(trainer: "pl.Trainer") -> None:
     trainer.__dumped_params = {
         "auto_lr_find": trainer.auto_lr_find,
         "current_epoch": trainer.current_epoch,
+        "global_step": trainer.global_step,
         "max_steps": trainer.max_steps,
         "weights_summary": trainer.weights_summary,
         "logger": trainer.logger,
@@ -128,6 +129,7 @@ def __scale_batch_reset_params(trainer: "pl.Trainer", model: "pl.LightningModule
 def __scale_batch_restore_params(trainer: "pl.Trainer") -> None:
     trainer.auto_lr_find = trainer.__dumped_params["auto_lr_find"]
     trainer.fit_loop.current_epoch = trainer.__dumped_params["current_epoch"]
+    trainer.fit_loop.global_step = trainer.__dumped_params["global_step"]
     trainer.fit_loop.max_steps = trainer.__dumped_params["max_steps"]
     trainer.weights_summary = trainer.__dumped_params["weights_summary"]
     trainer.logger = trainer.__dumped_params["logger"]

--- a/pytorch_lightning/tuner/lr_finder.py
+++ b/pytorch_lightning/tuner/lr_finder.py
@@ -284,6 +284,7 @@ def __lr_finder_dump_params(trainer, model):
         "auto_lr_find": trainer.auto_lr_find,
         "callbacks": trainer.callbacks,
         "logger": trainer.logger,
+        "global_step": trainer.global_step,
         "max_steps": trainer.max_steps,
         "checkpoint_callback": trainer.checkpoint_callback,
         "current_epoch": trainer.current_epoch,
@@ -295,6 +296,7 @@ def __lr_finder_restore_params(trainer, model):
     trainer.auto_lr_find = trainer.__dumped_params["auto_lr_find"]
     trainer.logger = trainer.__dumped_params["logger"]
     trainer.callbacks = trainer.__dumped_params["callbacks"]
+    trainer.fit_loop.global_step = trainer.__dumped_params["global_step"]
     trainer.fit_loop.max_steps = trainer.__dumped_params["max_steps"]
     trainer.fit_loop.current_epoch = trainer.__dumped_params["current_epoch"]
     model.configure_optimizers = trainer.__dumped_params["configure_optimizers"]

--- a/pytorch_lightning/utilities/enums.py
+++ b/pytorch_lightning/utilities/enums.py
@@ -118,6 +118,14 @@ class GradClipAlgorithmType(LightningEnum):
     VALUE = "value"
     NORM = "norm"
 
+    @staticmethod
+    def supported_type(val: str) -> bool:
+        return any(x.value == val for x in GradClipAlgorithmType)
+
+    @staticmethod
+    def supported_types() -> List[str]:
+        return [x.value for x in GradClipAlgorithmType]
+
 
 class AutoRestartBatchKeys(LightningEnum):
     """

--- a/tests/checkpointing/test_trainer_checkpoint.py
+++ b/tests/checkpointing/test_trainer_checkpoint.py
@@ -75,9 +75,6 @@ def test_finetuning_with_resume_from_checkpoint(tmpdir):
         results.append(deepcopy(trainer.callback_metrics))
         best_model_paths.append(trainer.checkpoint_callback.best_model_path)
 
-    for idx in range(len(results) - 1):
-        assert results[idx]["val_loss"] > results[idx + 1]["val_loss"]
-
     for idx, best_model_path in enumerate(best_model_paths):
         if idx == 0:
             assert best_model_path.endswith(f"epoch=0{idx}.ckpt")

--- a/tests/trainer/logging_/test_eval_loop_logging.py
+++ b/tests/trainer/logging_/test_eval_loop_logging.py
@@ -550,6 +550,12 @@ def test_validation_step_log_with_tensorboard(mock_log_metrics, tmpdir):
     # hp_metric + 2 steps + epoch + 2 steps + epoch
     expected_num_calls = 1 + 2 + 1 + 2 + 1
 
+    assert set(trainer.callback_metrics) == {
+        "train_loss",
+        "valid_loss_0_epoch",
+        "valid_loss_0",
+        "valid_loss_1",
+    }
     assert len(mock_log_metrics.mock_calls) == expected_num_calls
     assert mock_log_metrics.mock_calls[0] == call({"hp_metric": -1}, 0)
 
@@ -583,10 +589,6 @@ def test_validation_step_log_with_tensorboard(mock_log_metrics, tmpdir):
 
     results = trainer.test(model)
     assert set(trainer.callback_metrics) == {
-        "train_loss",
-        "valid_loss_0_epoch",
-        "valid_loss_0",
-        "valid_loss_1",
         "test_loss",
     }
     assert set(results[0]) == {"test_loss"}

--- a/tests/trainer/logging_/test_eval_loop_logging.py
+++ b/tests/trainer/logging_/test_eval_loop_logging.py
@@ -618,3 +618,59 @@ def test_logging_dict_on_validation_step(tmpdir):
     )
 
     trainer.fit(model)
+
+
+@pytest.mark.parametrize("val_check_interval", [0.5, 1.0])
+def test_multiple_dataloaders_reset(val_check_interval, tmpdir):
+    class TestModel(BoringModel):
+        def training_step(self, batch, batch_idx):
+            out = super().training_step(batch, batch_idx)
+            value = 1 + batch_idx
+            if self.current_epoch != 0:
+                value *= 10
+            self.log("batch_idx", value, on_step=True, on_epoch=True, prog_bar=True)
+            return out
+
+        def training_epoch_end(self, outputs):
+            metrics = self.trainer.progress_bar_metrics
+            v = 15 if self.current_epoch == 0 else 150
+            assert metrics["batch_idx_epoch"] == (v / 5.0)
+
+        def validation_step(self, batch, batch_idx, dataloader_idx):
+            value = (1 + batch_idx) * (1 + dataloader_idx)
+            if self.current_epoch != 0:
+                value *= 10
+            self.log("val_loss", value, on_step=False, on_epoch=True, prog_bar=True, logger=True)
+            return value
+
+        def validation_epoch_end(self, outputs):
+            if self.current_epoch == 0:
+                assert sum(outputs[0]) / 5 == 3
+                assert sum(outputs[1]) / 5 == 6
+            else:
+                assert sum(outputs[0]) / 5 == 30
+                assert sum(outputs[1]) / 5 == 60
+
+            tot_loss = torch.mean(torch.tensor(outputs, dtype=torch.float))
+            if self.current_epoch == 0:
+                assert tot_loss == (3 + 6) / 2
+            else:
+                assert tot_loss == (30 + 60) / 2
+            assert self.trainer._results["validation_step.val_loss.0"].cumulated_batch_size == 5
+            assert self.trainer._results["validation_step.val_loss.1"].cumulated_batch_size == 5
+
+        def val_dataloader(self):
+            return [super().val_dataloader(), super().val_dataloader()]
+
+    model = TestModel()
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_train_batches=5,
+        limit_val_batches=5,
+        num_sanity_val_steps=0,
+        val_check_interval=val_check_interval,
+        max_epochs=3,
+        log_every_n_steps=1,
+        weights_summary=None,
+    )
+    trainer.fit(model)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -800,6 +800,16 @@ def test_nan_loss_detection(tmpdir):
         assert torch.isfinite(param).all()
 
 
+def test_invalid_terminate_on_nan(tmpdir):
+    with pytest.raises(TypeError, match="`terminate_on_nan` should be a bool"):
+        Trainer(default_root_dir=tmpdir, terminate_on_nan="False")
+
+
+def test_invalid_track_grad_norm(tmpdir):
+    with pytest.raises(MisconfigurationException, match="`track_grad_norm` should be an int, a float"):
+        Trainer(default_root_dir=tmpdir, track_grad_norm="nan")
+
+
 def test_nan_params_detection(tmpdir):
     class CurrentModel(BoringModel):
         test_batch_nan = 3
@@ -1003,6 +1013,16 @@ def test_gradient_clipping_by_value_fp16(tmpdir):
     model.prev_called_batch_idx = 0
 
     trainer.fit(model)
+
+
+def test_invalid_gradient_clip_value(tmpdir):
+    with pytest.raises(TypeError, match="`gradient_clip_val` should be an int or a float"):
+        Trainer(default_root_dir=tmpdir, gradient_clip_val=(1, 2))
+
+
+def test_invalid_gradient_clip_algo(tmpdir):
+    with pytest.raises(MisconfigurationException, match="`gradient_clip_algorithm` norm2 is invalid"):
+        Trainer(default_root_dir=tmpdir, gradient_clip_algorithm="norm2")
 
 
 def test_gpu_choice(tmpdir):

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1897,3 +1897,49 @@ def test_multiple_trainer_constant_memory_allocated(tmpdir):
     trainer_2.fit(model)
 
     assert current_memory() <= initial
+
+
+def test_trainer_metrics_reset_before_each_task(tmpdir):
+    """Test that callback, logged and progress bar metrics are reset before each task starts."""
+
+    class TestMetricRestartCallback(Callback):
+        def _make_assertions(self, trainer):
+            assert trainer.callback_metrics == {}
+            assert trainer.progress_bar_metrics == {}
+            assert trainer.logged_metrics == {}
+
+        def on_train_start(self, trainer, *args, **kwargs):
+            self._make_assertions(trainer)
+
+        def on_validation_start(self, trainer, *args, **kwargs):
+            if trainer.state.fn == TrainerFn.VALIDATING:
+                self._make_assertions(trainer)
+
+        def on_test_start(self, trainer, *args, **kwargs):
+            self._make_assertions(trainer)
+
+        def on_predict_start(self, trainer, *args, **kwargs):
+            self._make_assertions(trainer)
+
+    class CustomBoringModel(BoringModel):
+        def __init__(self):
+            super().__init__()
+
+        def training_step(self, *args, **kwargs):
+            self.log("train/metric", 7.0)
+            return super().training_step(*args, **kwargs)
+
+        def validation_step(self, *args, **kwargs):
+            self.log("val/metric", 14.0)
+            return super().validation_step(*args, **kwargs)
+
+        def test_step(self, *args, **kwargs):
+            self.log("test/metric", 21.0)
+            return super().test_step(*args, **kwargs)
+
+    model = CustomBoringModel()
+    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=4, callbacks=[TestMetricRestartCallback()])
+    trainer.fit(model)
+    trainer.validate(model)
+    trainer.test(model)
+    trainer.predict(model)

--- a/tests/tuner/test_lr_finder.py
+++ b/tests/tuner/test_lr_finder.py
@@ -75,6 +75,7 @@ def test_trainer_reset_correctly(tmpdir):
         "checkpoint_callback",
         "current_epoch",
         "logger",
+        "global_step",
         "max_steps",
     ]
     expected = {ca: getattr(trainer, ca) for ca in changed_attributes}
@@ -282,3 +283,17 @@ def test_lr_finder_ends_before_num_training(tmpdir):
     trainer = Trainer(default_root_dir=tmpdir)
     num_training = 3
     trainer.tuner.lr_find(model=model, num_training=num_training)
+
+
+def test_multiple_lr_find_calls_gives_same_results(tmpdir):
+    """Tests that lr_finder gives same results if called multiple times."""
+    model = BoringModel()
+
+    trainer = Trainer(default_root_dir=tmpdir, max_epochs=2)
+    all_res = [trainer.tuner.lr_find(model).results for _ in range(3)]
+
+    assert all(
+        all_res[0][k] == curr_lr_finder[k] and len(curr_lr_finder[k]) > 10
+        for curr_lr_finder in all_res[1:]
+        for k in all_res[0].keys()
+    )

--- a/tests/tuner/test_scale_batch_size.py
+++ b/tests/tuner/test_scale_batch_size.py
@@ -108,6 +108,7 @@ def test_trainer_reset_correctly(tmpdir):
         "limit_train_batches",
         "logger",
         "max_steps",
+        "global_step",
         "weights_summary",
     ]
     expected = {ca: getattr(trainer, ca) for ca in changed_attributes}

--- a/tests/utilities/test_enums.py
+++ b/tests/utilities/test_enums.py
@@ -1,4 +1,4 @@
-from pytorch_lightning.utilities import DeviceType
+from pytorch_lightning.utilities.enums import DeviceType, GradClipAlgorithmType
 
 
 def test_consistency():
@@ -9,3 +9,10 @@ def test_consistency():
     # hash cannot be case invariant
     assert DeviceType.TPU not in {"TPU", "CPU"}
     assert DeviceType.TPU in {"tpu", "CPU"}
+
+
+def test_gradient_clip_algorithms():
+    assert GradClipAlgorithmType.supported_types() == ["value", "norm"]
+    assert GradClipAlgorithmType.supported_type("norm")
+    assert GradClipAlgorithmType.supported_type("value")
+    assert not GradClipAlgorithmType.supported_type("norm2")


### PR DESCRIPTION
## What does this PR do?

```fish
gh pr list -s merged -S 'merged:2021-09-21T18:30:00.000Z..2021-09-29T18:30:00.000Z' --json mergedAt,milestone,url,mergeCommit,title --jq 'sort_by(.mergedAt) | reverse | .[] | select((.milestone.title == "v1.4.x") or (.milestone.title == null)) | [.mergedAt, .url, .mergeCommit.oid, .title] | join(" ")' --limit 100
```

```fish
2021-09-27T19:36:57Z https://github.com/PyTorchLightning/pytorch-lightning/pull/9715 131176b9f5e544a1133240a46dca1960308b7849 [bugfix] Prevent on_before_batch_transfer to be called twice
2021-09-27T16:16:46Z https://github.com/PyTorchLightning/pytorch-lightning/pull/9717 64bbebc8694b90df2343185e702ca4d873aa8669 [bugfix] Resolve metrics not being properly resetted on validation epoch end
2021-09-27T13:33:27Z https://github.com/PyTorchLightning/pytorch-lightning/pull/9606 a69b940ce3894c08cc4b033f4fee63a838a6e8ca [Bugfix] Fix location of `unscale` in mixed precision plugin
2021-09-26T19:20:43Z https://github.com/PyTorchLightning/pytorch-lightning/pull/9704 83d83abc9dcb96a09e5eeda57daa2e83afed8731 Fix `lr_find` to generate same results on multiple calls
2021-09-25T16:02:26Z https://github.com/PyTorchLightning/pytorch-lightning/pull/9595 a4bc0acb02b729218c9aba83a211c5f8405b5e16 Update warnings in `TrainingTricksConnector`
2021-09-23T08:20:25Z https://github.com/PyTorchLightning/pytorch-lightning/pull/9410 86dd318dccb593fe1a65f196cceef377d2808eed Reset metrics before each task starts

```

Skipped:
```
2021-09-24T18:51:55Z https://github.com/PyTorchLightning/pytorch-lightning/pull/9652 8fcdcb598bbf0fbe6cda92415d1d69eb1e2d0aa0 Fix `accumulate_grad_batches` on init

2021-09-27T15:55:20Z https://github.com/PyTorchLightning/pytorch-lightning/pull/9696 faee9dfd532c96684445047c3dad6424feee1c02 Make `HorovodPlugin.all_gather` return a tensor

2021-09-25T05:53:32Z https://github.com/PyTorchLightning/pytorch-lightning/pull/9664 b3a5c7f44217c945c296479d6918ab68dd0f588e Add `enable_progress_bar` to Trainer constructor

2021-09-24T08:27:16Z https://github.com/PyTorchLightning/pytorch-lightning/pull/9679 c2e3ec164aea692f5a944b4f2d1782a2f363605c Add torch v1.11.0 to the list of versions in adjust_versions.py

2021-09-23T08:58:04Z https://github.com/PyTorchLightning/pytorch-lightning/pull/9616 491e4a2a6cebc39f271346bb797795ff99dad0da Deprecate `progress_bar_refresh_rate` from Trainer constructor

2021-09-22T19:14:24Z https://github.com/PyTorchLightning/pytorch-lightning/pull/9649 37469cd3e85bd203cf32d8f888edbc713a7bce09 fix modify _DDPSinkBackward view inplace error for pytorch nightly 1.10

```

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃

