### PR TITLE
Fix selection of standalone tests

### DIFF
--- a/.azure-pipelines/gpu-tests.yml
+++ b/.azure-pipelines/gpu-tests.yml
@@ -67,15 +67,17 @@ jobs:
         ls -l legacy/checkpoints/
       displayName: 'Get legacy checkpoints'
 
-    - bash: |
-        python -m coverage run --source pytorch_lightning -m pytest pytorch_lightning tests --ignore tests/benchmarks -v --junitxml=$(Build.StagingDirectory)/test-results.xml --durations=50
-      displayName: 'Testing: standard'
+
 
     - bash: |
         bash tests/standalone_tests.sh
       env:
         PL_USE_MOCKED_MNIST: "1"
       displayName: 'Testing: standalone'
+
+    - bash: |
+        python -m coverage run --source pytorch_lightning -m pytest pytorch_lightning tests --ignore tests/benchmarks -v --junitxml=$(Build.StagingDirectory)/test-results.xml --durations=50
+      displayName: 'Testing: standard'
 
     - bash: |
         python -m coverage report

--- a/.azure-pipelines/gpu-tests.yml
+++ b/.azure-pipelines/gpu-tests.yml
@@ -67,17 +67,15 @@ jobs:
         ls -l legacy/checkpoints/
       displayName: 'Get legacy checkpoints'
 
-
+    - bash: |
+        python -m coverage run --source pytorch_lightning -m pytest pytorch_lightning tests --ignore tests/benchmarks -v --junitxml=$(Build.StagingDirectory)/test-results.xml --durations=50
+      displayName: 'Testing: standard'
 
     - bash: |
         bash tests/standalone_tests.sh
       env:
         PL_USE_MOCKED_MNIST: "1"
       displayName: 'Testing: standalone'
-
-    - bash: |
-        python -m coverage run --source pytorch_lightning -m pytest pytorch_lightning tests --ignore tests/benchmarks -v --junitxml=$(Build.StagingDirectory)/test-results.xml --durations=50
-      displayName: 'Testing: standard'
 
     - bash: |
         python -m coverage report

--- a/tests/standalone_tests.sh
+++ b/tests/standalone_tests.sh
@@ -12,6 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+
+# STANDALONE_PATTERN allows filtering the tests to run when debugging.
+# use as `STANDALONE_PATTERN="foo_bar" ./standalone_tests.sh` to run only those tests with `foo_bar` in their name.
+
 set -e
 
 # this environment variable allows special tests to run
@@ -28,9 +33,9 @@ files=$(echo "$grep_output" | cut -f1 -d: | sort | uniq)
 # get the list of parametrizations. we need to call them separately. the last two lines are removed.
 # note: if there's a syntax error, this will fail with some garbled output
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  parametrizations=$(pytest $files --collect-only --quiet | tail -r | sed -e '1,3d' | tail -r)
+  parametrizations=$(pytest $files --collect-only --quiet -k $STANDALONE_PATTERN | tail -r | sed -e '1,3d' | tail -r)
 else
-  parametrizations=$(pytest $files --collect-only --quiet | head -n -2)
+  parametrizations=$(pytest $files --collect-only --quiet -k $STANDALONE_PATTERN | head -n -2)
 fi
 parametrizations_arr=($parametrizations)
 
@@ -43,14 +48,6 @@ for i in "${!parametrizations_arr[@]}"; do
 
   # check blocklist
   if echo $blocklist | grep -F "${parametrization}"; then
-    report+="Skipped\t$parametrization\n"
-    continue
-  fi
-
-  # STANDALONE_PATTERN allows filtering the tests to run when debugging.
-  # use as `STANDALONE_PATTERN="foo_bar" ./standalone_tests.sh` to run only those
-  # test with `foo_bar` in their name
-  if [[ $parametrization != *STANDALONE_PATTERN* ]]; then
     report+="Skipped\t$parametrization\n"
     continue
   fi

--- a/tests/standalone_tests.sh
+++ b/tests/standalone_tests.sh
@@ -12,11 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-# STANDALONE_PATTERN allows filtering the tests to run when debugging.
-# use as `STANDALONE_PATTERN="foo_bar" ./standalone_tests.sh` to run only those tests with `foo_bar` in their name.
-
 set -e
 
 # this environment variable allows special tests to run
@@ -33,9 +28,9 @@ files=$(echo "$grep_output" | cut -f1 -d: | sort | uniq)
 # get the list of parametrizations. we need to call them separately. the last two lines are removed.
 # note: if there's a syntax error, this will fail with some garbled output
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  parametrizations=$(pytest $files --collect-only --quiet -k $STANDALONE_PATTERN | tail -r | sed -e '1,3d' | tail -r)
+  parametrizations=$(pytest $files --collect-only --quiet "$@" | tail -r | sed -e '1,3d' | tail -r)
 else
-  parametrizations=$(pytest $files --collect-only --quiet -k $STANDALONE_PATTERN | head -n -2)
+  parametrizations=$(pytest $files --collect-only --quiet "$@" | head -n -2)
 fi
 parametrizations_arr=($parametrizations)
 


### PR DESCRIPTION
## What does this PR do?

Current master branch does not run the standalone (previously known as special) tests. There is a bug with reading the STANDALONE_PATTERN environment variable. Instead of a env variable, we will now rely on standard pytest argument passing, e.g., 

```bash
bash tests/standalone_tests.sh -k deepspeed
```
to run all tests that have the word "deepspeed" in their name.

This fix should also be included in 1.5.5. 


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃

Part of #1 (it's a lie, this is just here to avoid noisy GitHub bot)



cc @tchaton @carmocca @akihironitta @borda