### PR TITLE
Added variable interpolation and troubleshooting to LightningCLI doc

### DIFF
--- a/docs/source/common/lightning_cli.rst
+++ b/docs/source/common/lightning_cli.rst
@@ -757,14 +757,14 @@ Instantiation links are used to automatically determine the order of instantiati
     <https://jsonargparse.readthedocs.io/en/stable/#jsonargparse.core.ArgumentParser.link_arguments>`_.
 
 
-Variable interpolation
+Variable Interpolation
 ^^^^^^^^^^^^^^^^^^^^^^
 
-The linking of arguments is intended for things which are meant to be non-configurable. This improves the CLI user
+The linking of arguments is intended for things that are meant to be non-configurable. This improves the CLI user
 experience since it avoids the need for providing more parameters. A related concept is
 variable interpolation which in contrast keeps things being configurable.
 
-The yaml standard defines anchors and aliases which is a way reuse content in multiple places of the yaml. This is
+The YAML standard defines anchors and aliases which is a way to reuse the content in multiple places of the YAML. This is
 supported in the ``LightningCLI`` though it has limitations. Support for OmegaConf's more powerful `variable
 interpolation <https://omegaconf.readthedocs.io/en/2.1_branch/usage.html#variable-interpolation>`__ will be available
 out of the box if this package is installed. To install it run :code:`pip install omegaconf`. Then to enable the use
@@ -774,7 +774,7 @@ of OmegaConf in a ``LightningCLI``, when instantiating a parameter needs to be g
 
     cli = LightningCLI(MyModel, parser_kwargs={"parser_mode": "omegaconf"})
 
-With the encoder-decoder example model above a possible yaml that uses variable interpolation could be the following:
+With the encoder-decoder example model above a possible YAML that uses variable interpolation could be the following:
 
 .. code-block:: yaml
 
@@ -960,8 +960,8 @@ You can also pass the class path directly, for example, if the optimizer hasn't 
 Troubleshooting
 ^^^^^^^^^^^^^^^
 
-The standard behavior for CLIs when they fail is to terminate the process with a non-zero exit code and a short message
-to hint the user about the cause. This is problematic while developing the CLI since there is not information to track
+The standard behavior for CLIs, when they fail, is to terminate the process with a non-zero exit code and a short message
+to hint the user about the cause. This is problematic while developing the CLI since there is no information to track
 down the root of the problem. A simple change in the instantiation of the ``LightningCLI`` can be used such that when
 there is a failure an exception is raised and the full stack trace printed.
 
@@ -972,7 +972,7 @@ there is a failure an exception is raised and the full stack trace printed.
 .. note::
 
     When asking about problems and reporting issues please set the ``error_handler`` to ``None`` and include the stack
-    trace in you description. With this it is more likely for people to help out identifying the cause without needing
+    trace in your description. With this, it is more likely for people to help out identifying the cause without needing
     to create a reproducible script.
 
 

--- a/docs/source/common/lightning_cli.rst
+++ b/docs/source/common/lightning_cli.rst
@@ -80,7 +80,7 @@ LightningCLI
 
 The implementation of training command line tools is done via the :class:`~pytorch_lightning.utilities.cli.LightningCLI`
 class. The minimal installation of pytorch-lightning does not include this support. To enable it, either install
-Lightning as :code:`pytorch-lightning[extra]` or install the package :code:`jsonargparse[signatures]`.
+Lightning as :code:`pytorch-lightning[extra]` or install the package :code:`pip install -U jsonargparse[signatures]`.
 
 The case in which the user's :class:`~pytorch_lightning.core.lightning.LightningModule` class implements all required
 :code:`*_dataloader` methods, a :code:`trainer.py` tool can be as simple as:
@@ -757,6 +757,34 @@ Instantiation links are used to automatically determine the order of instantiati
     <https://jsonargparse.readthedocs.io/en/stable/#jsonargparse.core.ArgumentParser.link_arguments>`_.
 
 
+Variable interpolation
+^^^^^^^^^^^^^^^^^^^^^^
+
+The linking of arguments is intended for things which are meant to be non-configurable. This improves the CLI user
+experience since it avoids the need for providing more parameters. A related concept is
+variable interpolation which in contrast keeps things being configurable.
+
+The yaml standard defines anchors and aliases which is a way reuse content in multiple places of the yaml. This is
+supported in the ``LightningCLI`` though it has limitations. Support for OmegaConf's more powerful `variable
+interpolation <https://omegaconf.readthedocs.io/en/2.1_branch/usage.html#variable-interpolation>`__ will be available
+out of the box if this package is installed. To install it run :code:`pip install omegaconf`. Then to enable the use
+of OmegaConf in a ``LightningCLI``, when instantiating a parameter needs to be given for the parser as follows:
+
+.. testcode::
+
+    cli = LightningCLI(MyModel, parser_kwargs={'parser_mode': 'omegaconf'})
+
+With the encoder-decoder example model above a possible yaml that uses variable interpolation could be the following:
+
+.. code-block:: yaml
+
+    model:
+      encoder_layers: 12
+      decoder_layers:
+      - ${model.encoder_layers}
+      - 4
+
+
 Optimizers and learning rate schedulers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -927,6 +955,25 @@ You can also pass the class path directly, for example, if the optimizer hasn't 
         --gen_optimizer.init_args.lr=0.01 \
         --gen_discriminator.class_path=torch.optim.AdamW \
         --gen_discriminator.init_args.lr=0.0001
+
+
+Troubleshooting
+^^^^^^^^^^^^^^^
+
+The standard behavior for CLIs when they fail is to terminate the process with a non-zero exit code and a short message
+to hint the user about the cause. This is problematic while developing the CLI since there is not information to track
+down the root of the problem. A simple change in the instantiation of the ``LightningCLI`` can be used such that when
+there is a failure an exception is raised and the full stack trace printed.
+
+.. testcode::
+
+    cli = LightningCLI(MyModel, parser_kwargs={'error_handler': None})
+
+.. note::
+
+    When asking about problems and reporting issues please set the ``error_handler`` to ``None`` and include the stack
+    trace in you description. With this it is more likely for people to help out identifying the cause without needing
+    to create a reproducible script.
 
 
 Notes related to reproducibility

--- a/docs/source/common/lightning_cli.rst
+++ b/docs/source/common/lightning_cli.rst
@@ -772,7 +772,7 @@ of OmegaConf in a ``LightningCLI``, when instantiating a parameter needs to be g
 
 .. testcode::
 
-    cli = LightningCLI(MyModel, parser_kwargs={'parser_mode': 'omegaconf'})
+    cli = LightningCLI(MyModel, parser_kwargs={"parser_mode": "omegaconf"})
 
 With the encoder-decoder example model above a possible yaml that uses variable interpolation could be the following:
 
@@ -967,7 +967,7 @@ there is a failure an exception is raised and the full stack trace printed.
 
 .. testcode::
 
-    cli = LightningCLI(MyModel, parser_kwargs={'error_handler': None})
+    cli = LightningCLI(MyModel, parser_kwargs={"error_handler": None})
 
 .. note::
 


### PR DESCRIPTION
## What does this PR do?

Added two sections to the LightningCLI documentation. One explaining the use of OmegaConf's variable interpolation and the other for explaining how to best troubleshoot.

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
