### PR TITLE
Support special test parametrizations

### DIFF
--- a/.azure-pipelines/gpu-tests.yml
+++ b/.azure-pipelines/gpu-tests.yml
@@ -62,56 +62,7 @@ jobs:
       displayName: 'Env details'
 
     - bash: |
-        wget https://pl-public-data.s3.amazonaws.com/legacy/checkpoints.zip -P legacy/
-        unzip -o legacy/checkpoints.zip -d legacy/
-        ls -l legacy/checkpoints/
-      displayName: 'Get legacy checkpoints'
-
-    - bash: |
-        python -m coverage run --source pytorch_lightning -m pytest pytorch_lightning tests -v --junitxml=$(Build.StagingDirectory)/test-results.xml --durations=50
-      displayName: 'Testing: standard'
-
-    - bash: |
         bash tests/special_tests.sh
       env:
         PL_USE_MOCKED_MNIST: "1"
       displayName: 'Testing: special'
-
-    - bash: |
-        python -m coverage report
-        python -m coverage xml
-        python -m coverage html
-        python -m codecov --token=$(CODECOV_TOKEN) --commit=$(Build.SourceVersion) --flags=gpu,pytest --name="GPU-coverage" --env=linux,azure
-        ls -l
-      displayName: 'Statistics'
-
-    - task: PublishTestResults@2
-      displayName: 'Publish test results'
-      inputs:
-        testResultsFiles: '$(Build.StagingDirectory)/test-results.xml'
-        testRunTitle: '$(Agent.OS) - $(Build.DefinitionName) - Python $(python.version)'
-      condition: succeededOrFailed()
-
-    # todo: re-enable after schema check pass, also atm it seems does not have any effect
-    #- task: PublishCodeCoverageResults@2
-    #  displayName: 'Publish coverage report'
-    #  inputs:
-    #    codeCoverageTool: 'Cobertura'
-    #    summaryFileLocation: 'coverage.xml'
-    #    reportDirectory: '$(Build.SourcesDirectory)/htmlcov'
-    #    testRunTitle: '$(Agent.OS) - $(Build.BuildNumber)[$(Agent.JobName)] - Python $(python.version)'
-    #  condition: succeededOrFailed()
-
-    - script: |
-        set -e
-        python -m pytest pl_examples -v --maxfail=2 --durations=0
-        bash pl_examples/run_examples.sh --trainer.gpus=1
-        bash pl_examples/run_examples.sh --trainer.gpus=2 --trainer.strategy=ddp
-        bash pl_examples/run_examples.sh --trainer.gpus=2 --trainer.strategy=ddp --trainer.precision=16
-      env:
-        PL_USE_MOCKED_MNIST: "1"
-      displayName: 'Testing: examples'
-
-    - bash: |
-        python -m pytest benchmarks -v --maxfail=2 --durations=0
-      displayName: 'Testing: benchmarks'

--- a/.azure-pipelines/gpu-tests.yml
+++ b/.azure-pipelines/gpu-tests.yml
@@ -62,7 +62,56 @@ jobs:
       displayName: 'Env details'
 
     - bash: |
+        wget https://pl-public-data.s3.amazonaws.com/legacy/checkpoints.zip -P legacy/
+        unzip -o legacy/checkpoints.zip -d legacy/
+        ls -l legacy/checkpoints/
+      displayName: 'Get legacy checkpoints'
+
+    - bash: |
+        python -m coverage run --source pytorch_lightning -m pytest pytorch_lightning tests -v --junitxml=$(Build.StagingDirectory)/test-results.xml --durations=50
+      displayName: 'Testing: standard'
+
+    - bash: |
         bash tests/special_tests.sh
       env:
         PL_USE_MOCKED_MNIST: "1"
       displayName: 'Testing: special'
+
+    - bash: |
+        python -m coverage report
+        python -m coverage xml
+        python -m coverage html
+        python -m codecov --token=$(CODECOV_TOKEN) --commit=$(Build.SourceVersion) --flags=gpu,pytest --name="GPU-coverage" --env=linux,azure
+        ls -l
+      displayName: 'Statistics'
+
+    - task: PublishTestResults@2
+      displayName: 'Publish test results'
+      inputs:
+        testResultsFiles: '$(Build.StagingDirectory)/test-results.xml'
+        testRunTitle: '$(Agent.OS) - $(Build.DefinitionName) - Python $(python.version)'
+      condition: succeededOrFailed()
+
+    # todo: re-enable after schema check pass, also atm it seems does not have any effect
+    #- task: PublishCodeCoverageResults@2
+    #  displayName: 'Publish coverage report'
+    #  inputs:
+    #    codeCoverageTool: 'Cobertura'
+    #    summaryFileLocation: 'coverage.xml'
+    #    reportDirectory: '$(Build.SourcesDirectory)/htmlcov'
+    #    testRunTitle: '$(Agent.OS) - $(Build.BuildNumber)[$(Agent.JobName)] - Python $(python.version)'
+    #  condition: succeededOrFailed()
+
+    - script: |
+        set -e
+        python -m pytest pl_examples -v --maxfail=2 --durations=0
+        bash pl_examples/run_examples.sh --trainer.gpus=1
+        bash pl_examples/run_examples.sh --trainer.gpus=2 --trainer.strategy=ddp
+        bash pl_examples/run_examples.sh --trainer.gpus=2 --trainer.strategy=ddp --trainer.precision=16
+      env:
+        PL_USE_MOCKED_MNIST: "1"
+      displayName: 'Testing: examples'
+
+    - bash: |
+        python -m pytest benchmarks -v --maxfail=2 --durations=0
+      displayName: 'Testing: benchmarks'

--- a/tests/accelerators/test_ddp.py
+++ b/tests/accelerators/test_ddp.py
@@ -109,16 +109,8 @@ def test_ddp_torch_dist_is_available_in_setup(mock_set_device, mock_is_available
 
 
 @RunIf(min_gpus=2, min_torch="1.8.1", special=True)
-def test_ddp_wrapper_16(tmpdir):
-    _test_ddp_wrapper(tmpdir, precision=16)
-
-
-@RunIf(min_gpus=2, min_torch="1.8.1", special=True)
-def test_ddp_wrapper_32(tmpdir):
-    _test_ddp_wrapper(tmpdir, precision=32)
-
-
-def _test_ddp_wrapper(tmpdir, precision):
+@pytest.mark.parametrize("precision", (16, 32))
+def test_ddp_wrapper(tmpdir, precision):
     """Test parameters to ignore are carried over for DDP."""
 
     class WeirdModule(torch.nn.Module):

--- a/tests/callbacks/test_pruning.py
+++ b/tests/callbacks/test_pruning.py
@@ -161,25 +161,16 @@ def test_pruning_callback(
 
 
 @RunIf(special=True, min_gpus=2)
-def test_pruning_callback_ddp_0(tmpdir):
+@pytest.mark.parametrize("parameters_to_prune", (False, True))
+@pytest.mark.parametrize("use_global_unstructured", (False, True))
+def test_pruning_callback_ddp(tmpdir, parameters_to_prune, use_global_unstructured):
     train_with_pruning_callback(
-        tmpdir, parameters_to_prune=False, use_global_unstructured=False, strategy="ddp", gpus=2
+        tmpdir,
+        parameters_to_prune=parameters_to_prune,
+        use_global_unstructured=use_global_unstructured,
+        strategy="ddp",
+        gpus=2,
     )
-
-
-@RunIf(special=True, min_gpus=2)
-def test_pruning_callback_ddp_1(tmpdir):
-    train_with_pruning_callback(tmpdir, parameters_to_prune=False, use_global_unstructured=True, strategy="ddp", gpus=2)
-
-
-@RunIf(special=True, min_gpus=2)
-def test_pruning_callback_ddp_2(tmpdir):
-    train_with_pruning_callback(tmpdir, parameters_to_prune=True, use_global_unstructured=False, strategy="ddp", gpus=2)
-
-
-@RunIf(special=True, min_gpus=2)
-def test_pruning_callback_ddp_3(tmpdir):
-    train_with_pruning_callback(tmpdir, parameters_to_prune=True, use_global_unstructured=True, strategy="ddp", gpus=2)
 
 
 @RunIf(min_gpus=2, skip_windows=True)

--- a/tests/callbacks/test_tqdm_progress_bar.py
+++ b/tests/callbacks/test_tqdm_progress_bar.py
@@ -513,20 +513,11 @@ def test_tqdm_progress_bar_can_be_pickled():
 
 
 @RunIf(min_gpus=2, special=True)
-def test_tqdm_progress_bar_max_val_check_interval_0(tmpdir):
-    _test_progress_bar_max_val_check_interval(
-        tmpdir, total_train_samples=8, train_batch_size=4, total_val_samples=2, val_batch_size=1, val_check_interval=0.2
-    )
-
-
-@RunIf(min_gpus=2, special=True)
-def test_tqdm_progress_bar_max_val_check_interval_1(tmpdir):
-    _test_progress_bar_max_val_check_interval(
-        tmpdir, total_train_samples=8, train_batch_size=4, total_val_samples=2, val_batch_size=1, val_check_interval=0.5
-    )
-
-
-def _test_progress_bar_max_val_check_interval(
+@pytest.mark.parametrize(
+    ["total_train_samples", "train_batch_size", "total_val_samples", "val_batch_size", "val_check_interval"],
+    [(8, 4, 2, 1, 0.2), (8, 4, 2, 1, 0.5)],
+)
+def test_progress_bar_max_val_check_interval(
     tmpdir, total_train_samples, train_batch_size, total_val_samples, val_batch_size, val_check_interval
 ):
     world_size = 2

--- a/tests/checkpointing/test_checkpoint_callback_frequency.py
+++ b/tests/checkpointing/test_checkpoint_callback_frequency.py
@@ -88,17 +88,8 @@ def test_top_k(save_mock, tmpdir, k: int, epochs: int, val_check_interval: float
 
 @mock.patch("torch.save")
 @RunIf(special=True, min_gpus=2)
-def test_top_k_ddp_0(save_mock, tmpdir):
-    _top_k_ddp(save_mock, tmpdir, k=1, epochs=1, val_check_interval=1.0, expected=1)
-
-
-@mock.patch("torch.save")
-@RunIf(special=True, min_gpus=2)
-def test_top_k_ddp_1(save_mock, tmpdir):
-    _top_k_ddp(save_mock, tmpdir, k=2, epochs=2, val_check_interval=0.3, expected=4)
-
-
-def _top_k_ddp(save_mock, tmpdir, k, epochs, val_check_interval, expected):
+@pytest.mark.parametrize(["k", "epochs", "val_check_interval", "expected"], [(1, 1, 1.0, 1), (2, 2, 0.3, 4)])
+def test_top_k_ddp(save_mock, tmpdir, k, epochs, val_check_interval, expected):
     class TestModel(BoringModel):
         def training_step(self, batch, batch_idx):
             local_rank = int(os.getenv("LOCAL_RANK"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -154,3 +154,16 @@ def single_process_pg():
         torch.distributed.destroy_process_group()
         os.environ.clear()
         os.environ.update(orig_environ)
+
+
+def pytest_collection_modifyitems(items):
+    if os.getenv("PL_RUNNING_SPECIAL_TESTS", "0") != "1":
+        return
+    # filter out non-special tests
+    items[:] = [
+        item
+        for item in items
+        for marker in item.own_markers
+        # has `@RunIf(special=True)`
+        if marker.name == "skipif" and marker.kwargs.get("special")
+    ]

--- a/tests/helpers/runif.py
+++ b/tests/helpers/runif.py
@@ -150,6 +150,8 @@ class RunIf:
             env_flag = os.getenv("PL_RUNNING_SPECIAL_TESTS", "0")
             conditions.append(env_flag != "1")
             reasons.append("Special execution")
+            # used in tests/conftest.py::pytest_collection_modifyitems
+            kwargs["special"] = True
 
         if fairscale:
             conditions.append(not _FAIRSCALE_AVAILABLE)

--- a/tests/models/test_hooks.py
+++ b/tests/models/test_hooks.py
@@ -423,16 +423,10 @@ class HookedModel(BoringModel):
 
 
 @RunIf(deepspeed=True, min_gpus=1, special=True)
-def test_trainer_model_hook_system_fit_deepspeed_automatic_optimization(tmpdir):
+@pytest.mark.parametrize("automatic_optimization", (True, False))
+def test_trainer_model_hook_system_fit_deepspeed(tmpdir, automatic_optimization):
     _run_trainer_model_hook_system_fit(
-        dict(gpus=1, precision=16, strategy="deepspeed"), tmpdir, automatic_optimization=True
-    )
-
-
-@RunIf(deepspeed=True, min_gpus=1, special=True)
-def test_trainer_model_hook_system_fit_deepspeed_manual_optimization(tmpdir):
-    _run_trainer_model_hook_system_fit(
-        dict(gpus=1, precision=16, strategy="deepspeed"), tmpdir, automatic_optimization=False
+        dict(gpus=1, precision=16, strategy="deepspeed"), tmpdir, automatic_optimization=automatic_optimization
     )
 
 

--- a/tests/special_tests.sh
+++ b/tests/special_tests.sh
@@ -57,7 +57,7 @@ for i in "${!parametrizations_arr[@]}"; do
 
   # run the test
   echo "Running ${parametrization}"
-  #pytest ${defaults} "${parametrization}"
+  python ${defaults} "${parametrization}"
 
   report+="Ran\t$parametrization\n"
 done

--- a/tests/special_tests.sh
+++ b/tests/special_tests.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -ex
+set -e
 
 # this environment variable allows special tests to run
 export PL_RUNNING_SPECIAL_TESTS=1

--- a/tests/special_tests.sh
+++ b/tests/special_tests.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -e
+set -ex
 
 # this environment variable allows special tests to run
 export PL_RUNNING_SPECIAL_TESTS=1

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1469,7 +1469,7 @@ def test_trainer_predict_1_gpu(tmpdir):
     predict(tmpdir, accelerator="gpu", devices=1)
 
 
-@RunIf(skip_windows=True, skip_49370=True)
+@RunIf(skip_windows=True)
 def test_trainer_predict_ddp_spawn(tmpdir):
     predict(tmpdir, strategy="ddp_spawn", accelerator="auto", devices=2)
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1465,6 +1465,7 @@ def test_trainer_predict_special(tmpdir, kwargs):
     predict(tmpdir, accelerator="gpu", **kwargs)
 
 
+@RunIf(min_gpus=1)
 def test_trainer_predict_1_gpu(tmpdir):
     predict(tmpdir, accelerator="gpu", devices=1)
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1465,12 +1465,12 @@ def test_trainer_predict_special(tmpdir, kwargs):
     predict(tmpdir, accelerator="gpu", **kwargs)
 
 
-def test_trainer_predict_single_gpu(tmpdir):
+def test_trainer_predict_1_gpu(tmpdir):
     predict(tmpdir, accelerator="gpu", devices=1)
 
 
-@RunIf(skip_windows=True)
-def test_trainer_predict_ddp_cpu(tmpdir):
+@RunIf(skip_windows=True, skip_49370=True)
+def test_trainer_predict_ddp_spawn(tmpdir):
     predict(tmpdir, strategy="ddp_spawn", accelerator="auto", devices=2)
 
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1453,24 +1453,18 @@ def test_trainer_predict_cpu(tmpdir, datamodule, enable_progress_bar):
 
 
 @RunIf(min_gpus=2, special=True)
-@pytest.mark.parametrize("num_gpus", [1, 2])
-def test_trainer_predict_dp(tmpdir, num_gpus):
-    predict(tmpdir, strategy="dp", accelerator="gpu", devices=num_gpus)
-
-
-@RunIf(min_gpus=2, special=True, fairscale=True)
-def test_trainer_predict_ddp(tmpdir):
-    predict(tmpdir, strategy="ddp", accelerator="gpu", devices=2)
-
-
-@RunIf(min_gpus=2, skip_windows=True, special=True)
-def test_trainer_predict_ddp_spawn(tmpdir):
-    predict(tmpdir, strategy="dp", accelerator="gpu", devices=2)
-
-
-@RunIf(min_gpus=1, special=True)
-def test_trainer_predict_1_gpu(tmpdir):
-    predict(tmpdir, accelerator="gpu", devices=1)
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"strategy": "dp", "devices": 1},
+        {"strategy": "dp", "devices": 2},
+        {"strategy": "ddp", "devices": 2},
+        {"strategy": "ddp_spawn", "devices": 2},
+        {"devices": 1},
+    ],
+)
+def test_trainer_predict_special(tmpdir, kwargs):
+    predict(tmpdir, accelerator="gpu", **kwargs)
 
 
 @RunIf(skip_windows=True)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1459,17 +1459,19 @@ def test_trainer_predict_cpu(tmpdir, datamodule, enable_progress_bar):
         {"strategy": "dp", "devices": 1},
         {"strategy": "dp", "devices": 2},
         {"strategy": "ddp", "devices": 2},
-        {"strategy": "ddp_spawn", "devices": 2},
-        {"devices": 1},
     ],
 )
 def test_trainer_predict_special(tmpdir, kwargs):
     predict(tmpdir, accelerator="gpu", **kwargs)
 
 
+def test_trainer_predict_single_gpu(tmpdir):
+    predict(tmpdir, accelerator="gpu", devices=1)
+
+
 @RunIf(skip_windows=True)
 def test_trainer_predict_ddp_cpu(tmpdir):
-    predict(tmpdir, strategy="ddp_spawn", accelerator="cpu", devices=2)
+    predict(tmpdir, strategy="ddp_spawn", accelerator="auto", devices=2)
 
 
 @pytest.mark.parametrize("dataset_cls", [RandomDataset, RandomIterableDatasetWithLen, RandomIterableDataset])


### PR DESCRIPTION
## What does this PR do?

Second attempt after #10462

I have rolled back some of the parameterizations. If you know of any others, feel free to push a change to this PR.

The current list of tests is:

<details>

```console
================================================================================
Ran	tests/accelerators/test_accelerator_connector.py::test_accelerator_choice_ddp_cpu_and_strategy
Ran	tests/accelerators/test_ddp.py::test_ddp_wrapper[16]
Ran	tests/accelerators/test_ddp.py::test_ddp_wrapper[32]
Ran	tests/accelerators/test_multi_nodes_gpu.py::test_logging_sync_dist_true_ddp
Ran	tests/accelerators/test_multi_nodes_gpu.py::test__validation_step__log
Ran	tests/callbacks/test_pruning.py::test_pruning_callback_ddp[False-False]
Ran	tests/callbacks/test_pruning.py::test_pruning_callback_ddp[False-True]
Ran	tests/callbacks/test_pruning.py::test_pruning_callback_ddp[True-False]
Ran	tests/callbacks/test_pruning.py::test_pruning_callback_ddp[True-True]
Ran	tests/callbacks/test_stochastic_weight_avg.py::test_swa_callback_ddp
Ran	tests/callbacks/test_tqdm_progress_bar.py::test_progress_bar_max_val_check_interval[8-4-2-1-0.2]
Ran	tests/callbacks/test_tqdm_progress_bar.py::test_progress_bar_max_val_check_interval[8-4-2-1-0.5]
Ran	tests/checkpointing/test_checkpoint_callback_frequency.py::test_top_k_ddp[1-1-1.0-1]
Ran	tests/checkpointing/test_checkpoint_callback_frequency.py::test_top_k_ddp[2-2-0.3-4]
Ran	tests/core/test_metric_result_integration.py::test_result_collection_reload_2_gpus
Ran	tests/lite/test_lite.py::test_deepspeed_multiple_models
Ran	tests/lite/test_parity.py::test_boring_lite_model_ddp[32-ddp-2-gpu]
Ran	tests/models/test_hooks.py::test_transfer_batch_hook_ddp
Ran	tests/models/test_hooks.py::test_trainer_model_hook_system_fit_deepspeed[True]
Ran	tests/models/test_hooks.py::test_trainer_model_hook_system_fit_deepspeed[False]
Ran	tests/models/test_sync_batchnorm.py::test_sync_batchnorm_ddp
Ran	tests/plugins/test_amp_plugins.py::test_amp_apex_ddp_fit[O2]
Ran	tests/plugins/test_ddp_fully_sharded_with_full_state_dict.py::test_fully_sharded_plugin_checkpoint
Ran	tests/plugins/test_ddp_fully_sharded_with_full_state_dict.py::test_fully_sharded_plugin_checkpoint_multi_gpus
Ran	tests/plugins/test_ddp_fully_sharded_with_full_state_dict.py::test_fsdp_gradient_clipping_raises
Ran	tests/plugins/test_ddp_plugin.py::test_ddp_with_2_gpus
Ran	tests/plugins/test_ddp_plugin.py::test_ddp_barrier_non_consecutive_device_ids
Ran	tests/plugins/test_ddp_plugin_with_comm_hook.py::test_ddp_fp16_compress_comm_hook
Ran	tests/plugins/test_ddp_plugin_with_comm_hook.py::test_ddp_sgd_comm_hook
Ran	tests/plugins/test_ddp_plugin_with_comm_hook.py::test_ddp_fp16_compress_wrap_sgd_comm_hook
Ran	tests/plugins/test_ddp_plugin_with_comm_hook.py::test_ddp_spawn_fp16_compress_comm_hook
Ran	tests/plugins/test_ddp_plugin_with_comm_hook.py::test_ddp_post_local_sgd_comm_hook
Ran	tests/plugins/test_deepspeed_plugin.py::test_warn_deepspeed_ignored
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_run_configure_optimizers
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_config
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_custom_precision_params
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_multigpu
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_fp32_works
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_stage_3_save_warning
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_multigpu_single_file
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_multigpu_stage_3
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_multigpu_stage_3_manual_optimization
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_multigpu_stage_3_checkpointing
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_multigpu_stage_3_warns_resume_training
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_multigpu_stage_3_resume_training
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_multigpu_stage_3_checkpointing_full_weights_manual
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_multigpu_stage_2_accumulated_grad_batches
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_multigpu_stage_2_accumulated_grad_batches_offload_optimizer
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_multigpu_test
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_multigpu_partial_partition_parameters
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_multigpu_test_rnn
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_multigpu_no_schedulers
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_skip_backward_raises
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_setup_train_dataloader
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_scheduler_step_count
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_scheduler_step_count_epoch
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_configure_gradient_clipping
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_gradient_clip_by_value
Ran	tests/plugins/test_deepspeed_plugin.py::test_different_accumulate_grad_batches_fails
Ran	tests/plugins/test_deepspeed_plugin.py::test_specific_gpu_device_id
Ran	tests/plugins/test_deepspeed_plugin.py::test_deepspeed_with_meta_device
Ran	tests/plugins/test_sharded_plugin.py::test_ddp_sharded_plugin_test_multigpu[trainer_kwargs0]
Ran	tests/plugins/test_sharded_plugin.py::test_ddp_sharded_plugin_test_multigpu[trainer_kwargs1]
Ran	tests/plugins/test_sharded_plugin.py::test_ddp_sharded_plugin_manual_optimization_spawn
Ran	tests/plugins/test_sharded_plugin.py::test_ddp_sharded_plugin_manual_optimization
Ran	tests/profiler/test_profiler.py::test_pytorch_profiler_trainer_ddp
Ran	tests/profiler/test_profiler.py::test_pytorch_profiler_trainer_fit[ManualOptimBoringModel-1]
Ran	tests/profiler/test_profiler.py::test_pytorch_profiler_trainer_fit[ManualOptimBoringModel-2]
Ran	tests/profiler/test_profiler.py::test_pytorch_profiler_trainer_fit[ManualOptimBoringModel-3]
Ran	tests/profiler/test_profiler.py::test_pytorch_profiler_trainer_fit[ManualOptimBoringModel-4]
Ran	tests/profiler/test_profiler.py::test_pytorch_profiler_trainer_fit[ManualOptimBoringModel-5]
Ran	tests/profiler/test_profiler.py::test_pytorch_profiler_trainer_fit[BoringModel-1]
Ran	tests/profiler/test_profiler.py::test_pytorch_profiler_trainer_fit[BoringModel-2]
Ran	tests/profiler/test_profiler.py::test_pytorch_profiler_trainer_fit[BoringModel-3]
Ran	tests/profiler/test_profiler.py::test_pytorch_profiler_trainer_fit[BoringModel-4]
Ran	tests/profiler/test_profiler.py::test_pytorch_profiler_trainer_fit[BoringModel-5]
Skipped	tests/profiler/test_profiler.py::test_pytorch_profiler_nested_emit_nvtx
Ran	tests/trainer/logging_/test_train_loop_logging.py::test_logging_sync_dist_true_ddp
Ran	tests/trainer/optimization/test_manual_optimization.py::test_step_with_optimizer_closure_with_different_frequencies_ddp
Ran	tests/trainer/optimization/test_manual_optimization.py::test_step_with_optimizer_closure_with_different_frequencies_ddp_with_toggle_model
Ran	tests/trainer/optimization/test_optimizers.py::test_optimizer_state_on_device
Ran	tests/trainer/test_trainer.py::test_trainer_predict_special[kwargs0]
Ran	tests/trainer/test_trainer.py::test_trainer_predict_special[kwargs1]
Ran	tests/trainer/test_trainer.py::test_trainer_predict_special[kwargs2]
Ran	tests/trainer/test_trainer.py::test_ddp_terminate_when_deadlock_is_detected
Ran	tests/utilities/test_all_gather_grad.py::test_all_gather_collection
Ran	tests/utilities/test_all_gather_grad.py::test_all_gather_sync_grads
Ran	tests/utilities/test_deepspeed_collate_checkpoint.py::test_deepspeed_collate_checkpoint
Ran	tests/utilities/test_meta.py::test_init_meta_context
Ran	tests/utilities/test_warnings.py
Ran	manual ddp launch test
================================================================================
```

</details>

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [n/a] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @carmocca @akihironitta @borda