### PR TITLE
Add Trainer.state to spawn queue

### DIFF
--- a/pytorch_lightning/plugins/training_type/ddp_spawn.py
+++ b/pytorch_lightning/plugins/training_type/ddp_spawn.py
@@ -32,7 +32,7 @@ from pytorch_lightning.plugins.environments.cluster_environment import ClusterEn
 from pytorch_lightning.plugins.io.checkpoint_plugin import CheckpointIO
 from pytorch_lightning.plugins.precision import PrecisionPlugin
 from pytorch_lightning.plugins.training_type.parallel import ParallelPlugin
-from pytorch_lightning.trainer.states import TrainerFn
+from pytorch_lightning.trainer.states import TrainerFn, TrainerState
 from pytorch_lightning.utilities import _TORCH_GREATER_EQUAL_1_8, rank_zero_warn
 from pytorch_lightning.utilities.apply_func import apply_to_collection, move_data_to_device
 from pytorch_lightning.utilities.distributed import distributed_available
@@ -268,7 +268,8 @@ class DDPSpawnPlugin(ParallelPlugin):
         else:
             self.add_to_queue(trainer, extra)
 
-        return _SpawnOutput(best_model_path, last_path, results, extra)
+        trainer_state = trainer.state
+        return _SpawnOutput(best_model_path, last_path, trainer_state, results, extra)
 
     def __recover_results_in_main_process(self, spawn_output: "_SpawnOutput", trainer) -> None:
         # transfer back the best path to the trainer
@@ -282,6 +283,8 @@ class DDPSpawnPlugin(ParallelPlugin):
                 spawn_output.last_path, map_location=(lambda storage, loc: storage)
             )
             self.lightning_module.load_state_dict(ckpt)
+
+        trainer.state = spawn_output.trainer_state
 
         # get the `callback_metrics` and set it to the trainer
         if is_overridden("get_from_queue", self.lightning_module):
@@ -417,5 +420,6 @@ class _FakeQueue(UserList):
 class _SpawnOutput(NamedTuple):
     best_model_path: Optional[_PATH]
     last_path: Optional[_PATH]
+    trainer_state: TrainerState
     trainer_results: Any
     extra: _FakeQueue

--- a/pytorch_lightning/plugins/training_type/ddp_spawn.py
+++ b/pytorch_lightning/plugins/training_type/ddp_spawn.py
@@ -268,8 +268,7 @@ class DDPSpawnPlugin(ParallelPlugin):
         else:
             self.add_to_queue(trainer, extra)
 
-        trainer_state = trainer.state
-        return _SpawnOutput(best_model_path, last_path, trainer_state, results, extra)
+        return _SpawnOutput(best_model_path, last_path, trainer.state, results, extra)
 
     def __recover_results_in_main_process(self, spawn_output: "_SpawnOutput", trainer) -> None:
         # transfer back the best path to the trainer

--- a/pytorch_lightning/plugins/training_type/tpu_spawn.py
+++ b/pytorch_lightning/plugins/training_type/tpu_spawn.py
@@ -218,7 +218,8 @@ class TPUSpawnPlugin(DDPSpawnPlugin):
         else:
             self.add_to_queue(trainer, extra)
 
-        return _SpawnOutput(best_model_path, last_path, results, extra)
+        trainer_state = trainer.state
+        return _SpawnOutput(best_model_path, last_path, trainer_state, results, extra)
 
     def broadcast(self, obj: object, src: int = 0) -> object:
         if not self.is_distributed:

--- a/pytorch_lightning/plugins/training_type/tpu_spawn.py
+++ b/pytorch_lightning/plugins/training_type/tpu_spawn.py
@@ -218,8 +218,7 @@ class TPUSpawnPlugin(DDPSpawnPlugin):
         else:
             self.add_to_queue(trainer, extra)
 
-        trainer_state = trainer.state
-        return _SpawnOutput(best_model_path, last_path, trainer_state, results, extra)
+        return _SpawnOutput(best_model_path, last_path, trainer.state, results, extra)
 
     def broadcast(self, obj: object, src: int = 0) -> object:
         if not self.is_distributed:


### PR DESCRIPTION
## What does this PR do?

Part of #10896 splitting out the changes. 
In #10896 we will need to update the state of the Trainer in the the main process because the multiprocessing boundary will be moved beyond the point where we get to set the state (e.g. to finished). Therefore this information needs to come from the subprocess now, so we add it to the queue.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃

Part of #1 (it's a lie, this is just here to avoid noisy GitHub bot)



cc @borda @justusschock @kaushikb11 @awaelchli