### PR TITLE
Update DDPShardedPlugin precision handling after moving PrecisionPlugin

### DIFF
--- a/pytorch_lightning/lite/lite.py
+++ b/pytorch_lightning/lite/lite.py
@@ -32,7 +32,6 @@ from pytorch_lightning.lite.wrappers import (
     _replace_dataloader_init_method,
 )
 from pytorch_lightning.plugins import (
-    DDPShardedPlugin,
     DDPSpawnPlugin,
     DeepSpeedPlugin,
     PLUGIN_INPUT,

--- a/pytorch_lightning/lite/lite.py
+++ b/pytorch_lightning/lite/lite.py
@@ -31,13 +31,7 @@ from pytorch_lightning.lite.wrappers import (
     _LiteOptimizer,
     _replace_dataloader_init_method,
 )
-from pytorch_lightning.plugins import (
-    DDPSpawnPlugin,
-    DeepSpeedPlugin,
-    PLUGIN_INPUT,
-    TPUSpawnPlugin,
-    TrainingTypePlugin,
-)
+from pytorch_lightning.plugins import DDPSpawnPlugin, DeepSpeedPlugin, PLUGIN_INPUT, TPUSpawnPlugin, TrainingTypePlugin
 from pytorch_lightning.trainer.connectors.accelerator_connector import AcceleratorConnector
 from pytorch_lightning.utilities import _StrategyType, DeviceType, move_data_to_device
 from pytorch_lightning.utilities.apply_func import apply_to_collection, convert_to_tensors

--- a/pytorch_lightning/lite/lite.py
+++ b/pytorch_lightning/lite/lite.py
@@ -411,8 +411,6 @@ class LightningLite(ABC):
         # todo: these are hacks as plugins rely on access to the precision plugin
         if isinstance(self._strategy, DeepSpeedPlugin):
             self._set_deepspeed_precision_variables()
-        if isinstance(self._strategy, DDPShardedPlugin):
-            self._strategy._precision = self._accelerator_connector.precision
 
     def _move_model_to_device(self, model: nn.Module, optimizers: List[Optimizer]) -> nn.Module:
         if isinstance(self._strategy, TPUSpawnPlugin):

--- a/pytorch_lightning/plugins/training_type/sharded.py
+++ b/pytorch_lightning/plugins/training_type/sharded.py
@@ -39,10 +39,6 @@ class DDPShardedPlugin(DDPPlugin):
     distributed_backend = _StrategyType.DDP_SHARDED
     _REDUCE_BUFFER_SIZE_DEFAULT: int = 2 ** 23  # 8M
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._precision = None
-
     def configure_ddp(self) -> None:
         trainer = self.lightning_module.trainer
         if "reduce_buffer_size" not in self._ddp_kwargs:
@@ -75,8 +71,7 @@ class DDPShardedPlugin(DDPPlugin):
                 optim_class = type(optimizer)
                 zero_optimizer = OSS(params=optimizer.param_groups, optim=optim_class, **optimizer.defaults)
                 if _FAIRSCALE_OSS_FP16_BROADCAST_AVAILABLE:
-                    precision = self._precision or self.precision_plugin.precision
-                    is_fp16 = precision in ("mixed", 16)
+                    is_fp16 = self.precision_plugin.precision in ("mixed", 16)
                     # For multi-node training, compressing the model shards in fp16 before broadcasting
                     # improves performance. When using PyTorch AMP, it will not degrade
                     # the model performance.


### PR DESCRIPTION
## What does this PR do?

Part of #10416

Now that the PrecisionPlugin has been moved into the strategy / training type plugin, some logic around setting precision variables within Lite is no longer needed.


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃

Part of #1 (it's a lie, this is just here to avoid noisy GitHub bot)



cc @borda @justusschock @awaelchli @akihironitta @carmocca @SeanNaren