### PR TITLE
[WIP] Always dereference the experiment in spawn

### DIFF
--- a/pytorch_lightning/plugins/training_type/ddp_spawn.py
+++ b/pytorch_lightning/plugins/training_type/ddp_spawn.py
@@ -33,7 +33,7 @@ from pytorch_lightning.plugins.io.checkpoint_plugin import CheckpointIO
 from pytorch_lightning.plugins.precision import PrecisionPlugin
 from pytorch_lightning.plugins.training_type.parallel import ParallelPlugin
 from pytorch_lightning.trainer.states import TrainerFn
-from pytorch_lightning.utilities import _TORCH_GREATER_EQUAL_1_8, rank_zero_warn
+from pytorch_lightning.utilities import _TORCH_GREATER_EQUAL_1_8, _TORCH_GREATER_EQUAL_1_9, rank_zero_warn
 from pytorch_lightning.utilities.apply_func import apply_to_collection, move_data_to_device
 from pytorch_lightning.utilities.cloud_io import atomic_save
 from pytorch_lightning.utilities.cloud_io import load as pl_load
@@ -422,6 +422,9 @@ class DDPSpawnPlugin(ParallelPlugin):
 
     @staticmethod
     def _clean_logger(trainer: "pl.Trainer") -> None:
+        if _TORCH_GREATER_EQUAL_1_9:
+            # only seen this hang with torch<=1.8
+            return
         loggers = trainer.logger._logger_iterable if isinstance(trainer.logger, LoggerCollection) else [trainer.logger]
         for logger in loggers:
             if logger._experiment is not None:

--- a/pytorch_lightning/plugins/training_type/ddp_spawn.py
+++ b/pytorch_lightning/plugins/training_type/ddp_spawn.py
@@ -427,7 +427,10 @@ class DDPSpawnPlugin(ParallelPlugin):
             return
         loggers = trainer.logger._logger_iterable if isinstance(trainer.logger, LoggerCollection) else [trainer.logger]
         for logger in loggers:
-            if logger._experiment is not None:
+            if logger is None:
+                continue
+            experiment = getattr(logger, "_experiment", None)
+            if experiment is not None:
                 # make sure no experiment is open before we spawn our own threads.
                 # assuming nothing else references the experiment object, python should instantly `__del__` it.
                 logger._experiment = None

--- a/pytorch_lightning/plugins/training_type/ddp_spawn.py
+++ b/pytorch_lightning/plugins/training_type/ddp_spawn.py
@@ -429,6 +429,7 @@ class DDPSpawnPlugin(ParallelPlugin):
         for logger in loggers:
             if logger is None:
                 continue
+            logger.finalize("success")
             experiment = getattr(logger, "_experiment", None)
             if experiment is not None:
                 # make sure no experiment is open before we spawn our own threads.

--- a/tests/loggers/test_tensorboard.py
+++ b/tests/loggers/test_tensorboard.py
@@ -28,6 +28,7 @@ from pytorch_lightning.loggers import TensorBoardLogger
 from pytorch_lightning.loggers.base import LoggerCollection
 from pytorch_lightning.utilities.imports import _compare_version
 from tests.helpers import BoringModel
+from tests.helpers.runif import RunIf
 
 
 @pytest.mark.skipif(
@@ -335,6 +336,7 @@ def test_tensorboard_missing_folder_warning(tmpdir, caplog):
     assert "Missing logger folder:" in caplog.text
 
 
+@RunIf(max_torch="1.9")
 @pytest.mark.parametrize("use_list", [False, True])
 def test_tensorboard_ddp_spawn_cleanup(use_list, tmpdir):
     tensorboard_logger = TensorBoardLogger(save_dir=tmpdir)


### PR DESCRIPTION
## What does this PR do?

Attempts to avoid the flaky hangs seen in our CI:

```python
FAILED tests/loggers/test_all.py::test_logger_created_on_rank_zero_only[CSVLogger]
FAILED tests/loggers/test_all.py::test_logger_created_on_rank_zero_only[MLFlow]
FAILED tests/loggers/test_all.py::test_logger_created_on_rank_zero_only[TestTubeLogger]
```

Closes #10805 (can land first)

### Does your PR introduce any breaking changes? If yes, please list them.

None?

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [n/a] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [n/a] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @carmocca @akihironitta @borda