### PR TITLE
Fix `caplog` with `logger.propagate=False`

### DIFF
--- a/pytorch_lightning/__init__.py
+++ b/pytorch_lightning/__init__.py
@@ -1,7 +1,6 @@
 """Root package info."""
 
 import logging
-import os
 
 from pytorch_lightning.__about__ import *  # noqa: F401, F403
 
@@ -13,9 +12,6 @@ _logger.setLevel(logging.INFO)
 if not _root_logger.hasHandlers():
     _logger.addHandler(logging.StreamHandler())
     _logger.propagate = False
-
-_PACKAGE_ROOT = os.path.dirname(__file__)
-_PROJECT_ROOT = os.path.dirname(_PACKAGE_ROOT)
 
 from pytorch_lightning.callbacks import Callback  # noqa: E402
 from pytorch_lightning.core import LightningDataModule, LightningModule  # noqa: E402

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,7 +99,7 @@ def reset_deterministic_algorithm():
         torch.set_deterministic(False)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def caplog(caplog):
     """Workaround for https://github.com/pytest-dev/pytest/issues/3697.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,21 @@ def reset_deterministic_algorithm():
         torch.set_deterministic(False)
 
 
+@pytest.yield_fixture
+def caplog(caplog):
+    """Workaround for https://github.com/pytest-dev/pytest/issues/3697.
+
+    Setting ``filterwarnings`` with pytest breaks ``caplog`` when ``not logger.propagate``.
+    """
+    import logging
+
+    lightning_logger = logging.getLogger("pytorch_lightning")
+    propagate = lightning_logger.propagate
+    lightning_logger.propagate = True
+    yield caplog
+    lightning_logger.propagate = propagate
+
+
 @pytest.fixture
 def tmpdir_server(tmpdir):
     if sys.version_info >= (3, 7):


### PR DESCRIPTION
## What does this PR do?

Part of https://github.com/PyTorchLightning/pytorch-lightning/pull/9940

- Add a workaround for an issue with pytest's `filterwarnings` and `caplog` when the logger is not configured to propagate (our case).
- Add test for the logging output to avoid potential regressions.

This is not a bugfix as this was not broken.

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [n/a] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified
