### PR TITLE
Fix spawn plugins not deleting temp checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed an issue with item assignment on the logger on rank > 0 for those who support it ([#10917](https://github.com/PyTorchLightning/pytorch-lightning/pull/10917))
 
 
+- Fixed an issue with `DDPSpawnPlugin` and related plugins leaving a temporary checkpoint behind ([#10934](https://github.com/PyTorchLightning/pytorch-lightning/pull/10934))
+
 
 ## [1.5.4] - 2021-11-30
 

--- a/pytorch_lightning/plugins/io/torch_plugin.py
+++ b/pytorch_lightning/plugins/io/torch_plugin.py
@@ -75,5 +75,5 @@ class TorchCheckpointIO(CheckpointIO):
         """
         fs = get_filesystem(path)
         if fs.exists(path):
-            fs.rm(path, recursive=True)
+            fs.rm(str(path), recursive=True)
             log.debug(f"Removed checkpoint: {path}")

--- a/pytorch_lightning/plugins/io/torch_plugin.py
+++ b/pytorch_lightning/plugins/io/torch_plugin.py
@@ -75,5 +75,5 @@ class TorchCheckpointIO(CheckpointIO):
         """
         fs = get_filesystem(path)
         if fs.exists(path):
-            fs.rm(str(path), recursive=True)
+            fs.rm(path, recursive=True)
             log.debug(f"Removed checkpoint: {path}")

--- a/pytorch_lightning/plugins/training_type/ddp_spawn.py
+++ b/pytorch_lightning/plugins/training_type/ddp_spawn.py
@@ -282,6 +282,7 @@ class DDPSpawnPlugin(ParallelPlugin):
                 spawn_output.last_path, map_location=(lambda storage, loc: storage)
             )
             self.lightning_module.load_state_dict(ckpt)
+            self.checkpoint_io.remove_checkpoint(spawn_output.last_path)
 
         # get the `callback_metrics` and set it to the trainer
         if is_overridden("get_from_queue", self.lightning_module):


### PR DESCRIPTION
## What does this PR do?

Fixes #10933
A temporary checkpoint gets created when `Trainer(strategy="ddp_spawn")` but never gets deleted.


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃

Part of #1 (it's a lie, this is just here to avoid noisy GitHub bot)




cc @borda @awaelchli @ananthsub @ninginthecloud @justusschock @kaushikb11