### PR TITLE
Control automatic resubmission on SLURM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
--
+- Added a flag `SLURMEnvironment(auto_requeue=True|False)` to control whether Lightning handles the requeuing ([#10601](https://github.com/PyTorchLightning/pytorch-lightning/issues/10601))
 
 
 -

--- a/docs/source/clouds/cluster.rst
+++ b/docs/source/clouds/cluster.rst
@@ -210,6 +210,14 @@ To get this behavior make sure to add the correct signal to your SLURM script
     # 90 seconds before training ends
     SBATCH --signal=SIGUSR1@90
 
+If auto-resubmit is not desired, it can be turned off in the :class:`~pytorch_lightning.plugins.environments.slurm_environment.SLURMEnvironment` plugin:
+
+.. code-block:: python
+
+    from pytorch_lightning.plugins import SLURMEnvironment
+
+    trainer = Trainer(plugins=[SLURMEnvironment(auto_requeue=False)])
+
 
 Building SLURM scripts
 ----------------------

--- a/pytorch_lightning/plugins/environments/cluster_environment.py
+++ b/pytorch_lightning/plugins/environments/cluster_environment.py
@@ -23,7 +23,7 @@ class ClusterEnvironment(ABC):
     def __new__(cls, *args: Any, **kwargs: Any) -> "ClusterEnvironment":
         # TODO: remove in 1.7
         _check_for_deprecated_methods(cls)
-        return super().__new__(cls, *args, **kwargs)
+        return super().__new__(cls)
 
     @property
     @abstractmethod

--- a/pytorch_lightning/plugins/environments/slurm_environment.py
+++ b/pytorch_lightning/plugins/environments/slurm_environment.py
@@ -29,7 +29,7 @@ class SLURMEnvironment(ClusterEnvironment):
             rescheduled gets determined by the owner of this plugin.
     """
 
-    def __init__(self, auto_requeue: bool = True):
+    def __init__(self, auto_requeue: bool = True) -> None:
         super().__init__()
         self.auto_requeue = auto_requeue
 

--- a/pytorch_lightning/plugins/environments/slurm_environment.py
+++ b/pytorch_lightning/plugins/environments/slurm_environment.py
@@ -22,7 +22,16 @@ log = logging.getLogger(__name__)
 
 
 class SLURMEnvironment(ClusterEnvironment):
-    """Cluster environment for training on a cluster managed by SLURM."""
+    """Cluster environment for training on a cluster managed by SLURM.
+
+    Args:
+        auto_requeue: Whether automatic job resubmission is enabled or not. How and under which conditions a job gets
+            rescheduled gets determined by the owner of this plugin.
+    """
+
+    def __init__(self, auto_requeue: bool = True):
+        super().__init__()
+        self.auto_requeue = auto_requeue
 
     @property
     def creates_processes_externally(self) -> bool:

--- a/pytorch_lightning/trainer/connectors/signal_connector.py
+++ b/pytorch_lightning/trainer/connectors/signal_connector.py
@@ -8,6 +8,7 @@ from types import FrameType, FunctionType
 from typing import Callable, List, Union
 
 import pytorch_lightning as pl
+from pytorch_lightning.plugins.environments import SLURMEnvironment
 from pytorch_lightning.utilities.imports import _fault_tolerant_training
 
 log = logging.getLogger(__name__)
@@ -36,8 +37,9 @@ class SignalConnector:
         if _fault_tolerant_training():
             sigusr1_handlers.append(self.fault_tolerant_sigusr1_handler_fn)
 
-        if self._is_on_slurm():
-            log.info("Set SLURM handle signals.")
+        environment = self.trainer.accelerator_connector.cluster_environment
+        if isinstance(environment, SLURMEnvironment) and environment.auto_requeue:
+            log.info("SLURM auto-requeueing enabled. Setting signal handlers.")
             sigusr1_handlers.append(self.slurm_sigusr1_handler_fn)
             sigterm_handlers.append(self.sigterm_handler_fn)
 
@@ -85,19 +87,6 @@ class SignalConnector:
 
     def sigterm_handler_fn(self, signum: Signals, frame: FrameType) -> None:
         log.info("bypassing sigterm")
-
-    def _is_on_slurm(self) -> bool:
-        # see if we're using slurm (not interactive)
-        on_slurm = False
-        try:
-            job_name = os.environ["SLURM_JOB_NAME"]
-            if job_name != "bash":
-                on_slurm = True
-        # todo: specify the possible exception
-        except Exception:
-            pass
-
-        return on_slurm
 
     def _is_on_windows(self) -> bool:
         return sys.platform == "win32"

--- a/pytorch_lightning/trainer/connectors/signal_connector.py
+++ b/pytorch_lightning/trainer/connectors/signal_connector.py
@@ -37,7 +37,7 @@ class SignalConnector:
         if _fault_tolerant_training():
             sigusr1_handlers.append(self.fault_tolerant_sigusr1_handler_fn)
 
-        environment = self.trainer.accelerator_connector.cluster_environment
+        environment = self.trainer._accelerator_connector.cluster_environment
         if isinstance(environment, SLURMEnvironment) and environment.auto_requeue:
             log.info("SLURM auto-requeueing enabled. Setting signal handlers.")
             sigusr1_handlers.append(self.slurm_sigusr1_handler_fn)

--- a/pytorch_lightning/trainer/connectors/signal_connector.py
+++ b/pytorch_lightning/trainer/connectors/signal_connector.py
@@ -45,10 +45,10 @@ class SignalConnector:
 
         # signal.SIGUSR1 doesn't seem available on windows
         if not self._is_on_windows():
-            if not self._has_already_handler(signal.SIGUSR1):
+            if sigusr1_handlers and not self._has_already_handler(signal.SIGUSR1):
                 signal.signal(signal.SIGUSR1, HandlersCompose(sigusr1_handlers))
 
-            if not self._has_already_handler(signal.SIGTERM):
+            if sigterm_handlers and not self._has_already_handler(signal.SIGTERM):
                 signal.signal(signal.SIGTERM, HandlersCompose(sigterm_handlers))
 
     def slurm_sigusr1_handler_fn(self, signum: Signals, frame: FrameType) -> None:

--- a/tests/plugins/environments/test_slurm_environment.py
+++ b/tests/plugins/environments/test_slurm_environment.py
@@ -52,6 +52,7 @@ def test_default_attributes():
 def test_attributes_from_environment_variables(caplog):
     """Test that the SLURM cluster environment takes the attributes from the environment variables."""
     env = SLURMEnvironment()
+    assert env.auto_requeue is True
     assert env.main_address == "1.1.1.1"
     assert env.main_port == 15000 + 1234
     assert env.world_size() == 20

--- a/tests/trainer/connectors/test_signal_connector.py
+++ b/tests/trainer/connectors/test_signal_connector.py
@@ -31,9 +31,6 @@ from tests.helpers.runif import RunIf
 @RunIf(skip_windows=True)
 def test_fault_tolerant_sig_handler(register_handler, terminate_gracefully, tmpdir):
 
-    # hack to reset the signal
-    signal.signal(signal.SIGUSR1, 0)
-
     if register_handler:
 
         def handler(*_):
@@ -59,6 +56,9 @@ def test_fault_tolerant_sig_handler(register_handler, terminate_gracefully, tmpd
         else:
             trainer.fit(model)
         assert trainer._terminate_gracefully == (False if register_handler else terminate_gracefully)
+
+    # reset the signal to system defaults
+    signal.signal(signal.SIGUSR1, signal.SIG_DFL)
 
 
 @RunIf(skip_windows=True)

--- a/tests/trainer/connectors/test_signal_connector.py
+++ b/tests/trainer/connectors/test_signal_connector.py
@@ -20,7 +20,7 @@ import pytest
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.plugins.environments import SLURMEnvironment
-from pytorch_lightning.trainer.connectors.signal_connector import HandlersCompose, SignalConnector
+from pytorch_lightning.trainer.connectors.signal_connector import SignalConnector
 from pytorch_lightning.utilities.exceptions import ExitGracefullyException
 from tests.helpers import BoringModel
 from tests.helpers.runif import RunIf

--- a/tests/trainer/connectors/test_signal_connector.py
+++ b/tests/trainer/connectors/test_signal_connector.py
@@ -61,15 +61,28 @@ def test_fault_tolerant_sig_handler(register_handler, terminate_gracefully, tmpd
         assert trainer._terminate_gracefully == (False if register_handler else terminate_gracefully)
 
 
-def test_auto_requeue_flag():
-    trainer = Trainer(plugins=[SLURMEnvironment(auto_requeue=True)])
+@pytest.mark.parametrize("auto_requeue", (True, False))
+def test_auto_requeue_flag(auto_requeue):
+    sigterm_handler_default = signal.getsignal(signal.SIGTERM)
+    sigusr1_handler_default = signal.getsignal(signal.SIGUSR1)
+
+    trainer = Trainer(plugins=[SLURMEnvironment(auto_requeue=auto_requeue)])
     connector = SignalConnector(trainer)
     connector.register_signal_handlers()
 
-    sigterm_handlers = signal.getsignal(signal.SIGTERM).signal_handlers
-    assert len(sigterm_handlers) == 1
-    assert sigterm_handlers[0].__qualname__ == "SignalConnector.sigterm_handler_fn"
+    if auto_requeue:
+        sigterm_handlers = signal.getsignal(signal.SIGTERM).signal_handlers
+        assert len(sigterm_handlers) == 1
+        assert sigterm_handlers[0].__qualname__ == "SignalConnector.sigterm_handler_fn"
 
-    sigusr1_handlers = signal.getsignal(signal.SIGUSR1).signal_handlers
-    assert len(sigusr1_handlers) == 1
-    assert sigusr1_handlers[0].__qualname__ == "SignalConnector.slurm_sigusr1_handler_fn"
+        sigusr1_handlers = signal.getsignal(signal.SIGUSR1).signal_handlers
+        assert len(sigusr1_handlers) == 1
+        assert sigusr1_handlers[0].__qualname__ == "SignalConnector.slurm_sigusr1_handler_fn"
+    else:
+        assert signal.getsignal(signal.SIGTERM) is sigterm_handler_default
+        assert signal.getsignal(signal.SIGUSR1) is sigusr1_handler_default
+
+    # restore the signal handlers so the next test can run with system defaults
+    # TODO: should this be done in SignalConnector teardown?
+    signal.signal(signal.SIGTERM, sigterm_handler_default)
+    signal.signal(signal.SIGUSR1, sigusr1_handler_default)

--- a/tests/trainer/connectors/test_signal_connector.py
+++ b/tests/trainer/connectors/test_signal_connector.py
@@ -20,7 +20,7 @@ import pytest
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.plugins.environments import SLURMEnvironment
-from pytorch_lightning.trainer.connectors.signal_connector import SignalConnector, HandlersCompose
+from pytorch_lightning.trainer.connectors.signal_connector import HandlersCompose, SignalConnector
 from pytorch_lightning.utilities.exceptions import ExitGracefullyException
 from tests.helpers import BoringModel
 from tests.helpers.runif import RunIf

--- a/tests/trainer/connectors/test_signal_connector.py
+++ b/tests/trainer/connectors/test_signal_connector.py
@@ -61,6 +61,7 @@ def test_fault_tolerant_sig_handler(register_handler, terminate_gracefully, tmpd
         assert trainer._terminate_gracefully == (False if register_handler else terminate_gracefully)
 
 
+@RunIf(skip_windows=True)
 @pytest.mark.parametrize("auto_requeue", (True, False))
 def test_auto_requeue_flag(auto_requeue):
     sigterm_handler_default = signal.getsignal(signal.SIGTERM)


### PR DESCRIPTION
## What does this PR do?

Fixes #6389 

Adds the ability to turn on or off the automatic resubmission that Lightning does when a job gets interrupted by the SLURM controller (via signal handling). Users who prefer to let libraries handle the resubmission (e.g. submitit) can now set

```python
trainer = Trainer(plugins=SLURMEnvironment(auto_requeue=False))

``` 
Idea from @ananthsub. 

Whether the the default for `auto_requeue` is True or False is currently being debated on the linked issue. For now, the PR implements the behavior we have already (auto_requeue=True by default).



## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃

Part of #1 (it's a lie, this is just here to avoid noisy GitHub bot)




cc @borda @awaelchli