### PR TITLE
Improve error message on `TypeError` during `DataLoader` reconstruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 -
 
 
--
+- Show a better error message when a custom `DataLoader` implementation is not well implemented and we need to reconstruct it ([#10719](https://github.com/PyTorchLightning/pytorch-lightning/issues/10719))
 
 
 -

--- a/pytorch_lightning/utilities/data.py
+++ b/pytorch_lightning/utilities/data.py
@@ -184,8 +184,7 @@ def _update_dataloader(dataloader: DataLoader, sampler: Sampler, mode: Optional[
         # `__init__` arguments map to one `DataLoader.__init__` argument
         import re
 
-        pattern = re.compile(r".*__init__\(\) got multiple values .* '(\w+)'")
-        match = re.match(pattern, str(e))
+        match = re.match(r".*__init__\(\) got multiple values .* '(\w+)'", str(e))
         if not match:
             # an unexpected `TypeError`, continue failure
             raise

--- a/pytorch_lightning/utilities/data.py
+++ b/pytorch_lightning/utilities/data.py
@@ -194,7 +194,7 @@ def _update_dataloader(dataloader: DataLoader, sampler: Sampler, mode: Optional[
         argument = match.groups()[0]
         message = (
             f"The {dl_cls.__name__} `DataLoader` implementation has an error where more than one `__init__` argument"
-            f" can be passed to to its parent's `{argument}=...` `__init__` argument. This is likely caused by allowing"
+            f" can be passed to its parent's `{argument}=...` `__init__` argument. This is likely caused by allowing"
             f" passing both a custom argument that will map to the `{argument}` argument as well as `**kwargs`."
             f" `kwargs` should be filtered to make sure they don't contain the `{argument}` key."
         )

--- a/pytorch_lightning/utilities/data.py
+++ b/pytorch_lightning/utilities/data.py
@@ -177,7 +177,26 @@ def get_len(dataloader: DataLoader) -> Union[int, float]:
 def _update_dataloader(dataloader: DataLoader, sampler: Sampler, mode: Optional[RunningStage] = None) -> DataLoader:
     dl_kwargs = _get_dataloader_init_kwargs(dataloader, sampler, mode=mode)
     dl_cls = type(dataloader)
-    dataloader = dl_cls(**dl_kwargs)
+    try:
+        dataloader = dl_cls(**dl_kwargs)
+    except TypeError as e:
+        # improve exception message due to an incorrect implementation of the `DataLoader` where multiple subclass
+        # `__init__` arguments map to one `DataLoader.__init__` argument
+        import re
+
+        pattern = re.compile(r".*__init__\(\) got multiple values .* '(\w+)'")
+        match = re.match(pattern, str(e))
+        if not match:
+            # an unexpected `TypeError`, continue failure
+            raise
+        argument = match.groups()[0]
+        message = (
+            f"The {dl_cls.__name__} `DataLoader` implementation has an error where more than one `__init__` argument"
+            f" can be passed to to its parent's `{argument}=...` `__init__` argument. This is likely caused by allowing"
+            f" passing both a custom argument that will map to the `{argument}` argument as well as `**kwargs`."
+            f" `kwargs` should be filtered to make sure they don't contain the `{argument}` key."
+        )
+        raise MisconfigurationException(message) from e
     return dataloader
 
 

--- a/tests/utilities/test_data.py
+++ b/tests/utilities/test_data.py
@@ -4,8 +4,8 @@ from torch.utils.data.dataloader import DataLoader
 
 from pytorch_lightning import Trainer
 from pytorch_lightning.utilities.data import (
-    _update_dataloader,
     _replace_dataloader_init_method,
+    _update_dataloader,
     extract_batch_size,
     get_len,
     has_iterable_dataset,

--- a/tests/utilities/test_data.py
+++ b/tests/utilities/test_data.py
@@ -118,8 +118,8 @@ def test_has_len_all_rank():
 def test_update_dataloader_typerror_custom_exception():
     class BadImpl(DataLoader):
         def __init__(self, foo, *args, **kwargs):
-            # positional conflict with `dataset`
             self.foo = foo
+            # positional conflict with `dataset`
             super().__init__(foo, *args, **kwargs)
 
     dataloader = BadImpl([1, 2, 3])
@@ -128,8 +128,8 @@ def test_update_dataloader_typerror_custom_exception():
 
     class BadImpl2(DataLoader):
         def __init__(self, randomize, *args, **kwargs):
-            # keyword conflict with `shuffle`
             self.randomize = randomize
+            # keyword conflict with `shuffle`
             super().__init__(*args, shuffle=randomize, **kwargs)
 
     dataloader = BadImpl2(False, [])
@@ -138,7 +138,7 @@ def test_update_dataloader_typerror_custom_exception():
 
     class GoodImpl(DataLoader):
         def __init__(self, randomize, *args, **kwargs):
-            # fixed implementation
+            # fixed implementation, kwargs are filtered
             self.randomize = randomize or kwargs.pop("shuffle", False)
             super().__init__(*args, shuffle=randomize, **kwargs)
 


### PR DESCRIPTION
## What does this PR do?

Part of https://github.com/PyTorchLightning/pytorch-lightning/issues/10329

Due to the mechanism we have for injecting the distributed sampler, where the DataLoader is recreated, we have some strong requirements over the `__init__` signature arguments. This PR aims to improve the UX when one of these requirements is not met. 

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @borda @justusschock @awaelchli @ninginthecloud