### PR TITLE
Fix `move_metrics_to_cpu` with evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,10 +150,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 -
 
 
--
+- Fixed `Trainer(move_metrics_to_cpu=True)` not moving the evaluation logged results to CPU ([#10631](https://github.com/PyTorchLightning/pytorch-lightning/pull/10631))
 
 
--
+- Fixed the `{validation,test}_step` outputs getting moved to CPU with `Trainer(move_metrics_to_cpu=True)` ([#10631](https://github.com/PyTorchLightning/pytorch-lightning/pull/10631))
 
 
 

--- a/tests/trainer/logging_/test_eval_loop_logging.py
+++ b/tests/trainer/logging_/test_eval_loop_logging.py
@@ -26,6 +26,7 @@ from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.trainer.connectors.logger_connector import LoggerConnector
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.helpers import BoringModel, RandomDataset
+from tests.helpers.runif import RunIf
 
 
 def test__validation_step__log(tmpdir):
@@ -701,6 +702,7 @@ def test_filter_metrics_for_dataloader(kwargs, expected):
     assert actual == expected
 
 
+@RunIf(min_gpus=1)
 def test_evaluation_move_metrics_to_cpu_and_outputs(tmpdir):
     class TestModel(BoringModel):
         def validation_step(self, *args):
@@ -719,7 +721,5 @@ def test_evaluation_move_metrics_to_cpu_and_outputs(tmpdir):
             assert self.trainer.callback_metrics["foo"].device.type == "cpu"
 
     model = TestModel()
-    trainer = Trainer(
-        default_root_dir=tmpdir, limit_val_batches=2, move_metrics_to_cpu=True, accelerator="auto", devices=1
-    )
+    trainer = Trainer(default_root_dir=tmpdir, limit_val_batches=2, move_metrics_to_cpu=True, gpus=1)
     trainer.validate(model, verbose=False)

--- a/tests/trainer/logging_/test_eval_loop_logging.py
+++ b/tests/trainer/logging_/test_eval_loop_logging.py
@@ -714,7 +714,7 @@ def test_evaluation_move_metrics_to_cpu_and_outputs(tmpdir):
 
         def validation_epoch_end(self, outputs):
             # the step outputs were not moved
-            assert all(o.device == self.device for o in outputs)
+            assert all(o.device == self.device for o in outputs), outputs
             # but the logging results were
             assert self.trainer.callback_metrics["foo"].device.type == "cpu"
 


### PR DESCRIPTION
## What does this PR do?

Fixes the bug uncovered by the analysis here: https://github.com/PyTorchLightning/pytorch-lightning/issues/10595#issuecomment-972490354

- The outputs are no longer moved to CPU with `move_metrics_to_cpu=True`. This is consistent with how the training loops work.
- The recursive `detach()` call has been removed, it's not necessary as gradients arent computed during evaluation.
- `move_metrics_to_cpu=True` now actually moves the metrics to CPU. This is consistent with how the training loops work.
 
### Does your PR introduce any breaking changes? If yes, please list them.

- If the user relies on the outputs being on CPU in `{validation,test}_epoch_end`.
- If the user memory blows up due to this change. Keep in mind that the user is always able to do `return your_tensor_on_gpu.cpu()`.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @borda @carmocca @edward-io @ananthsub @awaelchli