### PR TITLE
WIP: Add calls to quant/dequant submodules for scripted QAT-trained modules

### DIFF
--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -32,6 +32,8 @@ from typing_extensions import Literal
 
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks.progress import base as progress_base
+from pytorch_lightning.callbacks.quantization import _fixup_quantization_torchscript
+
 from pytorch_lightning.core.hooks import CheckpointHooks, DataHooks, ModelHooks
 from pytorch_lightning.core.mixins import DeviceDtypeModuleMixin, HyperparametersMixin
 from pytorch_lightning.core.optimizer import LightningOptimizer
@@ -1874,6 +1876,9 @@ class LightningModule(
 
         if method == "script":
             torchscript_module = torch.jit.script(self.eval(), **kwargs)
+            # Add quant and dequant calls to scripted forward. This is usually done via a wrapper,
+            # but the JIT doesn't see it.
+            _fixup_quantization_torchscript(torchscript_module)
         elif method == "trace":
             # if no example inputs are provided, try to see if model has example_input_array set
             if example_inputs is None:

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -33,7 +33,6 @@ from typing_extensions import Literal
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks.progress import base as progress_base
 from pytorch_lightning.callbacks.quantization import _fixup_quantization_torchscript
-
 from pytorch_lightning.core.hooks import CheckpointHooks, DataHooks, ModelHooks
 from pytorch_lightning.core.mixins import DeviceDtypeModuleMixin, HyperparametersMixin
 from pytorch_lightning.core.optimizer import LightningOptimizer

--- a/tests/callbacks/test_quantization.py
+++ b/tests/callbacks/test_quantization.py
@@ -100,7 +100,10 @@ def test_quantize_torchscript(tmpdir):
     qmodel(qmodel.quant(batch[0]))
 
     tsmodel = qmodel.to_torchscript()
-    tsmodel(tsmodel.quant(batch[0]))
+    res1 = tsmodel(tsmodel.quant(batch[0]))
+    assert res1.is_quantized
+    res2 = tsmodel(batch[0])
+    assert not res2.is_quantized
 
 
 @RunIf(quantization=True)


### PR DESCRIPTION
This does a bit of JIT graph surgery to insert the calls to quant/dequant as neeeded.
To keep backward compat, we leave things alone if the input is already quantized.

Fixes: #7552 