### PR TITLE
Log LR using LearningRateMonitor even when LR Scheduler is not defined. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Log `learning rate` using `LearningRateMonitor` callback even when no scheduler is used ([#7468](https://github.com/PyTorchLightning/pytorch-lightning/issues/7468))
+
 
 - Register `ShardedTensor` state dict hooks in `LightningModule.__init__` if the pytorch version supports `ShardedTensor` ([#8944](https://github.com/PyTorchLightning/pytorch-lightning/pull/8944))
 


### PR DESCRIPTION
## What does this PR do?
In this PR, the `LearningRateMonitor` callback is extended to log learning rates of each optimizer even when LR schedulers are not specified by the user in training. 

When LR schedulers are not specified, `trainer.optimizers` is used instead of `trainer.lr_schedulers` for getting names of the optimizers, and then we iterate over the optimizers to log their learning rates.  

Extra tests are written to make sure that the learning rates are logged with correct names even when schedulers are not defined. 

## Motivation
Currently the LR monitor callback only takes effect if the user specifies LR schedulers for training. However, one could want to record what the initial learning rate used for their optimizer's parameter groups even without any LR schedulers. This PR tries to solve this issue. 
Fixes #7468 

### Does your PR introduce any breaking changes? 
No

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

