### PR TITLE
Remove `start_{training,evaluating,predicting}` from `HorovodPlugin` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed method `training_step`, `test_step`, `validation_step` and `predict_step` from the `Accelerator` ([#10890](https://github.com/PyTorchLightning/pytorch-lightning/pull/10890))
 
 
+- Removed `HorovodPlugin.start_{training,evaluating,predicting}` hooks ([#10989](https://github.com/PyTorchLightning/pytorch-lightning/pull/10989))
+
+
+
 ### Fixed
 
 - Fixed an issue with `SignalConnector` not restoring the default signal handlers on teardown when running on SLURM or with fault-tolerant training enabled ([#10611](https://github.com/PyTorchLightning/pytorch-lightning/pull/10611))

--- a/pytorch_lightning/plugins/training_type/horovod.py
+++ b/pytorch_lightning/plugins/training_type/horovod.py
@@ -24,7 +24,6 @@ from pytorch_lightning.core.optimizer import LightningOptimizer
 from pytorch_lightning.plugins.io.checkpoint_plugin import CheckpointIO
 from pytorch_lightning.plugins.precision import PrecisionPlugin
 from pytorch_lightning.plugins.training_type.parallel import ParallelPlugin
-from pytorch_lightning.trainer.states import TrainerFn
 from pytorch_lightning.utilities import _HOROVOD_AVAILABLE
 from pytorch_lightning.utilities.distributed import distributed_available
 from pytorch_lightning.utilities.distributed import group as dist_group

--- a/pytorch_lightning/plugins/training_type/horovod.py
+++ b/pytorch_lightning/plugins/training_type/horovod.py
@@ -112,7 +112,6 @@ class HorovodPlugin(ParallelPlugin):
 
         self.optimizers = self._wrap_optimizers(optimizers)
 
-
         self._exit_stack = ExitStack()
         self._exit_stack.__enter__()
         if trainer.state.fn == TrainerFn.FITTING:

--- a/pytorch_lightning/plugins/training_type/horovod.py
+++ b/pytorch_lightning/plugins/training_type/horovod.py
@@ -115,7 +115,7 @@ class HorovodPlugin(ParallelPlugin):
         self._exit_stack = ExitStack()
         self._exit_stack.__enter__()
         if trainer.state.fn == TrainerFn.FITTING:
-            for optimizer in optimizers:
+            for optimizer in self.optimizers:
                 # Synchronization will be performed explicitly following backward()
                 self._exit_stack.enter_context(optimizer.skip_synchronize())
 


### PR DESCRIPTION
## What does this PR do?

Preparation for #10896.

In #10896 the Trainer will no longer call `self.ttp.start_training()` on the plugin. Instead it directly calls `self.run_stage()`. This would break `HorovodPlugin` which relies on overrides for `start_training` to wrap the stage with a context manager. With this small refactor, we make this override obsolete and can unblock #10896 and subsequent follow-ups #10987.  

### Does your PR introduce any breaking changes? If yes, please list them.

Yes, custom `HorovodPlugins` that have `start_training`, `start_evaluation`, etc. overridden. These methods will no longer be called.

## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃

Part of #1 (it's a lie, this is just here to avoid noisy GitHub bot)

cc @justusschock @awaelchli @akihironitta @borda