### PR TITLE
Add the option to introduce help format in arguments added by Trainer

### DIFF
--- a/pytorch_lightning/utilities/argparse.py
+++ b/pytorch_lightning/utilities/argparse.py
@@ -16,7 +16,7 @@ import os
 from abc import ABC
 from argparse import _ArgumentGroup, ArgumentParser, Namespace
 from contextlib import suppress
-from typing import Any, Callable, Dict, List, Tuple, Type, Union, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union
 
 import pytorch_lightning as pl
 from pytorch_lightning.utilities.parsing import str_to_bool, str_to_bool_or_int, str_to_bool_or_str
@@ -157,10 +157,10 @@ def _get_abbrev_qualified_cls_name(cls: Any) -> str:
 
 
 def add_argparse_args(
-    cls: Type["pl.Trainer"], 
-    parent_parser: ArgumentParser, 
-    *, 
-    use_argument_group: bool = True, 
+    cls: Type["pl.Trainer"],
+    parent_parser: ArgumentParser,
+    *,
+    use_argument_group: bool = True,
     default_help: Optional[Union[str, Dict[str, str]]] = None,
 ) -> Union[_ArgumentGroup, ArgumentParser]:
     r"""Extends existing argparse by default attributes for ``cls``.
@@ -267,9 +267,7 @@ def add_argparse_args(
         if arg == "precision":
             use_type = _precision_allowed_type
 
-        parser.add_argument(
-            f"--{arg}", dest=arg, default=arg_default, type=use_type, help=args_help(arg), **arg_kwargs
-        )
+        parser.add_argument(f"--{arg}", dest=arg, default=arg_default, type=use_type, help=args_help(arg), **arg_kwargs)
 
     if use_argument_group:
         return parent_parser


### PR DESCRIPTION
## What does this PR do?

Add the option to introduce custom help format when adding arguments with Trainer.add_argparse_args. It can be a string, in which case every argument will have that format, or a dict, in which case only the keys in the dict will be updated to the ones usually given.

Use examples:
```
from argparse import ArgumentParser

import pytorch_lightning as pl


def get_parser():
    parser = ArgumentParser()

    default_help = {'gpus': 'Insert how many gpus you want to use.'}

    return pl.Trainer.add_argparse_args(parser, default_help=default_help)
```
```
root@090da1b56ad3:/workspace# python local_settings.py --help
  [...]
  --devices DEVICES     Will be mapped to either `gpus`, `tpu_cores`, `num_processes` or `ipus`, based on the accelerator
                        type.
  --gpus GPUS           Insert how many gpus you want to use.
  --auto_select_gpus [AUTO_SELECT_GPUS]
                        If enabled and ``gpus`` is an integer, pick available gpus automatically. This is especially useful
                        when GPUs are configured to be in "exclusive mode", such that only one process at a time can access
                        them.
  [...]
```
```
from argparse import ArgumentParser

import pytorch_lightning as pl


def get_parser():
    parser = ArgumentParser()

    default_help = h = '%(type)s (default: %(default)s)'

    return pl.Trainer.add_argparse_args(parser, default_help=default_help)
```
```    
root@090da1b56ad3:/workspace# python local_settings.py --help
   [...]
  --devices DEVICES     str (default: None)
  --gpus GPUS           _gpus_allowed_type (default: None)
  --auto_select_gpus [AUTO_SELECT_GPUS]
                        str_to_bool (default: False)
  [...]
```