### PR TITLE
Fix killed conda 1.10 CI workflow

### DIFF
--- a/.github/workflows/ci_test-conda.yml
+++ b/.github/workflows/ci_test-conda.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: pytorchlightning/pytorch_lightning:base-conda-py${{ matrix.python-version }}-torch${{ matrix.pytorch-version }}
-      options: --shm-size=1G
+      options: --ipc=host
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What does this PR do?

We have conda 1.10 workflow crashing randomly: https://github.com/PyTorchLightning/pytorch-lightning/runs/3971666315?check_suite_focus=true

This is the error:


```bash
tests/helpers/test_models.py::test_models[None-ParityModuleRNN] PASSED   [ 31%]
/__w/_temp/2a0a0b32-902c-4e18-bf17-5c09efcb74cf.sh: line 2:    90 Killed                  coverage run --source pytorch_lightning -m pytest pytorch_lightning tests -v --durations=50 --junitxml=junit/test-results-Linux-torch1.10.xml
tests/helpers/test_models.py::test_models[None-ParityModuleMNIST] 
Error: Process completed with exit code 137.

```

RIP


```py
This is the list of slowest tests in the 1.10 workflow:
135.69s call     tests/helpers/test_models.py::test_models[None-ParityModuleMNIST]
2626
54.44s call     tests/utilities/test_auto_restart.py::test_fast_forward_sampler_with_distributed_sampler_and_iterative_dataset
2627
38.72s call     tests/callbacks/test_quantization.py::test_quantization[False-False-average]
2628
29.42s call     tests/deprecated_api/test_remove_1-7.py::test_v1_7_0_deprecate_add_get_queue
2629
29.23s call     tests/callbacks/test_quantization.py::test_quantization[False-True-average]
2630
28.83s call     tests/callbacks/test_quantization.py::test_quantization[True-True-average]
2631
28.43s call     tests/checkpointing/test_torch_saving.py::test_model_torch_save_ddp_cpu
2632
26.92s call     tests/callbacks/test_quantization.py::test_quantization[False-True-histogram]
2633
26.00s call     tests/callbacks/test_quantization.py::test_quantization[True-False-average]
2634
25.44s call     tests/checkpointing/test_model_checkpoint.py::test_model_checkpoint_no_extraneous_invocations
2635
24.25s call     tests/trainer/test_trainer.py::test_model_in_correct_mode_during_stages[ddp_cpu-2]
2636
23.94s call     tests/core/test_results.py::test_result_reduce_ddp
2637
23.87s call     tests/plugins/test_ddp_spawn_plugin.py::test_ddp_spawn_configure_ddp
2638
22.44s call     tests/trainer/test_trainer.py::test_error_handling_all_stages[ddp_spawn-2]
2639
20.90s call     tests/callbacks/test_quantization.py::test_quantization[True-False-histogram]
2640
20.70s call     tests/callbacks/test_quantization.py::test_quantization[True-True-histogram]135.69s call     tests/helpers/test_models.py::test_models[None-ParityModuleMNIST]
2626
54.44s call     tests/utilities/test_auto_restart.py::test_fast_forward_sampler_with_distributed_sampler_and_iterative_dataset
2627
38.72s call     tests/callbacks/test_quantization.py::test_quantization[False-False-average]
2628
29.42s call     tests/deprecated_api/test_remove_1-7.py::test_v1_7_0_deprecate_add_get_queue
2629
29.23s call     tests/callbacks/test_quantization.py::test_quantization[False-True-average]
2630
28.83s call     tests/callbacks/test_quantization.py::test_quantization[True-True-average]
2631
28.43s call     tests/checkpointing/test_torch_saving.py::test_model_torch_save_ddp_cpu
2632
26.92s call     tests/callbacks/test_quantization.py::test_quantization[False-True-histogram]
2633
26.00s call     tests/callbacks/test_quantization.py::test_quantization[True-False-average]
2634
25.44s call     tests/checkpointing/test_model_checkpoint.py::test_model_checkpoint_no_extraneous_invocations
2635
24.25s call     tests/trainer/test_trainer.py::test_model_in_correct_mode_during_stages[ddp_cpu-2]
2636
23.94s call     tests/core/test_results.py::test_result_reduce_ddp
2637
23.87s call     tests/plugins/test_ddp_spawn_plugin.py::test_ddp_spawn_configure_ddp
2638
22.44s call     tests/trainer/test_trainer.py::test_error_handling_all_stages[ddp_spawn-2]
2639
20.90s call     tests/callbacks/test_quantization.py::test_quantization[True-False-histogram]
2640
20.70s call     tests/callbacks/test_quantization.py::test_quantization[True-True-histogram]
compare that to 1.9:
64.49s call     tests/trainer/test_trainer.py::test_model_in_correct_mode_during_stages[ddp_cpu-2]
2626
41.89s call     tests/utilities/test_auto_restart.py::test_fast_forward_sampler_with_distributed_sampler_and_iterative_dataset
2627
32.96s call     tests/plugins/test_ddp_spawn_plugin.py::test_ddp_spawn_configure_ddp
2628
32.09s call     tests/plugins/test_ddp_spawn_plugin.py::test_ddp_cpu
2629
22.45s call     tests/profiler/test_profiler.py::test_simple_profiler_distributed_files
2630
21.72s call     tests/models/test_horovod.py::test_horovod_cpu_clip_grad_by_value
2631
19.48s call     tests/models/test_horovod.py::test_horovod_cpu
2632
19.20s call     tests/trainer/test_data_loading.py::test_dataloader_warnings[1]
2633
18.29s call     tests/trainer/test_trainer.py::test_error_handling_all_stages[ddp_spawn-2]
2634
17.85s call     tests/deprecated_api/test_remove_1-7.py::test_v1_7_0_deprecate_add_get_queue
2635
17.81s call     tests/plugins/test_ddp_spawn_plugin.py::test_ddp_spawn_add_get_queue
2636
14.95s call     tests/callbacks/test_pruning.py::test_pruning_callback_ddp_cpu
2637
13.21s call     tests/trainer/test_trainer.py::test_trainer_predict_ddp_cpu
2638
13.12s call     tests/callbacks/test_quantization.py::test_quantization[False-True-average]
2639
11.73s call     tests/models/test_horovod.py::test_horovod_cpu_implicit
2640
11.48s call     tests/trainer/test_trainer.py::test_fit_test_synchronization
2641
11.42s call     tests/callbacks/test_quantization.py::test_quantization[False-False-histogram]
2642
10.71s call     tests/helpers/test_models.py::test_models[None-ParityModuleMNIST]
2643
10.69s call     tests/callbacks/test_early_stopping.py::test_multiple_early_stopping_callbacks[callbacks2-3-False-ddp_cpu-2]
2644
10.02s call     tests/callbacks/test_quantization.py::test_quantization[True-True-histogram]
2645
10.01s call     tests/callbacks/test_quantization.py::test_quantization[True-False-average]
2646
9.80s call     tests/callbacks/test_early_stopping.py::test_multiple_early_stopping_callbacks[callbacks6-3-True-ddp_cpu-2]
2647
9.69s call     tests/callbacks/test_quantization.py::test_quantization[True-True-average]
2648
9.44s call     tests/callbacks/test_quantization.py::test_quantization[True-False-histogram]
2649
9.25s call     tests/callbacks/test_quantization.py::test_quantization[False-True-histogram]

Adrian
It's entirely possible this is a problem with our test suite. I am posting here in case someone has an idea how to attack this problem.
```

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃
