### PR TITLE
rich moved from extra to base requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ torchmetrics>=0.4.1
 pyDeprecate==0.3.1
 packaging>=17.0
 typing-extensions
+rich>=10.2.2

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -7,4 +7,3 @@ omegaconf>=2.0.5
 hydra-core>=1.0.5
 jsonargparse[signatures]>=4.0.0
 gcsfs>=2021.5.0
-rich>=10.2.2


### PR DESCRIPTION
## What does this PR do?

Related to issue https://github.com/PyTorchLightning/pytorch-lightning/issues/10702

This change moves rich from being an extra requirement to being a base requirement so it's installed upon setup. rich.progress_bar is used when training with PL, so it should be indicated in the requirements file.