### PR TITLE
Fix retrieval of batch indices when dataloader num_workers > 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Deprecated the property `Trainer.slurm_job_id` in favor of the new `SLURMEnvironment.job_id()` method ([#10622](https://github.com/PyTorchLightning/pytorch-lightning/pull/10622))
 
 
--
+- Deprecated the access to the attribute `IndexBatchSamplerWrapper.batch_indices` in favor of `IndexBatchSamplerWrapper.seen_batch_indices` ([#10870](https://github.com/PyTorchLightning/pytorch-lightning/pull/10870))
+
 
 ### Removed
 
@@ -191,6 +192,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 
 - Improved exception message if `rich` version is less than `10.2.2` ([#10839](https://github.com/PyTorchLightning/pytorch-lightning/pull/10839))
+
+
+- Fixed a bug that caused incorrect batch indices to be passed to the `BasePredictionWriter` hooks when using a dataloader with `num_workers > 0` ([#10870](https://github.com/PyTorchLightning/pytorch-lightning/pull/10870))
+
 
 
 ## [1.5.4] - 2021-11-30

--- a/pl_examples/bug_report/bug_report_model.py
+++ b/pl_examples/bug_report/bug_report_model.py
@@ -4,6 +4,7 @@ import torch
 from torch.utils.data import DataLoader, Dataset
 
 from pytorch_lightning import LightningModule, Trainer
+from pytorch_lightning.callbacks import BasePredictionWriter
 
 
 class RandomDataset(Dataset):
@@ -26,40 +27,33 @@ class BoringModel(LightningModule):
     def forward(self, x):
         return self.layer(x)
 
-    def training_step(self, batch, batch_idx):
-        loss = self(batch).sum()
-        self.log("train_loss", loss)
-        return {"loss": loss}
-
-    def validation_step(self, batch, batch_idx):
-        loss = self(batch).sum()
-        self.log("valid_loss", loss)
-
-    def test_step(self, batch, batch_idx):
-        loss = self(batch).sum()
-        self.log("test_loss", loss)
+    def predict_step(self, batch, batch_idx):
+        return self(batch)
 
     def configure_optimizers(self):
         return torch.optim.SGD(self.layer.parameters(), lr=0.1)
 
 
+class Writer(BasePredictionWriter):
+    def write_on_batch_end(self, trainer, pl_module, prediction, batch_indices, batch, batch_idx, dataloader_idx):
+        pass
+
+    def write_on_epoch_end(self, trainer, pl_module, predictions, batch_indices):
+        print(batch_indices[0])
+
+
 def run():
-    train_data = DataLoader(RandomDataset(32, 64), batch_size=2)
-    val_data = DataLoader(RandomDataset(32, 64), batch_size=2)
-    test_data = DataLoader(RandomDataset(32, 64), batch_size=2)
+    predict_data = DataLoader(RandomDataset(32, 16), batch_size=4, num_workers=2)
 
     model = BoringModel()
     trainer = Trainer(
         default_root_dir=os.getcwd(),
-        limit_train_batches=1,
-        limit_val_batches=1,
-        limit_test_batches=1,
-        num_sanity_val_steps=0,
         max_epochs=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        callbacks=[Writer(write_interval="epoch")],
     )
-    trainer.fit(model, train_dataloaders=train_data, val_dataloaders=val_data)
-    trainer.test(model, dataloaders=test_data)
+    trainer.predict(model, predict_data)
 
 
 if __name__ == "__main__":

--- a/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
@@ -89,6 +89,7 @@ class PredictionEpochLoop(Loop):
             return_predictions: whether to return the obtained predictions
         """
         batch_idx, batch = next(dataloader_iter)
+        self._seen_batch_indices = self._get_batch_indices(dataloader_idx)
         if batch is None:
             raise StopIteration
 

--- a/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
@@ -90,6 +90,9 @@ class PredictionEpochLoop(Loop):
         """
         batch_idx, batch = next(dataloader_iter)
         self._seen_batch_indices = self._get_batch_indices(dataloader_idx)
+        # we need to truncate the list of batch indicies due to prefetching in the dataloader and Lightning
+        self._seen_batch_indices = self._seen_batch_indices[: (self.batch_progress.current.completed + 1)]
+
         if batch is None:
             raise StopIteration
 

--- a/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
@@ -121,9 +121,11 @@ class PredictionEpochLoop(Loop):
         """
         # configure step_kwargs
         step_kwargs = self._build_kwargs(batch, batch_idx, dataloader_idx)
-        model_ref = self.trainer.lightning_module
 
+        # extract batch_indices and store them
         self.current_batch_indices = self._seen_batch_indices[batch_idx] if self._seen_batch_indices else []
+
+        model_ref = self.trainer.lightning_module
 
         self.trainer.call_hook("on_predict_batch_start", batch, batch_idx, dataloader_idx)
 

--- a/pytorch_lightning/overrides/distributed.py
+++ b/pytorch_lightning/overrides/distributed.py
@@ -21,6 +21,7 @@ from torch.utils.data import BatchSampler, DistributedSampler, Sampler
 
 import pytorch_lightning as pl
 from pytorch_lightning.overrides.base import _LightningModuleWrapperBase
+from pytorch_lightning.utilities import rank_zero_deprecation
 
 
 class LightningDistributedModule(_LightningModuleWrapperBase):
@@ -123,13 +124,31 @@ class IndexBatchSamplerWrapper:
     """This class is used to wrap a :class:`torch.utils.data.BatchSampler` and capture its indices."""
 
     def __init__(self, sampler: BatchSampler) -> None:
+        self.all_batch_indices: List[List[int]] = []
         self._sampler = sampler
-        self.batch_indices: List[int] = []
+        self._batch_indices: List[int] = []
+
+    @property
+    def batch_indices(self) -> List[int]:
+        rank_zero_deprecation(
+            "The attribute `IndexBatchSamplerWrapper.batch_indices` was deprecated in v1.6 and will be removed in v1.8."
+            " Access the full list `all_batch_indices` instead."
+        )
+        return self._batch_indices
+
+    @batch_indices.setter
+    def batch_indices(self, indices: List[int]) -> None:
+        rank_zero_deprecation(
+            "The attribute `IndexBatchSamplerWrapper.batch_indices` was deprecated in v1.6 and will be removed in v1.8."
+            " Access the full list `all_batch_indices` instead."
+        )
+        self._batch_indices = indices
 
     def __iter__(self) -> Iterator[List[int]]:
-        self.batch_indices = []
+        self.all_batch_indices = []
         for batch in self._sampler:
-            self.batch_indices.append(batch)
+            self._batch_indices = batch
+            self.all_batch_indices.append(batch)
             yield batch
 
     def __len__(self) -> int:

--- a/pytorch_lightning/overrides/distributed.py
+++ b/pytorch_lightning/overrides/distributed.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import itertools
-from typing import Any, cast, Iterator, List, Optional, Sized, Union
+from typing import Any, cast, Iterator, List, Sized, Union
 
 import torch
 from torch import Tensor

--- a/pytorch_lightning/overrides/distributed.py
+++ b/pytorch_lightning/overrides/distributed.py
@@ -124,7 +124,7 @@ class IndexBatchSamplerWrapper:
     """This class is used to wrap a :class:`torch.utils.data.BatchSampler` and capture its indices."""
 
     def __init__(self, sampler: BatchSampler) -> None:
-        self.all_batch_indices: List[List[int]] = []
+        self.seen_batch_indices: List[List[int]] = []
         self._sampler = sampler
         self._batch_indices: List[int] = []
 
@@ -132,7 +132,7 @@ class IndexBatchSamplerWrapper:
     def batch_indices(self) -> List[int]:
         rank_zero_deprecation(
             "The attribute `IndexBatchSamplerWrapper.batch_indices` was deprecated in v1.6 and will be removed in v1.8."
-            " Access the full list `all_batch_indices` instead."
+            " Access the full list `seen_batch_indices` instead."
         )
         return self._batch_indices
 
@@ -140,15 +140,15 @@ class IndexBatchSamplerWrapper:
     def batch_indices(self, indices: List[int]) -> None:
         rank_zero_deprecation(
             "The attribute `IndexBatchSamplerWrapper.batch_indices` was deprecated in v1.6 and will be removed in v1.8."
-            " Access the full list `all_batch_indices` instead."
+            " Access the full list `seen_batch_indices` instead."
         )
         self._batch_indices = indices
 
     def __iter__(self) -> Iterator[List[int]]:
-        self.all_batch_indices = []
+        self.seen_batch_indices = []
         for batch in self._sampler:
             self._batch_indices = batch
-            self.all_batch_indices.append(batch)
+            self.seen_batch_indices.append(batch)
             yield batch
 
     def __len__(self) -> int:

--- a/pytorch_lightning/overrides/distributed.py
+++ b/pytorch_lightning/overrides/distributed.py
@@ -124,11 +124,12 @@ class IndexBatchSamplerWrapper:
 
     def __init__(self, sampler: BatchSampler) -> None:
         self._sampler = sampler
-        self.batch_indices: Optional[List[int]] = None
+        self.batch_indices: List[int] = []
 
     def __iter__(self) -> Iterator[List[int]]:
+        self.batch_indices = []
         for batch in self._sampler:
-            self.batch_indices = batch
+            self.batch_indices.append(batch)
             yield batch
 
     def __len__(self) -> int:

--- a/pytorch_lightning/overrides/distributed.py
+++ b/pytorch_lightning/overrides/distributed.py
@@ -131,7 +131,7 @@ class IndexBatchSamplerWrapper:
     @property
     def batch_indices(self) -> List[int]:
         rank_zero_deprecation(
-            "The attribute `IndexBatchSamplerWrapper.batch_indices` was deprecated in v1.5.5 and will be removed in"
+            "The attribute `IndexBatchSamplerWrapper.batch_indices` was deprecated in v1.5 and will be removed in"
             " v1.7. Access the full list `seen_batch_indices` instead."
         )
         return self._batch_indices
@@ -139,7 +139,7 @@ class IndexBatchSamplerWrapper:
     @batch_indices.setter
     def batch_indices(self, indices: List[int]) -> None:
         rank_zero_deprecation(
-            "The attribute `IndexBatchSamplerWrapper.batch_indices` was deprecated in v1.5.5 and will be removed in"
+            "The attribute `IndexBatchSamplerWrapper.batch_indices` was deprecated in v1.5 and will be removed in"
             " v1.7. Access the full list `seen_batch_indices` instead."
         )
         self._batch_indices = indices

--- a/pytorch_lightning/overrides/distributed.py
+++ b/pytorch_lightning/overrides/distributed.py
@@ -131,16 +131,16 @@ class IndexBatchSamplerWrapper:
     @property
     def batch_indices(self) -> List[int]:
         rank_zero_deprecation(
-            "The attribute `IndexBatchSamplerWrapper.batch_indices` was deprecated in v1.6 and will be removed in v1.8."
-            " Access the full list `seen_batch_indices` instead."
+            "The attribute `IndexBatchSamplerWrapper.batch_indices` was deprecated in v1.5.5 and will be removed in"
+            " v1.7. Access the full list `seen_batch_indices` instead."
         )
         return self._batch_indices
 
     @batch_indices.setter
     def batch_indices(self, indices: List[int]) -> None:
         rank_zero_deprecation(
-            "The attribute `IndexBatchSamplerWrapper.batch_indices` was deprecated in v1.6 and will be removed in v1.8."
-            " Access the full list `seen_batch_indices` instead."
+            "The attribute `IndexBatchSamplerWrapper.batch_indices` was deprecated in v1.5.5 and will be removed in"
+            " v1.7. Access the full list `seen_batch_indices` instead."
         )
         self._batch_indices = indices
 

--- a/tests/callbacks/test_prediction_writer.py
+++ b/tests/callbacks/test_prediction_writer.py
@@ -37,7 +37,8 @@ def test_prediction_writer_invalid_write_interval():
 
 
 def test_prediction_writer_hook_call_intervals(tmpdir):
-    """Test that the `write_on_batch_end` and `write_on_epoch_end` hooks get invoked based on the defined interval."""
+    """Test that the `write_on_batch_end` and `write_on_epoch_end` hooks get invoked based on the defined
+    interval."""
     DummyPredictionWriter.write_on_batch_end = Mock()
     DummyPredictionWriter.write_on_epoch_end = Mock()
 

--- a/tests/callbacks/test_prediction_writer.py
+++ b/tests/callbacks/test_prediction_writer.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import Mock, call, ANY
+from unittest.mock import ANY, call, Mock
 
 import pytest
 from torch.utils.data import DataLoader

--- a/tests/callbacks/test_prediction_writer.py
+++ b/tests/callbacks/test_prediction_writer.py
@@ -27,15 +27,17 @@ class DummyPredictionWriter(BasePredictionWriter):
         pass
 
     def write_on_epoch_end(self, *args, **kwargs):
-        print(*args, **kwargs)
+        pass
 
 
 def test_prediction_writer_invalid_write_interval():
+    """Test that configuring an unknown interval name raises an error."""
     with pytest.raises(MisconfigurationException, match=r"`write_interval` should be one of \['batch"):
         DummyPredictionWriter("something")
 
 
 def test_prediction_writer_hook_call_intervals(tmpdir):
+    """Test that the `write_on_batch_end` and `write_on_epoch_end` hooks get invoked based on the defined interval."""
     DummyPredictionWriter.write_on_batch_end = Mock()
     DummyPredictionWriter.write_on_epoch_end = Mock()
 
@@ -77,11 +79,12 @@ def test_prediction_writer_hook_call_intervals(tmpdir):
     assert cb.write_on_epoch_end.call_count == 1
 
 
-def test_prediction_writer_batch_indices(tmpdir):
+@pytest.mark.parametrize("num_workers", [0, 2])  # TODO: configure slow CI for num_workers=2
+def test_prediction_writer_batch_indices(tmpdir, num_workers):
     DummyPredictionWriter.write_on_batch_end = Mock()
     DummyPredictionWriter.write_on_epoch_end = Mock()
 
-    dataloader = DataLoader(RandomDataset(32, 64), batch_size=4, num_workers=2)
+    dataloader = DataLoader(RandomDataset(32, 64), batch_size=4, num_workers=num_workers)
     model = BoringModel()
     writer = DummyPredictionWriter("batch_and_epoch")
     trainer = Trainer(limit_predict_batches=4, callbacks=writer)
@@ -89,15 +92,15 @@ def test_prediction_writer_batch_indices(tmpdir):
 
     writer.write_on_batch_end.assert_has_calls(
         [
-            call(trainer, model, ANY, [[0, 1, 2, 3]], ANY, 0, 0),
-            call(trainer, model, ANY, [[4, 5, 6, 7]], ANY, 1, 0),
-            call(trainer, model, ANY, [[8, 9, 10, 11]], ANY, 2, 0),
-            call(trainer, model, ANY, [[12, 13, 14, 15]], ANY, 3, 0),
+            call(trainer, model, ANY, [0, 1, 2, 3], ANY, 0, 0),
+            call(trainer, model, ANY, [4, 5, 6, 7], ANY, 1, 0),
+            call(trainer, model, ANY, [8, 9, 10, 11], ANY, 2, 0),
+            call(trainer, model, ANY, [12, 13, 14, 15], ANY, 3, 0),
         ]
     )
 
-    writer.write_on_epoch_end.assert_has_calls(
-        [
-            call(trainer, model, ANY, [[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]]),
-        ]
-    )
+    # writer.write_on_epoch_end.assert_has_calls(
+    #     [
+    #         call(trainer, model, ANY, [[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]]),
+    #     ]
+    # )

--- a/tests/callbacks/test_prediction_writer.py
+++ b/tests/callbacks/test_prediction_writer.py
@@ -80,7 +80,7 @@ def test_prediction_writer_hook_call_intervals(tmpdir):
     assert cb.write_on_epoch_end.call_count == 1
 
 
-@pytest.mark.parametrize("num_workers", [0, 2])  # TODO: configure slow CI for num_workers=2
+@pytest.mark.parametrize("num_workers", [0, 2])  # TODO: configure slow CI for num_workers > 0
 def test_prediction_writer_batch_indices(tmpdir, num_workers):
     DummyPredictionWriter.write_on_batch_end = Mock()
     DummyPredictionWriter.write_on_epoch_end = Mock()
@@ -100,8 +100,8 @@ def test_prediction_writer_batch_indices(tmpdir, num_workers):
         ]
     )
 
-    # writer.write_on_epoch_end.assert_has_calls(
-    #     [
-    #         call(trainer, model, ANY, [[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]]),
-    #     ]
-    # )
+    writer.write_on_epoch_end.assert_has_calls(
+        [
+            call(trainer, model, ANY, [[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]]),
+        ]
+    )

--- a/tests/callbacks/test_prediction_writer.py
+++ b/tests/callbacks/test_prediction_writer.py
@@ -20,6 +20,7 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import BasePredictionWriter
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.helpers import BoringModel, RandomDataset
+from tests.helpers.runif import RunIf
 
 
 class DummyPredictionWriter(BasePredictionWriter):
@@ -80,7 +81,7 @@ def test_prediction_writer_hook_call_intervals(tmpdir):
     assert cb.write_on_epoch_end.call_count == 1
 
 
-@pytest.mark.parametrize("num_workers", [0, 2])  # TODO: configure slow CI for num_workers > 0
+@pytest.mark.parametrize("num_workers", [0, pytest.param(2, marks=RunIf(slow=True))])
 def test_prediction_writer_batch_indices(tmpdir, num_workers):
     DummyPredictionWriter.write_on_batch_end = Mock()
     DummyPredictionWriter.write_on_epoch_end = Mock()

--- a/tests/deprecated_api/test_remove_1-7.py
+++ b/tests/deprecated_api/test_remove_1-7.py
@@ -14,6 +14,7 @@
 """Test deprecated functionality which will be removed in v1.7.0."""
 import os
 from unittest import mock
+from unittest.mock import Mock
 
 import pytest
 
@@ -23,6 +24,7 @@ from pytorch_lightning.callbacks.lr_monitor import LearningRateMonitor
 from pytorch_lightning.callbacks.progress import ProgressBar
 from pytorch_lightning.callbacks.xla_stats_monitor import XLAStatsMonitor
 from pytorch_lightning.loggers import LoggerCollection, TestTubeLogger
+from pytorch_lightning.overrides.distributed import IndexBatchSamplerWrapper
 from pytorch_lightning.plugins.environments import (
     KubeflowEnvironment,
     LightningEnvironment,
@@ -528,3 +530,12 @@ def test_v1_7_0_cluster_environment_detection(cls, method_name):
         match=f"MyClusterEnvironment.{method_name}` has been deprecated in v1.6 and will be removed in v1.7"
     ):
         MyClusterEnvironment()
+
+
+def test_v1_7_0_index_batch_sampler_wrapper_batch_indices():
+    sampler = IndexBatchSamplerWrapper(Mock())
+    with pytest.deprecated_call(match="was deprecated in v1.5.5 and will be removed in v1.7"):
+        _ = sampler.batch_indices
+
+    with pytest.deprecated_call(match="was deprecated in v1.5.5 and will be removed in v1.7"):
+        sampler.batch_indices = []

--- a/tests/deprecated_api/test_remove_1-7.py
+++ b/tests/deprecated_api/test_remove_1-7.py
@@ -534,8 +534,8 @@ def test_v1_7_0_cluster_environment_detection(cls, method_name):
 
 def test_v1_7_0_index_batch_sampler_wrapper_batch_indices():
     sampler = IndexBatchSamplerWrapper(Mock())
-    with pytest.deprecated_call(match="was deprecated in v1.5.5 and will be removed in v1.7"):
+    with pytest.deprecated_call(match="was deprecated in v1.5 and will be removed in v1.7"):
         _ = sampler.batch_indices
 
-    with pytest.deprecated_call(match="was deprecated in v1.5.5 and will be removed in v1.7"):
+    with pytest.deprecated_call(match="was deprecated in v1.5 and will be removed in v1.7"):
         sampler.batch_indices = []

--- a/tests/deprecated_api/test_remove_1-8.py
+++ b/tests/deprecated_api/test_remove_1-8.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test deprecated functionality which will be removed in v1.8.0."""
+from unittest.mock import Mock
+
 import pytest
 import torch
 
+from pytorch_lightning.overrides.distributed import IndexBatchSamplerWrapper
 from pytorch_lightning.utilities.apply_func import move_data_to_device
 from pytorch_lightning.utilities.enums import DeviceType, DistributedType
 from pytorch_lightning.utilities.imports import _TORCHTEXT_LEGACY
@@ -40,3 +43,12 @@ def test_v1_8_0_deprecated_torchtext_batch():
         data_iterator, _ = get_dummy_torchtext_data_iterator(num_samples=3, batch_size=3)
         batch = next(iter(data_iterator))
         _ = move_data_to_device(batch=batch, device=torch.device("cpu"))
+
+
+def test_v1_8_0_index_batch_sampler_wrapper_batch_indices():
+    sampler = IndexBatchSamplerWrapper(Mock())
+    with pytest.deprecated_call(match="was deprecated in v1.6 and will be removed in v1.8"):
+        _ = sampler.batch_indices
+
+    with pytest.deprecated_call(match="was deprecated in v1.6 and will be removed in v1.8"):
+        sampler.batch_indices = []

--- a/tests/deprecated_api/test_remove_1-8.py
+++ b/tests/deprecated_api/test_remove_1-8.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test deprecated functionality which will be removed in v1.8.0."""
-from unittest.mock import Mock
 
 import pytest
 import torch
 
-from pytorch_lightning.overrides.distributed import IndexBatchSamplerWrapper
 from pytorch_lightning.utilities.apply_func import move_data_to_device
 from pytorch_lightning.utilities.enums import DeviceType, DistributedType
 from pytorch_lightning.utilities.imports import _TORCHTEXT_LEGACY
@@ -43,12 +41,3 @@ def test_v1_8_0_deprecated_torchtext_batch():
         data_iterator, _ = get_dummy_torchtext_data_iterator(num_samples=3, batch_size=3)
         batch = next(iter(data_iterator))
         _ = move_data_to_device(batch=batch, device=torch.device("cpu"))
-
-
-def test_v1_8_0_index_batch_sampler_wrapper_batch_indices():
-    sampler = IndexBatchSamplerWrapper(Mock())
-    with pytest.deprecated_call(match="was deprecated in v1.6 and will be removed in v1.8"):
-        _ = sampler.batch_indices
-
-    with pytest.deprecated_call(match="was deprecated in v1.6 and will be removed in v1.8"):
-        sampler.batch_indices = []

--- a/tests/overrides/test_distributed.py
+++ b/tests/overrides/test_distributed.py
@@ -54,9 +54,7 @@ def test_index_batch_sampler(tmpdir):
     assert batch_sampler.batch_size == index_batch_sampler.batch_size
     assert batch_sampler.drop_last == index_batch_sampler.drop_last
     assert batch_sampler.sampler is sampler
-
-    for batch in index_batch_sampler:
-        assert index_batch_sampler.batch_indices == batch
+    assert list(index_batch_sampler) == index_batch_sampler.all_batch_indices
 
 
 def test_index_batch_sampler_methods():

--- a/tests/overrides/test_distributed.py
+++ b/tests/overrides/test_distributed.py
@@ -54,7 +54,7 @@ def test_index_batch_sampler(tmpdir):
     assert batch_sampler.batch_size == index_batch_sampler.batch_size
     assert batch_sampler.drop_last == index_batch_sampler.drop_last
     assert batch_sampler.sampler is sampler
-    assert list(index_batch_sampler) == index_batch_sampler.all_batch_indices
+    assert list(index_batch_sampler) == index_batch_sampler.seen_batch_indices
 
 
 def test_index_batch_sampler_methods():


### PR DESCRIPTION
## What does this PR do?

Fixes  #10782

Please see my comment here https://github.com/PyTorchLightning/pytorch-lightning/issues/10782#issuecomment-983224935 for a detailed answer where the bug comes from and why we need to change the way we use the `IndexBatchSamplerWrapper`. In short, the way a PyTorch BatchSampler retrieves the batch indices differs between `num_workers=0` and `num_workers > 0` in the `DataLoader`, and our prediction loop needs to account for that.

### Does your PR introduce any breaking changes? If yes, please list them.

No.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃

Part of #1 (it's a lie, this is just here to avoid noisy GitHub bot)


cc @borda