### PR TITLE
Fix Deepspeed and lightning calling scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -436,6 +436,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed `broadcast` in `DDPPlugin` and ``DDPSpawnPlugin` to respect the `src` input  ([#9691](https://github.com/PyTorchLightning/pytorch-lightning/pull/9691))
 
 
+- Fixed DeepSpeed and Lightning both calling the scheduler ([#9788](https://github.com/PyTorchLightning/pytorch-lightning/pull/9788))
+
+
 ## [1.4.9] - 2021-09-30
 
 - Fixed `lr_find` to generate same results on multiple calls ([#9704](https://github.com/PyTorchLightning/pytorch-lightning/pull/9704))

--- a/pytorch_lightning/plugins/training_type/deepspeed.py
+++ b/pytorch_lightning/plugins/training_type/deepspeed.py
@@ -441,7 +441,11 @@ class DeepSpeedPlugin(DDPPlugin):
 
         # although we set these here, deepspeed manages the specific optimizer logic
         self.lightning_module.trainer.optimizers = [deepspeed_optimizer]
+
+        deepspeed_scheduler = model.lr_scheduler
         if deepspeed_scheduler is not None:
+            # disable deepspeed lr scheduling as lightning manages scheduling
+            model.lr_scheduler = None
             lr_scheduler["scheduler"] = deepspeed_scheduler
             self.lightning_module.trainer.lr_schedulers = [lr_scheduler]
         self.model = model

--- a/tests/plugins/test_deepspeed_plugin.py
+++ b/tests/plugins/test_deepspeed_plugin.py
@@ -265,8 +265,6 @@ def test_deepspeed_run_configure_optimizers(tmpdir):
             assert isinstance(trainer.lr_schedulers[0]["scheduler"], torch.optim.lr_scheduler.StepLR)
             # check that the lr_scheduler config was preserved
             assert trainer.lr_schedulers[0]["name"] == "Sean"
-            # Ensure DeepSpeed engine has initialized with our lr_scheduler
-            assert isinstance(trainer.model.lr_scheduler, torch.optim.lr_scheduler.StepLR)
 
     class TestModel(BoringModel):
         def configure_optimizers(self):
@@ -303,8 +301,6 @@ def test_deepspeed_config(tmpdir, deepspeed_zero_config):
             assert isinstance(trainer.optimizers[0], FP16_DeepSpeedZeroOptimizer)
             assert isinstance(trainer.optimizers[0].optimizer, torch.optim.SGD)
             assert isinstance(trainer.lr_schedulers[0]["scheduler"], WarmupLR)
-            # Ensure DeepSpeed engine has initialized with our lr_scheduler
-            assert isinstance(trainer.model.lr_scheduler, WarmupLR)
 
     model = BoringModel()
     trainer = Trainer(

--- a/tests/plugins/test_deepspeed_plugin.py
+++ b/tests/plugins/test_deepspeed_plugin.py
@@ -921,3 +921,47 @@ def test_deepspeed_setup_train_dataloader(tmpdir):
     )
     trainer.fit(model, datamodule=TestSetupIsCalledDataModule())
     trainer.test(model)
+
+
+@mock.patch("torch.optim.lr_scheduler.StepLR.step", autospec=True)
+@RunIf(min_gpus=1, deepspeed=True, special=True)
+def test_deepspeed_scheduler_step_count(mock_step):
+    """Test to ensure that the scheduler is called the correct amount of times during training when scheduler is
+    set to step."""
+    _run_scheduler_test(mock_step, max_epoch=2, limit_train_batches=2, interval="step")
+
+
+@mock.patch("torch.optim.lr_scheduler.StepLR.step", autospec=True)
+@RunIf(min_gpus=1, deepspeed=True, special=True)
+def test_deepspeed_scheduler_step_count_epoch(mock_step):
+    """Test to ensure that the scheduler is called the correct amount of times during training when scheduler is
+    set to epoch."""
+    _run_scheduler_test(mock_step, max_epoch=2, limit_train_batches=2, interval="epoch")
+
+
+def _run_scheduler_test(mock_step, max_epoch, limit_train_batches, interval):
+    class TestModel(BoringModel):
+        def configure_optimizers(self):
+            optimizer = torch.optim.SGD(self.layer.parameters(), lr=0.1)
+            scheduler = torch.optim.lr_scheduler.StepLR(optimizer, 1, gamma=0.1)
+            return {
+                "optimizer": optimizer,
+                "lr_scheduler": {"scheduler": scheduler, "interval": interval},
+            }
+
+    model = TestModel()
+    trainer = Trainer(
+        default_root_dir=os.getcwd(),
+        limit_train_batches=limit_train_batches,
+        limit_val_batches=0,
+        max_epochs=max_epoch,
+        gpus=1,
+        plugins="deepspeed",
+    )
+    trainer.fit(model)
+    if interval == "epoch":
+        # assert called once at init and once during training
+        assert mock_step.call_count == 1 + max_epoch
+    else:
+        # assert called once at init and once during training
+        assert mock_step.call_count == 1 + (max_epoch * limit_train_batches)


### PR DESCRIPTION
## What does this PR do?

Fixes #9771 

After speaking to @tchaton we decided to remove the scheduler responsibility from DeepSpeed, fully relying on Lightning to control when to call the lr scheduler step function. This also allows users to use epoch vs step calls which is not possible in DeepSpeed.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
