### PR TITLE
Do not autodetach extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed deprecated method `master_params` from PrecisionPlugin ([#10372](https://github.com/PyTorchLightning/pytorch-lightning/pull/10372))
 
 
-- Removed the automatic detachment of "extras" returned from `training_step`. For example, `return {'loss': ..., 'something': something.detach()}` will now be necessary if something has gradients which you do not want to store ([#10424](https://github.com/PyTorchLightning/pytorch-lightning/pull/10424))
+- Removed the automatic detachment of "extras" returned from `training_step`. For example, `return {'loss': ..., 'foo': foo.detach()}` will now be necessary if `foo` has gradients which you do not want to store ([#10424](https://github.com/PyTorchLightning/pytorch-lightning/pull/10424))
 
 
 - Removed deprecated passthrough methods and properties from `Accelerator` base class ([#10403](https://github.com/PyTorchLightning/pytorch-lightning/pull/10403))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed deprecated method `master_params` from PrecisionPlugin ([#10372](https://github.com/PyTorchLightning/pytorch-lightning/pull/10372))
 
 
+- Removed the automatic detachment of "extras" returned from `training_step`. For example, `return {'loss': ..., 'something': something.detach()}` will now be necessary if something has gradients which you do not want to store ([#10424](https://github.com/PyTorchLightning/pytorch-lightning/pull/10424))
+
+
 - Removed deprecated passthrough methods and properties from `Accelerator` base class ([#10403](https://github.com/PyTorchLightning/pytorch-lightning/pull/10403))
 
 

--- a/pytorch_lightning/loops/optimization/closure.py
+++ b/pytorch_lightning/loops/optimization/closure.py
@@ -15,10 +15,6 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, Generic, Optional, TypeVar
 
-from torch import Tensor
-
-from pytorch_lightning.utilities import rank_zero_deprecation
-from pytorch_lightning.utilities.apply_func import apply_to_collection
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 
 T = TypeVar("T")
@@ -26,22 +22,6 @@ T = TypeVar("T")
 
 @dataclass
 class OutputResult:
-    @staticmethod
-    def _check_extra_detach_deprecation(extra: Dict[str, Any]) -> Dict[str, Any]:
-        # TODO: remove with the deprecation removal in v1.6
-        # this is only here to avoid duplication
-        def check_fn(v: Tensor) -> Tensor:
-            if v.grad_fn is not None:
-                rank_zero_deprecation(
-                    f"One of the returned values {set(extra.keys())} has a `grad_fn`. We will detach it automatically"
-                    " but this behaviour will change in v1.6. Please detach it manually:"
-                    " `return {'loss': ..., 'something': something.detach()}`"
-                )
-                return v.detach()
-            return v
-
-        return apply_to_collection(extra, Tensor, check_fn)
-
     def asdict(self) -> Dict[str, Any]:
         raise NotImplementedError
 

--- a/pytorch_lightning/loops/optimization/manual_loop.py
+++ b/pytorch_lightning/loops/optimization/manual_loop.py
@@ -35,10 +35,6 @@ class ManualResult(OutputResult):
 
     extra: Dict[str, Any] = field(default_factory=dict)
 
-    def __post_init__(self) -> None:
-        # TODO: remove with the deprecation removal in v1.6
-        self.extra = self._check_extra_detach_deprecation(self.extra)
-
     @classmethod
     def from_training_step_output(cls, training_step_output: Optional[STEP_OUTPUT]) -> "ManualResult":
         extra = {}

--- a/pytorch_lightning/loops/optimization/optimizer_loop.py
+++ b/pytorch_lightning/loops/optimization/optimizer_loop.py
@@ -55,9 +55,6 @@ class ClosureResult(OutputResult):
     extra: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        # TODO: remove with the deprecation removal in v1.6
-        self.extra = self._check_extra_detach_deprecation(self.extra)
-
         self._clone_loss()
 
     def _clone_loss(self) -> None:

--- a/tests/deprecated_api/test_remove_1-6.py
+++ b/tests/deprecated_api/test_remove_1-6.py
@@ -114,19 +114,6 @@ def test_v1_6_0_early_stopping_monitor(tmpdir):
         EarlyStopping()
 
 
-def test_v1_6_0_extras_with_gradients(tmpdir):
-    class TestModel(BoringModel):
-        def training_step(self, *args):
-            loss = super().training_step(*args)["loss"]
-            return {"loss": loss, "foo": loss}
-
-    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=1)
-    model = TestModel()
-    match = r"\{'foo'\} has a `grad_fn`.*behaviour will change in v1\.6"
-    with pytest.deprecated_call(match=match):
-        trainer.fit(model)
-
-
 def test_v1_6_0_train_loop(tmpdir):
     trainer = Trainer()
     with pytest.deprecated_call(


### PR DESCRIPTION
## What does this PR do?

Part of #10312

Removes the automatic detachment of extras returned by `training_step`.

### Does your PR introduce any breaking changes? If yes, please list them.

Removes deprecated functionality. This is now up to the user.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified