### PR TITLE
docs: remove import of datasets separately since unused

### DIFF
--- a/docs/source/starter/introduction_guide.rst
+++ b/docs/source/starter/introduction_guide.rst
@@ -139,7 +139,7 @@ Lightning operates on pure dataloaders. Here's the PyTorch code for loading MNIS
     from torch.utils.data import DataLoader, random_split
     from torchvision.datasets import MNIST
     import os
-    from torchvision import datasets, transforms
+    from torchvision import transforms
 
     # transforms
     # prepare transforms standard to MNIST


### PR DESCRIPTION
It is a simple PR that removes an unnecessary import of `datasets` from `torchvision` which is not used anywhere in the guide.