### PR TITLE
Sort out the dataloader idx logic for evaluation

### DIFF
--- a/pytorch_lightning/accelerators/accelerator.py
+++ b/pytorch_lightning/accelerators/accelerator.py
@@ -126,21 +126,21 @@ class Accelerator:
         with self.training_type_plugin.precision_plugin.train_step_context():
             return self.training_type_plugin.training_step(*step_kwargs.values())
 
-    def validation_step(self, step_kwargs: Dict[str, Union[Any, int]]) -> Optional[STEP_OUTPUT]:
+    def validation_step(self, **kwargs: Any) -> Optional[STEP_OUTPUT]:
         """The actual validation step.
 
         See :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step` for more details
         """
         with self.training_type_plugin.precision_plugin.val_step_context():
-            return self.training_type_plugin.validation_step(*step_kwargs.values())
+            return self.training_type_plugin.validation_step(*kwargs.values())
 
-    def test_step(self, step_kwargs: Dict[str, Union[Any, int]]) -> Optional[STEP_OUTPUT]:
+    def test_step(self, **kwargs: Any) -> Optional[STEP_OUTPUT]:
         """The actual test step.
 
         See :meth:`~pytorch_lightning.core.lightning.LightningModule.test_step` for more details
         """
         with self.training_type_plugin.precision_plugin.test_step_context():
-            return self.training_type_plugin.test_step(*step_kwargs.values())
+            return self.training_type_plugin.test_step(*kwargs.values())
 
     def predict_step(self, step_kwargs: Dict[str, Union[Any, int]]) -> STEP_OUTPUT:
         """The actual predict step.

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -109,7 +109,6 @@ class LightningModule(
         # optionally can be set by user
         self._example_input_array = None
         self._current_fx_name: Optional[str] = None
-        self._current_dataloader_idx: Optional[int] = None
         self._automatic_optimization: bool = True
         self._truncated_bptt_steps: int = 0
         self._param_requires_grad_state = {}
@@ -419,7 +418,6 @@ class LightningModule(
             reduce_fx=reduce_fx,
             enable_graph=enable_graph,
             add_dataloader_idx=add_dataloader_idx,
-            dataloader_idx=self._current_dataloader_idx,
             batch_size=batch_size,
             sync_dist=sync_dist and distributed_available(),
             sync_dist_fn=self.trainer.training_type_plugin.reduce or sync_ddp,

--- a/pytorch_lightning/loops/dataloader/evaluation_loop.py
+++ b/pytorch_lightning/loops/dataloader/evaluation_loop.py
@@ -101,17 +101,15 @@ class EvaluationLoop(DataLoaderLoop):
         void(*args, **kwargs)
 
         dataloader_idx = self.current_dataloader_idx
-        maybe_dataloader_idx = dataloader_idx if self.num_dataloaders > 1 else None
-
-        self.trainer.logger_connector._dataloader_idx = maybe_dataloader_idx
-
         dataloader = self.trainer.training_type_plugin.process_dataloader(self.current_dataloader)
         self.data_fetcher = dataloader = self.trainer._data_connector.get_profiled_dataloader(
             dataloader, dataloader_idx=dataloader_idx
         )
         dl_max_batches = self._max_batches[dataloader_idx]
 
-        dl_outputs = self.epoch_loop.run(dataloader, maybe_dataloader_idx, dl_max_batches)
+        dl_outputs = self.epoch_loop.run(
+            dataloader, dataloader_idx if self.num_dataloaders > 1 else None, dl_max_batches
+        )
 
         # store batch level output per dataloader
         self._outputs.append(dl_outputs)

--- a/pytorch_lightning/loops/dataloader/evaluation_loop.py
+++ b/pytorch_lightning/loops/dataloader/evaluation_loop.py
@@ -100,14 +100,18 @@ class EvaluationLoop(DataLoaderLoop):
         """Performs evaluation on one single dataloader."""
         void(*args, **kwargs)
 
-        dataloader_idx: int = self.current_dataloader_idx
+        dataloader_idx = self.current_dataloader_idx
+        maybe_dataloader_idx = dataloader_idx if self.num_dataloaders > 1 else None
+
+        self.trainer.logger_connector._dataloader_idx = maybe_dataloader_idx
+
         dataloader = self.trainer.training_type_plugin.process_dataloader(self.current_dataloader)
         self.data_fetcher = dataloader = self.trainer._data_connector.get_profiled_dataloader(
             dataloader, dataloader_idx=dataloader_idx
         )
         dl_max_batches = self._max_batches[dataloader_idx]
 
-        dl_outputs = self.epoch_loop.run(dataloader, dataloader_idx, dl_max_batches, self.num_dataloaders)
+        dl_outputs = self.epoch_loop.run(dataloader, maybe_dataloader_idx, dl_max_batches)
 
         # store batch level output per dataloader
         self._outputs.append(dl_outputs)
@@ -212,17 +216,13 @@ class EvaluationLoop(DataLoaderLoop):
         # inform logger the batch loop has finished
         self.trainer.logger_connector.epoch_end_reached()
 
-        # call the model epoch end
-        model = self.trainer.lightning_module
-
-        # unset dataloader_idx in model
-        model._current_dataloader_idx = None
-
         # with a single dataloader don't pass a 2D list
         output_or_outputs: Union[EPOCH_OUTPUT, List[EPOCH_OUTPUT]] = (
             outputs[0] if len(outputs) > 0 and self.num_dataloaders == 1 else outputs
         )
 
+        # call the model epoch end
+        model = self.trainer.lightning_module
         if self.trainer.testing:
             if is_overridden("test_epoch_end", model):
                 model._current_fx_name = "test_epoch_end"

--- a/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
@@ -108,7 +108,7 @@ class EvaluationEpochLoop(Loop):
 
         if not data_fetcher.store_on_device:
             with self.trainer.profiler.profile("evaluation_batch_to_device"):
-                batch = self.trainer.training_type_plugin.batch_to_device(batch, dataloader_idx=dataloader_idx or 0)
+                batch = self.trainer.training_type_plugin.batch_to_device(batch, dataloader_idx=(dataloader_idx or 0))
 
         self.batch_progress.increment_ready()
 

--- a/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
@@ -69,7 +69,7 @@ class EvaluationEpochLoop(Loop):
             self.batch_progress.reset_on_restart()
 
     def on_run_start(  # type: ignore[override]
-        self, data_fetcher: AbstractDataFetcher, dataloader_idx: Optional[int], dl_max_batches: Optional[int]
+        self, data_fetcher: AbstractDataFetcher, dataloader_idx: Optional[int], dl_max_batches: int
     ) -> None:
         """Adds the passed arguments to the loop's state if necessary.
 

--- a/pytorch_lightning/loops/epoch/training_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/training_epoch_loop.py
@@ -158,7 +158,7 @@ class TrainingEpochLoop(loops.Loop[_OUTPUTS_TYPE]):
 
         self.batch_progress.increment_ready()
 
-        self.trainer.logger_connector.on_batch_start(batch_idx, batch)
+        self.trainer.logger_connector.on_batch_start(batch, batch_idx)
 
         if batch is None:
             self._warning_cache.warn("train_dataloader yielded None. If this was on purpose, ignore this warning...")

--- a/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -140,11 +140,11 @@ class LoggerConnector:
             self._test_log_step += 1
 
     def update_eval_step_metrics(self) -> None:
+        assert not self._epoch_end_reached
         if self.trainer.sanity_checking:
             return
 
         # logs user requested information to logger
-        assert not self._epoch_end_reached
         self.log_metrics(self.metrics["log"], step=self._eval_log_step)
 
         # increment the step even if nothing was logged

--- a/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -270,12 +270,13 @@ class LoggerConnector:
         self._batch_idx = None
         self._split_idx = None
 
-        results = self.trainer._results
-        assert results is not None
-        results.dataloader_idx = None
-
     def on_epoch_end(self) -> None:
         assert self._epoch_end_reached
+        results = self.trainer._results
+        assert results is not None
+        # we need to reset this index before the `self.metrics` call below
+        results.dataloader_idx = None
+
         metrics = self.metrics
         self._progress_bar_metrics.update(metrics["pbar"])
         self._callback_metrics.update(metrics["callback"])
@@ -308,8 +309,9 @@ class LoggerConnector:
         self._callback_metrics = {}
 
     def reset_results(self) -> None:
-        if self.trainer._results is not None:
-            self.trainer._results.reset()
+        results = self.trainer._results
+        if results is not None:
+            results.reset()
 
         self._batch_idx = None
         self._split_idx = None

--- a/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/logger_connector.py
@@ -139,11 +139,6 @@ class LoggerConnector:
         elif self.trainer.state.stage is RunningStage.TESTING:
             self._test_log_step += 1
 
-    def on_evaluation_batch_start(self, dataloader_idx: int, num_dataloaders: int) -> None:
-        model = self.trainer.lightning_module
-        # set dataloader_idx only if multiple ones
-        model._current_dataloader_idx = dataloader_idx if num_dataloaders > 1 else None
-
     def update_eval_step_metrics(self) -> None:
         if self.trainer.sanity_checking:
             return
@@ -259,20 +254,25 @@ class LoggerConnector:
     def on_epoch_start(self) -> None:
         self._epoch_end_reached = False
 
-    def on_batch_start(self, batch_idx: int, batch: Any) -> None:
+    def on_batch_start(self, batch: Any, batch_idx: int, dataloader_idx: Optional[int] = None) -> None:
         self._batch_idx = batch_idx
         self._epoch_end_reached = False
 
-        assert self.trainer._results is not None
+        results = self.trainer._results
+        assert results is not None
         # attach reference to the new batch and remove the cached batch_size
-        self.trainer._results.batch = batch
-        self.trainer._results.batch_size = None
+        results.batch = batch
+        results.batch_size = None
+        results.dataloader_idx = dataloader_idx
 
     def epoch_end_reached(self) -> None:
         self._epoch_end_reached = True
         self._batch_idx = None
         self._split_idx = None
-        assert self.trainer._results is not None
+
+        results = self.trainer._results
+        assert results is not None
+        results.dataloader_idx = None
 
     def on_epoch_end(self) -> None:
         assert self._epoch_end_reached

--- a/pytorch_lightning/trainer/connectors/logger_connector/result.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/result.py
@@ -393,6 +393,7 @@ class ResultCollection(dict):
         self.device: Optional[Union[str, torch.device]] = device
         self.batch: Optional[Any] = None
         self.batch_size: Optional[int] = None
+        self.dataloader_idx: Optional[int] = None
 
     @property
     def result_metrics(self) -> List[ResultMetric]:
@@ -436,7 +437,6 @@ class ResultCollection(dict):
         sync_dist_fn: Callable = _Sync.no_op,
         sync_dist_group: Optional[Any] = None,
         add_dataloader_idx: bool = True,
-        dataloader_idx: Optional[int] = None,
         batch_size: Optional[int] = None,
         metric_attribute: Optional[str] = None,
         rank_zero_only: bool = False,
@@ -453,9 +453,9 @@ class ResultCollection(dict):
         # storage key
         key = f"{fx}.{name}"
         # add dataloader_suffix to both key and fx
-        if add_dataloader_idx and dataloader_idx is not None:
-            key += f".{dataloader_idx}"
-            fx += f".{dataloader_idx}"
+        if add_dataloader_idx and self.dataloader_idx is not None:
+            key += f".{self.dataloader_idx}"
+            fx += f".{self.dataloader_idx}"
 
         meta = _Metadata(
             fx=fx,
@@ -467,7 +467,7 @@ class ResultCollection(dict):
             reduce_fx=reduce_fx,
             enable_graph=enable_graph,
             add_dataloader_idx=add_dataloader_idx,
-            dataloader_idx=dataloader_idx,
+            dataloader_idx=self.dataloader_idx,
             metric_attribute=metric_attribute,
         )
         meta.sync = _Sync(_should=sync_dist, fn=sync_dist_fn, _group=sync_dist_group, rank_zero_only=rank_zero_only)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1430,7 +1430,6 @@ class Trainer(
         self.call_hook("teardown", stage=fn)
 
         self.lightning_module._current_fx_name = None
-        self.lightning_module._current_dataloader_idx = None
         # these could have become stale if metrics are defined in `setup`
         self.lightning_module._metric_attributes = None
 

--- a/tests/loops/test_loop_state_dict.py
+++ b/tests/loops/test_loop_state_dict.py
@@ -81,6 +81,7 @@ def test_loops_state_dict_structure():
             "epoch_loop.val_loop._results": {
                 "batch": None,
                 "batch_size": None,
+                "dataloader_idx": None,
                 "training": False,
                 "device": None,
                 "items": {},
@@ -88,6 +89,7 @@ def test_loops_state_dict_structure():
             "epoch_loop._results": {
                 "batch": None,
                 "batch_size": None,
+                "dataloader_idx": None,
                 "training": True,
                 "device": None,
                 "items": {},
@@ -109,6 +111,7 @@ def test_loops_state_dict_structure():
             "_results": {
                 "batch": None,
                 "batch_size": None,
+                "dataloader_idx": None,
                 "training": False,
                 "device": None,
                 "items": {},
@@ -126,6 +129,7 @@ def test_loops_state_dict_structure():
             "_results": {
                 "batch": None,
                 "batch_size": None,
+                "dataloader_idx": None,
                 "training": False,
                 "device": None,
                 "items": {},

--- a/tests/trainer/logging_/test_eval_loop_logging.py
+++ b/tests/trainer/logging_/test_eval_loop_logging.py
@@ -471,13 +471,13 @@ def test_log_works_in_test_callback(tmpdir):
     assert cb.funcs_called_count["on_test_batch_end"] == 4
     assert cb.funcs_called_count["on_test_epoch_end"] == 1
 
-    callback_metrics_keys = list(trainer.callback_metrics)
-    for func_name in cb.callback_funcs_called.keys():
-        is_in = False
-        for callback_metrics_key in callback_metrics_keys:
-            if func_name in callback_metrics_key:
-                is_in = True
-        assert is_in, (func_name, callback_metrics_keys)
+    callback_metrics = trainer.callback_metrics
+    for func_name in cb.callback_funcs_called:
+        for key in callback_metrics:
+            if func_name in key:
+                break
+        else:
+            assert False, (func_name, list(callback_metrics))
 
     def get_expected(on_epoch, values):
         reduction = np.mean if on_epoch else np.max

--- a/tests/trainer/logging_/test_eval_loop_logging.py
+++ b/tests/trainer/logging_/test_eval_loop_logging.py
@@ -393,8 +393,8 @@ def test_log_works_in_test_callback(tmpdir):
                 pl_module.log(custom_func_name, self.count, on_step=on_step, on_epoch=on_epoch, prog_bar=prog_bar)
 
                 num_dl_ext = ""
-                if pl_module._current_dataloader_idx is not None:
-                    dl_idx = pl_module._current_dataloader_idx
+                dl_idx = pl_module.trainer._results.dataloader_idx
+                if dl_idx is not None:
                     num_dl_ext = f"/dataloader_idx_{dl_idx}"
                     func_name += num_dl_ext
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1880,11 +1880,9 @@ def test_module_current_fx_attributes_reset(tmpdir):
 
     trainer.fit(model)
     assert model._current_fx_name is None
-    assert model._current_dataloader_idx is None
 
     trainer.test(model)
     assert model._current_fx_name is None
-    assert model._current_dataloader_idx is None
 
 
 def test_exception_when_lightning_module_is_not_set_on_trainer():


### PR DESCRIPTION
## What does this PR do?

- Save the current dataloader idx in the `ResultCollection` instead of the `LightningModule`
- Avoid leaking the dataloader idx logic from the EvaluationLoop (where it should be contained) to the `EvaluationEpochLoop`

Follow-up to #10810

This will enable an optimization where we don't compute the results multiple times when multiple dataloaders are used during evaluation.

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [n/a] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @borda @justusschock @awaelchli @akihironitta @carmocca @edward-io @ananthsub @ninginthecloud