### PR TITLE
Unroll dict input before call Accelerator X_steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The `LightningModule.{add_to_queue,get_from_queue}` hooks no longer get a `torch.multiprocessing.SimpleQueue` and instead receive a list based queue ([#10034](https://github.com/PyTorchLightning/pytorch-lightning/pull/10034))
 
 
+- Changed `training_step`, `validation_step`, `test_step` and `predict_step` functions signatures in `Accelerator` and update input from caller side ([#10908](https://github.com/PyTorchLightning/pytorch-lightning/pull/10908))
+
+
 ### Deprecated
 
 - Deprecated `ClusterEnvironment.master_{address,port}` in favor of `ClusterEnvironment.main_{address,port}` ([#10103](https://github.com/PyTorchLightning/pytorch-lightning/issues/10103))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The `LightningModule.{add_to_queue,get_from_queue}` hooks no longer get a `torch.multiprocessing.SimpleQueue` and instead receive a list based queue ([#10034](https://github.com/PyTorchLightning/pytorch-lightning/pull/10034))
 
 
-- Changed `training_step`, `validation_step`, `test_step` and `predict_step` functions signatures in `Accelerator` and update input from caller side ([#10908](https://github.com/PyTorchLightning/pytorch-lightning/pull/10908))
+- Changed `training_step`, `validation_step`, `test_step` and `predict_step` method signatures in `Accelerator` and updated input from caller side ([#10908](https://github.com/PyTorchLightning/pytorch-lightning/pull/10908))
 
 
 ### Deprecated

--- a/pl_examples/loop_examples/yielding_training_step.py
+++ b/pl_examples/loop_examples/yielding_training_step.py
@@ -77,7 +77,7 @@ class YieldLoop(OptimizerLoop):
         # Here we are basically calling `lightning_module.training_step()`
         # and this returns a generator! The `training_step` is handled by the
         # accelerator to enable distributed training.
-        return self.trainer.accelerator.training_step(step_kwargs)
+        return self.trainer.accelerator.training_step(*step_kwargs.values())
 
     def _training_step(self, generator):
         # required for logging

--- a/pytorch_lightning/accelerators/accelerator.py
+++ b/pytorch_lightning/accelerators/accelerator.py
@@ -121,37 +121,37 @@ class Accelerator:
         """
         self.training_type_plugin.teardown()
 
-    def training_step(self, step_kwargs: Dict[str, Union[Any, int]]) -> STEP_OUTPUT:
+    def training_step(self, *args, **kwargs) -> STEP_OUTPUT:
         """The actual training step.
 
         See :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step` for more details
         """
         with self.training_type_plugin.precision_plugin.train_step_context():
-            return self.training_type_plugin.training_step(*step_kwargs.values())
+            return self.training_type_plugin.training_step(*args, **kwargs)
 
-    def validation_step(self, step_kwargs: Dict[str, Union[Any, int]]) -> Optional[STEP_OUTPUT]:
+    def validation_step(self, *args, **kwargs) -> Optional[STEP_OUTPUT]:
         """The actual validation step.
 
         See :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step` for more details
         """
         with self.training_type_plugin.precision_plugin.val_step_context():
-            return self.training_type_plugin.validation_step(*step_kwargs.values())
+            return self.training_type_plugin.validation_step(*args, **kwargs)
 
-    def test_step(self, step_kwargs: Dict[str, Union[Any, int]]) -> Optional[STEP_OUTPUT]:
+    def test_step(self, *args, **kwargs) -> Optional[STEP_OUTPUT]:
         """The actual test step.
 
         See :meth:`~pytorch_lightning.core.lightning.LightningModule.test_step` for more details
         """
         with self.training_type_plugin.precision_plugin.test_step_context():
-            return self.training_type_plugin.test_step(*step_kwargs.values())
+            return self.training_type_plugin.test_step(*args, **kwargs)
 
-    def predict_step(self, step_kwargs: Dict[str, Union[Any, int]]) -> STEP_OUTPUT:
+    def predict_step(self, *args, **kwargs) -> STEP_OUTPUT:
         """The actual predict step.
 
         See :meth:`~pytorch_lightning.core.lightning.LightningModule.predict_step` for more details
         """
         with self.training_type_plugin.precision_plugin.predict_step_context():
-            return self.training_type_plugin.predict_step(*step_kwargs.values())
+            return self.training_type_plugin.predict_step(*args, **kwargs)
 
     def get_device_stats(self, device: Union[str, torch.device]) -> Dict[str, Any]:
         """Gets stats for a given device.

--- a/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
@@ -225,11 +225,11 @@ class EvaluationEpochLoop(Loop):
         if self.trainer.testing:
             self.trainer.lightning_module._current_fx_name = "test_step"
             with self.trainer.profiler.profile("test_step"):
-                output = self.trainer.accelerator.test_step(step_kwargs)
+                output = self.trainer.accelerator.test_step(*step_kwargs.values())
         else:
             self.trainer.lightning_module._current_fx_name = "validation_step"
             with self.trainer.profiler.profile("validation_step"):
-                output = self.trainer.accelerator.validation_step(step_kwargs)
+                output = self.trainer.accelerator.validation_step(*step_kwargs.values())
 
         return output
 

--- a/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
@@ -132,7 +132,7 @@ class PredictionEpochLoop(Loop):
         self.batch_progress.increment_started()
 
         model_ref._current_fx_name = "predict_step"
-        predictions = self.trainer.accelerator.predict_step(step_kwargs)
+        predictions = self.trainer.accelerator.predict_step(*step_kwargs.values())
 
         self.batch_progress.increment_processed()
 

--- a/pytorch_lightning/loops/optimization/manual_loop.py
+++ b/pytorch_lightning/loops/optimization/manual_loop.py
@@ -104,7 +104,7 @@ class ManualOptimization(Loop[_OUTPUTS_TYPE]):
             # manually capture logged metrics
             lightning_module._current_fx_name = "training_step"
             with self.trainer.profiler.profile("training_step"):
-                training_step_output = self.trainer.accelerator.training_step(step_kwargs)
+                training_step_output = self.trainer.accelerator.training_step(*step_kwargs.values())
                 self.trainer.training_type_plugin.post_training_step()
 
             del step_kwargs

--- a/pytorch_lightning/loops/optimization/optimizer_loop.py
+++ b/pytorch_lightning/loops/optimization/optimizer_loop.py
@@ -428,7 +428,7 @@ class OptimizerLoop(Loop[_OUTPUTS_TYPE]):
             # manually capture logged metrics
             lightning_module._current_fx_name = "training_step"
             with self.trainer.profiler.profile("training_step"):
-                training_step_output = self.trainer.accelerator.training_step(step_kwargs)
+                training_step_output = self.trainer.accelerator.training_step(*step_kwargs.values())
                 self.trainer.training_type_plugin.post_training_step()
 
             del step_kwargs


### PR DESCRIPTION
From @justusschock's comments in #10890
Refactor accelerator X_steps()'s signature, to support both positional and keyword arguments
Instead of unrolling step_kwarg dictionary in accelerator steps, unroll them in caller side.

This will unblock #10648 move functions from accelerator to strategies part
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #10907

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
