### PR TITLE
Allow separate config files for parameters with class type when LightningCLI is in subclass_mode=False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,6 +366,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Disable quantization aware training observers by default during validating/testing/predicting stages ([#8540](https://github.com/PyTorchLightning/pytorch-lightning/pull/8540))
 
 
+- Allow separate config files for parameters with class type when LightningCLI is in subclass_mode=False ([#10286](https://github.com/PyTorchLightning/pytorch-lightning/pull/10286))
+
+
 ### Deprecated
 
 - Deprecated trainer argument `terminate_on_nan` in favour of `detect_anomaly`([#9175](https://github.com/PyTorchLightning/pytorch-lightning/pull/9175))

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -155,7 +155,7 @@ class LightningArgumentParser(ArgumentParser):
             if subclass_mode:
                 return self.add_subclass_arguments(lightning_class, nested_key, fail_untyped=False, required=required)
             return self.add_class_arguments(
-                lightning_class, nested_key, fail_untyped=False, instantiate=not issubclass(lightning_class, Trainer)
+                lightning_class, nested_key, fail_untyped=False, instantiate=not issubclass(lightning_class, Trainer), sub_configs=True
             )
         raise MisconfigurationException(
             f"Cannot add arguments from: {lightning_class}. You should provide either a callable or a subclass of: "
@@ -184,7 +184,7 @@ class LightningArgumentParser(ArgumentParser):
             self.add_subclass_arguments(optimizer_class, nested_key, **kwargs)
             self.set_choices(nested_key, optimizer_class)
         else:
-            self.add_class_arguments(optimizer_class, nested_key, **kwargs)
+            self.add_class_arguments(optimizer_class, nested_key, sub_configs=True, **kwargs)
         self._optimizers[nested_key] = (optimizer_class, link_to)
 
     def add_lr_scheduler_args(
@@ -209,7 +209,7 @@ class LightningArgumentParser(ArgumentParser):
             self.add_subclass_arguments(lr_scheduler_class, nested_key, **kwargs)
             self.set_choices(nested_key, lr_scheduler_class)
         else:
-            self.add_class_arguments(lr_scheduler_class, nested_key, **kwargs)
+            self.add_class_arguments(lr_scheduler_class, nested_key, sub_configs=True, **kwargs)
         self._lr_schedulers[nested_key] = (lr_scheduler_class, link_to)
 
     def parse_args(self, *args: Any, **kwargs: Any) -> Dict[str, Any]:

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -155,7 +155,11 @@ class LightningArgumentParser(ArgumentParser):
             if subclass_mode:
                 return self.add_subclass_arguments(lightning_class, nested_key, fail_untyped=False, required=required)
             return self.add_class_arguments(
-                lightning_class, nested_key, fail_untyped=False, instantiate=not issubclass(lightning_class, Trainer), sub_configs=True
+                lightning_class,
+                nested_key,
+                fail_untyped=False,
+                instantiate=not issubclass(lightning_class, Trainer),
+                sub_configs=True,
             )
         raise MisconfigurationException(
             f"Cannot add arguments from: {lightning_class}. You should provide either a callable or a subclass of: "


### PR DESCRIPTION
## What does this PR do?

This enables the possibility of having separate config files for parameters whose type hint is a class when the `LightningCLI` is in `subclass_mode=False`. For `subclass_mode=True` this option is enabled by default so this change also makes it more consistent.

For example for a CLI like:

```python
from torchaudio.transforms import MelSpectrogram
from pytorch_lightning.utilities.cli import LightningCLI
import pytorch_lightning as pl

class PrxMelDataModule(pl.LightningDataModule):
    def __init__(self, mel_spec: MelSpectrogram):
        ...

class HifiGAN(pl.LightningModule):
    def __init__(self, mel_spec: MelSpectrogram):
        ...

if __name__ == "__main__":
    LightningCLI(
        model_class=HifiGAN,
        datamodule_class=PrxMelDataModule,
    )
```

it would be possible to have a config like:

```yaml
data:
  mel_spec: mel_spec_config.yml
model:
  mel_spec: mel_spec_config.yml
```

Fixes https://github.com/omni-us/jsonargparse/issues/95#issuecomment-944367550

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
