### PR TITLE
Revert part of #10279

### DIFF
--- a/pytorch_lightning/lite/lite.py
+++ b/pytorch_lightning/lite/lite.py
@@ -239,9 +239,7 @@ class LightningLite(ABC):
             sampler = self._get_distributed_sampler(dataloader, **self._strategy.distributed_sampler_kwargs)
 
         # the dataloader needs to be re-instantiated because we want to update the input arguments (e.g., sampler)
-        dataloader_kwargs = TrainerDataLoadingMixin._get_dataloader_init_kwargs(dataloader, sampler)
-        dataloader_cls = type(dataloader)
-        dataloader = dataloader_cls(**dataloader_kwargs)
+        dataloader = TrainerDataLoadingMixin._update_dataloader(dataloader, sampler)
 
         # add worker_init_fn for correct seeding in worker processes
         TrainerDataLoadingMixin._auto_add_worker_init_fn(dataloader, self.global_rank)

--- a/pytorch_lightning/lite/lite.py
+++ b/pytorch_lightning/lite/lite.py
@@ -240,7 +240,8 @@ class LightningLite(ABC):
 
         # the dataloader needs to be re-instantiated because we want to update the input arguments (e.g., sampler)
         dataloader_kwargs = TrainerDataLoadingMixin._get_dataloader_init_kwargs(dataloader, sampler)
-        dataloader = type(dataloader)(**dataloader_kwargs)
+        dataloader_cls = type(dataloader)
+        dataloader = dataloader_cls(**dataloader_kwargs)
 
         # add worker_init_fn for correct seeding in worker processes
         TrainerDataLoadingMixin._auto_add_worker_init_fn(dataloader, self.global_rank)

--- a/tests/lite/test_lite.py
+++ b/tests/lite/test_lite.py
@@ -460,7 +460,9 @@ def test_replace_dataloader_init_method():
 
     with _replace_dataloader_init_method():
         dataloader = CustomDataLoader(extra_argument=1, dataset=range(1))
+        assert dataloader.extra_argument == 1
         dataloader = lite.setup_dataloaders(dataloader)
 
         dataloader = CustomDataLoader(1, range(1))
+        assert dataloader.extra_argument == 1
         dataloader = lite.setup_dataloaders(dataloader)

--- a/tests/lite/test_lite.py
+++ b/tests/lite/test_lite.py
@@ -24,7 +24,12 @@ from torch import nn
 from torch.utils.data import DataLoader, DistributedSampler, Sampler
 
 from pytorch_lightning.lite import LightningLite
-from pytorch_lightning.lite.wrappers import _LiteDataLoader, _LiteModule, _LiteOptimizer
+from pytorch_lightning.lite.wrappers import (
+    _LiteDataLoader,
+    _LiteModule,
+    _LiteOptimizer,
+    _replace_dataloader_init_method,
+)
 from pytorch_lightning.plugins import DeepSpeedPlugin, PrecisionPlugin, TrainingTypePlugin
 from pytorch_lightning.utilities import DistributedType
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
@@ -439,3 +444,23 @@ def test_deepspeed_multiple_models():
             assert self.is_global_zero == (self.local_rank == 0)
 
     Lite(strategy=DeepSpeedPlugin(stage=3, logging_batch_size_per_gpu=1), devices=2, accelerator="gpu").run()
+
+
+def test_replace_dataloader_init_method():
+    """Test that the context manager enables to save the parameters passed to the DataLoader __init__ method."""
+
+    class CustomDataLoader(DataLoader):
+        def __init__(self, extra_argument: int, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+    dataloader = CustomDataLoader(extra_argument=1, dataset=range(1))
+    lite = EmptyLite()
+    with pytest.raises(MisconfigurationException, match="extra_argument"):
+        dataloader = lite.setup_dataloaders(dataloader)
+
+    with _replace_dataloader_init_method():
+        dataloader = CustomDataLoader(extra_argument=1, dataset=range(1))
+        dataloader = lite.setup_dataloaders(dataloader)
+
+        dataloader = CustomDataLoader(1, range(1))
+        dataloader = lite.setup_dataloaders(dataloader)

--- a/tests/lite/test_lite.py
+++ b/tests/lite/test_lite.py
@@ -164,57 +164,6 @@ def test_setup_dataloaders_return_type():
     assert lite_dataloader1.dataset is dataset1
 
 
-def test_setup_custom_dataloaders():
-    """Test that the setup_dataloaders method returns the dataloaders wrapped as LiteDataLoader."""
-    lite = EmptyLite()
-
-    class CustomDataLoader(DataLoader):
-        def __init__(self, value: int = 2, *args, **kwargs):
-            self.value = value
-            super().__init__(range(value), *args, **kwargs)
-
-    dataloader = CustomDataLoader(2, batch_size=2)
-
-    # single dataloader
-    lite_dataloader = lite.setup_dataloaders(dataloader)
-    assert lite_dataloader._dataloader
-    assert lite_dataloader.value == 2
-    batch0 = next(iter(lite_dataloader))
-    assert torch.equal(batch0, torch.tensor([0, 1]))
-
-    class CustomDataLoader2(DataLoader):
-        def __init__(self, range, *args, **kwargs):
-            self.range = range
-            super().__init__(range, *args, **kwargs)
-
-    dataloader = CustomDataLoader2(range(2), batch_size=2)
-
-    # single dataloader
-    lite_dataloader = lite.setup_dataloaders(dataloader)
-    assert lite_dataloader._dataloader
-    batch0 = next(iter(lite_dataloader))
-    assert torch.equal(batch0, torch.tensor([0, 1]))
-
-    class CustomDataLoader(DataLoader):
-        def __init__(self, value: int, *args, **kwargs):
-            super().__init__(range(value), *args, **kwargs)
-
-    class LiteWithCustomDataLoader(LightningLite):
-        def run(self):
-            # This doesn't fail as the context manager would save all the arguments provided
-            # to the dataloaders.
-            dataloader = CustomDataLoader(2, batch_size=2)
-            self.setup_dataloaders(dataloader)
-
-    LiteWithCustomDataLoader().run()
-
-    with pytest.raises(
-        MisconfigurationException, match="Trying to inject `DistributedSampler` into the `CustomDataLoader` instance"
-    ):
-        dataloader = CustomDataLoader(2, batch_size=2)
-        lite_dataloader = lite.setup_dataloaders(dataloader)
-
-
 def test_setup_dataloaders_twice_fails():
     """Test that calling setup_dataloaders with a dataloader that is already wrapped fails."""
     lite = EmptyLite()


### PR DESCRIPTION
## What does this PR do?

We shouldn't support this, as this is a bug in the DataLoader implementation.

Adding arbitrary `**kwargs` to a custom DataLoader allows for duplicate arguments.
This is something that should be checked by the user.

The fix that this PR removes only works for the first argument and if the name is "dataset", but this would still break for any of the other duplications.

Instead, the author of the DataLoader should write something like:

```python
def __init__(self, value: int = 2, *args, **kwargs):
    if "dataset" in kwargs:
        dataset = kwargs["dataset"]
    else:
        dataset = range(value)
    super().__init__(dataset, *args, **kwargs)
```

Partly reverts #10279
Part of https://github.com/PyTorchLightning/pytorch-lightning/issues/10329

A follow-up PR will add a `MisconfigurationException` to help the user in these cases.

### Does your PR introduce any breaking changes? If yes, please list them.

This will no longer work for anybody already relying on this. Lite is experimental

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified