### PR TITLE
Fix pickling error with CSVLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed failure when `DataLoader(batch_size=None)` is passed ([#10345](https://github.com/PyTorchLightning/pytorch-lightning/issues/10345))
 
 
+- Fixed issue with pickling `CSVLogger` after a call to `CSVLogger.save` ([#10388](https://github.com/PyTorchLightning/pytorch-lightning/pull/10388))
+
 -
 
 

--- a/pytorch_lightning/loggers/csv_logs.py
+++ b/pytorch_lightning/loggers/csv_logs.py
@@ -95,9 +95,9 @@ class ExperimentWriter:
         metrics_keys = list(last_m.keys())
 
         with open(self.metrics_file_path, "w", newline="") as f:
-            self.writer = csv.DictWriter(f, fieldnames=metrics_keys)
-            self.writer.writeheader()
-            self.writer.writerows(self.metrics)
+            writer = csv.DictWriter(f, fieldnames=metrics_keys)
+            writer.writeheader()
+            writer.writerows(self.metrics)
 
 
 class CSVLogger(LightningLoggerBase):

--- a/tests/loggers/test_all.py
+++ b/tests/loggers/test_all.py
@@ -263,6 +263,10 @@ def _test_loggers_pickle(tmpdir, monkeypatch, logger_class):
     # the logger needs to remove it from the state before pickle
     _ = logger.experiment
 
+    # logger also has to avoid adding un-picklable attributes to self in .save
+    logger.log_metrics({"a": 1})
+    logger.save()
+
     # test pickling loggers
     pickle.dumps(logger)
 


### PR DESCRIPTION
## Fix pickling error with CSVLogger

Pickling CSVLogger will lead to an error if some metrics have been logged and `.save` has been called. This PR fixes that issue. 

```python
import pytorch_lightning as pl
import pickle

logger = pl.loggers.CSVLogger("test")

pickle.dumps(logger) # works fine

logger.log_metrics({"a": 1})
logger.save()

pickle.dumps(logger)  # crashes: TypeError: cannot pickle '_csv.writer' object

```

Fixes #10387

### Does your PR introduce any breaking changes? If yes, please list them.

No

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
