### PR TITLE
Fix yielding from iterator in LiteDataLoader

### DIFF
--- a/pytorch_lightning/lite/wrappers.py
+++ b/pytorch_lightning/lite/wrappers.py
@@ -174,9 +174,9 @@ class _LiteDataLoader:
         return self._device
 
     def __iter__(self) -> Union[Iterator[Any], Generator[Any, None, None]]:
-        dataloader_iter = iter(self._dataloader)
+        iterator = iter(self._dataloader)
         if self._device is None:
-            return dataloader_iter
+            yield from iterator
 
-        for item in dataloader_iter:
+        for item in iterator:
             yield move_data_to_device(item, self._device)

--- a/tests/lite/test_wrappers.py
+++ b/tests/lite/test_wrappers.py
@@ -61,7 +61,8 @@ def test_lite_module_forward_conversion(precision, input_type, expected_type):
 
 
 def test_lite_dataloader_iterator():
-    """Test that the iteration over a LiteDataLoader wraps the iterator of the underlying dataloader."""
+    """Test that the iteration over a LiteDataLoader wraps the iterator of the underlying dataloader
+    (no automatic device placement)."""
     dataloader = DataLoader(range(5), batch_size=2)
     dataloader2 = DataLoader(range(5), batch_size=2)
     lite_dataloader = _LiteDataLoader(dataloader2)

--- a/tests/lite/test_wrappers.py
+++ b/tests/lite/test_wrappers.py
@@ -64,8 +64,7 @@ def test_lite_dataloader_iterator():
     """Test that the iteration over a LiteDataLoader wraps the iterator of the underlying dataloader
     (no automatic device placement)."""
     dataloader = DataLoader(range(5), batch_size=2)
-    dataloader2 = DataLoader(range(5), batch_size=2)
-    lite_dataloader = _LiteDataLoader(dataloader2)
+    lite_dataloader = _LiteDataLoader(dataloader)
     assert len(lite_dataloader) == len(dataloader) == 3
 
     iterator = iter(dataloader)

--- a/tests/lite/test_wrappers.py
+++ b/tests/lite/test_wrappers.py
@@ -60,6 +60,27 @@ def test_lite_module_forward_conversion(precision, input_type, expected_type):
     assert out.dtype == torch.get_default_dtype()
 
 
+def test_lite_dataloader_iterator():
+    """Test that the iteration over a LiteDataLoader wraps the iterator of the underlying dataloader."""
+    dataloader = DataLoader(range(5), batch_size=2)
+    dataloader2 = DataLoader(range(5), batch_size=2)
+    lite_dataloader = _LiteDataLoader(dataloader2)
+    assert len(lite_dataloader) == len(dataloader) == 3
+
+    iterator = iter(dataloader)
+    lite_iterator = iter(lite_dataloader)
+
+    assert torch.equal(next(iterator), next(lite_iterator))
+    assert torch.equal(next(iterator), next(lite_iterator))
+    assert torch.equal(next(iterator), next(lite_iterator))
+
+    with pytest.raises(StopIteration):
+        next(iterator)
+
+    with pytest.raises(StopIteration):
+        next(lite_iterator)
+
+
 @pytest.mark.parametrize(
     "src_device, dest_device",
     [
@@ -83,17 +104,6 @@ def test_lite_dataloader_device_placement(src_device, dest_device):
 
     batch1 = next(iterator)
     assert torch.equal(batch1["data"], torch.tensor([2, 3], device=dest_device))
-
-    with pytest.raises(StopIteration):
-        batch1 = next(iterator)
-
-    lite_dataloader = _LiteDataLoader(dataloader=[sample0, sample1, sample2, sample3], device=dest_device)
-    iterator = iter(lite_dataloader)
-
-    batch0 = next(iterator)
-    assert batch0 == 0
-
-    assert len(lite_dataloader) == 4
 
 
 def test_lite_optimizer_wraps():


### PR DESCRIPTION
## What does this PR do?

Fixes an issue with yielding in the iterator if device=None (no automatic device placement). 
The test on master raises StopIteration on the first batch.



## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃

Part of #1 (it's a lie, this is just here to avoid noisy GitHub bot)
