### PR TITLE
CombinedLoader example fix

### DIFF
--- a/docs/source/guides/data.rst
+++ b/docs/source/guides/data.rst
@@ -227,8 +227,8 @@ needs to wrap the DataLoaders with `CombinedLoader`.
 
 
     def val_dataloader(self):
-        loader_1 = DataLoader()
-        loader_2 = DataLoader()
+        loader_a = DataLoader()
+        loader_b = DataLoader()
         loaders = {"a": loader_a, "b": loader_b}
         combined_loaders = CombinedLoader(loaders, "max_size_cycle")
         return combined_loaders


### PR DESCRIPTION
## What does this PR do?
In the `CombinedLoader` example, the variables had inconsistent namings:

Created `loader_1`, but accessed `loader_a`, and so on.

### Does your PR introduce any breaking changes? If yes, please list them.
No