### PR TITLE
Change attributes of `RichProgressBarTheme` dataclass

### DIFF
--- a/pytorch_lightning/callbacks/progress/rich_progress.py
+++ b/pytorch_lightning/callbacks/progress/rich_progress.py
@@ -169,7 +169,7 @@ class RichProgressBarTheme:
         description: Style for the progress bar description. For eg., Epoch x, Testing, etc.
         progress_bar: Style for the bar in progress.
         progress_bar_finished: Style for the finished progress bar.
-        progress_bar_pulse: Style for the progress bar when `IterableDataset` is being processed. 
+        progress_bar_pulse: Style for the progress bar when `IterableDataset` is being processed.
         batch_progress: Style for the progress tracker (i.e 10/50 batches completed).
         time: Style for the processed time and estimate time remaining.
         processing_speed: Style for the speed of the batches being processed.

--- a/pytorch_lightning/callbacks/progress/rich_progress.py
+++ b/pytorch_lightning/callbacks/progress/rich_progress.py
@@ -165,6 +165,15 @@ if _RICH_AVAILABLE:
 class RichProgressBarTheme:
     """Styles to associate to different base components.
 
+    Args:
+        text_color: Colour for progress bar titles.
+        progress_bar: Progress bar colour for progress made so far.
+        progress_bar_finished: Progress bar colour for when the task is completed.
+        progress_bar_pulse: Progress bar colour for when `IterableDataset` is being processed.
+        batch_progress: Colour of the text for the progress tracker (i.e 10/50 batches completed).
+        time: Colour for the time since the start of the task and the estimated time remaining.
+        processing_speed: Colour for the current speed of operations.
+
     https://rich.readthedocs.io/en/stable/style.html
     """
 

--- a/pytorch_lightning/callbacks/progress/rich_progress.py
+++ b/pytorch_lightning/callbacks/progress/rich_progress.py
@@ -129,11 +129,12 @@ if _RICH_AVAILABLE:
     class MetricsTextColumn(ProgressColumn):
         """A column containing text."""
 
-        def __init__(self, trainer):
+        def __init__(self, trainer, style):
             self._trainer = trainer
             self._tasks = {}
             self._current_task_id = 0
             self._metrics = {}
+            self._style = style
             super().__init__()
 
         def update(self, metrics):
@@ -158,7 +159,7 @@ if _RICH_AVAILABLE:
 
             for k, v in self._metrics.items():
                 _text += f"{k}: {round(v, 3) if isinstance(v, float) else v} "
-            return Text(_text, justify="left")
+            return Text(_text, justify="left", style=self._style)
 
 
 @dataclass
@@ -184,6 +185,7 @@ class RichProgressBarTheme:
     batch_progress: Union[str, Style] = "white"
     time: Union[str, Style] = "grey54"
     processing_speed: Union[str, Style] = "grey70"
+    metrics: Union[str, Style] = "white"
 
 
 class RichProgressBar(ProgressBarBase):
@@ -282,7 +284,7 @@ class RichProgressBar(ProgressBarBase):
             self._reset_progress_bar_ids()
             self._console: Console = Console()
             self._console.clear_live()
-            self._metric_component = MetricsTextColumn(trainer)
+            self._metric_component = MetricsTextColumn(trainer, self.theme.metrics)
             self.progress = CustomProgress(
                 *self.configure_columns(trainer),
                 self._metric_component,

--- a/pytorch_lightning/callbacks/progress/rich_progress.py
+++ b/pytorch_lightning/callbacks/progress/rich_progress.py
@@ -169,8 +169,8 @@ class RichProgressBarTheme:
     """
 
     text_color: str = "white"
-    progress_bar_completed_so_far: Union[str, Style] = "#6206E0"
-    progress_bar_on_completion: Union[str, Style] = "#6206E0"
+    progress_bar: Union[str, Style] = "#6206E0"
+    progress_bar_finished: Union[str, Style] = "#6206E0"
     progress_bar_pulse: Union[str, Style] = "#6206E0"
     batch_progress: str = "white"
     time: str = "grey54"
@@ -453,8 +453,8 @@ class RichProgressBar(ProgressBarBase):
         return [
             TextColumn("[progress.description]{task.description}"),
             CustomBarColumn(
-                complete_style=self.theme.progress_bar_completed_so_far,
-                finished_style=self.theme.progress_bar_on_completion,
+                complete_style=self.theme.progress_bar,
+                finished_style=self.theme.progress_bar_finished,
                 pulse_style=self.theme.progress_bar_pulse,
             ),
             BatchesProcessedColumn(style=self.theme.batch_progress),

--- a/pytorch_lightning/callbacks/progress/rich_progress.py
+++ b/pytorch_lightning/callbacks/progress/rich_progress.py
@@ -174,6 +174,7 @@ class RichProgressBarTheme:
         batch_progress: Style for the progress tracker (i.e 10/50 batches completed).
         time: Style for the processed time and estimate time remaining.
         processing_speed: Style for the speed of the batches being processed.
+        metrics: Style for the metrics
 
     https://rich.readthedocs.io/en/stable/style.html
     """

--- a/pytorch_lightning/callbacks/progress/rich_progress.py
+++ b/pytorch_lightning/callbacks/progress/rich_progress.py
@@ -166,13 +166,13 @@ class RichProgressBarTheme:
     """Styles to associate to different base components.
 
     Args:
-        text_color: Colour for progress bar titles.
-        progress_bar: Progress bar colour for progress made so far.
-        progress_bar_finished: Progress bar colour for when the task is completed.
-        progress_bar_pulse: Progress bar colour for when `IterableDataset` is being processed.
-        batch_progress: Colour of the text for the progress tracker (i.e 10/50 batches completed).
-        time: Colour for the time since the start of the task and the estimated time remaining.
-        processing_speed: Colour for the current speed of operations.
+        description: Style for the progress bar description. For eg., Epoch x, Testing, etc.
+        progress_bar: Style for the bar in progress.
+        progress_bar_finished: Style for the finished progress bar.
+        progress_bar_pulse: Style for the progress bar when `IterableDataset` is being processed. 
+        batch_progress: Style for the progress tracker (i.e 10/50 batches completed).
+        time: Style for the processed time and estimate time remaining.
+        processing_speed: Style for the speed of the batches being processed.
 
     https://rich.readthedocs.io/en/stable/style.html
     """

--- a/pytorch_lightning/callbacks/progress/rich_progress.py
+++ b/pytorch_lightning/callbacks/progress/rich_progress.py
@@ -177,14 +177,13 @@ class RichProgressBarTheme:
     https://rich.readthedocs.io/en/stable/style.html
     """
 
-    text_color: str = "white"
+    description: Union[str, Style] = "white"
     progress_bar: Union[str, Style] = "#6206E0"
     progress_bar_finished: Union[str, Style] = "#6206E0"
     progress_bar_pulse: Union[str, Style] = "#6206E0"
-    batch_progress: str = "white"
-    time: str = "grey54"
-    processing_speed: str = "grey70"
-
+    batch_progress: Union[str, Style] = "white"
+    time: Union[str, Style] = "grey54"
+    processing_speed: Union[str, Style] = "grey70"
 
 class RichProgressBar(ProgressBarBase):
     """Create a progress bar with `rich text formatting <https://github.com/willmcgugan/rich>`_.
@@ -365,7 +364,7 @@ class RichProgressBar(ProgressBarBase):
     def _add_task(self, total_batches: int, description: str, visible: bool = True) -> Optional[int]:
         if self.progress is not None:
             return self.progress.add_task(
-                f"[{self.theme.text_color}]{description}", total=total_batches, visible=visible
+                f"[{self.theme.description}]{description}", total=total_batches, visible=visible
             )
 
     def _update(self, progress_bar_id: int, visible: bool = True) -> None:

--- a/pytorch_lightning/callbacks/progress/rich_progress.py
+++ b/pytorch_lightning/callbacks/progress/rich_progress.py
@@ -169,10 +169,10 @@ class RichProgressBarTheme:
     """
 
     text_color: str = "white"
-    progress_bar_complete: Union[str, Style] = "#6206E0"
-    progress_bar_finished: Union[str, Style] = "#6206E0"
+    progress_bar_completed_so_far: Union[str, Style] = "#6206E0"
+    progress_bar_on_completion: Union[str, Style] = "#6206E0"
     progress_bar_pulse: Union[str, Style] = "#6206E0"
-    batch_process: str = "white"
+    batch_progress: str = "white"
     time: str = "grey54"
     processing_speed: str = "grey70"
 
@@ -453,11 +453,11 @@ class RichProgressBar(ProgressBarBase):
         return [
             TextColumn("[progress.description]{task.description}"),
             CustomBarColumn(
-                complete_style=self.theme.progress_bar_complete,
-                finished_style=self.theme.progress_bar_finished,
+                complete_style=self.theme.progress_bar_completed_so_far,
+                finished_style=self.theme.progress_bar_on_completion,
                 pulse_style=self.theme.progress_bar_pulse,
             ),
-            BatchesProcessedColumn(style=self.theme.batch_process),
+            BatchesProcessedColumn(style=self.theme.batch_progress),
             CustomTimeColumn(style=self.theme.time),
             ProcessingSpeedColumn(style=self.theme.processing_speed),
         ]

--- a/pytorch_lightning/callbacks/progress/rich_progress.py
+++ b/pytorch_lightning/callbacks/progress/rich_progress.py
@@ -185,6 +185,7 @@ class RichProgressBarTheme:
     time: Union[str, Style] = "grey54"
     processing_speed: Union[str, Style] = "grey70"
 
+
 class RichProgressBar(ProgressBarBase):
     """Create a progress bar with `rich text formatting <https://github.com/willmcgugan/rich>`_.
 

--- a/tests/callbacks/test_rich_progress_bar.py
+++ b/tests/callbacks/test_rich_progress_bar.py
@@ -106,8 +106,8 @@ def test_rich_progress_bar_custom_theme(tmpdir):
 
         assert progress_bar.theme == theme
         args, kwargs = mocks["CustomBarColumn"].call_args
-        assert kwargs["complete_style"] == theme.progress_bar_completed_so_far
-        assert kwargs["finished_style"] == theme.progress_bar_on_completion
+        assert kwargs["complete_style"] == theme.progress_bar
+        assert kwargs["finished_style"] == theme.progress_bar_finished
 
         args, kwargs = mocks["BatchesProcessedColumn"].call_args
         assert kwargs["style"] == theme.batch_progress

--- a/tests/callbacks/test_rich_progress_bar.py
+++ b/tests/callbacks/test_rich_progress_bar.py
@@ -106,11 +106,11 @@ def test_rich_progress_bar_custom_theme(tmpdir):
 
         assert progress_bar.theme == theme
         args, kwargs = mocks["CustomBarColumn"].call_args
-        assert kwargs["complete_style"] == theme.progress_bar_complete
-        assert kwargs["finished_style"] == theme.progress_bar_finished
+        assert kwargs["complete_style"] == theme.progress_bar_completed_so_far
+        assert kwargs["finished_style"] == theme.progress_bar_on_completion
 
         args, kwargs = mocks["BatchesProcessedColumn"].call_args
-        assert kwargs["style"] == theme.batch_process
+        assert kwargs["style"] == theme.batch_progress
 
         args, kwargs = mocks["CustomTimeColumn"].call_args
         assert kwargs["style"] == theme.time


### PR DESCRIPTION
Just some name changes to Rich Progress Bar Themes.

Closes #10435 

To visually test the params, I created the following theme:
```python
            theme=RichProgressBarTheme(
                text_color="bright_red",
                progress_bar_complete="bright_green",
                progress_bar_finished="bright_yellow",
                progress_bar_pulse="bright_blue",
                batch_process="bright_magenta",
                time="bright_cyan",
                processing_speed="bright_white",
            )

```
This is what I get:

<img width="851" alt="Screenshot 2021-11-10 at 2 33 12 PM" src="https://user-images.githubusercontent.com/40922068/141087602-0063f6e8-dfdc-436b-ac0b-536fc4fe227e.png">
<img width="616" alt="Screenshot 2021-11-10 at 2 32 22 PM" src="https://user-images.githubusercontent.com/40922068/141087597-e26f14bb-6fda-404b-8b1a-867fa1c511cb.png">


Considering this, I propose we change the params to the following:
* `progress_bar_complete` -> `progress_bar_completed_so_far`
* `progress_bar_finished` -> `progress_bar_on_completion`
* `batch_process` -> `batch_progress`

Also, I am a little confused about what `progress_bar_pulse` does. Could you guys help me out with this?