### PR TITLE
Use single quotes in action job

### DIFF
--- a/.github/workflows/probot-auto-cc.yml
+++ b/.github/workflows/probot-auto-cc.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   auto-cc:
     runs-on: ubuntu-latest
-    if: github.event_name == "issue" || github.event.pull_request.draft == false
+    if: github.event_name == 'issue' || github.event.pull_request.draft == false
     steps:
       - uses: carmocca/probot@v1
         env:


### PR DESCRIPTION
## What does this PR do?

My bad, https://github.com/PyTorchLightning/pytorch-lightning/pull/10544 broke the cc-bot.

Seems like GitHub actions require single quotes. Tested on my fork.

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [n/a] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [n/a] Did you list all the **breaking changes** introduced by this pull request?
- [n/a] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @carmocca @akihironitta @borda