### PR TITLE
Set better Trainer defaults in our tests

### DIFF
--- a/tests/accelerators/test_common.py
+++ b/tests/accelerators/test_common.py
@@ -40,7 +40,15 @@ def test_evaluate(tmpdir, trainer_kwargs):
     dm = ClassifDataModule()
     model = CustomClassificationModelDP()
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=2, limit_train_batches=10, limit_val_batches=10, **trainer_kwargs
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        limit_train_batches=10,
+        limit_val_batches=10,
+        **trainer_kwargs,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model, datamodule=dm)
@@ -68,7 +76,16 @@ def test_model_parallel_setup_called(tmpdir):
             self.layer = torch.nn.Linear(32, 2)
 
     model = TestModel()
-    trainer = Trainer(default_root_dir=tmpdir, limit_train_batches=2, limit_val_batches=2, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     assert model.configure_sharded_model_called

--- a/tests/accelerators/test_ddp_spawn.py
+++ b/tests/accelerators/test_ddp_spawn.py
@@ -78,6 +78,9 @@ def test_ddp_all_dataloaders_passed_to_fit(tmpdir):
         limit_val_batches=0.2,
         gpus=[0, 1],
         strategy="ddp_spawn",
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model, train_dataloaders=model.train_dataloader(), val_dataloaders=model.val_dataloader())
     assert trainer.state.finished, "DDP doesn't work with dataloaders passed to fit()."

--- a/tests/accelerators/test_dp.py
+++ b/tests/accelerators/test_dp.py
@@ -194,5 +194,9 @@ def test_dp_training_step_dict(tmpdir):
         limit_test_batches=1,
         gpus=2,
         strategy="dp",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)

--- a/tests/accelerators/test_ipu.py
+++ b/tests/accelerators/test_ipu.py
@@ -120,7 +120,15 @@ def test_warning_if_ipus_not_used(tmpdir):
 @RunIf(ipu=True)
 def test_no_warning_plugin(tmpdir):
     with pytest.warns(None) as record:
-        Trainer(default_root_dir=tmpdir, max_epochs=1, strategy=IPUPlugin(training_opts=poptorch.Options()))
+        Trainer(
+            default_root_dir=tmpdir,
+            max_epochs=1,
+            strategy=IPUPlugin(training_opts=poptorch.Options()),
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
+        )
     assert len(record) == 0
 
 
@@ -153,7 +161,15 @@ def test_optimization(tmpdir):
     dm = ClassifDataModule(length=1024)
     model = IPUClassificationModel()
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, ipus=2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        ipus=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     # fit model
     trainer.fit(model, dm)

--- a/tests/accelerators/test_multi_nodes_gpu.py
+++ b/tests/accelerators/test_multi_nodes_gpu.py
@@ -58,6 +58,9 @@ def test_logging_sync_dist_true_ddp(tmpdir):
         strategy="ddp",
         gpus=1,
         num_nodes=2,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -105,6 +108,9 @@ def test__validation_step__log(tmpdir):
         strategy="ddp",
         gpus=1,
         num_nodes=2,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 

--- a/tests/accelerators/test_tpu.py
+++ b/tests/accelerators/test_tpu.py
@@ -52,7 +52,14 @@ def test_resume_training_on_cpu(tmpdir):
     """Checks if training can be resumed from a saved checkpoint on CPU."""
     # Train a model on TPU
     model = BoringModel()
-    trainer = Trainer(max_epochs=1, tpu_cores=8)
+    trainer = Trainer(
+        max_epochs=1,
+        tpu_cores=8,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     model_path = trainer.checkpoint_callback.best_model_path
@@ -63,7 +70,14 @@ def test_resume_training_on_cpu(tmpdir):
     assert weight_tensor.device == torch.device("cpu")
 
     # Verify that training is resumed on CPU
-    trainer = Trainer(max_epochs=1, default_root_dir=tmpdir)
+    trainer = Trainer(
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model, ckpt_path=model_path)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
 
@@ -75,7 +89,16 @@ def test_if_test_works_after_train(tmpdir):
 
     # Train a model on TPU
     model = BoringModel()
-    trainer = Trainer(max_epochs=1, tpu_cores=8, default_root_dir=tmpdir, fast_dev_run=True)
+    trainer = Trainer(
+        max_epochs=1,
+        tpu_cores=8,
+        default_root_dir=tmpdir,
+        fast_dev_run=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     assert len(trainer.test(model)) == 1
 
@@ -215,6 +238,10 @@ def test_manual_optimization_tpus(tmpdir):
         limit_test_batches=0,
         limit_val_batches=0,
         tpu_cores=8,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -249,7 +276,16 @@ def test_auto_parameters_tying_tpus(tmpdir):
 
     assert shared_params[0] == ["layer_1.weight", "layer_3.weight"]
 
-    trainer = Trainer(default_root_dir=tmpdir, limit_train_batches=5, tpu_cores=8, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_train_batches=5,
+        tpu_cores=8,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     assert torch.all(torch.eq(model.layer_1.weight, model.layer_3.weight))
@@ -281,7 +317,16 @@ def test_auto_parameters_tying_tpus_nested_module(tmpdir):
 
     model = NestedModule()
 
-    trainer = Trainer(default_root_dir=tmpdir, limit_train_batches=5, tpu_cores=8, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_train_batches=5,
+        tpu_cores=8,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     assert torch.all(torch.eq(model.net_a.layer.weight, model.net_b.layer.weight))

--- a/tests/benchmarks/test_sharded_parity.py
+++ b/tests/benchmarks/test_sharded_parity.py
@@ -137,7 +137,17 @@ def plugin_parity_test(
     ddp_model = model_cls()
     use_cuda = gpus > 0
 
-    trainer = Trainer(fast_dev_run=True, max_epochs=1, gpus=gpus, precision=precision, strategy="ddp_spawn")
+    trainer = Trainer(
+        fast_dev_run=True,
+        max_epochs=1,
+        gpus=gpus,
+        precision=precision,
+        strategy="ddp_spawn",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     max_memory_ddp, ddp_time = record_ddp_fit_model_stats(trainer=trainer, model=ddp_model, use_cuda=use_cuda)
 
@@ -145,7 +155,17 @@ def plugin_parity_test(
     seed_everything(seed)
     custom_plugin_model = model_cls()
 
-    trainer = Trainer(fast_dev_run=True, max_epochs=1, gpus=gpus, precision=precision, strategy="ddp_sharded_spawn")
+    trainer = Trainer(
+        fast_dev_run=True,
+        max_epochs=1,
+        gpus=gpus,
+        precision=precision,
+        strategy="ddp_sharded_spawn",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     assert isinstance(trainer.training_type_plugin, DDPSpawnShardedPlugin)
 
     max_memory_custom, custom_model_time = record_ddp_fit_model_stats(

--- a/tests/callbacks/test_callback_hook_outputs.py
+++ b/tests/callbacks/test_callback_hook_outputs.py
@@ -54,6 +54,9 @@ def test_train_step_no_return(tmpdir, single_cb: bool):
         max_epochs=1,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     assert any(isinstance(c, CB) for c in trainer.callbacks)
@@ -75,6 +78,9 @@ def test_free_memory_on_eval_outputs(tmpdir):
         limit_val_batches=2,
         max_epochs=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)

--- a/tests/callbacks/test_callbacks.py
+++ b/tests/callbacks/test_callbacks.py
@@ -126,13 +126,29 @@ def test_resume_callback_state_saved_by_type(tmpdir):
     """Test that a legacy checkpoint that didn't use a state key before can still be loaded."""
     model = BoringModel()
     callback = OldStatefulCallback(state=111)
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=1, callbacks=[callback])
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+        callbacks=[callback],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     ckpt_path = Path(trainer.checkpoint_callback.best_model_path)
     assert ckpt_path.exists()
 
     callback = OldStatefulCallback(state=222)
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=2, callbacks=[callback])
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=2,
+        callbacks=[callback],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model, ckpt_path=ckpt_path)
     assert callback.state == 111
 
@@ -145,6 +161,10 @@ def test_resume_incomplete_callbacks_list_warning(tmpdir):
         default_root_dir=tmpdir,
         max_steps=1,
         callbacks=[callback0, callback1],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     ckpt_path = trainer.checkpoint_callback.best_model_path
@@ -153,6 +173,10 @@ def test_resume_incomplete_callbacks_list_warning(tmpdir):
         default_root_dir=tmpdir,
         max_steps=1,
         callbacks=[callback1],  # one callback is missing!
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     with pytest.warns(UserWarning, match=escape(f"Please add the following callbacks: [{repr(callback0.state_key)}]")):
         trainer.fit(model, ckpt_path=ckpt_path)
@@ -161,6 +185,10 @@ def test_resume_incomplete_callbacks_list_warning(tmpdir):
         default_root_dir=tmpdir,
         max_steps=1,
         callbacks=[callback1, callback0],  # all callbacks here, order switched
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     with no_warning_call(UserWarning, match="Please add the following callbacks:"):
         trainer.fit(model, ckpt_path=ckpt_path)

--- a/tests/callbacks/test_callbacks.py
+++ b/tests/callbacks/test_callbacks.py
@@ -132,7 +132,6 @@ def test_resume_callback_state_saved_by_type(tmpdir):
         callbacks=[callback],
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)
@@ -163,7 +162,6 @@ def test_resume_incomplete_callbacks_list_warning(tmpdir):
         callbacks=[callback0, callback1],
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)
@@ -175,7 +173,6 @@ def test_resume_incomplete_callbacks_list_warning(tmpdir):
         callbacks=[callback1],  # one callback is missing!
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     with pytest.warns(UserWarning, match=escape(f"Please add the following callbacks: [{repr(callback0.state_key)}]")):
@@ -187,7 +184,6 @@ def test_resume_incomplete_callbacks_list_warning(tmpdir):
         callbacks=[callback1, callback0],  # all callbacks here, order switched
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     with no_warning_call(UserWarning, match="Please add the following callbacks:"):

--- a/tests/callbacks/test_device_stats_monitor.py
+++ b/tests/callbacks/test_device_stats_monitor.py
@@ -48,6 +48,7 @@ def test_device_stats_gpu_from_torch(tmpdir):
         logger=DebugLogger(tmpdir),
         enable_checkpointing=False,
         enable_progress_bar=False,
+        enable_model_summary=False,
     )
 
     trainer.fit(model)
@@ -77,6 +78,7 @@ def test_device_stats_gpu_from_nvidia(tmpdir):
         logger=DebugLogger(tmpdir),
         enable_checkpointing=False,
         enable_progress_bar=False,
+        enable_model_summary=False,
     )
 
     trainer.fit(model)
@@ -106,6 +108,7 @@ def test_device_stats_monitor_tpu(tmpdir):
         logger=DebugLogger(tmpdir),
         enable_checkpointing=False,
         enable_progress_bar=False,
+        enable_model_summary=False,
     )
 
     trainer.fit(model)
@@ -124,6 +127,7 @@ def test_device_stats_monitor_no_logger(tmpdir):
         logger=False,
         enable_checkpointing=False,
         enable_progress_bar=False,
+        enable_model_summary=False,
     )
 
     with pytest.raises(MisconfigurationException, match="Trainer that has no logger."):

--- a/tests/callbacks/test_early_stopping.py
+++ b/tests/callbacks/test_early_stopping.py
@@ -71,6 +71,9 @@ def test_resume_early_stopping_from_checkpoint(tmpdir):
         callbacks=[early_stop_callback, checkpoint_callback],
         num_sanity_val_steps=0,
         max_epochs=4,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     trainer.fit(model, datamodule=dm)
 
@@ -91,6 +94,10 @@ def test_resume_early_stopping_from_checkpoint(tmpdir):
         default_root_dir=tmpdir,
         max_epochs=1,
         callbacks=[early_stop_callback],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with pytest.raises(MisconfigurationException, match=r"You restored a checkpoint with current_epoch"):
@@ -111,6 +118,9 @@ def test_early_stopping_no_extraneous_invocations(tmpdir):
         limit_val_batches=4,
         max_epochs=expected_count,
         enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     trainer.fit(model, datamodule=dm)
 
@@ -141,6 +151,9 @@ def test_early_stopping_patience(tmpdir, loss_values: list, patience: int, expec
         num_sanity_val_steps=0,
         max_epochs=10,
         enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     assert trainer.current_epoch == expected_stop_epoch
@@ -177,6 +190,9 @@ def test_early_stopping_patience_train(
         num_sanity_val_steps=0,
         max_epochs=10,
         enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     assert trainer.current_epoch == expected_stop_epoch
@@ -203,7 +219,16 @@ def test_early_stopping_no_val_step(tmpdir):
     model.val_dataloader = None
 
     stopping = EarlyStopping(monitor="train_loss", min_delta=0.1, patience=0, check_on_train_epoch_end=True)
-    trainer = Trainer(default_root_dir=tmpdir, callbacks=[stopping], overfit_batches=0.20, max_epochs=10)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        callbacks=[stopping],
+        overfit_batches=0.20,
+        max_epochs=10,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model, datamodule=dm)
 
     assert trainer.state.finished, f"Training failed with {trainer.state}"
@@ -234,6 +259,10 @@ def test_early_stopping_thresholds(tmpdir, stopping_threshold, divergence_thesho
         limit_train_batches=0.2,
         limit_val_batches=0.2,
         max_epochs=20,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     assert trainer.current_epoch == expected_epoch, "early_stopping failed"
@@ -258,6 +287,10 @@ def test_early_stopping_on_non_finite_monitor(tmpdir, stop_value):
         limit_train_batches=0.2,
         limit_val_batches=0.2,
         max_epochs=10,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     assert trainer.current_epoch == expected_stop_epoch
@@ -329,6 +362,10 @@ def test_min_steps_override_early_stopping_functionality(tmpdir, step_freeze: in
         limit_val_batches=2,
         min_steps=min_steps,
         min_epochs=min_epochs,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -444,6 +481,10 @@ def test_multiple_early_stopping_callbacks(
         strategy=strategy,
         accelerator="cpu",
         num_processes=num_processes,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -469,6 +510,9 @@ def test_check_on_train_epoch_end_smart_handling(tmpdir, case):
         callbacks=EarlyStopping(monitor="foo"),
         enable_progress_bar=False,
         **kwargs,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     side_effect = [(False, "A"), (True, "B")]

--- a/tests/callbacks/test_finetuning_callback.py
+++ b/tests/callbacks/test_finetuning_callback.py
@@ -72,7 +72,16 @@ def test_finetuning_callback(tmpdir):
     model = FinetuningBoringModel()
     callback = TestBackboneFinetuningCallback(unfreeze_backbone_at_epoch=3, verbose=False)
 
-    trainer = Trainer(limit_train_batches=4, default_root_dir=tmpdir, callbacks=[callback], max_epochs=8)
+    trainer = Trainer(
+        limit_train_batches=4,
+        default_root_dir=tmpdir,
+        callbacks=[callback],
+        max_epochs=8,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     assert model.backbone.has_been_used
@@ -124,11 +133,22 @@ def test_finetuning_callback_warning(tmpdir):
     callback = TestBackboneFinetuningWarningCallback(unfreeze_backbone_at_epoch=3, verbose=False)
 
     with pytest.warns(UserWarning, match="Did you init your optimizer in"):
-        trainer = Trainer(limit_train_batches=1, default_root_dir=tmpdir, callbacks=[callback, chk], max_epochs=2)
+        trainer = Trainer(
+            limit_train_batches=1,
+            default_root_dir=tmpdir,
+            callbacks=[callback, chk],
+            max_epochs=2,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
+        )
         trainer.fit(model)
 
     assert model.backbone.has_been_used
-    trainer = Trainer(max_epochs=3)
+    trainer = Trainer(
+        max_epochs=3, enable_progress_bar=False, enable_model_summary=False, enable_checkpointing=False, logger=False
+    )
     trainer.fit(model, ckpt_path=chk.last_model_path)
 
 
@@ -246,7 +266,16 @@ def test_base_finetuning_internal_optimizer_metadata(tmpdir):
     cb = OnEpochLayerFinetuning()
     chk = ModelCheckpoint(dirpath=tmpdir, save_last=True)
     model = FreezeModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=5, limit_train_batches=1, callbacks=[cb, chk])
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=5,
+        limit_train_batches=1,
+        callbacks=[cb, chk],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     assert len(cb._internal_optimizer_metadata[0]) == 6
     assert cb._internal_optimizer_metadata[0][0]["params"] == ["layer.0.weight"]
@@ -258,7 +287,14 @@ def test_base_finetuning_internal_optimizer_metadata(tmpdir):
 
     model = FreezeModel()
     cb = OnEpochLayerFinetuning()
-    trainer = Trainer(max_epochs=10, callbacks=[cb])
+    trainer = Trainer(
+        max_epochs=10,
+        callbacks=[cb],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.raises(IndexError, match="index 6 is out of range"):
         trainer.fit(model, ckpt_path=chk.last_model_path)
 
@@ -426,6 +462,8 @@ def test_callbacks_restore_backbone(tmpdir):
         max_epochs=2,
         enable_progress_bar=False,
         callbacks=[ckpt, BackboneFinetuning(unfreeze_backbone_at_epoch=1)],
+        enable_model_summary=False,
+        logger=False,
     )
     trainer.fit(BackboneBoringModel())
 
@@ -437,5 +475,8 @@ def test_callbacks_restore_backbone(tmpdir):
         max_epochs=3,
         enable_progress_bar=False,
         callbacks=BackboneFinetuning(unfreeze_backbone_at_epoch=1),
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(BackboneBoringModel(), ckpt_path=ckpt.last_model_path)

--- a/tests/callbacks/test_finetuning_callback.py
+++ b/tests/callbacks/test_finetuning_callback.py
@@ -140,7 +140,6 @@ def test_finetuning_callback_warning(tmpdir):
             max_epochs=2,
             enable_progress_bar=False,
             enable_model_summary=False,
-            enable_checkpointing=False,
             logger=False,
         )
         trainer.fit(model)
@@ -273,7 +272,6 @@ def test_base_finetuning_internal_optimizer_metadata(tmpdir):
         callbacks=[cb, chk],
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)

--- a/tests/callbacks/test_gpu_stats_monitor.py
+++ b/tests/callbacks/test_gpu_stats_monitor.py
@@ -44,6 +44,9 @@ def test_gpu_stats_monitor(tmpdir):
         gpus=1,
         callbacks=[gpu_stats],
         logger=logger,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
 
     trainer.fit(model)
@@ -68,10 +71,7 @@ def test_gpu_stats_monitor_no_queries(tmpdir):
     model = BoringModel()
     with pytest.deprecated_call(match="GPUStatsMonitor` callback was deprecated in v1.5"):
         gpu_stats = GPUStatsMonitor(
-            memory_utilization=False,
-            gpu_utilization=False,
-            intra_step_time=True,
-            inter_step_time=True,
+            memory_utilization=False, gpu_utilization=False, intra_step_time=True, inter_step_time=True
         )
     trainer = Trainer(
         default_root_dir=tmpdir,
@@ -81,6 +81,10 @@ def test_gpu_stats_monitor_no_queries(tmpdir):
         log_every_n_steps=1,
         gpus=1,
         callbacks=[gpu_stats],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     with mock.patch("pytorch_lightning.loggers.tensorboard.TensorBoardLogger.log_metrics") as log_metrics_mock:
         trainer.fit(model)
@@ -108,7 +112,16 @@ def test_gpu_stats_monitor_no_logger(tmpdir):
     with pytest.deprecated_call(match="GPUStatsMonitor` callback was deprecated in v1.5"):
         gpu_stats = GPUStatsMonitor()
 
-    trainer = Trainer(default_root_dir=tmpdir, callbacks=[gpu_stats], max_epochs=1, gpus=1, logger=False)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        callbacks=[gpu_stats],
+        max_epochs=1,
+        gpus=1,
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
 
     with pytest.raises(MisconfigurationException, match="Trainer that has no logger."):
         trainer.fit(model)
@@ -121,7 +134,16 @@ def test_gpu_stats_monitor_no_gpu_warning(tmpdir):
     with pytest.deprecated_call(match="GPUStatsMonitor` callback was deprecated in v1.5"):
         gpu_stats = GPUStatsMonitor()
 
-    trainer = Trainer(default_root_dir=tmpdir, callbacks=[gpu_stats], max_steps=1, gpus=None)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        callbacks=[gpu_stats],
+        max_steps=1,
+        gpus=None,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.raises(MisconfigurationException, match="not running on GPU"):
         trainer.fit(model)

--- a/tests/callbacks/test_lambda_function.py
+++ b/tests/callbacks/test_lambda_function.py
@@ -47,6 +47,10 @@ def test_lambda_call(tmpdir):
         limit_train_batches=1,
         limit_val_batches=1,
         callbacks=[LambdaCallback(**hooks_args)],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     with pytest.deprecated_call(match="on_keyboard_interrupt` callback hook was deprecated in v1.5"):
         trainer.fit(model)
@@ -62,6 +66,10 @@ def test_lambda_call(tmpdir):
         limit_test_batches=1,
         limit_predict_batches=1,
         callbacks=[LambdaCallback(**hooks_args)],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     with pytest.deprecated_call(match="on_keyboard_interrupt` callback hook was deprecated in v1.5"):
         trainer.fit(model, ckpt_path=ckpt_path)

--- a/tests/callbacks/test_lambda_function.py
+++ b/tests/callbacks/test_lambda_function.py
@@ -49,7 +49,6 @@ def test_lambda_call(tmpdir):
         callbacks=[LambdaCallback(**hooks_args)],
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     with pytest.deprecated_call(match="on_keyboard_interrupt` callback hook was deprecated in v1.5"):

--- a/tests/callbacks/test_lr_monitor.py
+++ b/tests/callbacks/test_lr_monitor.py
@@ -34,7 +34,15 @@ def test_lr_monitor_single_lr(tmpdir):
 
     lr_monitor = LearningRateMonitor()
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=2, limit_val_batches=0.1, limit_train_batches=0.5, callbacks=[lr_monitor]
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        limit_val_batches=0.1,
+        limit_train_batches=0.5,
+        callbacks=[lr_monitor],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -72,6 +80,10 @@ def test_lr_monitor_single_lr_with_momentum(tmpdir, opt: str):
         limit_train_batches=5,
         log_every_n_steps=1,
         callbacks=[lr_monitor],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -98,6 +110,10 @@ def test_log_momentum_no_momentum_optimizer(tmpdir):
         limit_train_batches=5,
         log_every_n_steps=1,
         callbacks=[lr_monitor],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     with pytest.warns(RuntimeWarning, match="optimizers do not have momentum."):
         trainer.fit(model)
@@ -120,7 +136,15 @@ def test_lr_monitor_no_lr_scheduler_single_lr(tmpdir):
 
     lr_monitor = LearningRateMonitor()
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=2, limit_val_batches=0.1, limit_train_batches=0.5, callbacks=[lr_monitor]
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        limit_val_batches=0.1,
+        limit_train_batches=0.5,
+        callbacks=[lr_monitor],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)
@@ -157,6 +181,10 @@ def test_lr_monitor_no_lr_scheduler_single_lr_with_momentum(tmpdir, opt: str):
         limit_train_batches=5,
         log_every_n_steps=1,
         callbacks=[lr_monitor],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -182,6 +210,10 @@ def test_log_momentum_no_momentum_optimizer_no_lr_scheduler(tmpdir):
         limit_train_batches=5,
         log_every_n_steps=1,
         callbacks=[lr_monitor],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     with pytest.warns(RuntimeWarning, match="optimizers do not have momentum."):
         trainer.fit(model)
@@ -197,7 +229,15 @@ def test_lr_monitor_no_logger(tmpdir):
     model = BoringModel()
 
     lr_monitor = LearningRateMonitor()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, callbacks=[lr_monitor], logger=False)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        callbacks=[lr_monitor],
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
 
     with pytest.raises(MisconfigurationException, match="`Trainer` that has no logger"):
         trainer.fit(model)
@@ -233,6 +273,10 @@ def test_lr_monitor_multi_lrs(tmpdir, logging_interval: str):
         limit_train_batches=7,
         limit_val_batches=0.1,
         callbacks=[lr_monitor],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -276,6 +320,10 @@ def test_lr_monitor_no_lr_scheduler_multi_lrs(tmpdir, logging_interval: str):
         limit_train_batches=7,
         limit_val_batches=0.1,
         callbacks=[lr_monitor],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -311,7 +359,15 @@ def test_lr_monitor_param_groups(tmpdir):
 
     lr_monitor = LearningRateMonitor()
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=2, limit_val_batches=0.1, limit_train_batches=0.5, callbacks=[lr_monitor]
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        limit_val_batches=0.1,
+        limit_train_batches=0.5,
+        callbacks=[lr_monitor],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model, datamodule=dm)
 
@@ -336,6 +392,8 @@ def test_lr_monitor_custom_name(tmpdir):
         callbacks=[lr_monitor],
         enable_progress_bar=False,
         enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(TestModel())
     assert list(lr_monitor.lrs) == ["my_logging_name"]
@@ -357,6 +415,8 @@ def test_lr_monitor_custom_pg_name(tmpdir):
         callbacks=[lr_monitor],
         enable_progress_bar=False,
         enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(TestModel())
     assert list(lr_monitor.lrs) == ["lr-SGD/linear"]
@@ -394,6 +454,8 @@ def test_lr_monitor_duplicate_custom_pg_names(tmpdir):
         callbacks=[lr_monitor],
         enable_progress_bar=False,
         enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with pytest.raises(
@@ -486,6 +548,7 @@ def test_multiple_optimizers_basefinetuning(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
+        logger=False,
     )
     model = TestModel()
     model.training_epoch_end = None
@@ -527,10 +590,7 @@ def test_lr_monitor_multiple_param_groups_no_lr_scheduler(tmpdir):
             return x
 
         def configure_optimizers(self):
-            param_groups = [
-                {"params": list(self.linear_a.parameters())},
-                {"params": list(self.linear_b.parameters())},
-            ]
+            param_groups = [{"params": list(self.linear_a.parameters())}, {"params": list(self.linear_b.parameters())}]
             optimizer = torch.optim.Adam(param_groups, lr=self.hparams.lr, betas=self.hparams.momentum)
             return optimizer
 
@@ -543,6 +603,8 @@ def test_lr_monitor_multiple_param_groups_no_lr_scheduler(tmpdir):
         callbacks=[lr_monitor],
         enable_progress_bar=False,
         enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     lr = 1e-2

--- a/tests/callbacks/test_lr_monitor.py
+++ b/tests/callbacks/test_lr_monitor.py
@@ -42,7 +42,6 @@ def test_lr_monitor_single_lr(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     trainer.fit(model)
 
@@ -83,7 +82,6 @@ def test_lr_monitor_single_lr_with_momentum(tmpdir, opt: str):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     trainer.fit(model)
 
@@ -113,7 +111,6 @@ def test_log_momentum_no_momentum_optimizer(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     with pytest.warns(RuntimeWarning, match="optimizers do not have momentum."):
         trainer.fit(model)
@@ -144,7 +141,6 @@ def test_lr_monitor_no_lr_scheduler_single_lr(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
 
     trainer.fit(model)
@@ -184,7 +180,6 @@ def test_lr_monitor_no_lr_scheduler_single_lr_with_momentum(tmpdir, opt: str):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     trainer.fit(model)
 
@@ -213,7 +208,6 @@ def test_log_momentum_no_momentum_optimizer_no_lr_scheduler(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     with pytest.warns(RuntimeWarning, match="optimizers do not have momentum."):
         trainer.fit(model)
@@ -276,7 +270,6 @@ def test_lr_monitor_multi_lrs(tmpdir, logging_interval: str):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     trainer.fit(model)
 
@@ -323,7 +316,6 @@ def test_lr_monitor_no_lr_scheduler_multi_lrs(tmpdir, logging_interval: str):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     trainer.fit(model)
 
@@ -367,7 +359,6 @@ def test_lr_monitor_param_groups(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     trainer.fit(model, datamodule=dm)
 
@@ -393,7 +384,6 @@ def test_lr_monitor_custom_name(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     trainer.fit(TestModel())
     assert list(lr_monitor.lrs) == ["my_logging_name"]
@@ -416,7 +406,6 @@ def test_lr_monitor_custom_pg_name(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     trainer.fit(TestModel())
     assert list(lr_monitor.lrs) == ["lr-SGD/linear"]
@@ -455,7 +444,6 @@ def test_lr_monitor_duplicate_custom_pg_names(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
 
     with pytest.raises(
@@ -548,7 +536,6 @@ def test_multiple_optimizers_basefinetuning(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     model = TestModel()
     model.training_epoch_end = None
@@ -604,7 +591,6 @@ def test_lr_monitor_multiple_param_groups_no_lr_scheduler(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
 
     lr = 1e-2

--- a/tests/callbacks/test_model_summary.py
+++ b/tests/callbacks/test_model_summary.py
@@ -82,6 +82,13 @@ def test_custom_model_summary_callback_summarize(tmpdir):
             assert trainable_parameters == 66
 
     model = BoringModel()
-    trainer = Trainer(default_root_dir=tmpdir, callbacks=CustomModelSummary(), max_steps=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        callbacks=CustomModelSummary(),
+        max_steps=1,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     trainer.fit(model)

--- a/tests/callbacks/test_prediction_writer.py
+++ b/tests/callbacks/test_prediction_writer.py
@@ -47,7 +47,14 @@ def test_prediction_writer_hook_call_intervals(tmpdir):
 
     model = BoringModel()
     cb = DummyPredictionWriter("batch_and_epoch")
-    trainer = Trainer(limit_predict_batches=4, callbacks=cb)
+    trainer = Trainer(
+        limit_predict_batches=4,
+        callbacks=cb,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     results = trainer.predict(model, dataloaders=dataloader)
     assert len(results) == 4
     assert cb.write_on_batch_end.call_count == 4
@@ -57,7 +64,14 @@ def test_prediction_writer_hook_call_intervals(tmpdir):
     DummyPredictionWriter.write_on_epoch_end.reset_mock()
 
     cb = DummyPredictionWriter("batch_and_epoch")
-    trainer = Trainer(limit_predict_batches=4, callbacks=cb)
+    trainer = Trainer(
+        limit_predict_batches=4,
+        callbacks=cb,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.predict(model, dataloaders=dataloader, return_predictions=False)
     assert cb.write_on_batch_end.call_count == 4
     assert cb.write_on_epoch_end.call_count == 1
@@ -66,7 +80,14 @@ def test_prediction_writer_hook_call_intervals(tmpdir):
     DummyPredictionWriter.write_on_epoch_end.reset_mock()
 
     cb = DummyPredictionWriter("batch")
-    trainer = Trainer(limit_predict_batches=4, callbacks=cb)
+    trainer = Trainer(
+        limit_predict_batches=4,
+        callbacks=cb,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.predict(model, dataloaders=dataloader, return_predictions=False)
     assert cb.write_on_batch_end.call_count == 4
     assert cb.write_on_epoch_end.call_count == 0
@@ -75,7 +96,14 @@ def test_prediction_writer_hook_call_intervals(tmpdir):
     DummyPredictionWriter.write_on_epoch_end.reset_mock()
 
     cb = DummyPredictionWriter("epoch")
-    trainer = Trainer(limit_predict_batches=4, callbacks=cb)
+    trainer = Trainer(
+        limit_predict_batches=4,
+        callbacks=cb,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.predict(model, dataloaders=dataloader, return_predictions=False)
     assert cb.write_on_batch_end.call_count == 0
     assert cb.write_on_epoch_end.call_count == 1
@@ -89,7 +117,14 @@ def test_prediction_writer_batch_indices(tmpdir, num_workers):
     dataloader = DataLoader(RandomDataset(32, 64), batch_size=4, num_workers=num_workers)
     model = BoringModel()
     writer = DummyPredictionWriter("batch_and_epoch")
-    trainer = Trainer(limit_predict_batches=4, callbacks=writer)
+    trainer = Trainer(
+        limit_predict_batches=4,
+        callbacks=writer,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.predict(model, dataloaders=dataloader)
 
     writer.write_on_batch_end.assert_has_calls(
@@ -102,7 +137,5 @@ def test_prediction_writer_batch_indices(tmpdir, num_workers):
     )
 
     writer.write_on_epoch_end.assert_has_calls(
-        [
-            call(trainer, model, ANY, [[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]]),
-        ]
+        [call(trainer, model, ANY, [[[0, 1, 2, 3], [4, 5, 6, 7], [8, 9, 10, 11], [12, 13, 14, 15]]])]
     )

--- a/tests/callbacks/test_pruning.py
+++ b/tests/callbacks/test_pruning.py
@@ -304,7 +304,13 @@ def test_permanent_when_model_is_saved_multiple_times(
     ckpt_callback = ModelCheckpoint(
         monitor="test", save_top_k=2, save_last=True, save_on_train_epoch_end=save_on_train_epoch_end
     )
-    trainer = Trainer(callbacks=[pruning_callback, ckpt_callback], max_epochs=3, enable_progress_bar=False)
+    trainer = Trainer(
+        callbacks=[pruning_callback, ckpt_callback],
+        max_epochs=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
+    )
     with caplog.at_level(INFO):
         trainer.fit(model)
 

--- a/tests/callbacks/test_quantization.py
+++ b/tests/callbacks/test_quantization.py
@@ -93,7 +93,15 @@ def test_quantize_torchscript(tmpdir):
     dm = RegressDataModule()
     qmodel = RegressionModel()
     qcb = QuantizationAwareTraining(input_compatible=False)
-    trainer = Trainer(callbacks=[qcb], default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        callbacks=[qcb],
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(qmodel, datamodule=dm)
 
     batch = iter(dm.test_dataloader()).next()
@@ -123,7 +131,15 @@ def test_quantization_exceptions(tmpdir):
 
     fusing_layers = [(f"layers.mlp_{i}", f"layers.NONE-mlp_{i}a") for i in range(3)]
     qcb = QuantizationAwareTraining(modules_to_fuse=fusing_layers)
-    trainer = Trainer(callbacks=[qcb], default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        callbacks=[qcb],
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.raises(MisconfigurationException, match="one or more of them is not your model attributes"):
         trainer.fit(RegressionModel(), datamodule=RegressDataModule())
 
@@ -151,7 +167,15 @@ def test_quantization_triggers(tmpdir, trigger_fn: Union[None, int, Callable], e
     qmodel = RegressionModel()
     qcb = QuantizationAwareTraining(collect_quantization=trigger_fn)
     trainer = Trainer(
-        callbacks=[qcb], default_root_dir=tmpdir, limit_train_batches=1, limit_val_batches=1, max_epochs=4
+        callbacks=[qcb],
+        default_root_dir=tmpdir,
+        limit_train_batches=1,
+        limit_val_batches=1,
+        max_epochs=4,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(qmodel, datamodule=dm)
 
@@ -222,6 +246,10 @@ def test_quantization_val_test_predict(tmpdir):
         val_check_interval=1,
         num_sanity_val_steps=1,
         max_epochs=4,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(val_test_predict_qmodel, datamodule=dm)
     trainer.validate(model=val_test_predict_qmodel, datamodule=dm, verbose=False)
@@ -238,6 +266,10 @@ def test_quantization_val_test_predict(tmpdir):
         limit_train_batches=1,
         limit_val_batches=0,
         max_epochs=4,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     ).fit(expected_qmodel, datamodule=dm)
 
     expected_state_dict = expected_qmodel.state_dict()

--- a/tests/callbacks/test_rich_progress_bar.py
+++ b/tests/callbacks/test_rich_progress_bar.py
@@ -73,6 +73,9 @@ def test_rich_progress_bar(progress_update, tmpdir, dataset):
         limit_predict_batches=1,
         max_steps=1,
         callbacks=RichProgressBar(),
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)
@@ -133,11 +136,7 @@ def test_rich_progress_bar_keyboard_interrupt(tmpdir):
         "pytorch_lightning.callbacks.progress.rich_progress.Progress.stop", autospec=True
     ) as mock_progress_stop:
         progress_bar = RichProgressBar()
-        trainer = Trainer(
-            default_root_dir=tmpdir,
-            fast_dev_run=True,
-            callbacks=progress_bar,
-        )
+        trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=True, callbacks=progress_bar)
 
         trainer.fit(model)
     mock_progress_stop.assert_called_once()
@@ -177,6 +176,9 @@ def test_rich_progress_bar_leave(tmpdir, leave, reset_call_count):
             limit_train_batches=1,
             max_epochs=6,
             callbacks=progress_bar,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
         )
         trainer.fit(model)
     assert mock_progress_reset.call_count == reset_call_count
@@ -196,6 +198,9 @@ def test_rich_progress_bar_refresh_rate(progress_update, tmpdir, refresh_rate, e
         limit_val_batches=6,
         max_epochs=1,
         callbacks=RichProgressBar(refresh_rate=refresh_rate),
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)
@@ -218,6 +223,9 @@ def test_rich_progress_bar_num_sanity_val_steps(tmpdir, limit_val_batches: int):
         limit_val_batches=limit_val_batches,
         max_epochs=1,
         callbacks=progress_bar,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)

--- a/tests/callbacks/test_stochastic_weight_avg.py
+++ b/tests/callbacks/test_stochastic_weight_avg.py
@@ -129,6 +129,9 @@ def train_with_swa(
         strategy=strategy,
         gpus=gpus,
         num_processes=num_processes,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with mock.patch.object(TrainingTypePlugin, "backward", wraps=trainer.training_type_plugin.backward):
@@ -269,10 +272,6 @@ def test_swa_multiple_lrs(tmpdir):
 
     model = TestModel()
     swa_callback = StochasticWeightAveraging(swa_lrs=swa_lrs)
-    trainer = Trainer(
-        default_root_dir=tmpdir,
-        callbacks=swa_callback,
-        fast_dev_run=1,
-    )
+    trainer = Trainer(default_root_dir=tmpdir, callbacks=swa_callback, fast_dev_run=1)
     trainer.fit(model)
     assert model.on_train_epoch_start_called

--- a/tests/callbacks/test_timer.py
+++ b/tests/callbacks/test_timer.py
@@ -31,19 +31,39 @@ def test_trainer_flag(caplog):
         def on_fit_start(self):
             raise SystemExit()
 
-    trainer = Trainer(max_time=dict(seconds=1337))
+    trainer = Trainer(
+        max_time=dict(seconds=1337),
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.raises(SystemExit):
         trainer.fit(TestModel())
     timer = [c for c in trainer.callbacks if isinstance(c, Timer)][0]
     assert timer._duration == 1337
 
-    trainer = Trainer(max_time=dict(seconds=1337), callbacks=[Timer()])
+    trainer = Trainer(
+        max_time=dict(seconds=1337),
+        callbacks=[Timer()],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.raises(SystemExit), caplog.at_level(level=logging.INFO):
         trainer.fit(TestModel())
     assert "callbacks list already contains a Timer" in caplog.text
 
     # Make sure max_time still honored even if max_epochs == -1
-    trainer = Trainer(max_time=dict(seconds=1), max_epochs=-1)
+    trainer = Trainer(
+        max_time=dict(seconds=1),
+        max_epochs=-1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.raises(SystemExit):
         trainer.fit(TestModel())
     timer = [c for c in trainer.callbacks if isinstance(c, Timer)][0]
@@ -109,7 +129,15 @@ def test_timer_stops_training(tmpdir, caplog):
     duration = timedelta(milliseconds=100)
     timer = Timer(duration=duration)
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1000, callbacks=[timer])
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1000,
+        callbacks=[timer],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with caplog.at_level(logging.INFO):
         trainer.fit(model)
     assert trainer.global_step > 1
@@ -161,6 +189,9 @@ def test_timer_resume_training(tmpdir):
         default_root_dir=tmpdir,
         max_epochs=100,
         callbacks=[timer, checkpoint_callback],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     trainer.fit(model)
     assert not timer._offset
@@ -170,10 +201,7 @@ def test_timer_resume_training(tmpdir):
 
     # resume training (with depleted timer
     timer = Timer(duration=timedelta(milliseconds=200))
-    trainer = Trainer(
-        default_root_dir=tmpdir,
-        callbacks=[timer, checkpoint_callback],
-    )
+    trainer = Trainer(default_root_dir=tmpdir, callbacks=[timer, checkpoint_callback])
     trainer.fit(model, ckpt_path=checkpoint_callback.best_model_path)
     assert timer._offset > 0
     assert trainer.global_step == saved_global_step + 1
@@ -185,7 +213,15 @@ def test_timer_track_stages(tmpdir):
     # note: skipped on windows because time resolution of time.monotonic() is not high enough for this fast test
     model = BoringModel()
     timer = Timer()
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=5, callbacks=[timer])
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=5,
+        callbacks=[timer],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     assert timer.time_elapsed() == timer.time_elapsed("train") > 0
     assert timer.time_elapsed("validate") > 0

--- a/tests/callbacks/test_tqdm_progress_bar.py
+++ b/tests/callbacks/test_tqdm_progress_bar.py
@@ -80,7 +80,14 @@ def test_tqdm_progress_bar_totals(tmpdir):
 
     model = BoringModel()
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     bar = trainer.progress_bar_callback
 
     trainer.fit(model)
@@ -204,6 +211,9 @@ def test_tqdm_progress_bar_progress_refresh(tmpdir, refresh_rate: int):
             limit_train_batches=1.0,
             num_sanity_val_steps=2,
             max_epochs=3,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
         )
     assert trainer.progress_bar_callback.refresh_rate == refresh_rate
 
@@ -252,6 +262,7 @@ def test_num_sanity_val_steps_progress_bar(tmpdir, limit_val_batches: int):
         callbacks=[progress_bar],
         logger=False,
         enable_checkpointing=False,
+        enable_model_summary=False,
     )
     trainer.fit(model)
 
@@ -332,6 +343,7 @@ def test_main_progress_bar_update_amount(
         callbacks=[progress_bar],
         logger=False,
         enable_checkpointing=False,
+        enable_model_summary=False,
     )
     trainer.fit(model)
     if train_batches > 0:
@@ -352,6 +364,7 @@ def test_test_progress_bar_update_amount(tmpdir, test_batches: int, refresh_rate
         callbacks=[progress_bar],
         logger=False,
         enable_checkpointing=False,
+        enable_model_summary=False,
     )
     trainer.test(model)
     progress_bar.test_progress_bar.update.assert_has_calls([call(delta) for delta in test_deltas])
@@ -368,7 +381,13 @@ def test_tensor_to_float_conversion(tmpdir):
             return super().training_step(batch, batch_idx)
 
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=2, logger=False, enable_checkpointing=False
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_train_batches=2,
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
     trainer.fit(TestModel())
 
@@ -430,6 +449,10 @@ def test_tqdm_progress_bar_print(tqdm_write, tmpdir):
         limit_predict_batches=1,
         max_steps=1,
         callbacks=[bar],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     trainer.test(model)
@@ -456,6 +479,10 @@ def test_tqdm_progress_bar_print_no_train(tqdm_write, tmpdir):
         limit_predict_batches=1,
         max_steps=1,
         callbacks=[bar],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.validate(model)
@@ -484,6 +511,10 @@ def test_tqdm_progress_bar_print_disabled(tqdm_write, mock_print, tmpdir):
         limit_predict_batches=1,
         max_steps=1,
         callbacks=[bar],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     bar.disable()
     trainer.fit(model)
@@ -498,7 +529,15 @@ def test_tqdm_progress_bar_print_disabled(tqdm_write, mock_print, tmpdir):
 
 def test_tqdm_progress_bar_can_be_pickled():
     bar = TQDMProgressBar()
-    trainer = Trainer(fast_dev_run=True, callbacks=[bar], max_steps=1)
+    trainer = Trainer(
+        fast_dev_run=True,
+        callbacks=[bar],
+        max_steps=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     model = BoringModel()
 
     pickle.dumps(bar)
@@ -531,6 +570,9 @@ def test_progress_bar_max_val_check_interval(
         val_check_interval=val_check_interval,
         gpus=world_size,
         strategy="ddp",
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model, train_dataloaders=train_data, val_dataloaders=val_data)
 
@@ -554,11 +596,7 @@ def test_get_progress_bar_metrics(tmpdir: str):
             return items
 
     progress_bar = TestProgressBar()
-    trainer = Trainer(
-        default_root_dir=tmpdir,
-        callbacks=[progress_bar],
-        fast_dev_run=True,
-    )
+    trainer = Trainer(default_root_dir=tmpdir, callbacks=[progress_bar], fast_dev_run=True)
     model = BoringModel()
     trainer.fit(model)
     model.truncated_bptt_steps = 2
@@ -637,6 +675,7 @@ def test_tqdm_progress_bar_correct_value_epoch_end(tmpdir):
         enable_checkpointing=False,
         log_every_n_steps=1,
         callbacks=pbar,
+        logger=False,
     )
 
     trainer.fit(model)

--- a/tests/callbacks/test_tqdm_progress_bar.py
+++ b/tests/callbacks/test_tqdm_progress_bar.py
@@ -83,7 +83,6 @@ def test_tqdm_progress_bar_totals(tmpdir):
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_epochs=1,
-        enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
         logger=False,
@@ -386,7 +385,6 @@ def test_tensor_to_float_conversion(tmpdir):
         limit_train_batches=2,
         logger=False,
         enable_checkpointing=False,
-        enable_progress_bar=False,
         enable_model_summary=False,
     )
     trainer.fit(TestModel())
@@ -449,7 +447,6 @@ def test_tqdm_progress_bar_print(tqdm_write, tmpdir):
         limit_predict_batches=1,
         max_steps=1,
         callbacks=[bar],
-        enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
         logger=False,
@@ -479,7 +476,6 @@ def test_tqdm_progress_bar_print_no_train(tqdm_write, tmpdir):
         limit_predict_batches=1,
         max_steps=1,
         callbacks=[bar],
-        enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
         logger=False,
@@ -511,7 +507,6 @@ def test_tqdm_progress_bar_print_disabled(tqdm_write, mock_print, tmpdir):
         limit_predict_batches=1,
         max_steps=1,
         callbacks=[bar],
-        enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
         logger=False,
@@ -533,7 +528,6 @@ def test_tqdm_progress_bar_can_be_pickled():
         fast_dev_run=True,
         callbacks=[bar],
         max_steps=1,
-        enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
         logger=False,
@@ -642,7 +636,6 @@ def test_tqdm_progress_bar_correct_value_epoch_end(tmpdir):
 
         def get_metrics(self, trainer, pl_module):
             items = super().get_metrics(trainer, model)
-            del items["v_num"]
             del items["loss"]
             # this is equivalent to mocking `set_postfix` as this method gets called every time
             self.calls[trainer.state.fn].append(

--- a/tests/callbacks/test_xla_stats_monitor.py
+++ b/tests/callbacks/test_xla_stats_monitor.py
@@ -34,7 +34,15 @@ def test_xla_stats_monitor(tmpdir):
     logger = CSVLogger(tmpdir)
 
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=2, limit_train_batches=5, tpu_cores=8, callbacks=[xla_stats], logger=logger
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        limit_train_batches=5,
+        tpu_cores=8,
+        callbacks=[xla_stats],
+        logger=logger,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
 
     trainer.fit(model)
@@ -56,7 +64,16 @@ def test_xla_stats_monitor_no_logger(tmpdir):
     model = BoringModel()
     xla_stats = XLAStatsMonitor()
 
-    trainer = Trainer(default_root_dir=tmpdir, callbacks=[xla_stats], max_epochs=1, tpu_cores=[1], logger=False)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        callbacks=[xla_stats],
+        max_epochs=1,
+        tpu_cores=[1],
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
 
     with pytest.raises(MisconfigurationException, match="Trainer that has no logger."):
         trainer.fit(model)
@@ -69,7 +86,16 @@ def test_xla_stats_monitor_no_tpu_warning(tmpdir):
     model = BoringModel()
     xla_stats = XLAStatsMonitor()
 
-    trainer = Trainer(default_root_dir=tmpdir, callbacks=[xla_stats], max_steps=1, tpu_cores=None)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        callbacks=[xla_stats],
+        max_steps=1,
+        tpu_cores=None,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.raises(MisconfigurationException, match="not running on TPU"):
         trainer.fit(model)

--- a/tests/checkpointing/test_checkpoint_callback_frequency.py
+++ b/tests/checkpointing/test_checkpoint_callback_frequency.py
@@ -24,7 +24,9 @@ from tests.helpers.runif import RunIf
 
 def test_disabled_checkpointing(tmpdir):
     # no callback
-    trainer = Trainer(max_epochs=3, enable_checkpointing=False)
+    trainer = Trainer(
+        max_epochs=3, enable_checkpointing=False, enable_progress_bar=False, enable_model_summary=False, logger=False
+    )
     assert not trainer.checkpoint_callbacks
     trainer.fit(BoringModel())
     assert not trainer.checkpoint_callbacks
@@ -44,6 +46,8 @@ def test_default_checkpoint_freq(save_mock, tmpdir, epochs: int, val_check_inter
         val_check_interval=val_check_interval,
         limit_val_batches=1,
         enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -77,6 +81,8 @@ def test_top_k(save_mock, tmpdir, k: int, epochs: int, val_check_interval: float
         max_epochs=epochs,
         enable_model_summary=False,
         val_check_interval=val_check_interval,
+        enable_progress_bar=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -118,6 +124,7 @@ def test_top_k_ddp(save_mock, tmpdir, k, epochs, val_check_interval, expected):
         gpus=2,
         limit_train_batches=64,
         limit_val_batches=32,
+        logger=False,
     )
     trainer.fit(model)
     if os.getenv("LOCAL_RANK") == "0":

--- a/tests/checkpointing/test_checkpoint_callback_frequency.py
+++ b/tests/checkpointing/test_checkpoint_callback_frequency.py
@@ -46,7 +46,6 @@ def test_default_checkpoint_freq(save_mock, tmpdir, epochs: int, val_check_inter
         val_check_interval=val_check_interval,
         limit_val_batches=1,
         enable_progress_bar=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)

--- a/tests/checkpointing/test_legacy_checkpoints.py
+++ b/tests/checkpointing/test_legacy_checkpoints.py
@@ -82,6 +82,10 @@ def test_resume_legacy_checkpoints(tmpdir, pl_version: str):
             callbacks=[es, stop],
             max_epochs=21,
             accumulate_grad_batches=2,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
         )
         torch.backends.cudnn.deterministic = True
         trainer.fit(model, datamodule=dm, ckpt_path=path_ckpt)

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -152,6 +152,8 @@ def test_model_checkpoint_score_and_ckpt(
         limit_val_batches=limit_val_batches,
         max_epochs=max_epochs,
         enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     calls = mock_training_epoch_loop(trainer)
     trainer.fit(model)
@@ -250,6 +252,8 @@ def test_model_checkpoint_score_and_ckpt_val_check_interval(
         val_check_interval=val_check_interval,
         enable_progress_bar=False,
         num_sanity_val_steps=0,
+        enable_model_summary=False,
+        logger=False,
     )
     calls = mock_training_epoch_loop(trainer)
     trainer.fit(model)
@@ -305,7 +309,15 @@ def test_model_checkpoint_with_non_string_input(tmpdir, save_top_k: int):
 
     checkpoint = ModelCheckpoint(monitor="early_stop_on", dirpath=None, filename="{epoch}", save_top_k=save_top_k)
     max_epochs = 2
-    trainer = Trainer(default_root_dir=tmpdir, callbacks=[checkpoint], overfit_batches=0.20, max_epochs=max_epochs)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        callbacks=[checkpoint],
+        overfit_batches=0.20,
+        max_epochs=max_epochs,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
+    )
     trainer.fit(model)
     assert checkpoint.dirpath == tmpdir / trainer.logger.name / "version_0" / "checkpoints"
 
@@ -324,7 +336,15 @@ def test_model_checkpoint_to_yaml(tmpdir, save_top_k: int):
 
     checkpoint = ModelCheckpoint(dirpath=tmpdir, monitor="early_stop_on", save_top_k=save_top_k)
 
-    trainer = Trainer(default_root_dir=tmpdir, callbacks=[checkpoint], overfit_batches=0.20, max_epochs=2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        callbacks=[checkpoint],
+        overfit_batches=0.20,
+        max_epochs=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     path_yaml = os.path.join(tmpdir, "best_k_models.yaml")
@@ -341,7 +361,15 @@ def test_model_checkpoint_path(tmpdir, logger_version: Union[None, int, str], ex
     model = LogInTwoMethods()
     logger = TensorBoardLogger(str(tmpdir), version=logger_version)
 
-    trainer = Trainer(default_root_dir=tmpdir, overfit_batches=0.2, max_epochs=2, logger=logger)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        overfit_batches=0.2,
+        max_epochs=2,
+        logger=logger,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     trainer.fit(model)
 
     ckpt_version = Path(trainer.checkpoint_callback.dirpath).parent.name
@@ -400,6 +428,9 @@ def test_model_checkpoint_no_extraneous_invocations(tmpdir):
         default_root_dir=tmpdir,
         callbacks=[model_checkpoint],
         max_epochs=num_epochs,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
@@ -466,7 +497,14 @@ def test_model_checkpoint_file_extension(tmpdir):
     model_checkpoint = ModelCheckpointExtensionTest(
         monitor="early_stop_on", dirpath=tmpdir, save_top_k=1, save_last=True
     )
-    trainer = Trainer(default_root_dir=tmpdir, callbacks=[model_checkpoint], max_steps=1, logger=False)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        callbacks=[model_checkpoint],
+        max_steps=1,
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
     trainer.fit(model)
 
     expected = ["epoch=0-step=0.tpkc", "last.tpkc"]
@@ -487,6 +525,8 @@ def test_model_checkpoint_save_last(tmpdir):
         limit_train_batches=10,
         limit_val_batches=10,
         logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
     trainer.fit(model)
     last_filename = model_checkpoint._format_checkpoint_name(
@@ -575,6 +615,8 @@ def test_model_checkpoint_save_last_none_monitor(tmpdir, caplog):
         limit_val_batches=10,
         max_epochs=epochs,
         logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
 
     with caplog.at_level(INFO):
@@ -609,6 +651,8 @@ def test_model_checkpoint_every_n_epochs(tmpdir, every_n_epochs):
         limit_train_batches=1,
         limit_val_batches=1,
         logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
     trainer.fit(model)
 
@@ -638,6 +682,7 @@ def test_ckpt_every_n_train_steps(tmpdir):
         enable_progress_bar=False,
         callbacks=[checkpoint_callback],
         logger=False,
+        enable_model_summary=False,
     )
 
     trainer.fit(model)
@@ -673,6 +718,7 @@ def test_model_checkpoint_train_time_interval(mock_datetime, tmpdir) -> None:
             )
         ],
         logger=False,
+        enable_model_summary=False,
     )
 
     trainer.fit(model)
@@ -686,7 +732,14 @@ def test_model_checkpoint_topk_zero(tmpdir):
     """Test that no checkpoints are saved when save_top_k=0."""
     model = LogInTwoMethods()
     checkpoint_callback = ModelCheckpoint(dirpath=tmpdir, save_top_k=0, save_last=True)
-    trainer = Trainer(default_root_dir=tmpdir, callbacks=[checkpoint_callback], max_epochs=2, logger=False)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        callbacks=[checkpoint_callback],
+        max_epochs=2,
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
     trainer.fit(model)
     # these should not be set if monitor is None
     assert checkpoint_callback.monitor is None
@@ -714,6 +767,8 @@ def test_model_checkpoint_topk_all(tmpdir):
         max_epochs=epochs,
         logger=False,
         val_check_interval=1.0,
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
     trainer.fit(model)
 
@@ -737,6 +792,8 @@ def test_ckpt_metric_names(tmpdir):
         limit_train_batches=0.01,
         limit_val_batches=0.01,
         callbacks=[ModelCheckpoint(monitor="early_stop_on", dirpath=tmpdir, filename="{val_loss:.2f}")],
+        enable_model_summary=False,
+        logger=False,
     )
 
     trainer.fit(model)
@@ -754,7 +811,14 @@ def test_default_checkpoint_behavior(tmpdir):
 
     model = LogInTwoMethods()
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=3, enable_progress_bar=False, limit_train_batches=5, limit_val_batches=5
+        default_root_dir=tmpdir,
+        max_epochs=3,
+        enable_progress_bar=False,
+        limit_train_batches=5,
+        limit_val_batches=5,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with patch.object(trainer, "save_checkpoint", wraps=trainer.save_checkpoint) as save_mock:
@@ -789,7 +853,14 @@ def test_model_checkpoint_save_last_warning(
         model.validation_step = None
     ckpt = ModelCheckpoint(monitor="early_stop_on", dirpath=tmpdir, save_top_k=0, save_last=save_last, verbose=verbose)
     trainer = Trainer(
-        default_root_dir=tmpdir, callbacks=[ckpt], max_epochs=max_epochs, limit_train_batches=1, limit_val_batches=1
+        default_root_dir=tmpdir,
+        callbacks=[ckpt],
+        max_epochs=max_epochs,
+        limit_train_batches=1,
+        limit_val_batches=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     with caplog.at_level(logging.INFO):
         trainer.fit(model)
@@ -810,6 +881,9 @@ def test_model_checkpoint_save_last_checkpoint_contents(tmpdir):
         max_epochs=num_epochs,
         limit_train_batches=2,
         limit_val_batches=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -856,6 +930,10 @@ def test_checkpointing_with_nan_as_first(tmpdir, mode):
         default_root_dir=tmpdir,
         val_check_interval=1.0,
         max_epochs=len(monitor),
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.save_checkpoint = MagicMock()
 
@@ -1142,6 +1220,7 @@ def test_ckpt_version_after_rerun_new_trainer(tmpdir):
             logger=False,
             enable_progress_bar=False,
             enable_model_summary=False,
+            enable_checkpointing=False,
         )
         trainer.fit(BoringModel())
 
@@ -1168,6 +1247,7 @@ def test_ckpt_version_after_rerun_same_trainer(tmpdir):
         logger=False,
         enable_progress_bar=False,
         enable_model_summary=False,
+        enable_checkpointing=False,
     )
     trainer.fit(BoringModel())
     trainer.fit_loop.max_epochs = 4
@@ -1199,6 +1279,8 @@ def test_check_val_every_n_epochs_top_k_integration(tmpdir):
         callbacks=mc,
         enable_model_summary=False,
         logger=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
     )
     trainer.fit(model)
     assert set(os.listdir(tmpdir)) == {"epoch=1.ckpt", "epoch=3.ckpt"}

--- a/tests/checkpointing/test_torch_saving.py
+++ b/tests/checkpointing/test_torch_saving.py
@@ -24,7 +24,14 @@ def test_model_torch_save(tmpdir):
     """Test to ensure torch save does not fail for model and trainer."""
     model = BoringModel()
     num_epochs = 1
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=num_epochs)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=num_epochs,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     temp_path = os.path.join(tmpdir, "temp.pt")
     trainer.fit(model)
 
@@ -40,7 +47,14 @@ def test_model_torch_save_ddp_cpu(tmpdir):
     model = BoringModel()
     num_epochs = 1
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=num_epochs, strategy="ddp_spawn", num_processes=2, logger=False
+        default_root_dir=tmpdir,
+        max_epochs=num_epochs,
+        strategy="ddp_spawn",
+        num_processes=2,
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
     temp_path = os.path.join(tmpdir, "temp.pt")
     trainer.fit(model)
@@ -55,7 +69,16 @@ def test_model_torch_save_ddp_cuda(tmpdir):
     """Test to ensure torch save does not fail for model and trainer using gpu ddp."""
     model = BoringModel()
     num_epochs = 1
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=num_epochs, strategy="ddp_spawn", gpus=2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=num_epochs,
+        strategy="ddp_spawn",
+        gpus=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     temp_path = os.path.join(tmpdir, "temp.pt")
     trainer.fit(model)
 

--- a/tests/checkpointing/test_trainer_checkpoint.py
+++ b/tests/checkpointing/test_trainer_checkpoint.py
@@ -48,6 +48,8 @@ def test_finetuning_with_ckpt_path(tmpdir):
         limit_test_batches=12,
         callbacks=[checkpoint_callback],
         logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
     trainer.fit(model)
     assert os.listdir(tmpdir) == ["epoch=00.ckpt"]
@@ -64,6 +66,9 @@ def test_finetuning_with_ckpt_path(tmpdir):
             limit_val_batches=12,
             limit_test_batches=12,
             enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
         )
         trainer.fit(model, ckpt_path=best_model_paths[-1])
         trainer.test()

--- a/tests/checkpointing/test_trainer_checkpoint.py
+++ b/tests/checkpointing/test_trainer_checkpoint.py
@@ -67,7 +67,6 @@ def test_finetuning_with_ckpt_path(tmpdir):
             limit_test_batches=12,
             enable_progress_bar=False,
             enable_model_summary=False,
-            enable_checkpointing=False,
             logger=False,
         )
         trainer.fit(model, ckpt_path=best_model_paths[-1])

--- a/tests/core/test_datamodules.py
+++ b/tests/core/test_datamodules.py
@@ -162,7 +162,14 @@ def test_train_loop_only(tmpdir):
     model.test_step_end = None
     model.test_epoch_end = None
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, enable_model_summary=False)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     # fit model
     trainer.fit(model, datamodule=dm)
@@ -180,7 +187,14 @@ def test_train_val_loop_only(tmpdir):
     model.validation_step_end = None
     model.validation_epoch_end = None
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, enable_model_summary=False)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     # fit model
     trainer.fit(model, datamodule=dm)
@@ -213,6 +227,8 @@ def test_dm_checkpoint_save_and_load(tmpdir):
         limit_val_batches=1,
         enable_model_summary=False,
         callbacks=[ModelCheckpoint(dirpath=tmpdir, monitor="early_stop_on")],
+        enable_progress_bar=False,
+        logger=False,
     )
 
     # fit model
@@ -236,7 +252,15 @@ def test_full_loop(tmpdir):
     dm = ClassifDataModule()
     model = ClassificationModel()
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, enable_model_summary=False, deterministic=True)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_model_summary=False,
+        deterministic=True,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     # fit model
     trainer.fit(model, dm)
@@ -345,7 +369,16 @@ def test_dm_reload_dataloaders_every_n_epochs(tmpdir):
     model.test_step_end = None
     model.test_epoch_end = None
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=3, limit_train_batches=2, reload_dataloaders_every_n_epochs=2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=3,
+        limit_train_batches=2,
+        reload_dataloaders_every_n_epochs=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model, dm)
 
 

--- a/tests/core/test_lightning_module.py
+++ b/tests/core/test_lightning_module.py
@@ -112,7 +112,15 @@ def test_params_groups_and_state_are_accessible(tmpdir):
     model.training_epoch_end = None
 
     trainer = Trainer(
-        max_epochs=1, default_root_dir=tmpdir, limit_train_batches=8, limit_val_batches=1, accumulate_grad_batches=1
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        limit_train_batches=8,
+        limit_val_batches=1,
+        accumulate_grad_batches=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)
@@ -178,7 +186,15 @@ def test_toggle_untoggle_2_optimizers_no_shared_parameters(tmpdir):
     model.training_epoch_end = None
 
     trainer = Trainer(
-        max_epochs=1, default_root_dir=tmpdir, limit_train_batches=8, accumulate_grad_batches=2, limit_val_batches=0
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        limit_train_batches=8,
+        accumulate_grad_batches=2,
+        limit_val_batches=0,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -278,7 +294,16 @@ def test_toggle_untoggle_3_optimizers_shared_parameters(tmpdir):
     model = TestModel()
     model.training_epoch_end = None
 
-    trainer = Trainer(max_epochs=1, default_root_dir=tmpdir, limit_train_batches=8, accumulate_grad_batches=2)
+    trainer = Trainer(
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        limit_train_batches=8,
+        accumulate_grad_batches=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     trainer.fit(model)
 
@@ -313,12 +338,7 @@ class BoringModelWithShardedTensor(BoringModel):
 
 @RunIf(min_torch="1.10", skip_windows=True)
 def test_sharded_tensor_state_dict(tmpdir, single_process_pg):
-    spec = dist._sharding_spec.ChunkShardingSpec(
-        dim=0,
-        placements=[
-            "rank:0/cpu",
-        ],
-    )
+    spec = dist._sharding_spec.ChunkShardingSpec(dim=0, placements=["rank:0/cpu"])
 
     m_0 = BoringModelWithShardedTensor(spec)
     m_0.sharded_tensor.local_shards()[0].tensor.fill_(1)
@@ -353,7 +373,15 @@ def test_lightning_module_configure_gradient_clipping(tmpdir):
 
     model = TestModel()
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=1, limit_val_batches=0, gradient_clip_val=1e-4
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_train_batches=1,
+        limit_val_batches=0,
+        gradient_clip_val=1e-4,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -377,7 +405,15 @@ def test_lightning_module_configure_gradient_clipping_different_argument_values(
 
     model = TestModel()
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=2, limit_val_batches=0, gradient_clip_val=1e-4
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_train_batches=2,
+        limit_val_batches=0,
+        gradient_clip_val=1e-4,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     with pytest.raises(
         MisconfigurationException,
@@ -398,6 +434,10 @@ def test_lightning_module_configure_gradient_clipping_different_argument_values(
         limit_train_batches=2,
         limit_val_batches=0,
         gradient_clip_algorithm="norm",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     with pytest.raises(
         MisconfigurationException,

--- a/tests/core/test_lightning_optimizer.py
+++ b/tests/core/test_lightning_optimizer.py
@@ -40,7 +40,14 @@ def test_lightning_optimizer(tmpdir, auto):
 
     model = TestModel()
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_train_batches=1, limit_val_batches=1, max_epochs=1, enable_model_summary=False
+        default_root_dir=tmpdir,
+        limit_train_batches=1,
+        limit_val_batches=1,
+        max_epochs=1,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -88,7 +95,14 @@ def test_lightning_optimizer_manual_optimization_and_accumulated_gradients(tmpdi
     model.training_step_end = None
     model.training_epoch_end = None
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_train_batches=8, limit_val_batches=1, max_epochs=1, enable_model_summary=False
+        default_root_dir=tmpdir,
+        limit_train_batches=8,
+        limit_val_batches=1,
+        max_epochs=1,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with patch.multiple(torch.optim.SGD, zero_grad=DEFAULT, step=DEFAULT) as sgd, patch.multiple(
@@ -160,7 +174,14 @@ def test_lightning_optimizer_automatic_optimization_optimizer_zero_grad(tmpdir):
 
     model = TestModel()
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_train_batches=20, limit_val_batches=1, max_epochs=1, enable_model_summary=False
+        default_root_dir=tmpdir,
+        limit_train_batches=20,
+        limit_val_batches=1,
+        max_epochs=1,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with patch("torch.optim.Adam.zero_grad") as adam_zero_grad, patch("torch.optim.SGD.zero_grad") as sgd_zero_grad:
@@ -205,6 +226,9 @@ def test_lightning_optimizer_automatic_optimization_optimizer_step(tmpdir):
         limit_val_batches=1,
         max_epochs=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with patch.multiple(torch.optim.SGD, zero_grad=DEFAULT, step=DEFAULT) as sgd, patch.multiple(
@@ -229,7 +253,14 @@ def test_lightning_optimizer_automatic_optimization_lbfgs_zero_grad(tmpdir):
 
     model = TestModel()
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_train_batches=1, limit_val_batches=1, max_epochs=1, enable_model_summary=False
+        default_root_dir=tmpdir,
+        limit_train_batches=1,
+        limit_val_batches=1,
+        max_epochs=1,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with patch("torch.optim.LBFGS.zero_grad") as zero_grad:
@@ -304,7 +335,16 @@ def test_lightning_optimizer_keeps_hooks(tmpdir):
             del self.trainer._lightning_optimizers
             gc.collect()  # not necessary, just in case
 
-    trainer = Trainer(default_root_dir=tmpdir, limit_train_batches=4, limit_val_batches=1, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_train_batches=4,
+        limit_val_batches=1,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     model = TestModel()
     trainer.fit(model)
     assert model.count_on_train_batch_start == 4

--- a/tests/core/test_metric_result_integration.py
+++ b/tests/core/test_metric_result_integration.py
@@ -350,6 +350,9 @@ def test_lightning_module_logging_result_collection(tmpdir, device):
         limit_val_batches=2,
         callbacks=[ckpt],
         gpus=1 if device == "cuda" else 0,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -543,7 +546,16 @@ def test_metric_collections(tmpdir):
 
     model = TestModel()
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=2, limit_train_batches=2, limit_val_batches=0)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        limit_train_batches=2,
+        limit_val_batches=0,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
 

--- a/tests/deprecated_api/test_remove_1-7.py
+++ b/tests/deprecated_api/test_remove_1-7.py
@@ -468,7 +468,6 @@ def test_v1_7_0_resume_from_checkpoint_trainer_constructor(tmpdir):
         callbacks=[callback],
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)

--- a/tests/deprecated_api/test_remove_1-7.py
+++ b/tests/deprecated_api/test_remove_1-7.py
@@ -108,11 +108,7 @@ def test_v1_7_0_moved_get_progress_bar_dict(tmpdir):
             items.pop("v_num", None)
             return items
 
-    trainer = Trainer(
-        default_root_dir=tmpdir,
-        progress_bar_refresh_rate=None,
-        fast_dev_run=True,
-    )
+    trainer = Trainer(default_root_dir=tmpdir, progress_bar_refresh_rate=None, fast_dev_run=True)
     test_model = TestModel()
     with pytest.deprecated_call(match=r"`LightningModule.get_progress_bar_dict` method was deprecated in v1.5"):
         trainer.fit(test_model)
@@ -219,6 +215,8 @@ def test_v1_7_0_on_interrupt(tmpdir):
         enable_progress_bar=False,
         logger=False,
         default_root_dir=tmpdir,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
     with pytest.deprecated_call(
         match="The `on_keyboard_interrupt` callback hook was deprecated in v1.5 and will be removed in v1.7"
@@ -295,12 +293,27 @@ def test_v1_7_0_old_on_train_batch_start(tmpdir):
             ...
 
     model = BoringModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, callbacks=OldSignature())
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        callbacks=OldSignature(),
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.deprecated_call(match="`dataloader_idx` argument will be removed in v1.7."):
         trainer.fit(model)
 
     model = OldSignatureModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.deprecated_call(match="`dataloader_idx` argument will be removed in v1.7."):
         trainer.fit(model)
 
@@ -315,12 +328,30 @@ def test_v1_7_0_old_on_train_batch_end(tmpdir):
             ...
 
     model = BoringModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, callbacks=OldSignature(), fast_dev_run=True)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        callbacks=OldSignature(),
+        fast_dev_run=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.deprecated_call(match="`dataloader_idx` argument will be removed in v1.7."):
         trainer.fit(model)
 
     model = OldSignatureModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, callbacks=OldSignature(), fast_dev_run=True)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        callbacks=OldSignature(),
+        fast_dev_run=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.deprecated_call(match="`dataloader_idx` argument will be removed in v1.7."):
         trainer.fit(model)
 
@@ -332,7 +363,15 @@ def test_v1_7_0_deprecate_on_post_move_to_device(tmpdir):
 
     model = TestModel()
 
-    trainer = Trainer(default_root_dir=tmpdir, limit_train_batches=5, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_train_batches=5,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.deprecated_call(
         match=r"Method `on_post_move_to_device` has been deprecated in v1.5 and will be removed in v1.7"
@@ -406,7 +445,13 @@ def test_v1_7_0_progress_bar():
 
 def test_v1_7_0_deprecated_max_steps_none(tmpdir):
     with pytest.deprecated_call(match="`max_steps = None` is deprecated in v1.5"):
-        _ = Trainer(max_steps=None)
+        _ = Trainer(
+            max_steps=None,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
+        )
 
     trainer = Trainer()
     with pytest.deprecated_call(match="`max_steps = None` is deprecated in v1.5"):
@@ -417,13 +462,29 @@ def test_v1_7_0_resume_from_checkpoint_trainer_constructor(tmpdir):
     # test resume_from_checkpoint still works until v1.7 deprecation
     model = BoringModel()
     callback = OldStatefulCallback(state=111)
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=1, callbacks=[callback])
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+        callbacks=[callback],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     ckpt_path = trainer.checkpoint_callback.best_model_path
 
     callback = OldStatefulCallback(state=222)
     with pytest.deprecated_call(match=r"Setting `Trainer\(resume_from_checkpoint=\)` is deprecated in v1.5"):
-        trainer = Trainer(default_root_dir=tmpdir, max_steps=2, callbacks=[callback], resume_from_checkpoint=ckpt_path)
+        trainer = Trainer(
+            default_root_dir=tmpdir,
+            max_steps=2,
+            callbacks=[callback],
+            resume_from_checkpoint=ckpt_path,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            logger=False,
+        )
     with pytest.deprecated_call(
         match=r"trainer.resume_from_checkpoint` is deprecated in v1.5 and will be removed in v1.7."
     ):
@@ -448,7 +509,7 @@ def test_v1_7_0_resume_from_checkpoint_trainer_constructor(tmpdir):
     assert trainer.checkpoint_connector.resume_checkpoint_path is None
     assert trainer.checkpoint_connector.resume_from_checkpoint_fit_path is None
 
-    # test fit(ckpt_path=) precedence over Trainer(resume_from_checkpoint=) path
+    # test fit(ckpt_path=) precedence over Trainer(resume_from_checkpoint=,) path
     model = BoringModel()
     with pytest.deprecated_call(match=r"Setting `Trainer\(resume_from_checkpoint=\)` is deprecated in v1.5"):
         trainer = Trainer(resume_from_checkpoint="trainer_arg_path")
@@ -466,15 +527,7 @@ def test_v1_7_0_deprecate_lr_sch_names(tmpdir):
         assert lr_monitor.lr_sch_names == ["lr-SGD"]
 
 
-@pytest.mark.parametrize(
-    "cls",
-    [
-        KubeflowEnvironment,
-        LightningEnvironment,
-        SLURMEnvironment,
-        TorchElasticEnvironment,
-    ],
-)
+@pytest.mark.parametrize("cls", [KubeflowEnvironment, LightningEnvironment, SLURMEnvironment, TorchElasticEnvironment])
 def test_v1_7_0_cluster_environment_master_address(cls):
     class MyClusterEnvironment(cls):
         def master_address(self):
@@ -486,15 +539,7 @@ def test_v1_7_0_cluster_environment_master_address(cls):
         MyClusterEnvironment()
 
 
-@pytest.mark.parametrize(
-    "cls",
-    [
-        KubeflowEnvironment,
-        LightningEnvironment,
-        SLURMEnvironment,
-        TorchElasticEnvironment,
-    ],
-)
+@pytest.mark.parametrize("cls", [KubeflowEnvironment, LightningEnvironment, SLURMEnvironment, TorchElasticEnvironment])
 def test_v1_7_0_cluster_environment_master_port(cls):
     class MyClusterEnvironment(cls):
         def master_port(self):

--- a/tests/deprecated_api/test_remove_1-8.py
+++ b/tests/deprecated_api/test_remove_1-8.py
@@ -62,6 +62,8 @@ def test_v1_8_0_on_init_start_end(tmpdir):
         enable_progress_bar=False,
         logger=False,
         default_root_dir=tmpdir,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
     with pytest.deprecated_call(
         match="The `on_init_start` callback hook was deprecated in v1.6 and will be removed in v1.8"
@@ -80,6 +82,8 @@ def test_v1_8_0_deprecated_call_hook():
         limit_train_batches=0.2,
         enable_progress_bar=False,
         logger=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
     with pytest.deprecated_call(match="was deprecated in v1.6 and will be removed in v1.8."):
         trainer.call_hook("test_hook")
@@ -96,7 +100,15 @@ def test_v1_8_0_deprecated_on_hpc_hooks(tmpdir):
 
     save_model = TestModelSave()
     load_model = TestModelLoad()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, fast_dev_run=True)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        fast_dev_run=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.deprecated_call(
         match=r"Method `LightningModule.on_hpc_save` is deprecated in v1.6 and will be removed in v1.8."

--- a/tests/helpers/test_models.py
+++ b/tests/helpers/test_models.py
@@ -37,7 +37,14 @@ def test_models(tmpdir, data_class, model_class):
     """Test simple models."""
     dm = data_class() if data_class else data_class
     model = model_class()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     trainer.fit(model, datamodule=dm)
 

--- a/tests/lite/test_lite.py
+++ b/tests/lite/test_lite.py
@@ -208,9 +208,7 @@ def test_setup_dataloaders_twice_fails():
 
 
 @mock.patch(
-    "pytorch_lightning.lite.lite.LightningLite.device",
-    new_callable=PropertyMock,
-    return_value=torch.device("cuda", 1),
+    "pytorch_lightning.lite.lite.LightningLite.device", new_callable=PropertyMock, return_value=torch.device("cuda", 1)
 )
 def test_setup_dataloaders_move_to_device(lite_device_mock):
     """Test that the setup configures LiteDataLoader to move the data to the device automatically."""

--- a/tests/loggers/test_all.py
+++ b/tests/loggers/test_all.py
@@ -144,7 +144,7 @@ def _test_loggers_fit_test(tmpdir, logger_class):
         enable_checkpointing=False,
     )
     trainer.fit(model)
-    trainer.test()
+    trainer.test(model)
 
     log_metric_names = [(s, sorted(m.keys())) for s, m in logger.history]
     if logger_class == TensorBoardLogger:

--- a/tests/loggers/test_all.py
+++ b/tests/loggers/test_all.py
@@ -139,6 +139,9 @@ def _test_loggers_fit_test(tmpdir, logger_class):
         limit_val_batches=1,
         log_every_n_steps=1,
         default_root_dir=tmpdir,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
     trainer.fit(model)
     trainer.test()
@@ -278,7 +281,9 @@ def _test_loggers_pickle(tmpdir, monkeypatch, logger_class):
     # test pickling loggers
     pickle.dumps(logger)
 
-    trainer = Trainer(max_epochs=1, logger=logger)
+    trainer = Trainer(
+        max_epochs=1, logger=logger, enable_progress_bar=False, enable_model_summary=False, enable_checkpointing=False
+    )
     pkl_bytes = pickle.dumps(trainer)
 
     trainer2 = pickle.loads(pkl_bytes)
@@ -355,6 +360,9 @@ def _test_logger_created_on_rank_zero_only(tmpdir, logger_class):
         num_processes=2,
         max_steps=1,
         callbacks=[RankZeroLoggerCheck()],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"

--- a/tests/loggers/test_base.py
+++ b/tests/loggers/test_base.py
@@ -115,7 +115,6 @@ def test_custom_logger(tmpdir):
         default_root_dir=tmpdir,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
     )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
@@ -324,7 +323,6 @@ def test_log_hyperparams_being_called(log_hyperparams_mock, tmpdir, logger):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     trainer.fit(model)
 
@@ -351,7 +349,6 @@ def test_log_hyperparams_key_collision(log_hyperparams_mock, tmpdir):
 
     same_params = {1: 1, "2": 2, "three": 3.0, "test": _Test(), "4": torch.tensor(4)}
     model = TestModel(same_params)
-    dm = TestDataModule(same_params)
 
     trainer = Trainer(
         default_root_dir=tmpdir,
@@ -362,7 +359,6 @@ def test_log_hyperparams_key_collision(log_hyperparams_mock, tmpdir):
         enable_checkpointing=False,
         enable_progress_bar=False,
         enable_model_summary=False,
-        logger=False,
     )
     # there should be no exceptions raised for the same key/value pair in the hparams of both
     # the lightning module and data module
@@ -371,7 +367,6 @@ def test_log_hyperparams_key_collision(log_hyperparams_mock, tmpdir):
     obj_params = deepcopy(same_params)
     obj_params["test"] = _Test()
     model = TestModel(same_params)
-    dm = TestDataModule(obj_params)
     trainer.fit(model)
 
     diff_params = deepcopy(same_params)
@@ -387,7 +382,6 @@ def test_log_hyperparams_key_collision(log_hyperparams_mock, tmpdir):
         enable_checkpointing=False,
         enable_progress_bar=False,
         enable_model_summary=False,
-        logger=False,
     )
     with pytest.raises(MisconfigurationException, match="Error while merging hparams"):
         trainer.fit(model, dm)
@@ -405,7 +399,6 @@ def test_log_hyperparams_key_collision(log_hyperparams_mock, tmpdir):
         enable_checkpointing=False,
         enable_progress_bar=False,
         enable_model_summary=False,
-        logger=False,
     )
     with pytest.raises(MisconfigurationException, match="Error while merging hparams"):
         trainer.fit(model, dm)

--- a/tests/loggers/test_base.py
+++ b/tests/loggers/test_base.py
@@ -108,7 +108,15 @@ def test_custom_logger(tmpdir):
 
     logger = CustomLogger()
     model = CustomModel()
-    trainer = Trainer(max_steps=2, log_every_n_steps=1, logger=logger, default_root_dir=tmpdir)
+    trainer = Trainer(
+        max_steps=2,
+        log_every_n_steps=1,
+        logger=logger,
+        default_root_dir=tmpdir,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
     assert logger.hparams_logged == model.hparams
@@ -129,7 +137,15 @@ def test_multiple_loggers(tmpdir):
     logger1 = CustomLogger()
     logger2 = CustomLogger()
 
-    trainer = Trainer(max_steps=2, log_every_n_steps=1, logger=[logger1, logger2], default_root_dir=tmpdir)
+    trainer = Trainer(
+        max_steps=2,
+        log_every_n_steps=1,
+        logger=[logger1, logger2],
+        default_root_dir=tmpdir,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
 
@@ -186,6 +202,9 @@ def test_adding_step_key(tmpdir):
         limit_train_batches=0.1,
         limit_val_batches=0.1,
         num_sanity_val_steps=0,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
     trainer.fit(model)
 
@@ -297,7 +316,15 @@ def test_log_hyperparams_being_called(log_hyperparams_mock, tmpdir, logger):
 
     model = TestModel("pytorch", "lightning")
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=0.1, limit_val_batches=0.1, num_sanity_val_steps=0
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_train_batches=0.1,
+        limit_val_batches=0.1,
+        num_sanity_val_steps=0,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -335,6 +362,7 @@ def test_log_hyperparams_key_collision(log_hyperparams_mock, tmpdir):
         enable_checkpointing=False,
         enable_progress_bar=False,
         enable_model_summary=False,
+        logger=False,
     )
     # there should be no exceptions raised for the same key/value pair in the hparams of both
     # the lightning module and data module
@@ -359,6 +387,7 @@ def test_log_hyperparams_key_collision(log_hyperparams_mock, tmpdir):
         enable_checkpointing=False,
         enable_progress_bar=False,
         enable_model_summary=False,
+        logger=False,
     )
     with pytest.raises(MisconfigurationException, match="Error while merging hparams"):
         trainer.fit(model, dm)
@@ -376,6 +405,7 @@ def test_log_hyperparams_key_collision(log_hyperparams_mock, tmpdir):
         enable_checkpointing=False,
         enable_progress_bar=False,
         enable_model_summary=False,
+        logger=False,
     )
     with pytest.raises(MisconfigurationException, match="Error while merging hparams"):
         trainer.fit(model, dm)

--- a/tests/loggers/test_comet.py
+++ b/tests/loggers/test_comet.py
@@ -159,7 +159,6 @@ def test_comet_logger_dirs_creation(comet, comet_experiment, tmpdir, monkeypatch
         limit_val_batches=3,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
     )
     assert trainer.log_dir == logger.save_dir
     trainer.fit(model)

--- a/tests/loggers/test_comet.py
+++ b/tests/loggers/test_comet.py
@@ -151,7 +151,16 @@ def test_comet_logger_dirs_creation(comet, comet_experiment, tmpdir, monkeypatch
     logger.experiment.project_name = "test"
 
     model = BoringModel()
-    trainer = Trainer(default_root_dir=tmpdir, logger=logger, max_epochs=1, limit_train_batches=3, limit_val_batches=3)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        logger=logger,
+        max_epochs=1,
+        limit_train_batches=3,
+        limit_val_batches=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     assert trainer.log_dir == logger.save_dir
     trainer.fit(model)
 

--- a/tests/loggers/test_mlflow.py
+++ b/tests/loggers/test_mlflow.py
@@ -132,7 +132,16 @@ def test_mlflow_log_dir(client, mlflow, tmpdir):
     assert logger.name == "exp-id"
 
     model = BoringModel()
-    trainer = Trainer(default_root_dir=tmpdir, logger=logger, max_epochs=1, limit_train_batches=1, limit_val_batches=3)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        logger=logger,
+        max_epochs=1,
+        limit_train_batches=1,
+        limit_val_batches=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     assert trainer.log_dir == logger.save_dir
     trainer.fit(model)
     assert trainer.checkpoint_callback.dirpath == (tmpdir / "exp-id" / "run-id" / "checkpoints")
@@ -171,6 +180,9 @@ def test_mlflow_logger_dirs_creation(tmpdir):
         max_epochs=1,
         limit_train_batches=limit_batches,
         limit_val_batches=limit_batches,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
     trainer.fit(model)
     assert set(os.listdir(tmpdir / exp_id)) == {run_id, "meta.yaml"}

--- a/tests/loggers/test_mlflow.py
+++ b/tests/loggers/test_mlflow.py
@@ -140,7 +140,6 @@ def test_mlflow_log_dir(client, mlflow, tmpdir):
         limit_val_batches=3,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
     )
     assert trainer.log_dir == logger.save_dir
     trainer.fit(model)
@@ -182,7 +181,6 @@ def test_mlflow_logger_dirs_creation(tmpdir):
         limit_val_batches=limit_batches,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
     )
     trainer.fit(model)
     assert set(os.listdir(tmpdir / exp_id)) == {run_id, "meta.yaml"}

--- a/tests/loggers/test_neptune.py
+++ b/tests/loggers/test_neptune.py
@@ -85,9 +85,7 @@ class TestNeptuneLogger(unittest.TestCase):
         self.assertEqual(neptune.init.call_count, 1)
         self.assertEqual(created_run_mock.__getitem__.call_count, 1)
         self.assertEqual(created_run_mock.__setitem__.call_count, 1)
-        created_run_mock.__getitem__.assert_called_once_with(
-            "sys/name",
-        )
+        created_run_mock.__getitem__.assert_called_once_with("sys/name")
         created_run_mock.__setitem__.assert_called_once_with("source_code/integrations/pytorch-lightning", __version__)
 
     @patch("pytorch_lightning.loggers.neptune.Run", Run)
@@ -155,7 +153,15 @@ class TestNeptuneLogger(unittest.TestCase):
         run_instance_mock.__getitem__().log.assert_called_once_with(torch.ones(1))
 
     def _fit_and_test(self, logger, model):
-        trainer = Trainer(default_root_dir=self.tmpdir, max_epochs=1, limit_train_batches=0.05, logger=logger)
+        trainer = Trainer(
+            default_root_dir=self.tmpdir,
+            max_epochs=1,
+            limit_train_batches=0.05,
+            logger=logger,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+        )
         assert trainer.log_dir == os.path.join(os.getcwd(), ".neptune")
         trainer.fit(model)
         trainer.test(model)
@@ -168,10 +174,7 @@ class TestNeptuneLogger(unittest.TestCase):
         logger, run_instance_mock, _ = self._get_logger_with_mocks(api_key="test", project="project")
 
         # when
-        self._fit_and_test(
-            logger=logger,
-            model=BoringModel(),
-        )
+        self._fit_and_test(logger=logger, model=BoringModel())
 
         # then
         assert run_instance_mock.stop.call_count == 0
@@ -188,10 +191,7 @@ class TestNeptuneLogger(unittest.TestCase):
         logger, run_instance_mock, _ = self._get_logger_with_mocks(api_key="test", project="project")
 
         # when
-        self._fit_and_test(
-            logger=logger,
-            model=LoggingModel(),
-        )
+        self._fit_and_test(logger=logger, model=LoggingModel())
 
         # then
         run_instance_mock.__getitem__.assert_any_call("training/some/key")
@@ -217,10 +217,7 @@ class TestNeptuneLogger(unittest.TestCase):
             run_instance_mock.__setitem__.assert_called_once_with(hyperparams_key, params)
 
     def test_log_metrics(self, neptune):
-        metrics = {
-            "foo": 42,
-            "bar": 555,
-        }
+        metrics = {"foo": 42, "bar": 555}
         test_variants = [
             ({}, ("training/foo", "training/bar")),
             ({"prefix": "custom_prefix"}, ("custom_prefix/foo", "custom_prefix/bar")),

--- a/tests/loggers/test_tensorboard.py
+++ b/tests/loggers/test_tensorboard.py
@@ -43,7 +43,14 @@ def test_tensorboard_hparams_reload(tmpdir):
             super().__init__()
             self.save_hyperparameters()
 
-    trainer = Trainer(max_steps=1, default_root_dir=tmpdir)
+    trainer = Trainer(
+        max_steps=1,
+        default_root_dir=tmpdir,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     model = CustomModel()
     assert trainer.log_dir == trainer.logger.log_dir
     trainer.fit(model)
@@ -210,14 +217,7 @@ def test_tensorboard_log_hparams_and_metrics(tmpdir):
 @RunIf(omegaconf=True)
 def test_tensorboard_log_omegaconf_hparams_and_metrics(tmpdir):
     logger = TensorBoardLogger(tmpdir, default_hp_metric=False)
-    hparams = {
-        "float": 0.3,
-        "int": 1,
-        "string": "abc",
-        "bool": True,
-        "dict": {"a": {"b": "c"}},
-        "list": [1, 2, 3],
-    }
+    hparams = {"float": 0.3, "int": 1, "string": "abc", "bool": True, "dict": {"a": {"b": "c"}}, "list": [1, 2, 3]}
     hparams = OmegaConf.create(hparams)
 
     metrics = {"abc": torch.tensor([0.54])}
@@ -275,6 +275,9 @@ def test_tensorboard_with_accummulated_gradients(mock_log_metrics, tmpdir):
         accumulate_grad_batches=2,
         logger=[logger_0],
         log_every_n_steps=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
     trainer.fit(model)
 
@@ -298,7 +301,14 @@ def test_tensorboard_finalize(summary_writer, tmpdir):
 def test_tensorboard_save_hparams_to_yaml_once(tmpdir):
     model = BoringModel()
     logger = TensorBoardLogger(save_dir=tmpdir, default_hp_metric=False)
-    trainer = Trainer(max_steps=1, default_root_dir=tmpdir, logger=logger)
+    trainer = Trainer(
+        max_steps=1,
+        default_root_dir=tmpdir,
+        logger=logger,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     assert trainer.log_dir == trainer.logger.log_dir
     trainer.fit(model)
 

--- a/tests/loggers/test_wandb.py
+++ b/tests/loggers/test_wandb.py
@@ -157,7 +157,6 @@ def test_wandb_logger_dirs_creation(wandb, tmpdir):
         limit_val_batches=3,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
     )
     assert trainer.log_dir == logger.save_dir
     trainer.fit(model)
@@ -186,7 +185,6 @@ def test_wandb_log_model(wandb, tmpdir):
         limit_val_batches=3,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
     )
     trainer.fit(model)
     wandb.init().log_artifact.assert_called_once()
@@ -205,7 +203,6 @@ def test_wandb_log_model(wandb, tmpdir):
         limit_val_batches=3,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
     )
     trainer.fit(model)
     assert wandb.init().log_artifact.call_count == 2
@@ -224,7 +221,6 @@ def test_wandb_log_model(wandb, tmpdir):
         limit_val_batches=3,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
     )
     trainer.fit(model)
     assert not wandb.init().log_artifact.called
@@ -247,7 +243,6 @@ def test_wandb_log_model(wandb, tmpdir):
         limit_val_batches=3,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
     )
     trainer.fit(model)
     wandb.Artifact.assert_called_once_with(

--- a/tests/loggers/test_wandb.py
+++ b/tests/loggers/test_wandb.py
@@ -102,7 +102,14 @@ def test_wandb_pickle(wandb, tmpdir):
     wandb.init.return_value = Experiment()
     logger = WandbLogger(id="the_id", offline=True)
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, logger=logger)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        logger=logger,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     # Access the experiment to ensure it's created
     assert trainer.logger.experiment, "missing experiment"
     assert trainer.log_dir == logger.save_dir
@@ -142,7 +149,16 @@ def test_wandb_logger_dirs_creation(wandb, tmpdir):
 
     version = logger.version
     model = BoringModel()
-    trainer = Trainer(default_root_dir=tmpdir, logger=logger, max_epochs=1, limit_train_batches=3, limit_val_batches=3)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        logger=logger,
+        max_epochs=1,
+        limit_train_batches=3,
+        limit_val_batches=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     assert trainer.log_dir == logger.save_dir
     trainer.fit(model)
 
@@ -162,7 +178,16 @@ def test_wandb_log_model(wandb, tmpdir):
     logger = WandbLogger(log_model=True)
     logger.experiment.id = "1"
     logger.experiment.project_name.return_value = "project"
-    trainer = Trainer(default_root_dir=tmpdir, logger=logger, max_epochs=2, limit_train_batches=3, limit_val_batches=3)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        logger=logger,
+        max_epochs=2,
+        limit_train_batches=3,
+        limit_val_batches=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     trainer.fit(model)
     wandb.init().log_artifact.assert_called_once()
 
@@ -172,7 +197,16 @@ def test_wandb_log_model(wandb, tmpdir):
     logger = WandbLogger(log_model="all")
     logger.experiment.id = "1"
     logger.experiment.project_name.return_value = "project"
-    trainer = Trainer(default_root_dir=tmpdir, logger=logger, max_epochs=2, limit_train_batches=3, limit_val_batches=3)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        logger=logger,
+        max_epochs=2,
+        limit_train_batches=3,
+        limit_val_batches=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     trainer.fit(model)
     assert wandb.init().log_artifact.call_count == 2
 
@@ -182,7 +216,16 @@ def test_wandb_log_model(wandb, tmpdir):
     logger = WandbLogger(log_model=False)
     logger.experiment.id = "1"
     logger.experiment.project_name.return_value = "project"
-    trainer = Trainer(default_root_dir=tmpdir, logger=logger, max_epochs=2, limit_train_batches=3, limit_val_batches=3)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        logger=logger,
+        max_epochs=2,
+        limit_train_batches=3,
+        limit_val_batches=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     trainer.fit(model)
     assert not wandb.init().log_artifact.called
 
@@ -196,7 +239,16 @@ def test_wandb_log_model(wandb, tmpdir):
     logger = pl_wandb.WandbLogger(log_model=True)
     logger.experiment.id = "1"
     logger.experiment.project_name.return_value = "project"
-    trainer = Trainer(default_root_dir=tmpdir, logger=logger, max_epochs=2, limit_train_batches=3, limit_val_batches=3)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        logger=logger,
+        max_epochs=2,
+        limit_train_batches=3,
+        limit_val_batches=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     trainer.fit(model)
     wandb.Artifact.assert_called_once_with(
         name="model-1",
@@ -239,11 +291,7 @@ def test_wandb_log_media(wandb, tmpdir):
     wandb.init().log.reset_mock()
     df = 'pandas.DataFrame({"col1": [1, 2], "col2": [3, 4]})'  # TODO: incompatible numpy/pandas versions in test env
     logger.log_text(key="samples", dataframe=df)
-    wandb.Table.assert_called_once_with(
-        columns=None,
-        data=None,
-        dataframe=df,
-    )
+    wandb.Table.assert_called_once_with(columns=None, data=None, dataframe=df)
     wandb.init().log.assert_called_once_with({"samples": wandb.Table()})
 
     # test log_image
@@ -271,11 +319,7 @@ def test_wandb_log_media(wandb, tmpdir):
     wandb.Table.reset_mock()
     wandb.init().log.reset_mock()
     logger.log_table(key="samples", columns=columns, data=data, dataframe=df, step=5)
-    wandb.Table.assert_called_once_with(
-        columns=columns,
-        data=data,
-        dataframe=df,
-    )
+    wandb.Table.assert_called_once_with(columns=columns, data=data, dataframe=df)
     wandb.init().log.assert_called_once_with({"samples": wandb.Table(), "trainer/global_step": 5})
 
 

--- a/tests/loops/batch/test_truncated_bptt.py
+++ b/tests/loops/batch/test_truncated_bptt.py
@@ -102,6 +102,7 @@ def test_persistent_hidden_state_transfer(tmpdir, model_class):
         enable_model_summary=False,
         logger=False,
         enable_checkpointing=False,
+        enable_progress_bar=False,
     )
     trainer.fit(model)
 
@@ -143,6 +144,7 @@ def test_tbptt_split_shapes(tmpdir, model_class):
         enable_model_summary=False,
         logger=False,
         enable_checkpointing=False,
+        enable_progress_bar=False,
     )
     trainer.fit(model, train_dataloaders=train_dataloader)
 
@@ -167,6 +169,8 @@ def test_tbptt_logging(tmpdir, model_class):
         log_every_n_steps=2,
         enable_model_summary=False,
         enable_checkpointing=False,
+        enable_progress_bar=False,
+        logger=False,
     )
     trainer.fit(model)
     assert set(trainer.logged_metrics) == {"loss_step", "loss_epoch"}

--- a/tests/loops/epoch/test_training_epoch_loop.py
+++ b/tests/loops/epoch/test_training_epoch_loop.py
@@ -37,17 +37,9 @@ _out13 = {"loss": 1.3}
         # 1 batch, 2 optimizers
         (2, [[{0: _out00, 1: _out01}]], [_out00, _out01]),
         # 2 batches, 2 optimizers
-        (
-            2,
-            [[{0: _out00, 1: _out01}], [{0: _out10, 1: _out11}]],
-            [[_out00, _out10], [_out01, _out11]],
-        ),
+        (2, [[{0: _out00, 1: _out01}], [{0: _out10, 1: _out11}]], [[_out00, _out10], [_out01, _out11]]),
         # 4 batches, 2 optimizers, different frequency
-        (
-            2,
-            [[{0: _out00}], [{1: _out10}], [{1: _out11}], [{0: _out01}]],
-            [[_out00, _out01], [_out10, _out11]],
-        ),
+        (2, [[{0: _out00}], [{1: _out10}], [{1: _out11}], [{0: _out01}]], [[_out00, _out01], [_out10, _out11]]),
         # 1 batch, tbptt with 2 splits (uneven)
         (1, [[{0: _out00}, {0: _out01}], [{0: _out03}]], [[_out00, _out01], [_out03]]),
         # 3 batches, tbptt with 2 splits, 2 optimizers alternating
@@ -62,9 +54,7 @@ def test_prepare_outputs_training_epoch_end_automatic(num_optimizers, batch_outp
     """Test that the loop converts the nested lists of outputs to the format that the `training_epoch_end` hook
     currently expects in the case of automatic optimization."""
     prepared = TrainingEpochLoop._prepare_outputs_training_epoch_end(
-        batch_outputs,
-        automatic=True,
-        num_optimizers=num_optimizers,
+        batch_outputs, automatic=True, num_optimizers=num_optimizers
     )
     assert prepared == expected
 
@@ -88,9 +78,7 @@ def test_prepare_outputs_training_epoch_end_manual(batch_outputs, expected):
     """Test that the loop converts the nested lists of outputs to the format that the `training_epoch_end` hook
     currently expects in the case of manual optimization."""
     prepared = TrainingEpochLoop._prepare_outputs_training_epoch_end(
-        batch_outputs,
-        automatic=False,
-        num_optimizers=-1,  # does not matter for manual optimization
+        batch_outputs, automatic=False, num_optimizers=-1  # does not matter for manual optimization
     )
     assert prepared == expected
 
@@ -114,9 +102,7 @@ def test_prepare_outputs_training_batch_end_automatic(num_optimizers, batch_end_
     """Test that the loop converts the nested lists of outputs to the format that the `on_train_batch_end` hook
     currently expects in the case of automatic optimization."""
     prepared = TrainingEpochLoop._prepare_outputs_training_batch_end(
-        batch_end_outputs,
-        automatic=True,
-        num_optimizers=num_optimizers,
+        batch_end_outputs, automatic=True, num_optimizers=num_optimizers
     )
     assert prepared == expected
 
@@ -136,8 +122,6 @@ def test_prepare_outputs_training_batch_end_manual(batch_end_outputs, expected):
     """Test that the loop converts the nested lists of outputs to the format that the `on_train_batch_end` hook
     currently expects in the case of manual optimization."""
     prepared = TrainingEpochLoop._prepare_outputs_training_batch_end(
-        batch_end_outputs,
-        automatic=False,
-        num_optimizers=-1,  # does not matter for manual optimization
+        batch_end_outputs, automatic=False, num_optimizers=-1  # does not matter for manual optimization
     )
     assert prepared == expected

--- a/tests/loops/optimization/test_optimizer_loop.py
+++ b/tests/loops/optimization/test_optimizer_loop.py
@@ -120,11 +120,7 @@ def test_optimizer_frequencies(tmpdir, frequencies, expected):
 
     model = CurrentModel()
     model.optimizer_step = Mock(wraps=model.optimizer_step)
-    trainer = Trainer(
-        default_root_dir=tmpdir,
-        fast_dev_run=10,
-        enable_progress_bar=False,
-    )
+    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=10, enable_progress_bar=False)
     trainer.fit(model)
 
     positional_args = [c[0] for c in model.optimizer_step.call_args_list]
@@ -193,6 +189,8 @@ def test_loop_restart_progress_multiple_optimizers(tmpdir, n_optimizers, stop_op
         num_sanity_val_steps=0,
         logger=False,
         enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
     trainer.fit(model)
     weights_complete = model.parameters()
@@ -212,6 +210,8 @@ def test_loop_restart_progress_multiple_optimizers(tmpdir, n_optimizers, stop_op
         num_sanity_val_steps=0,
         logger=False,
         enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
     with pytest.raises(CustomException):
         trainer.fit(model)
@@ -232,6 +232,8 @@ def test_loop_restart_progress_multiple_optimizers(tmpdir, n_optimizers, stop_op
         num_sanity_val_steps=0,
         logger=False,
         enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
     trainer.fit(model, ckpt_path=str(tmpdir / ".pl_auto_save.ckpt"))
     weights_resumed = model.parameters()

--- a/tests/loops/test_all.py
+++ b/tests/loops/test_all.py
@@ -84,6 +84,10 @@ def test_callback_batch_on_device(tmpdir):
         limit_predict_batches=1,
         gpus=1,
         callbacks=[batch_callback],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     trainer.validate(model)

--- a/tests/loops/test_evaluation_loop.py
+++ b/tests/loops/test_evaluation_loop.py
@@ -44,7 +44,7 @@ def test_on_evaluation_epoch_end(eval_epoch_end_mock, tmpdir):
     # sanity + 2 epochs
     assert eval_epoch_end_mock.call_count == 3
 
-    trainer.test()
+    trainer.test(model)
     # sanity + 2 epochs + called once for test
     assert eval_epoch_end_mock.call_count == 4
 

--- a/tests/loops/test_evaluation_loop.py
+++ b/tests/loops/test_evaluation_loop.py
@@ -30,7 +30,14 @@ def test_on_evaluation_epoch_end(eval_epoch_end_mock, tmpdir):
     model = BoringModel()
 
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_train_batches=2, limit_val_batches=2, max_epochs=2, enable_model_summary=False
+        default_root_dir=tmpdir,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        max_epochs=2,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)

--- a/tests/loops/test_evaluation_loop_flow.py
+++ b/tests/loops/test_evaluation_loop_flow.py
@@ -53,6 +53,9 @@ def test__eval_step__flow(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -116,6 +119,9 @@ def test__eval_step__eval_step_end__flow(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -185,6 +191,9 @@ def test__eval_step__epoch_end__flow(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)
@@ -243,6 +252,9 @@ def test__validation_step__step_end__epoch_end__flow(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)

--- a/tests/loops/test_flow_warnings.py
+++ b/tests/loops/test_flow_warnings.py
@@ -36,6 +36,9 @@ def test_no_depre_without_epoch_end(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with warnings.catch_warnings(record=True) as w:

--- a/tests/loops/test_loops.py
+++ b/tests/loops/test_loops.py
@@ -108,7 +108,14 @@ def test_replace_loops():
         def __init__(self, foo):
             super().__init__()
 
-    trainer = Trainer(min_steps=123, max_steps=321)
+    trainer = Trainer(
+        min_steps=123,
+        max_steps=321,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.raises(
         MisconfigurationException, match=r"FitLoop.replace\(TestLoop\)`.*`__init__`.*`TrainingEpochLoop`"
@@ -325,6 +332,10 @@ def test_loop_restart_progress_multiple_dataloaders(tmpdir, n_dataloaders, stop_
         limit_train_batches=1,
         limit_val_batches=n_batches,
         num_sanity_val_steps=0,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     # simulate a failure
@@ -409,6 +420,7 @@ def test_loop_state_on_exception(accumulate_grad_batches, stop_epoch, stop_batch
         enable_progress_bar=False,
         logger=False,
         enable_checkpointing=False,
+        enable_model_summary=False,
     )
 
     # simulate a failure
@@ -607,6 +619,8 @@ def test_loop_state_on_complete_run(n_optimizers, tmpdir):
         accumulate_grad_batches=accumulate_grad_batches,
         enable_progress_bar=False,
         logger=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
     trainer.fit(model)
 
@@ -650,12 +664,7 @@ def test_loop_state_on_complete_run(n_optimizers, tmpdir):
                 "processed": n_epochs * n_batches,
                 "completed": n_epochs * n_batches,
             },
-            "current": {
-                "ready": n_batches,
-                "started": n_batches,
-                "processed": n_batches,
-                "completed": n_batches,
-            },
+            "current": {"ready": n_batches, "started": n_batches, "processed": n_batches, "completed": n_batches},
             "is_last_batch": True,
         },
         "epoch_loop.scheduler_progress": {
@@ -673,10 +682,7 @@ def test_loop_state_on_complete_run(n_optimizers, tmpdir):
                         "ready": n_epochs * n_batches * n_optimizers,
                         "completed": n_epochs * n_batches * n_optimizers,
                     },
-                    "current": {
-                        "ready": n_batches * n_optimizers,
-                        "completed": n_batches * n_optimizers,
-                    },
+                    "current": {"ready": n_batches * n_optimizers, "completed": n_batches * n_optimizers},
                 },
                 "zero_grad": {
                     "total": {
@@ -709,11 +715,7 @@ def test_fit_loop_reset(tmpdir):
 
     # generate checkpoints at end of epoch and mid-epoch
     model = BoringModel()
-    checkpoint_callback = ModelCheckpoint(
-        dirpath=tmpdir,
-        every_n_train_steps=2,
-        save_top_k=-1,
-    )
+    checkpoint_callback = ModelCheckpoint(dirpath=tmpdir, every_n_train_steps=2, save_top_k=-1)
     trainer = Trainer(
         default_root_dir=tmpdir,
         limit_train_batches=4,
@@ -722,6 +724,7 @@ def test_fit_loop_reset(tmpdir):
         callbacks=[checkpoint_callback],
         logger=False,
         enable_model_summary=False,
+        enable_progress_bar=False,
     )
     trainer.fit(model)
 
@@ -835,6 +838,9 @@ def test_fit_can_fail_during_validation(train_datasets, val_datasets, val_check_
         val_check_interval=val_check_interval,
         num_sanity_val_steps=0,
         enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -873,6 +879,9 @@ def test_fit_can_fail_during_validation(train_datasets, val_datasets, val_check_
         val_check_interval=val_check_interval,
         num_sanity_val_steps=0,
         enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     with pytest.raises(CustomException):
         # will stop during validation
@@ -924,6 +933,9 @@ def test_fit_can_fail_during_validation(train_datasets, val_datasets, val_check_
         val_check_interval=val_check_interval,
         num_sanity_val_steps=0,
         enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model, ckpt_path=ckpt_path)
 
@@ -994,6 +1006,10 @@ def test_workers_are_shutdown(tmpdir, should_fail, persistent_workers):
         limit_val_batches=2,
         max_epochs=max_epochs,
         callbacks=TestCallback() if should_fail else None,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     if should_fail:

--- a/tests/loops/test_loops.py
+++ b/tests/loops/test_loops.py
@@ -620,7 +620,6 @@ def test_loop_state_on_complete_run(n_optimizers, tmpdir):
         enable_progress_bar=False,
         logger=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
     )
     trainer.fit(model)
 

--- a/tests/loops/test_training_loop.py
+++ b/tests/loops/test_training_loop.py
@@ -54,6 +54,8 @@ def test_outputs_format(tmpdir):
         limit_test_batches=1,
         enable_progress_bar=False,
         enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -90,7 +92,15 @@ def test_on_train_batch_start_return_minus_one(max_epochs, batch_idx_, tmpdir):
                 return -1
 
     model = CurrentModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=max_epochs, limit_train_batches=10)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=max_epochs,
+        limit_train_batches=10,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     if batch_idx_ > trainer.num_training_batches - 1:
         assert trainer.fit_loop.batch_idx == trainer.num_training_batches - 1
@@ -118,7 +128,16 @@ def test_should_stop_mid_epoch(tmpdir):
             return super().validation_step(*args)
 
     model = TestModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_train_batches=10, limit_val_batches=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_train_batches=10,
+        limit_val_batches=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     assert trainer.current_epoch == 0

--- a/tests/loops/test_training_loop_flow_dict.py
+++ b/tests/loops/test_training_loop_flow_dict.py
@@ -43,6 +43,9 @@ def test__training_step__flow_dict(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -82,6 +85,9 @@ def test__training_step__tr_step_end__flow_dict(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -129,6 +135,9 @@ def test__training_step__epoch_end__flow_dict(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -182,6 +191,9 @@ def test__training_step__step_end__epoch_end__flow_dict(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 

--- a/tests/loops/test_training_loop_flow_scalar.py
+++ b/tests/loops/test_training_loop_flow_scalar.py
@@ -48,6 +48,9 @@ def test__training_step__flow_scalar(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -87,6 +90,9 @@ def test__training_step__tr_step_end__flow_scalar(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -132,6 +138,9 @@ def test__training_step__epoch_end__flow_scalar(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -204,6 +213,9 @@ def test__training_step__step_end__epoch_end__flow_scalar(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -294,6 +306,7 @@ def test_training_step_no_return_when_even(tmpdir):
         enable_model_summary=False,
         logger=False,
         enable_checkpointing=False,
+        enable_progress_bar=False,
     )
 
     Closure.warning_cache.clear()
@@ -343,6 +356,7 @@ def test_training_step_none_batches(tmpdir):
         enable_model_summary=False,
         logger=False,
         enable_checkpointing=False,
+        enable_progress_bar=False,
     )
 
     with pytest.warns(UserWarning, match=r".*train_dataloader yielded None.*"):

--- a/tests/models/data/horovod/train_default_model.py
+++ b/tests/models/data/horovod/train_default_model.py
@@ -96,7 +96,15 @@ def run_test_from_config(trainer_options, on_gpu, check_size=True):
     trainer.checkpoint_connector.restore(checkpoint_path)
 
     if on_gpu:
-        trainer = Trainer(gpus=1, strategy="horovod", max_epochs=1)
+        trainer = Trainer(
+            gpus=1,
+            strategy="horovod",
+            max_epochs=1,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
+        )
         # Test the root_gpu property
         assert trainer.root_gpu == hvd.local_rank()
 

--- a/tests/models/test_cpu.py
+++ b/tests/models/test_cpu.py
@@ -41,6 +41,8 @@ def test_cpu_slurm_save_load(tmpdir):
         limit_train_batches=0.2,
         limit_val_batches=0.2,
         callbacks=[ModelCheckpoint(dirpath=tmpdir)],
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
     trainer.fit(model)
     real_global_step = trainer.global_step
@@ -87,6 +89,8 @@ def test_cpu_slurm_save_load(tmpdir):
         max_epochs=1,
         logger=logger,
         callbacks=[_StartCallback(), ModelCheckpoint(dirpath=tmpdir)],
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
     # by calling fit again, we trigger training, loading weights from the cluster
     # and our hook to predict using current model before any more weight updates
@@ -156,11 +160,7 @@ def test_lbfgs_cpu_model(tmpdir):
             self.save_hyperparameters()
 
     trainer_options = dict(
-        default_root_dir=tmpdir,
-        max_epochs=1,
-        enable_progress_bar=False,
-        limit_train_batches=0.2,
-        limit_val_batches=0.2,
+        default_root_dir=tmpdir, max_epochs=1, enable_progress_bar=False, limit_train_batches=0.2, limit_val_batches=0.2
     )
 
     model = ModelSpecifiedOptimizer(optimizer_name="LBFGS", learning_rate=0.004)
@@ -219,6 +219,7 @@ def test_running_test_after_fitting(tmpdir):
         limit_test_batches=0.2,
         callbacks=[checkpoint],
         logger=logger,
+        enable_model_summary=False,
     )
     trainer.fit(model)
 
@@ -263,6 +264,7 @@ def test_running_test_no_val(tmpdir):
         limit_test_batches=0.2,
         callbacks=[checkpoint],
         logger=logger,
+        enable_model_summary=False,
     )
     trainer.fit(model)
 
@@ -279,7 +281,16 @@ def test_simple_cpu(tmpdir):
     model = BoringModel()
 
     # fit model
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_val_batches=0.1, limit_train_batches=20)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_val_batches=0.1,
+        limit_train_batches=20,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     # traning complete

--- a/tests/models/test_grad_norm.py
+++ b/tests/models/test_grad_norm.py
@@ -75,6 +75,10 @@ def test_grad_tracking(tmpdir, norm_type, rtol=5e-3):
         max_epochs=3,
         track_grad_norm=norm_type,
         log_every_n_steps=1,  # request grad_norms every batch
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
@@ -89,7 +93,16 @@ def test_grad_tracking(tmpdir, norm_type, rtol=5e-3):
 @pytest.mark.parametrize("log_every_n_steps", [1, 2, 3])
 def test_grad_tracking_interval(tmpdir, log_every_n_steps):
     """Test that gradient norms get tracked in the right interval and that everytime the same keys get logged."""
-    trainer = Trainer(default_root_dir=tmpdir, track_grad_norm=2, log_every_n_steps=log_every_n_steps, max_steps=10)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        track_grad_norm=2,
+        log_every_n_steps=log_every_n_steps,
+        max_steps=10,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with patch.object(trainer.logger, "log_metrics") as mocked:
         model = BoringModel()

--- a/tests/models/test_grad_norm.py
+++ b/tests/models/test_grad_norm.py
@@ -78,7 +78,6 @@ def test_grad_tracking(tmpdir, norm_type, rtol=5e-3):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
@@ -101,7 +100,6 @@ def test_grad_tracking_interval(tmpdir, log_every_n_steps):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
 
     with patch.object(trainer.logger, "log_metrics") as mocked:

--- a/tests/models/test_hooks.py
+++ b/tests/models/test_hooks.py
@@ -35,7 +35,15 @@ def test_on_before_zero_grad_called(tmpdir, max_steps):
 
     model = CurrentTestModel()
 
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=max_steps, max_epochs=2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=max_steps,
+        max_epochs=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     assert 0 == model.on_before_zero_grad_called
     trainer.fit(model)
     assert max_steps == model.on_before_zero_grad_called
@@ -63,7 +71,15 @@ def test_training_epoch_end_metrics_collection(tmpdir):
             )
 
     model = CurrentModel()
-    trainer = Trainer(max_epochs=num_epochs, default_root_dir=tmpdir, overfit_batches=2)
+    trainer = Trainer(
+        max_epochs=num_epochs,
+        default_root_dir=tmpdir,
+        overfit_batches=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
     metrics = trainer.progress_bar_callback.get_metrics(trainer, model)
@@ -105,7 +121,15 @@ def test_training_epoch_end_metrics_collection_on_override(tmpdir):
     not_overridden_model = NotOverriddenModel()
     not_overridden_model.training_epoch_end = None
 
-    trainer = Trainer(max_epochs=1, default_root_dir=tmpdir, overfit_batches=2)
+    trainer = Trainer(
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        overfit_batches=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     trainer.fit(overridden_model)
     assert overridden_model.len_outputs == overridden_model.num_train_batches
@@ -204,6 +228,9 @@ def test_transfer_batch_hook_ddp(tmpdir):
         enable_model_summary=False,
         strategy="ddp",
         gpus=2,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -483,6 +510,8 @@ def _run_trainer_model_hook_system_fit(kwargs, tmpdir, automatic_optimization):
         callbacks=[callback],
         track_grad_norm=1,
         **kwargs,
+        enable_checkpointing=False,
+        logger=False,
     )
     assert called == [
         dict(name="Callback.on_init_start", args=(trainer,)),
@@ -589,6 +618,8 @@ def test_trainer_model_hook_system_fit_no_val_and_resume(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         callbacks=[HookedCallback([])],
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     best_model_path = trainer.checkpoint_callback.best_model_path
@@ -609,6 +640,8 @@ def test_trainer_model_hook_system_fit_no_val_and_resume(tmpdir):
         enable_model_summary=False,
         callbacks=[callback],
         track_grad_norm=1,
+        enable_checkpointing=False,
+        logger=False,
     )
     assert called == [
         dict(name="Callback.on_init_start", args=(trainer,)),
@@ -693,6 +726,8 @@ def test_trainer_model_hook_system_eval(tmpdir, batches, verb, noun, dataloader,
         enable_progress_bar=False,
         enable_model_summary=False,
         callbacks=[callback],
+        enable_checkpointing=False,
+        logger=False,
     )
     assert called == [
         dict(name="Callback.on_init_start", args=(trainer,)),
@@ -737,7 +772,13 @@ def test_trainer_model_hook_system_predict(tmpdir):
     callback = HookedCallback(called)
     batches = 2
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_predict_batches=batches, enable_progress_bar=False, callbacks=[callback]
+        default_root_dir=tmpdir,
+        limit_predict_batches=batches,
+        enable_progress_bar=False,
+        callbacks=[callback],
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     assert called == [
         dict(name="Callback.on_init_start", args=(trainer,)),
@@ -862,6 +903,8 @@ def test_trainer_datamodule_hook_system(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         reload_dataloaders_every_n_epochs=1,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     called = []

--- a/tests/models/test_hooks.py
+++ b/tests/models/test_hooks.py
@@ -75,7 +75,6 @@ def test_training_epoch_end_metrics_collection(tmpdir):
         max_epochs=num_epochs,
         default_root_dir=tmpdir,
         overfit_batches=2,
-        enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
         logger=False,
@@ -510,8 +509,6 @@ def _run_trainer_model_hook_system_fit(kwargs, tmpdir, automatic_optimization):
         callbacks=[callback],
         track_grad_norm=1,
         **kwargs,
-        enable_checkpointing=False,
-        logger=False,
     )
     assert called == [
         dict(name="Callback.on_init_start", args=(trainer,)),
@@ -618,7 +615,6 @@ def test_trainer_model_hook_system_fit_no_val_and_resume(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         callbacks=[HookedCallback([])],
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)
@@ -640,8 +636,6 @@ def test_trainer_model_hook_system_fit_no_val_and_resume(tmpdir):
         enable_model_summary=False,
         callbacks=[callback],
         track_grad_norm=1,
-        enable_checkpointing=False,
-        logger=False,
     )
     assert called == [
         dict(name="Callback.on_init_start", args=(trainer,)),
@@ -903,7 +897,6 @@ def test_trainer_datamodule_hook_system(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         reload_dataloaders_every_n_epochs=1,
-        enable_checkpointing=False,
         logger=False,
     )
 

--- a/tests/models/test_horovod.py
+++ b/tests/models/test_horovod.py
@@ -245,6 +245,9 @@ def test_horovod_multi_optimizer(tmpdir):
         limit_train_batches=0.4,
         limit_val_batches=0.2,
         strategy="horovod",
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
@@ -308,6 +311,8 @@ def test_result_reduce_horovod(tmpdir):
             log_every_n_steps=1,
             enable_model_summary=False,
             logger=False,
+            enable_progress_bar=False,
+            enable_checkpointing=False,
         )
 
         trainer.fit(model)
@@ -388,7 +393,15 @@ def test_horovod_multi_optimizer_with_scheduling_stepping(tmpdir):
 
         # fit model
         trainer = Trainer(
-            default_root_dir=tmpdir, max_epochs=1, limit_val_batches=0.5, limit_train_batches=0.2, strategy="horovod"
+            default_root_dir=tmpdir,
+            max_epochs=1,
+            limit_val_batches=0.5,
+            limit_train_batches=0.2,
+            strategy="horovod",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
         )
         trainer.fit(model)
 

--- a/tests/models/test_hparams.py
+++ b/tests/models/test_hparams.py
@@ -79,7 +79,15 @@ def _run_standard_hparams_test(tmpdir, model, cls, try_overwrite=False):
     assert model.hparams.test_arg == 14
 
     # verify we can train
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, overfit_batches=2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        overfit_batches=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     # make sure the raw checkpoint saved the properties
@@ -191,7 +199,15 @@ def test_explicit_missing_args_hparams(tmpdir):
     assert model.hparams.test_arg == 14
 
     # verify we can train
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=2, overfit_batches=0.5)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        overfit_batches=0.5,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     # make sure the raw checkpoint saved the properties
@@ -325,7 +341,15 @@ def test_collect_init_arguments(tmpdir, cls):
         assert isinstance(model.hparams.my_loss, torch.nn.CosineEmbeddingLoss)
 
     # verify that the checkpoint saved the correct values
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=2, overfit_batches=0.5)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        overfit_batches=0.5,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     raw_checkpoint_path = _raw_checkpoint_path(trainer)
@@ -422,7 +446,14 @@ def test_load_past_checkpoint(tmpdir, past_key):
     model = CustomBoringModel()
 
     # verify we can train
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     # make sure the raw checkpoint saved the properties
@@ -459,7 +490,14 @@ class UnpickleableArgsBoringModel(BoringModel):
 
 def test_hparams_pickle_warning(tmpdir):
     model = UnpickleableArgsBoringModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.warns(UserWarning, match="attribute 'pickle_me' removed from hparams because it cannot be pickled"):
         trainer.fit(model)
     assert "pickle_me" not in model.hparams
@@ -513,7 +551,14 @@ def test_model_nohparams_train_test(tmpdir, cls):
     """Test models that do not take any argument in init."""
 
     model = cls()
-    trainer = Trainer(max_epochs=1, default_root_dir=tmpdir)
+    trainer = Trainer(
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     train_loader = DataLoader(RandomDataset(32, 64), batch_size=32)
     trainer.fit(model, train_loader)
@@ -534,7 +579,14 @@ def test_model_ignores_non_exist_kwargument(tmpdir):
     assert model.hparams.batch_size == 15
 
     # verify that the checkpoint saved the correct values
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     # verify that we can overwrite whatever we want
@@ -560,7 +612,14 @@ def test_args(tmpdir):
     """Test for inheritance: super class takes positional arg, subclass takes varargs."""
     hparams = dict(test=1)
     model = SubClassVarArgs(hparams)
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     raw_checkpoint_path = _raw_checkpoint_path(trainer)
@@ -583,7 +642,15 @@ def test_init_arg_with_runtime_change(tmpdir, cls):
     assert model.hparams.running_arg == -1
 
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_train_batches=2, limit_val_batches=2, limit_test_batches=2, max_epochs=1
+        default_root_dir=tmpdir,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        limit_test_batches=2,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -601,7 +668,15 @@ class UnsafeParamModel(BoringModel):
 def test_model_with_fsspec_as_parameter(tmpdir):
     model = UnsafeParamModel(LocalFileSystem(tmpdir))
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_train_batches=2, limit_val_batches=2, limit_test_batches=2, max_epochs=1
+        default_root_dir=tmpdir,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        limit_test_batches=2,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     trainer.test()
@@ -635,6 +710,8 @@ def test_model_save_hyper_parameters_interpolation_with_hydra(tmpdir):
             limit_val_batches=10,
             max_epochs=epochs,
             logger=False,
+            enable_progress_bar=False,
+            enable_model_summary=False,
         )
         trainer.fit(model)
         _ = TestHydraModel.load_from_checkpoint(checkpoint_callback.best_model_path)
@@ -657,7 +734,15 @@ def test_ignore_args_list_hparams(tmpdir, ignore):
         assert arg not in model.hparams
 
     # verify we can train
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=2, overfit_batches=0.5)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        overfit_batches=0.5,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     # make sure the raw checkpoint saved the properties
@@ -754,7 +839,14 @@ def test_adding_datamodule_hparams(tmpdir, model, data):
     org_data_hparams = copy.deepcopy(data.hparams_initial)
 
     mock_logger = _get_mock_logger(tmpdir)
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, logger=mock_logger)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        logger=mock_logger,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     trainer.fit(model, datamodule=data)
 
     # Hparams of model and data were not modified
@@ -775,7 +867,14 @@ def test_no_datamodule_for_hparams(tmpdir):
     data.setup()
 
     mock_logger = _get_mock_logger(tmpdir)
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, logger=mock_logger)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        logger=mock_logger,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     trainer.fit(model, datamodule=data)
 
     # Merged hparams were logged
@@ -787,6 +886,13 @@ def test_colliding_hparams(tmpdir):
     model = SaveHparamsModel({"data_dir": "abc", "arg2": "abc"})
     data = DataModuleWithHparams({"data_dir": "foo"})
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.raises(MisconfigurationException, match=r"Error while merging hparams:"):
         trainer.fit(model, datamodule=data)

--- a/tests/models/test_hparams.py
+++ b/tests/models/test_hparams.py
@@ -85,7 +85,6 @@ def _run_standard_hparams_test(tmpdir, model, cls, try_overwrite=False):
         overfit_batches=2,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)
@@ -205,7 +204,6 @@ def test_explicit_missing_args_hparams(tmpdir):
         overfit_batches=0.5,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)
@@ -347,7 +345,6 @@ def test_collect_init_arguments(tmpdir, cls):
         overfit_batches=0.5,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)
@@ -451,7 +448,6 @@ def test_load_past_checkpoint(tmpdir, past_key):
         max_epochs=1,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)
@@ -564,7 +560,7 @@ def test_model_nohparams_train_test(tmpdir, cls):
     trainer.fit(model, train_loader)
 
     test_loader = DataLoader(RandomDataset(32, 64), batch_size=32)
-    trainer.test(dataloaders=test_loader)
+    trainer.test(model, dataloaders=test_loader)
 
 
 def test_model_ignores_non_exist_kwargument(tmpdir):
@@ -584,7 +580,6 @@ def test_model_ignores_non_exist_kwargument(tmpdir):
         max_epochs=1,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)
@@ -617,7 +612,6 @@ def test_args(tmpdir):
         max_epochs=1,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)
@@ -649,8 +643,6 @@ def test_init_arg_with_runtime_change(tmpdir, cls):
         max_epochs=1,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
-        logger=False,
     )
     trainer.fit(model)
 
@@ -679,7 +671,7 @@ def test_model_with_fsspec_as_parameter(tmpdir):
         logger=False,
     )
     trainer.fit(model)
-    trainer.test()
+    trainer.test(model)
 
 
 @pytest.mark.skipif(not _HYDRA_EXPERIMENTAL_AVAILABLE, reason="Hydra experimental is not available")
@@ -740,7 +732,6 @@ def test_ignore_args_list_hparams(tmpdir, ignore):
         overfit_batches=0.5,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)
@@ -892,7 +883,6 @@ def test_colliding_hparams(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     with pytest.raises(MisconfigurationException, match=r"Error while merging hparams:"):
         trainer.fit(model, datamodule=data)

--- a/tests/models/test_onnx.py
+++ b/tests/models/test_onnx.py
@@ -69,10 +69,7 @@ def test_model_saves_with_example_output(tmpdir):
 
 @pytest.mark.parametrize(
     ["modelclass", "input_sample"],
-    [
-        (BoringModel, torch.randn(1, 32)),
-        (UnorderedModel, (torch.rand(2, 3), torch.rand(2, 10))),
-    ],
+    [(BoringModel, torch.randn(1, 32)), (UnorderedModel, (torch.rand(2, 3), torch.rand(2, 10)))],
 )
 def test_model_saves_with_example_input_array(tmpdir, modelclass, input_sample):
     """Test that ONNX model saves with example_input_array and size is greater than 3 MB."""

--- a/tests/models/test_restore.py
+++ b/tests/models/test_restore.py
@@ -569,6 +569,8 @@ def test_model_saving_loading(tmpdir):
         logger=logger,
         callbacks=[ModelCheckpoint(dirpath=tmpdir)],
         default_root_dir=tmpdir,
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
     trainer.fit(model)
 
@@ -623,6 +625,8 @@ def test_strict_model_load_more_params(monkeypatch, tmpdir, tmpdir_server, url_c
         limit_val_batches=2,
         logger=logger,
         callbacks=[ModelCheckpoint(dirpath=tmpdir)],
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
     trainer.fit(model)
 
@@ -663,6 +667,8 @@ def test_strict_model_load_less_params(monkeypatch, tmpdir, tmpdir_server, url_c
         limit_val_batches=2,
         logger=logger,
         callbacks=[ModelCheckpoint(dirpath=tmpdir)],
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
     trainer.fit(model)
 

--- a/tests/models/test_sync_batchnorm.py
+++ b/tests/models/test_sync_batchnorm.py
@@ -123,6 +123,10 @@ def test_sync_batchnorm_ddp(tmpdir):
         sync_batchnorm=True,
         num_sanity_val_steps=0,
         replace_sampler_ddp=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model, dm)

--- a/tests/models/test_tpu.py
+++ b/tests/models/test_tpu.py
@@ -188,6 +188,9 @@ def test_model_tpu_early_stop(tmpdir):
         limit_train_batches=2,
         limit_val_batches=2,
         tpu_cores=8,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     trainer.test(dataloaders=DataLoader(RandomDataset(32, 2000), batch_size=32))
@@ -239,15 +242,20 @@ def test_dataloaders_passed_to_fit(tmpdir):
     tutils.reset_seed()
     model = BoringModel()
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, tpu_cores=8)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        tpu_cores=8,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model, train_dataloaders=model.train_dataloader(), val_dataloaders=model.val_dataloader())
     assert trainer.state.finished, f"Training failed with {trainer.state}"
 
 
-@pytest.mark.parametrize(
-    ["tpu_cores", "expected_tpu_id"],
-    [(1, None), (8, None), ([1], 1), ([8], 8)],
-)
+@pytest.mark.parametrize(["tpu_cores", "expected_tpu_id"], [(1, None), (8, None), ([1], 1), ([8], 8)])
 @RunIf(tpu=True)
 def test_tpu_id_to_be_as_expected(tpu_cores, expected_tpu_id):
     """Test if trainer.tpu_id is set as expected."""
@@ -319,8 +327,7 @@ def test_tpu_choice(tmpdir, tpu_cores, expected_tpu_id, error_expected):
 
 
 @pytest.mark.parametrize(
-    ["cli_args", "expected"],
-    [("--tpu_cores=8", {"tpu_cores": 8}), ("--tpu_cores=1,", {"tpu_cores": "1,"})],
+    ["cli_args", "expected"], [("--tpu_cores=8", {"tpu_cores": 8}), ("--tpu_cores=1,", {"tpu_cores": "1,"})]
 )
 @RunIf(tpu=True)
 @pl_multi_process_test
@@ -396,7 +403,16 @@ def test_if_test_works_with_checkpoint_false(tmpdir):
 
     # Train a model on TPU
     model = BoringModel()
-    trainer = Trainer(max_epochs=1, tpu_cores=8, default_root_dir=tmpdir, fast_dev_run=True, enable_checkpointing=False)
+    trainer = Trainer(
+        max_epochs=1,
+        tpu_cores=8,
+        default_root_dir=tmpdir,
+        fast_dev_run=True,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
+    )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
 

--- a/tests/plugins/environments/test_lsf_environment.py
+++ b/tests/plugins/environments/test_lsf_environment.py
@@ -81,12 +81,6 @@ def test_detect():
         assert not LSFEnvironment.detect()
 
     with mock.patch.dict(
-        os.environ,
-        {
-            "LSB_HOSTS": "",
-            "LSB_JOBID": "",
-            "JSM_NAMESPACE_SIZE": "",
-            "JSM_NAMESPACE_LOCAL_RANK": "",
-        },
+        os.environ, {"LSB_HOSTS": "", "LSB_JOBID": "", "JSM_NAMESPACE_SIZE": "", "JSM_NAMESPACE_LOCAL_RANK": ""}
     ):
         assert LSFEnvironment.detect()

--- a/tests/plugins/environments/test_torchelastic_environment.py
+++ b/tests/plugins/environments/test_torchelastic_environment.py
@@ -75,13 +75,5 @@ def test_detect():
     with mock.patch.dict(os.environ, {}):
         assert not TorchElasticEnvironment.detect()
 
-    with mock.patch.dict(
-        os.environ,
-        {
-            "RANK": "",
-            "GROUP_RANK": "",
-            "LOCAL_RANK": "",
-            "LOCAL_WORLD_SIZE": "",
-        },
-    ):
+    with mock.patch.dict(os.environ, {"RANK": "", "GROUP_RANK": "", "LOCAL_RANK": "", "LOCAL_WORLD_SIZE": ""}):
         assert TorchElasticEnvironment.detect()

--- a/tests/plugins/environments/torch_elastic_deadlock.py
+++ b/tests/plugins/environments/torch_elastic_deadlock.py
@@ -23,7 +23,16 @@ if os.getenv("PL_RUN_STANDALONE_TESTS", "0") == "1" and os.getenv("PL_RECONCILE_
     model = Model()
 
     trainer = Trainer(
-        default_root_dir=".", max_epochs=1, limit_train_batches=5, num_sanity_val_steps=0, gpus=2, strategy="ddp"
+        default_root_dir=".",
+        max_epochs=1,
+        limit_train_batches=5,
+        num_sanity_val_steps=0,
+        gpus=2,
+        strategy="ddp",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     assert isinstance(trainer.training_type_plugin, DDPPlugin)
 

--- a/tests/plugins/test_amp_plugins.py
+++ b/tests/plugins/test_amp_plugins.py
@@ -60,14 +60,7 @@ def test_amp_apex_ddp(mocked_device_count, strategy, gpus, amp, custom_plugin, p
     plugin = None
     if custom_plugin:
         plugin = plugin_cls(16, "cpu") if amp == "native" else plugin_cls()
-    trainer = Trainer(
-        fast_dev_run=True,
-        precision=16,
-        amp_backend=amp,
-        gpus=gpus,
-        strategy=strategy,
-        plugins=plugin,
-    )
+    trainer = Trainer(fast_dev_run=True, precision=16, amp_backend=amp, gpus=gpus, strategy=strategy, plugins=plugin)
     assert isinstance(trainer.precision_plugin, plugin_cls)
 
 
@@ -154,6 +147,9 @@ def test_amp_gradient_unscale(tmpdir, accum: int):
         log_every_n_steps=1,
         accumulate_grad_batches=accum,
         enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 

--- a/tests/plugins/test_checkpoint_io_plugin.py
+++ b/tests/plugins/test_checkpoint_io_plugin.py
@@ -52,6 +52,9 @@ def test_checkpoint_plugin_called(tmpdir):
         strategy=SingleDevicePlugin(device, checkpoint_io=checkpoint_plugin),
         callbacks=ck,
         max_epochs=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -72,6 +75,9 @@ def test_checkpoint_plugin_called(tmpdir):
         plugins=[checkpoint_plugin],
         callbacks=ck,
         max_epochs=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     trainer.fit(model)
 

--- a/tests/plugins/test_custom_plugin.py
+++ b/tests/plugins/test_custom_plugin.py
@@ -36,7 +36,16 @@ def test_sync_batchnorm_set(tmpdir):
     model = BoringModel()
     plugin = CustomParallelPlugin()
     assert plugin.sync_batchnorm is None
-    trainer = Trainer(max_epochs=1, strategy=plugin, default_root_dir=tmpdir, sync_batchnorm=True)
+    trainer = Trainer(
+        max_epochs=1,
+        strategy=plugin,
+        default_root_dir=tmpdir,
+        sync_batchnorm=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     assert plugin.sync_batchnorm is True
 

--- a/tests/plugins/test_ddp_fully_sharded_with_full_state_dict.py
+++ b/tests/plugins/test_ddp_fully_sharded_with_full_state_dict.py
@@ -94,7 +94,17 @@ def test_fully_sharded_plugin_checkpoint(tmpdir):
     """Test to ensure that checkpoint is saved correctly when using a single GPU, and all stages can be run."""
 
     model = TestFSDPModel()
-    trainer = Trainer(default_root_dir=tmpdir, gpus=1, strategy="fsdp", precision=16, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        gpus=1,
+        strategy="fsdp",
+        precision=16,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     _run_multiple_stages(trainer, model, os.path.join(tmpdir, "last.ckpt"))
 
 
@@ -104,7 +114,18 @@ def test_fully_sharded_plugin_checkpoint_multi_gpus(tmpdir):
 
     model = TestFSDPModel()
     ck = ModelCheckpoint(save_last=True)
-    trainer = Trainer(default_root_dir=tmpdir, gpus=2, strategy="fsdp", precision=16, max_epochs=1, callbacks=[ck])
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        gpus=2,
+        strategy="fsdp",
+        precision=16,
+        max_epochs=1,
+        callbacks=[ck],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     _run_multiple_stages(trainer, model)
 
 

--- a/tests/plugins/test_ddp_plugin.py
+++ b/tests/plugins/test_ddp_plugin.py
@@ -70,7 +70,16 @@ def test_ddp_barrier_non_consecutive_device_ids(barrier_mock, tmpdir):
     """Test correct usage of barriers when device ids do not start at 0 or are not consecutive."""
     model = BoringModel()
     gpus = [1, 3]
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=1, gpus=gpus, strategy="ddp")
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+        gpus=gpus,
+        strategy="ddp",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     barrier_mock.assert_any_call(device_ids=[gpus[trainer.local_rank]])
 
@@ -87,10 +96,7 @@ def test_incorrect_ddp_script_spawning(tmpdir):
 
     model = BoringModel()
     trainer = Trainer(
-        default_root_dir=tmpdir,
-        strategy="ddp",
-        num_processes=2,
-        plugins=[WronglyImplementedEnvironment()],
+        default_root_dir=tmpdir, strategy="ddp", num_processes=2, plugins=[WronglyImplementedEnvironment()]
     )
     with pytest.raises(
         RuntimeError, match="Lightning attempted to launch new distributed processes with `local_rank > 0`."
@@ -106,6 +112,10 @@ def test_ddp_configure_ddp():
     trainer = Trainer(
         max_epochs=1,
         strategy=ddp_plugin,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     # test wrap the model if fitting
     trainer.state.fn = TrainerFn.FITTING
@@ -121,6 +131,10 @@ def test_ddp_configure_ddp():
     trainer = Trainer(
         max_epochs=1,
         strategy=ddp_plugin,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     # test do not wrap the model if trainerFN is not fitting
     trainer.training_type_plugin.connect(model)

--- a/tests/plugins/test_ddp_plugin_with_comm_hook.py
+++ b/tests/plugins/test_ddp_plugin_with_comm_hook.py
@@ -38,6 +38,10 @@ def test_ddp_fp16_compress_comm_hook(tmpdir):
         default_root_dir=tmpdir,
         sync_batchnorm=True,
         fast_dev_run=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     trainer_comm_hook = trainer.training_type_plugin.model.get_ddp_logging_data().comm_hook
@@ -51,8 +55,7 @@ def test_ddp_sgd_comm_hook(tmpdir):
     """Test for DDP FP16 compress hook."""
     model = BoringModel()
     training_type_plugin = DDPPlugin(
-        ddp_comm_state=powerSGD.PowerSGDState(process_group=None),
-        ddp_comm_hook=powerSGD.powerSGD_hook,
+        ddp_comm_state=powerSGD.PowerSGDState(process_group=None), ddp_comm_hook=powerSGD.powerSGD_hook
     )
     trainer = Trainer(
         max_epochs=1,
@@ -61,6 +64,10 @@ def test_ddp_sgd_comm_hook(tmpdir):
         default_root_dir=tmpdir,
         sync_batchnorm=True,
         fast_dev_run=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     trainer_comm_hook = trainer.training_type_plugin.model.get_ddp_logging_data().comm_hook
@@ -85,6 +92,10 @@ def test_ddp_fp16_compress_wrap_sgd_comm_hook(tmpdir):
         default_root_dir=tmpdir,
         sync_batchnorm=True,
         fast_dev_run=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     trainer_comm_hook = trainer.training_type_plugin.model.get_ddp_logging_data().comm_hook
@@ -105,6 +116,10 @@ def test_ddp_spawn_fp16_compress_comm_hook(tmpdir):
         default_root_dir=tmpdir,
         sync_batchnorm=True,
         fast_dev_run=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
@@ -116,20 +131,12 @@ def test_ddp_post_local_sgd_comm_hook(tmpdir):
     model = BoringModel()
 
     training_type_plugin = DDPPlugin(
-        ddp_comm_state=post_localSGD.PostLocalSGDState(
-            process_group=None,
-            subgroup=None,
-            start_localSGD_iter=8,
-        ),
+        ddp_comm_state=post_localSGD.PostLocalSGDState(process_group=None, subgroup=None, start_localSGD_iter=8),
         ddp_comm_hook=post_localSGD.post_localSGD_hook,
         model_averaging_period=4,
     )
     trainer = Trainer(
-        fast_dev_run=True,
-        gpus=2,
-        strategy=training_type_plugin,
-        default_root_dir=tmpdir,
-        sync_batchnorm=True,
+        fast_dev_run=True, gpus=2, strategy=training_type_plugin, default_root_dir=tmpdir, sync_batchnorm=True
     )
     trainer.fit(model)
     trainer_comm_hook = trainer.training_type_plugin.model.get_ddp_logging_data().comm_hook

--- a/tests/plugins/test_double_plugin.py
+++ b/tests/plugins/test_double_plugin.py
@@ -133,16 +133,22 @@ class DoublePrecisionBoringModelComplexBuffer(BoringModel):
 
 @pytest.mark.parametrize(
     "boring_model",
-    [
-        DoublePrecisionBoringModel,
-        DoublePrecisionBoringModelNoForward,
-        DoublePrecisionBoringModelComplexBuffer,
-    ],
+    [DoublePrecisionBoringModel, DoublePrecisionBoringModelNoForward, DoublePrecisionBoringModelComplexBuffer],
 )
 def test_double_precision(tmpdir, boring_model):
     model = boring_model()
 
-    trainer = Trainer(max_epochs=2, default_root_dir=tmpdir, fast_dev_run=2, precision=64, log_every_n_steps=1)
+    trainer = Trainer(
+        max_epochs=2,
+        default_root_dir=tmpdir,
+        fast_dev_run=2,
+        precision=64,
+        log_every_n_steps=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     trainer.test(model)
     trainer.predict(model)
@@ -160,6 +166,10 @@ def test_double_precision_ddp(tmpdir):
         fast_dev_run=2,
         precision=64,
         log_every_n_steps=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -123,7 +123,6 @@ def test_simple_profiler_log_dir(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     trainer.fit(model)
 
@@ -150,7 +149,6 @@ def test_simple_profiler_with_nonexisting_log_dir(tmpdir):
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     trainer.fit(model)
 

--- a/tests/profiler/test_profiler.py
+++ b/tests/profiler/test_profiler.py
@@ -116,7 +116,15 @@ def test_simple_profiler_log_dir(tmpdir):
     assert profiler._log_dir is None
 
     model = BoringModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, profiler=profiler)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        profiler=profiler,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     expected = tmpdir / "lightning_logs" / "version_0"
@@ -134,7 +142,15 @@ def test_simple_profiler_with_nonexisting_log_dir(tmpdir):
 
     model = BoringModel()
     trainer = Trainer(
-        default_root_dir=nonexisting_tmpdir, max_epochs=1, limit_train_batches=1, limit_val_batches=1, profiler=profiler
+        default_root_dir=nonexisting_tmpdir,
+        max_epochs=1,
+        limit_train_batches=1,
+        limit_val_batches=1,
+        profiler=profiler,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -154,7 +170,15 @@ def test_simple_profiler_with_nonexisting_dirpath(tmpdir):
 
     model = BoringModel()
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=1, limit_val_batches=1, profiler=profiler
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_train_batches=1,
+        limit_val_batches=1,
+        profiler=profiler,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -308,6 +332,9 @@ def test_pytorch_profiler_trainer_ddp(tmpdir, pytorch_profiler):
         profiler=pytorch_profiler,
         strategy="ddp",
         gpus=2,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -340,7 +367,16 @@ def test_pytorch_profiler_trainer_fit(fast_dev_run, boring_model_cls, tmpdir):
     """Ensure that the profiler can be given to the trainer and test step are properly recorded."""
     pytorch_profiler = PyTorchProfiler(dirpath=tmpdir, filename="profile")
     model = boring_model_cls()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, fast_dev_run=fast_dev_run, profiler=pytorch_profiler)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        fast_dev_run=fast_dev_run,
+        profiler=pytorch_profiler,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     assert sum(e.name == "validation_step" for e in pytorch_profiler.function_events)
@@ -362,7 +398,16 @@ def test_pytorch_profiler_trainer(fn, step_name, boring_model_cls, tmpdir):
     pytorch_profiler = PyTorchProfiler(dirpath=tmpdir, filename="profile", schedule=None)
     model = boring_model_cls()
     model.predict_dataloader = model.train_dataloader
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_test_batches=2, profiler=pytorch_profiler)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_test_batches=2,
+        profiler=pytorch_profiler,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     getattr(trainer, fn)(model)
 
     assert sum(e.name == f"{step_name}_step" for e in pytorch_profiler.function_events)
@@ -421,7 +466,16 @@ def test_pytorch_profiler_logger_collection(tmpdir):
 
     # Wrap the logger in a list so it becomes a LoggerCollection
     logger = [TensorBoardLogger(save_dir=tmpdir)]
-    trainer = Trainer(default_root_dir=tmpdir, profiler="pytorch", logger=logger, limit_train_batches=5, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        profiler="pytorch",
+        logger=logger,
+        limit_train_batches=5,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
 
     assert isinstance(trainer.logger, LoggerCollection)
     trainer.fit(model)
@@ -532,13 +586,7 @@ def test_trainer_profiler_incorrect_str_arg():
     [
         ({"limit_train_batches": 4, "limit_val_batches": 7}, "fit"),
         ({"limit_train_batches": 7, "limit_val_batches": 4, "num_sanity_val_steps": 0}, "fit"),
-        (
-            {
-                "limit_train_batches": 7,
-                "limit_val_batches": 2,
-            },
-            "fit",
-        ),
+        ({"limit_train_batches": 7, "limit_val_batches": 2}, "fit"),
         ({"limit_val_batches": 4}, "validate"),
         ({"limit_test_batches": 4}, "test"),
         ({"limit_predict_batches": 4}, "predict"),
@@ -546,7 +594,16 @@ def test_trainer_profiler_incorrect_str_arg():
 )
 def test_pytorch_profiler_raises_warning_for_limited_steps(tmpdir, trainer_config, trainer_fn):
     model = BoringModel()
-    trainer = Trainer(default_root_dir=tmpdir, profiler="pytorch", max_epochs=1, **trainer_config)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        profiler="pytorch",
+        max_epochs=1,
+        **trainer_config,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     warning_cache.clear()
     with pytest.warns(UserWarning, match="not enough steps to properly record traces"):
         getattr(trainer, trainer_fn)(model)

--- a/tests/profiler/test_xla_profiler.py
+++ b/tests/profiler/test_xla_profiler.py
@@ -48,7 +48,16 @@ def test_xla_profiler_prog_capture(tmpdir):
 
     def train_worker():
         model = BoringModel()
-        trainer = Trainer(default_root_dir=tmpdir, max_epochs=4, profiler="xla", tpu_cores=8)
+        trainer = Trainer(
+            default_root_dir=tmpdir,
+            max_epochs=4,
+            profiler="xla",
+            tpu_cores=8,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
+        )
 
         trainer.fit(model)
 

--- a/tests/trainer/connectors/test_callback_connector.py
+++ b/tests/trainer/connectors/test_callback_connector.py
@@ -121,6 +121,9 @@ def test_all_callback_states_saved_before_checkpoint_callback(tmpdir):
             callback1,
             callback2,
         ],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -170,8 +173,7 @@ def test_attach_model_callbacks():
 
     # same callback type twice, different instance
     trainer = _attach_callbacks(
-        trainer_callbacks=[progress_bar, EarlyStopping(monitor="foo")],
-        model_callbacks=[early_stopping],
+        trainer_callbacks=[progress_bar, EarlyStopping(monitor="foo")], model_callbacks=[early_stopping]
     )
     assert trainer.callbacks == [progress_bar, trainer.accumulation_scheduler, early_stopping]
 

--- a/tests/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/trainer/connectors/test_checkpoint_connector.py
@@ -41,7 +41,14 @@ class HPCHookdedModel(BoringModel):
 
 def test_hpc_hook_calls(tmpdir):
     model = HPCHookdedModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=1, enable_checkpointing=False, logger=False)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+        enable_checkpointing=False,
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
     with pytest.deprecated_call(
         match=r"Method `LightningModule.on_hpc_save` is deprecated in v1.6 and will be removed in v1.8."
     ):
@@ -53,7 +60,14 @@ def test_hpc_hook_calls(tmpdir):
 
     # new training run, restore from hpc checkpoint file automatically
     assert set(os.listdir(tmpdir)) == {"hpc_ckpt_1.ckpt"}
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=1, enable_checkpointing=False, logger=False)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+        enable_checkpointing=False,
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
     with pytest.deprecated_call(
         match=r"Method `LightningModule.on_hpc_save` is deprecated in v1.6 and will be removed in v1.8."
     ):
@@ -65,7 +79,14 @@ def test_hpc_hook_calls(tmpdir):
 def test_preloaded_checkpoint_lifecycle(tmpdir):
     """Tests that the preloaded checkpoint contents gets cleared from memory when it is not required anymore."""
     model = BoringModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     connector = trainer.checkpoint_connector
@@ -81,7 +102,14 @@ def test_preloaded_checkpoint_lifecycle(tmpdir):
     assert not connector._loaded_checkpoint
 
     ckpt_path = trainer.checkpoint_callback.best_model_path
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     connector = trainer.checkpoint_connector
     connector.resume_start(ckpt_path)
     assert connector.resume_checkpoint_path == ckpt_path
@@ -96,7 +124,14 @@ def test_preloaded_checkpoint_lifecycle(tmpdir):
 def test_hpc_restore_attempt(tmpdir):
     """Test that restore() attempts to restore the hpc_ckpt with highest priority."""
     model = BoringModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=1, enable_checkpointing=False, logger=False)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+        enable_checkpointing=False,
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
     trainer.fit(model)
 
     hpc_ckpt_path = tmpdir / "hpc_ckpt_3.ckpt"
@@ -108,7 +143,14 @@ def test_hpc_restore_attempt(tmpdir):
         torch.nn.init.constant_(param, 0)
 
     # case 1: restore hpc first, no explicit resume path provided
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=2, enable_checkpointing=False, logger=False)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=2,
+        enable_checkpointing=False,
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
     trainer.fit(model)
 
     for param in model.parameters():
@@ -116,7 +158,14 @@ def test_hpc_restore_attempt(tmpdir):
         torch.nn.init.constant_(param, 0)
 
     # case 2: explicit resume path provided, restore hpc anyway
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=3)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model, ckpt_path="not existing")
 
     for param in model.parameters():
@@ -126,7 +175,14 @@ def test_hpc_restore_attempt(tmpdir):
 def test_hpc_max_ckpt_version(tmpdir):
     """Test that the CheckpointConnector is able to find the hpc checkpoint file with the highest version."""
     model = BoringModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     trainer.save_checkpoint(tmpdir / "hpc_ckpt.ckpt")
     trainer.save_checkpoint(tmpdir / "hpc_ckpt_0.ckpt")

--- a/tests/trainer/connectors/test_checkpoint_connector.py
+++ b/tests/trainer/connectors/test_checkpoint_connector.py
@@ -84,7 +84,6 @@ def test_preloaded_checkpoint_lifecycle(tmpdir):
         max_steps=1,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)

--- a/tests/trainer/connectors/test_signal_connector.py
+++ b/tests/trainer/connectors/test_signal_connector.py
@@ -64,7 +64,16 @@ def test_fault_tolerant_sig_handler(register_handler, terminate_gracefully, tmpd
     model = TestModel()
 
     with mock.patch.dict(os.environ, {"PL_FAULT_TOLERANT_TRAINING": str(int(terminate_gracefully))}):
-        trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_train_batches=2, limit_val_batches=0)
+        trainer = Trainer(
+            default_root_dir=tmpdir,
+            max_epochs=1,
+            limit_train_batches=2,
+            limit_val_batches=0,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
+        )
         if terminate_gracefully and not register_handler:
             with pytest.raises(ExitGracefullyException):
                 trainer.fit(model)

--- a/tests/trainer/dynamic_args/test_multiple_eval_dataloaders.py
+++ b/tests/trainer/dynamic_args/test_multiple_eval_dataloaders.py
@@ -71,6 +71,9 @@ def test_multiple_eval_dataloaders_tuple(tmpdir):
         max_epochs=1,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)
@@ -101,6 +104,9 @@ def test_multiple_eval_dataloaders_list(tmpdir):
         max_epochs=1,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)
@@ -158,6 +164,9 @@ def test_multiple_optimizers_multiple_dataloaders(tmpdir):
         max_epochs=1,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)

--- a/tests/trainer/flags/test_check_val_every_n_epoch.py
+++ b/tests/trainer/flags/test_check_val_every_n_epoch.py
@@ -40,7 +40,6 @@ def test_check_val_every_n_epoch(tmpdir, max_epochs, expected_val_loop_calls, ex
         limit_val_batches=2,
         check_val_every_n_epoch=2,
         logger=False,
-        enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
     )

--- a/tests/trainer/flags/test_check_val_every_n_epoch.py
+++ b/tests/trainer/flags/test_check_val_every_n_epoch.py
@@ -40,6 +40,9 @@ def test_check_val_every_n_epoch(tmpdir, max_epochs, expected_val_loop_calls, ex
         limit_val_batches=2,
         check_val_every_n_epoch=2,
         logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"

--- a/tests/trainer/flags/test_env_vars.py
+++ b/tests/trainer/flags/test_env_vars.py
@@ -23,7 +23,14 @@ def test_passing_no_env_variables():
     assert trainer.logger is not None
     assert trainer.max_steps == -1
     assert trainer.max_epochs == 1000
-    trainer = Trainer(False, max_steps=42)
+    trainer = Trainer(
+        False,
+        max_steps=42,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     assert trainer.logger is None
     assert trainer.max_steps == 42
     assert trainer.max_epochs == -1
@@ -40,7 +47,14 @@ def test_passing_env_variables_only():
 @mock.patch.dict(os.environ, {"PL_TRAINER_LOGGER": "True", "PL_TRAINER_MAX_STEPS": "7"})
 def test_passing_env_variables_defaults():
     """Testing overwriting trainer arguments."""
-    trainer = Trainer(False, max_steps=42)
+    trainer = Trainer(
+        False,
+        max_steps=42,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     assert trainer.logger is None
     assert trainer.max_steps == 42
 

--- a/tests/trainer/flags/test_fast_dev_run.py
+++ b/tests/trainer/flags/test_fast_dev_run.py
@@ -22,6 +22,10 @@ def test_skip_on_fast_dev_run_tuner(tmpdir, tuner_alg):
         auto_scale_batch_size=(tuner_alg == "batch size scaler"),
         auto_lr_find=(tuner_alg == "learning rate finder"),
         fast_dev_run=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     expected_message = f"Skipping {tuner_alg} since fast_dev_run is enabled."
     with pytest.warns(UserWarning, match=expected_message):

--- a/tests/trainer/flags/test_limit_batches.py
+++ b/tests/trainer/flags/test_limit_batches.py
@@ -23,7 +23,16 @@ def test_num_dataloader_batches(tmpdir):
     """Tests that the correct number of batches are allocated."""
     # when we have fewer batches in the dataloader we should use those instead of the limit
     model = BoringModel()
-    trainer = Trainer(limit_val_batches=100, limit_train_batches=100, max_epochs=1, default_root_dir=tmpdir)
+    trainer = Trainer(
+        limit_val_batches=100,
+        limit_train_batches=100,
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     assert len(model.train_dataloader()) == 64
@@ -34,7 +43,16 @@ def test_num_dataloader_batches(tmpdir):
 
     # when we have more batches in the dataloader we should limit them
     model = BoringModel()
-    trainer = Trainer(limit_val_batches=7, limit_train_batches=7, max_epochs=1, default_root_dir=tmpdir)
+    trainer = Trainer(
+        limit_val_batches=7,
+        limit_train_batches=7,
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     assert len(model.train_dataloader()) == 64
@@ -46,11 +64,7 @@ def test_num_dataloader_batches(tmpdir):
 
 @pytest.mark.parametrize(
     ["stage", "mode"],
-    [
-        (RunningStage.VALIDATING, "val"),
-        (RunningStage.TESTING, "test"),
-        (RunningStage.PREDICTING, "predict"),
-    ],
+    [(RunningStage.VALIDATING, "val"), (RunningStage.TESTING, "test"), (RunningStage.PREDICTING, "predict")],
 )
 @pytest.mark.parametrize("limit_batches", [0.1, 10])
 def test_eval_limit_batches(stage, mode, limit_batches):

--- a/tests/trainer/flags/test_min_max_epochs.py
+++ b/tests/trainer/flags/test_min_max_epochs.py
@@ -28,6 +28,9 @@ def test_min_max_steps_epochs(tmpdir, min_epochs, max_epochs, min_steps, max_ste
         min_steps=min_steps,
         max_steps=max_steps,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -39,5 +42,11 @@ def test_min_max_steps_epochs(tmpdir, min_epochs, max_epochs, min_steps, max_ste
 def test_max_epochs_not_set_warning():
     """Test that a warning is emitted when `max_epochs` was not set by the user."""
     with pytest.warns(PossibleUserWarning, match="`max_epochs` was not set. Setting it to 1000 epochs."):
-        trainer = Trainer(max_epochs=None)
+        trainer = Trainer(
+            max_epochs=None,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
+        )
         assert trainer.max_epochs == 1000

--- a/tests/trainer/flags/test_overfit_batches.py
+++ b/tests/trainer/flags/test_overfit_batches.py
@@ -31,7 +31,13 @@ def test_overfit_basic(tmpdir, overfit_batches):
     total_train_samples = len(BoringModel().train_dataloader())
 
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, overfit_batches=overfit_batches, enable_model_summary=False
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        overfit_batches=overfit_batches,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -59,7 +65,15 @@ def test_overfit_batches_raises_warning_in_case_of_sequential_sampler(tmpdir):
             return torch.utils.data.DataLoader(dataset, sampler=sampler)
 
     model = TestModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, overfit_batches=2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        overfit_batches=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.warns(UserWarning, match="requested to overfit but enabled training dataloader shuffling"):
         trainer.fit(model)
@@ -125,11 +139,7 @@ def test_overfit_batch_limits_train(overfit_batches):
 @RunIf(skip_windows=True)
 def test_distributed_sampler_with_overfit_batches():
     model = BoringModel()
-    trainer = Trainer(
-        overfit_batches=1,
-        strategy="ddp_spawn",
-        num_processes=2,
-    )
+    trainer = Trainer(overfit_batches=1, strategy="ddp_spawn", num_processes=2)
     model.trainer = trainer
     trainer.model = model
     trainer._data_connector.attach_dataloaders(model)

--- a/tests/trainer/flags/test_val_check_interval.py
+++ b/tests/trainer/flags/test_val_check_interval.py
@@ -34,7 +34,14 @@ def test_val_check_interval(tmpdir, max_epochs, denominator):
                 self.val_epoch_calls += 1
 
     model = TestModel()
-    trainer = Trainer(max_epochs=max_epochs, val_check_interval=1 / denominator, logger=False)
+    trainer = Trainer(
+        max_epochs=max_epochs,
+        val_check_interval=1 / denominator,
+        logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     trainer.fit(model)
 
     assert model.train_epoch_calls == max_epochs

--- a/tests/trainer/logging_/test_distributed_logging.py
+++ b/tests/trainer/logging_/test_distributed_logging.py
@@ -74,6 +74,8 @@ def test_all_rank_logging_ddp_cpu(tmpdir):
         enable_model_summary=False,
         logger=all_rank_logger,
         log_every_n_steps=1,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
     )
     trainer.fit(model)
 
@@ -93,6 +95,8 @@ def test_all_rank_logging_ddp_spawn(tmpdir):
         max_epochs=1,
         logger=all_rank_logger,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
     )
     trainer.fit(model)
 
@@ -128,6 +132,9 @@ def test_first_logger_call_in_subprocess(tmpdir):
         max_epochs=1,
         logger=logger,
         callbacks=[LoggerCallsObserver()],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
     trainer.fit(model)
 
@@ -184,6 +191,9 @@ def test_logger_after_fit_predict_test_calls(tmpdir):
         max_epochs=1,
         logger=BufferLogger(),
         callbacks=[LoggerCallsObserver()],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
 
     assert not trainer.logger.logs

--- a/tests/trainer/logging_/test_eval_loop_logging.py
+++ b/tests/trainer/logging_/test_eval_loop_logging.py
@@ -54,6 +54,9 @@ def test__validation_step__log(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -92,6 +95,9 @@ def test__validation_step__epoch_end__log(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -120,6 +126,9 @@ def test_eval_epoch_logging(tmpdir, batches, log_interval, max_epochs):
         max_epochs=max_epochs,
         log_every_n_steps=log_interval,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -152,6 +161,9 @@ def test_eval_float_logging(tmpdir):
         max_epochs=1,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -184,6 +196,9 @@ def test_eval_logging_auto_reduce(tmpdir):
         log_every_n_steps=1,
         enable_model_summary=False,
         num_sanity_val_steps=0,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -213,6 +228,9 @@ def test_eval_epoch_only_logging(tmpdir, batches, log_interval, max_epochs):
         limit_test_batches=batches,
         log_every_n_steps=log_interval,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     results = trainer.test(model)
 
@@ -247,6 +265,9 @@ def test_multi_dataloaders_add_suffix_properly(tmpdir, suffix):
         max_epochs=1,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     results = trainer.test(model)
 
@@ -333,6 +354,10 @@ def test_log_works_in_val_callback(tmpdir):
         num_sanity_val_steps=0,
         max_epochs=1,
         callbacks=[cb],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -462,7 +487,15 @@ def test_log_works_in_test_callback(tmpdir):
     model.test_epoch_end = None
     cb = TestCallback()
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_test_batches=2, num_sanity_val_steps=0, max_epochs=2, callbacks=[cb]
+        default_root_dir=tmpdir,
+        limit_test_batches=2,
+        num_sanity_val_steps=0,
+        max_epochs=2,
+        callbacks=[cb],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.test(model)
 
@@ -542,6 +575,9 @@ def test_validation_step_log_with_tensorboard(mock_log_metrics, tmpdir):
         limit_val_batches=2,
         limit_test_batches=2,
         max_epochs=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
 
     # Train the model ⚡
@@ -550,12 +586,7 @@ def test_validation_step_log_with_tensorboard(mock_log_metrics, tmpdir):
     # hp_metric + 2 steps + epoch + 2 steps + epoch
     expected_num_calls = 1 + 2 + 1 + 2 + 1
 
-    assert set(trainer.callback_metrics) == {
-        "train_loss",
-        "valid_loss_0_epoch",
-        "valid_loss_0",
-        "valid_loss_1",
-    }
+    assert set(trainer.callback_metrics) == {"train_loss", "valid_loss_0_epoch", "valid_loss_0", "valid_loss_1"}
     assert len(mock_log_metrics.mock_calls) == expected_num_calls
     assert mock_log_metrics.mock_calls[0] == call({"hp_metric": -1}, 0)
 
@@ -588,9 +619,7 @@ def test_validation_step_log_with_tensorboard(mock_log_metrics, tmpdir):
     assert get_metrics_at_idx(6)["valid_loss_1"] == torch.stack(model.val_losses[4:]).mean()
 
     results = trainer.test(model)
-    assert set(trainer.callback_metrics) == {
-        "test_loss",
-    }
+    assert set(trainer.callback_metrics) == {"test_loss"}
     assert set(results[0]) == {"test_loss"}
 
 
@@ -599,10 +628,7 @@ def test_logging_dict_on_validation_step(tmpdir):
         def validation_step(self, batch, batch_idx):
             loss = super().validation_step(batch, batch_idx)
             loss = loss["x"]
-            metrics = {
-                "loss": loss,
-                "loss_1": loss,
-            }
+            metrics = {"loss": loss, "loss_1": loss}
             self.log("val_metrics", metrics)
 
         validation_epoch_end = None
@@ -614,6 +640,10 @@ def test_logging_dict_on_validation_step(tmpdir):
         limit_train_batches=2,
         limit_val_batches=2,
         max_epochs=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)
@@ -671,6 +701,9 @@ def test_multiple_dataloaders_reset(val_check_interval, tmpdir):
         max_epochs=3,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -694,7 +727,16 @@ def test_evaluation_move_metrics_to_cpu_and_outputs(tmpdir):
             assert self.trainer.callback_metrics["foo"].device.type == "cpu"
 
     model = TestModel()
-    trainer = Trainer(default_root_dir=tmpdir, limit_val_batches=2, move_metrics_to_cpu=True, gpus=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_val_batches=2,
+        move_metrics_to_cpu=True,
+        gpus=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.validate(model, verbose=False)
 
 
@@ -710,11 +752,7 @@ def test_logging_results_with_no_dataloader_idx(tmpdir):
         def test_step(self, batch, batch_idx, dataloader_idx):
             self.log_dict(log_common_same_val)
             self.log(log_common_diff_val, dataloader_idx + 1)
-            self.log(
-                log_key_no_dl_idx.format(dataloader_idx),
-                321 * (dataloader_idx + 1),
-                add_dataloader_idx=False,
-            )
+            self.log(log_key_no_dl_idx.format(dataloader_idx), 321 * (dataloader_idx + 1), add_dataloader_idx=False)
             self.log_dict(log_key_dl0 if dataloader_idx == 0 else log_key_dl1, add_dataloader_idx=False)
 
         def test_dataloader(self):

--- a/tests/trainer/logging_/test_logger_connector.py
+++ b/tests/trainer/logging_/test_logger_connector.py
@@ -249,6 +249,10 @@ def test_fx_validator_integration(tmpdir):
         limit_test_batches=1,
         limit_predict_batches=1,
         callbacks=callback,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     with pytest.deprecated_call(match="on_train_dataloader` is deprecated in v1.5"):
         trainer.fit(model)
@@ -334,7 +338,16 @@ def test_epoch_results_cache_dp(tmpdir):
 
     model = TestModel()
     trainer = Trainer(
-        default_root_dir=tmpdir, strategy="dp", gpus=2, limit_train_batches=2, limit_val_batches=2, max_epochs=1
+        default_root_dir=tmpdir,
+        strategy="dp",
+        gpus=2,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     trainer.test(model)
@@ -517,6 +530,8 @@ def test_metrics_reset(tmpdir):
         enable_progress_bar=False,
         num_sanity_val_steps=2,
         enable_checkpointing=False,
+        enable_model_summary=False,
+        logger=False,
     )
 
     trainer.fit(model)

--- a/tests/trainer/logging_/test_progress_bar_logging.py
+++ b/tests/trainer/logging_/test_progress_bar_logging.py
@@ -17,7 +17,6 @@ def test_logging_to_progress_bar_with_reserved_key(tmpdir):
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_steps=2,
-        enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
         logger=False,

--- a/tests/trainer/logging_/test_progress_bar_logging.py
+++ b/tests/trainer/logging_/test_progress_bar_logging.py
@@ -14,6 +14,13 @@ def test_logging_to_progress_bar_with_reserved_key(tmpdir):
             return output
 
     model = TestModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.warns(UserWarning, match="The progress bar already tracks a metric with the .* 'loss'"):
         trainer.fit(model)

--- a/tests/trainer/logging_/test_train_loop_logging.py
+++ b/tests/trainer/logging_/test_train_loop_logging.py
@@ -339,7 +339,6 @@ def test_log_works_in_train_callback(tmpdir):
         num_sanity_val_steps=0,
         max_epochs=1,
         callbacks=[cb],
-        enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
         logger=False,

--- a/tests/trainer/logging_/test_train_loop_logging.py
+++ b/tests/trainer/logging_/test_train_loop_logging.py
@@ -81,6 +81,8 @@ def test__training_step__log(tmpdir):
         log_every_n_steps=1,
         enable_model_summary=False,
         callbacks=[ModelCheckpoint(monitor="l_se")],
+        enable_progress_bar=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -118,6 +120,9 @@ def test__training_step__epoch_end__log(tmpdir):
         max_epochs=2,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -158,6 +163,9 @@ def test__training_step__step_end__epoch_end__log(tmpdir, batches, log_interval,
         max_epochs=max_epochs,
         log_every_n_steps=log_interval,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -196,6 +204,9 @@ def test__training_step__log_max_reduce_fx(tmpdir, batches, fx, result):
         limit_val_batches=batches,
         max_epochs=2,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -235,6 +246,9 @@ def test_different_batch_types_for_sizing(tmpdir):
         max_epochs=1,
         enable_model_summary=False,
         fast_dev_run=True,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -325,6 +339,10 @@ def test_log_works_in_train_callback(tmpdir):
         num_sanity_val_steps=0,
         max_epochs=1,
         callbacks=[cb],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -411,6 +429,9 @@ def test_logging_sync_dist_true(tmpdir, devices):
         strategy="ddp_spawn" if use_multiple_devices else None,
         accelerator="auto",
         devices=devices,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -460,6 +481,9 @@ def test_logging_sync_dist_true_ddp(tmpdir):
         strategy="ddp",
         gpus=2,
         profiler="pytorch",
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -538,6 +562,9 @@ def test_logging_in_callbacks_with_log_function(tmpdir):
         max_epochs=1,
         enable_model_summary=False,
         callbacks=[LoggingCallback()],
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -585,6 +612,9 @@ def test_metric_are_properly_reduced(tmpdir):
         limit_train_batches=5,
         limit_val_batches=32,
         callbacks=[early_stop, checkpoint],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -682,7 +712,15 @@ def test_sanity_metrics_are_reset(tmpdir):
             return loss
 
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=1, limit_val_batches=2, num_sanity_val_steps=2
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_train_batches=1,
+        limit_val_batches=2,
+        num_sanity_val_steps=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(TestModel())
 
@@ -696,12 +734,7 @@ def test_move_metrics_to_cpu(tmpdir):
             assert loss.device.type == "cuda"
 
     trainer = Trainer(
-        default_root_dir=tmpdir,
-        fast_dev_run=True,
-        amp_backend="native",
-        precision=16,
-        move_metrics_to_cpu=True,
-        gpus=1,
+        default_root_dir=tmpdir, fast_dev_run=True, amp_backend="native", precision=16, move_metrics_to_cpu=True, gpus=1
     )
     trainer.fit(TestModel())
 
@@ -741,6 +774,9 @@ def test_on_epoch_logging_with_sum_and_on_batch_start(tmpdir):
         limit_val_batches=3,
         num_sanity_val_steps=3,
         max_epochs=1,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     train_data = DataLoader(RandomDataset(32, 64), batch_size=2)
     val_data = DataLoader(RandomDataset(32, 64), batch_size=2)

--- a/tests/trainer/optimization/test_backward_calls.py
+++ b/tests/trainer/optimization/test_backward_calls.py
@@ -12,7 +12,13 @@ from tests.helpers import BoringModel
 def test_backward_count_simple(torch_backward, num_steps):
     """Test that backward is called exactly once per step."""
     model = BoringModel()
-    trainer = Trainer(max_steps=num_steps)
+    trainer = Trainer(
+        max_steps=num_steps,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     assert torch_backward.call_count == num_steps
 
@@ -26,13 +32,28 @@ def test_backward_count_simple(torch_backward, num_steps):
 def test_backward_count_with_grad_accumulation(torch_backward):
     """Test that backward is called the correct number of times when accumulating gradients."""
     model = BoringModel()
-    trainer = Trainer(max_epochs=1, limit_train_batches=6, accumulate_grad_batches=2)
+    trainer = Trainer(
+        max_epochs=1,
+        limit_train_batches=6,
+        accumulate_grad_batches=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     assert torch_backward.call_count == 6
 
     torch_backward.reset_mock()
 
-    trainer = Trainer(max_steps=6, accumulate_grad_batches=2)
+    trainer = Trainer(
+        max_steps=6,
+        accumulate_grad_batches=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     assert torch_backward.call_count == 12
 
@@ -46,12 +67,21 @@ def test_backward_count_with_closure(torch_backward):
             return torch.optim.LBFGS(self.parameters(), lr=0.1)
 
     model = TestModel()
-    trainer = Trainer(max_steps=5)
+    trainer = Trainer(
+        max_steps=5, enable_progress_bar=False, enable_model_summary=False, enable_checkpointing=False, logger=False
+    )
     trainer.fit(model)
     assert torch_backward.call_count == 5
 
     torch_backward.reset_mock()
 
-    trainer = Trainer(max_steps=5, accumulate_grad_batches=2)
+    trainer = Trainer(
+        max_steps=5,
+        accumulate_grad_batches=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     assert torch_backward.call_count == 10

--- a/tests/trainer/optimization/test_manual_optimization.py
+++ b/tests/trainer/optimization/test_manual_optimization.py
@@ -119,6 +119,9 @@ def test_multiple_optimizers_manual_no_return(tmpdir, kwargs):
         log_every_n_steps=1,
         enable_model_summary=False,
         **kwargs,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     if kwargs.get("amp_backend") == "native":
@@ -160,6 +163,9 @@ def test_multiple_optimizers_manual_return(tmpdir):
         max_epochs=1,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with mock.patch.object(TrainingTypePlugin, "backward", wraps=trainer.training_type_plugin.backward) as bwd_mock:
@@ -187,6 +193,9 @@ def test_multiple_optimizers_manual_log(tmpdir):
         max_epochs=1,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with mock.patch.object(TrainingTypePlugin, "backward", wraps=trainer.training_type_plugin.backward) as bwd_mock:
@@ -210,6 +219,9 @@ def test_multiple_optimizers_manual_native_amp(tmpdir):
         enable_model_summary=False,
         precision=16,
         gpus=1,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with mock.patch.object(TrainingTypePlugin, "backward", wraps=trainer.training_type_plugin.backward) as bwd_mock:
@@ -297,6 +309,10 @@ def test_manual_optimization_and_return_tensor(tmpdir):
         amp_backend="native",
         strategy="ddp_spawn",
         gpus=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -384,6 +400,10 @@ def test_manual_optimization_and_accumulated_gradient(tmpdir):
         precision=16,
         amp_backend="native",
         gpus=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -468,6 +488,9 @@ def test_multiple_optimizers_step(tmpdir):
         amp_backend="native",
         gpus=1,
         track_grad_norm=2,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with mock.patch.object(TrainingTypePlugin, "backward", wraps=trainer.training_type_plugin.backward) as bwd_mock:
@@ -538,6 +561,10 @@ def test_step_with_optimizer_closure(tmpdir):
         limit_val_batches=2,
         max_epochs=1,
         log_every_n_steps=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with mock.patch.object(TrainingTypePlugin, "backward", wraps=trainer.training_type_plugin.backward) as bwd_mock:
@@ -594,6 +621,10 @@ def test_step_with_optimizer_closure_and_accumulated_grad(tmpdir):
         limit_val_batches=2,
         max_epochs=1,
         log_every_n_steps=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with mock.patch.object(TrainingTypePlugin, "backward", wraps=trainer.training_type_plugin.backward) as bwd_mock:
@@ -645,6 +676,10 @@ def test_step_with_optimizer_closure_and_extra_arguments(step_mock, tmpdir):
         limit_val_batches=2,
         max_epochs=1,
         log_every_n_steps=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)
@@ -719,6 +754,10 @@ def test_step_with_optimizer_closure_with_different_frequencies(mock_sgd_step, m
         limit_val_batches=2,
         max_epochs=1,
         log_every_n_steps=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)
@@ -832,6 +871,10 @@ def train_manual_optimization(tmpdir, strategy, model_cls=TesManualOptimizationD
         log_every_n_steps=1,
         gpus=2,
         strategy=strategy,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)
@@ -939,7 +982,15 @@ def test_lr_schedulers(tmpdir):
     model.training_epoch_end = None
 
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=1, limit_val_batches=1, limit_test_batches=1
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_train_batches=1,
+        limit_val_batches=1,
+        limit_test_batches=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)
@@ -978,7 +1029,15 @@ def test_lr_schedulers_reduce_lr_on_plateau(tmpdir, scheduler_as_dict):
     model = TestModel(scheduler_as_dict=scheduler_as_dict)
 
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=1, limit_val_batches=1, limit_test_batches=1
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_train_batches=1,
+        limit_val_batches=1,
+        limit_test_batches=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     if scheduler_as_dict:
@@ -1010,7 +1069,15 @@ def test_lr_scheduler_step_not_called(tmpdir):
     model.training_step_end = None
     model.training_epoch_end = None
 
-    trainer = Trainer(max_epochs=1, default_root_dir=tmpdir, fast_dev_run=2)
+    trainer = Trainer(
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        fast_dev_run=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with patch("torch.optim.lr_scheduler.StepLR.step") as lr_step:
         trainer.fit(model)
@@ -1076,6 +1143,9 @@ def test_multiple_optimizers_logging(precision, tmpdir):
         enable_model_summary=False,
         gpus=1,
         precision=precision,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)

--- a/tests/trainer/optimization/test_multiple_optimizers.py
+++ b/tests/trainer/optimization/test_multiple_optimizers.py
@@ -45,7 +45,14 @@ def test_unbalanced_logging_with_multiple_optimizers(tmpdir):
 
     # Initialize a trainer
     trainer = pl.Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=5, limit_val_batches=5, enable_model_summary=False
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_train_batches=5,
+        limit_val_batches=5,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -78,6 +85,9 @@ def test_multiple_optimizers(tmpdir):
         max_epochs=1,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -117,7 +127,14 @@ def test_multiple_optimizers_manual(tmpdir):
     model.val_dataloader = None
 
     trainer = pl.Trainer(
-        default_root_dir=tmpdir, limit_train_batches=2, max_epochs=1, log_every_n_steps=1, enable_model_summary=False
+        default_root_dir=tmpdir,
+        limit_train_batches=2,
+        max_epochs=1,
+        log_every_n_steps=1,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -190,6 +207,9 @@ def test_custom_optimizer_step_with_multiple_optimizers(tmpdir):
         max_epochs=1,
         log_every_n_steps=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     assert len(model.training_step_called) == len(model.optimizer_step_called) == len(model.optimizers())

--- a/tests/trainer/optimization/test_optimizers.py
+++ b/tests/trainer/optimization/test_optimizers.py
@@ -30,7 +30,15 @@ def test_optimizer_with_scheduling(tmpdir):
 
     model = BoringModel()
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_val_batches=0.1, limit_train_batches=0.2, val_check_interval=0.5
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_val_batches=0.1,
+        limit_train_batches=0.2,
+        val_check_interval=0.5,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
@@ -61,7 +69,16 @@ def test_multi_optimizer_with_scheduling(tmpdir):
 
     model = TestModel()
     model.training_epoch_end = None
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_val_batches=0.1, limit_train_batches=0.2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_val_batches=0.1,
+        limit_train_batches=0.2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
 
@@ -222,7 +239,16 @@ def test_optimizer_return_options(tmpdir):
 def test_none_optimizer(tmpdir):
     model = BoringModel()
     model.configure_optimizers = lambda: None
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_val_batches=0.1, limit_train_batches=0.2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_val_batches=0.1,
+        limit_train_batches=0.2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.warns(UserWarning, match="will run with no optimizer"):
         trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
@@ -298,7 +324,16 @@ def test_step_scheduling_for_multiple_optimizers_with_frequency(
 
     model = DummyModel()
 
-    trainer = Trainer(default_root_dir=tmpdir, limit_val_batches=1, limit_train_batches=5, max_epochs=max_epochs)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_val_batches=1,
+        limit_train_batches=5,
+        max_epochs=max_epochs,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     assert trainer.state.finished, f"Training failed with {trainer.state}"
 
@@ -371,6 +406,9 @@ def test_multiple_optimizers_callbacks(tmpdir):
         limit_val_batches=2,
         max_epochs=1,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -384,7 +422,15 @@ def test_lr_scheduler_strict(step_mock, tmpdir, complete_epoch):
     scheduler = optim.lr_scheduler.ReduceLROnPlateau(optimizer)
     max_epochs = 1 if complete_epoch else None
     max_steps = -1 if complete_epoch else 1
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=max_epochs, max_steps=max_steps)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=max_epochs,
+        max_steps=max_steps,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     model.configure_optimizers = lambda: {
         "optimizer": optimizer,
@@ -569,6 +615,10 @@ def test_lr_scheduler_epoch_step_frequency(mocked_sched, check_val_every_n_epoch
         limit_val_batches=2,
         check_val_every_n_epoch=check_val_every_n_epoch,
         max_epochs=epochs,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     assert mocked_sched.call_count == expected_steps
@@ -587,6 +637,7 @@ def test_lr_scheduler_state_updated_before_saving(tmpdir, every_n_train_steps, e
         limit_train_batches=batches,
         limit_val_batches=1,
         callbacks=[ModelCheckpoint(dirpath=tmpdir, every_n_train_steps=every_n_train_steps)],
+        enable_model_summary=False,
     )
 
     class TestModel(BoringModel):
@@ -623,6 +674,7 @@ def test_plateau_scheduler_lr_step_interval_updated_after_saving(tmpdir, save_on
         limit_train_batches=batches,
         limit_val_batches=1,
         callbacks=[ModelCheckpoint(dirpath=tmpdir, save_on_train_epoch_end=save_on_train_epoch_end)],
+        enable_model_summary=False,
     )
 
     class TestModel(BoringModel):

--- a/tests/trainer/properties/test_get_model.py
+++ b/tests/trainer/properties/test_get_model.py
@@ -32,7 +32,14 @@ def test_get_model(tmpdir):
 
     limit_train_batches = 2
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_train_batches=limit_train_batches, limit_val_batches=2, max_epochs=1
+        default_root_dir=tmpdir,
+        limit_train_batches=limit_train_batches,
+        limit_val_batches=2,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -51,6 +58,10 @@ def test_get_model_ddp_cpu(tmpdir):
         max_epochs=1,
         strategy="ddp_spawn",
         num_processes=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 
@@ -63,6 +74,14 @@ def test_get_model_gpu(tmpdir):
 
     limit_train_batches = 2
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_train_batches=limit_train_batches, limit_val_batches=2, max_epochs=1, gpus=1
+        default_root_dir=tmpdir,
+        limit_train_batches=limit_train_batches,
+        limit_val_batches=2,
+        max_epochs=1,
+        gpus=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)

--- a/tests/trainer/properties/test_log_dir.py
+++ b/tests/trainer/properties/test_log_dir.py
@@ -35,7 +35,14 @@ def test_logdir(tmpdir):
 
     model = TestModel(expected)
 
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=2, callbacks=[ModelCheckpoint(dirpath=tmpdir)])
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=2,
+        callbacks=[ModelCheckpoint(dirpath=tmpdir)],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
+    )
 
     assert trainer.log_dir == expected
     trainer.fit(model)
@@ -47,7 +54,14 @@ def test_logdir_no_checkpoint_cb(tmpdir):
     expected = os.path.join(tmpdir, "lightning_logs", "version_0")
     model = TestModel(expected)
 
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=2, enable_checkpointing=False)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=2,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
+    )
 
     assert trainer.log_dir == expected
     trainer.fit(model)
@@ -59,7 +73,14 @@ def test_logdir_no_logger(tmpdir):
     expected = os.path.join(tmpdir)
     model = TestModel(expected)
 
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=2, logger=False, callbacks=[ModelCheckpoint(dirpath=tmpdir)])
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=2,
+        logger=False,
+        callbacks=[ModelCheckpoint(dirpath=tmpdir)],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
 
     assert trainer.log_dir == expected
     trainer.fit(model)
@@ -71,7 +92,14 @@ def test_logdir_no_logger_no_checkpoint(tmpdir):
     expected = os.path.join(tmpdir)
     model = TestModel(expected)
 
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=2, logger=False, enable_checkpointing=False)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=2,
+        logger=False,
+        enable_checkpointing=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+    )
 
     assert trainer.log_dir == expected
     trainer.fit(model)
@@ -84,7 +112,12 @@ def test_logdir_custom_callback(tmpdir):
     model = TestModel(expected)
 
     trainer = Trainer(
-        default_root_dir=tmpdir, max_steps=2, callbacks=[ModelCheckpoint(dirpath=os.path.join(tmpdir, "ckpts"))]
+        default_root_dir=tmpdir,
+        max_steps=2,
+        callbacks=[ModelCheckpoint(dirpath=os.path.join(tmpdir, "ckpts"))],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
 
     assert trainer.log_dir == expected
@@ -102,6 +135,8 @@ def test_logdir_custom_logger(tmpdir):
         max_steps=2,
         callbacks=[ModelCheckpoint(dirpath=tmpdir)],
         logger=TensorBoardLogger(save_dir=tmpdir, name="custom_logs"),
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
 
     assert trainer.log_dir == expected
@@ -118,6 +153,9 @@ def test_logdir_logger_collection(tmpdir):
         default_root_dir=default_root_dir,
         max_steps=2,
         logger=[TensorBoardLogger(save_dir=save_dir, name="custom_logs")],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
     )
     assert isinstance(trainer.logger, LoggerCollection)
     assert trainer.log_dir == default_root_dir

--- a/tests/trainer/properties/test_log_dir.py
+++ b/tests/trainer/properties/test_log_dir.py
@@ -41,7 +41,6 @@ def test_logdir(tmpdir):
         callbacks=[ModelCheckpoint(dirpath=tmpdir)],
         enable_progress_bar=False,
         enable_model_summary=False,
-        logger=False,
     )
 
     assert trainer.log_dir == expected
@@ -60,7 +59,6 @@ def test_logdir_no_checkpoint_cb(tmpdir):
         enable_checkpointing=False,
         enable_progress_bar=False,
         enable_model_summary=False,
-        logger=False,
     )
 
     assert trainer.log_dir == expected
@@ -117,7 +115,6 @@ def test_logdir_custom_callback(tmpdir):
         callbacks=[ModelCheckpoint(dirpath=os.path.join(tmpdir, "ckpts"))],
         enable_progress_bar=False,
         enable_model_summary=False,
-        logger=False,
     )
 
     assert trainer.log_dir == expected

--- a/tests/trainer/test_config_validator.py
+++ b/tests/trainer/test_config_validator.py
@@ -24,7 +24,14 @@ def test_wrong_train_setting(tmpdir):
     * Test that an error is thrown when no `train_dataloader()` is defined
     * Test that an error is thrown when no `training_step()` is defined
     """
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.raises(MisconfigurationException, match=r"No `train_dataloader\(\)` method defined."):
         model = BoringModel()
@@ -39,7 +46,14 @@ def test_wrong_train_setting(tmpdir):
 
 def test_wrong_configure_optimizers(tmpdir):
     """Test that an error is thrown when no `configure_optimizers()` is defined."""
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.raises(MisconfigurationException, match=r"No `configure_optimizers\(\)` method defined."):
         model = BoringModel()
@@ -49,7 +63,14 @@ def test_wrong_configure_optimizers(tmpdir):
 
 def test_fit_val_loop_config(tmpdir):
     """When either val loop or val data are missing raise warning."""
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     # no val data has val loop
     with pytest.warns(UserWarning, match=r"You passed in a `val_dataloader` but have no `validation_step`"):
@@ -66,7 +87,14 @@ def test_fit_val_loop_config(tmpdir):
 
 def test_eval_loop_config(tmpdir):
     """When either eval step or eval data is missing."""
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     # has val step but no val data
     model = BoringModel()

--- a/tests/trainer/test_data_loading.py
+++ b/tests/trainer/test_data_loading.py
@@ -87,7 +87,14 @@ def test_replace_distributed_sampler(tmpdir, mode):
     model.test_epoch_end = None
 
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_test_batches=2, strategy="ddp_find_unused_parameters_false", num_processes=1
+        default_root_dir=tmpdir,
+        limit_test_batches=2,
+        strategy="ddp_find_unused_parameters_false",
+        num_processes=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.test(model)
 
@@ -345,7 +352,13 @@ def test_error_raised_with_float_limited_eval_batches():
     model = BoringModel()
     dl_size = len(model.val_dataloader())
     limit_val_batches = 1 / (dl_size + 2)
-    trainer = Trainer(limit_val_batches=limit_val_batches)
+    trainer = Trainer(
+        limit_val_batches=limit_val_batches,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer._data_connector.attach_data(model)
     with pytest.raises(
         MisconfigurationException,

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -70,7 +70,15 @@ def test_fit_val_loader_only(tmpdir):
 @pytest.mark.parametrize("dataloader_options", [dict(val_check_interval=10000)])
 def test_dataloader_config_errors_runtime(tmpdir, dataloader_options):
     model = EvalModelTemplate()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, **dataloader_options)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        **dataloader_options,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.raises(ValueError):
         # fit model
         trainer.fit(model)
@@ -93,7 +101,15 @@ def test_dataloader_config_errors_runtime(tmpdir, dataloader_options):
 )
 def test_dataloader_config_errors_init(tmpdir, dataloader_options):
     with pytest.raises(MisconfigurationException, match="passed invalid value"):
-        Trainer(default_root_dir=tmpdir, max_epochs=1, **dataloader_options)
+        Trainer(
+            default_root_dir=tmpdir,
+            max_epochs=1,
+            **dataloader_options,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
+        )
 
 
 def test_multiple_val_dataloader(tmpdir):
@@ -105,7 +121,16 @@ def test_multiple_val_dataloader(tmpdir):
     model.validation_epoch_end = model.validation_epoch_end__multiple_dataloaders
 
     # fit model
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_val_batches=0.1, limit_train_batches=1.0)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_val_batches=0.1,
+        limit_train_batches=1.0,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     # verify training completed
@@ -140,7 +165,16 @@ def test_multiple_eval_dataloader(tmpdir, ckpt_path):
     model = MultipleTestDataloaderModel()
 
     # fit model
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_val_batches=10, limit_train_batches=100)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_val_batches=10,
+        limit_train_batches=100,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     if ckpt_path == "specific":
         ckpt_path = trainer.checkpoint_callback.best_model_path
@@ -163,7 +197,16 @@ def test_train_dataloader_passed_to_fit(tmpdir):
 
     # only train passed to fit
     model = EvalModelTemplate()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_val_batches=0.1, limit_train_batches=0.2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_val_batches=0.1,
+        limit_train_batches=0.2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     fit_options = dict(train_dataloaders=model.dataloader(train=True))
     trainer.fit(model, **fit_options)
 
@@ -185,7 +228,16 @@ def test_dataloaders_passed_to_fn(tmpdir, ckpt_path, n):
         model.test_step = model.test_step__multiple_dataloaders
 
     # multiple val dataloaders passed to fit
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_val_batches=0.1, limit_train_batches=0.2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_val_batches=0.1,
+        limit_train_batches=0.2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model, train_dataloaders=model.dataloader(train=True), val_dataloaders=dataloaders)
 
     assert trainer.state.finished, f"Training failed with {trainer.state}"
@@ -255,6 +307,9 @@ def test_inf_dataloaders_with_limit_percent_batches(tmpdir, limit_train_batches,
         limit_train_batches=limit_train_batches,
         limit_val_batches=limit_val_batches,
         limit_test_batches=limit_test_batches,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     model = DummyModel()
 
@@ -307,6 +362,9 @@ def test_dataloaders_with_limit_train_batches(tmpdir, dataset, limit_train_batch
         max_epochs=epochs,
         callbacks=[epoch_cb, ckpt_callback],
         limit_train_batches=limit_train_batches,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     model = DummyModel()
 
@@ -350,6 +408,9 @@ def test_dataloaders_with_limit_val_batches(tmpdir, dataset, limit_val_batches):
         callbacks=callbacks,
         limit_val_batches=limit_val_batches,
         enable_checkpointing=enable_checkpointing,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     model = DummyModel()
 
@@ -391,6 +452,9 @@ def test_datasets_dataloaders_with_limit_num_batches(
         limit_train_batches=limit_train_batches,
         limit_val_batches=limit_val_batches,
         limit_test_batches=limit_test_batches,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
     model = DummyModel()
 
@@ -437,6 +501,10 @@ def test_dataloaders_with_limit_percent_batches(tmpdir, limit_train_batches, lim
         limit_train_batches=limit_train_batches,
         limit_val_batches=limit_val_batches,
         limit_test_batches=limit_test_batches,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     if limit_train_batches != 0.0:
@@ -474,6 +542,10 @@ def test_dataloaders_with_limit_num_batches(tmpdir, limit_train_batches, limit_v
         limit_val_batches=limit_val_batches,
         limit_test_batches=limit_test_batches,
         num_sanity_val_steps=0,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with patch.object(
@@ -490,9 +562,7 @@ def test_dataloaders_with_limit_num_batches(tmpdir, limit_train_batches, limit_v
             assert trainer.val_dataloaders is None
 
     with patch.object(
-        trainer.test_loop.epoch_loop,
-        "_evaluation_step",
-        wraps=trainer.test_loop.epoch_loop._evaluation_step,
+        trainer.test_loop.epoch_loop, "_evaluation_step", wraps=trainer.test_loop.epoch_loop._evaluation_step
     ) as mocked:
         trainer.test(model)
         test_dataloader_lengths = [len(x) for x in model.test_dataloader()]
@@ -578,7 +648,15 @@ def test_train_inf_dataloader_error(tmpdir):
     model = EvalModelTemplate()
     model.train_dataloader = model.train_dataloader__infinite
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, val_check_interval=0.5)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        val_check_interval=0.5,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.raises(MisconfigurationException, match="using an IterableDataset"):
         trainer.fit(model)
@@ -589,7 +667,15 @@ def test_val_inf_dataloader_error(tmpdir):
     model = EvalModelTemplate()
     model.val_dataloader = model.val_dataloader__infinite
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_val_batches=0.5)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_val_batches=0.5,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.raises(MisconfigurationException, match="using an IterableDataset"):
         trainer.fit(model)
@@ -600,7 +686,15 @@ def test_test_inf_dataloader_error(tmpdir):
     model = EvalModelTemplate()
     model.test_dataloader = model.test_dataloader__infinite
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_test_batches=0.5)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_test_batches=0.5,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.raises(MisconfigurationException, match="using an IterableDataset"):
         trainer.test(model)
@@ -613,7 +707,15 @@ def test_inf_train_dataloader(tmpdir, check_interval):
     model = EvalModelTemplate()
     model.train_dataloader = model.train_dataloader__infinite
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, val_check_interval=check_interval)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        val_check_interval=check_interval,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     # verify training completed
     assert trainer.state.finished, f"Training failed with {trainer.state}"
@@ -627,7 +729,15 @@ def test_inf_val_dataloader(tmpdir, check_interval):
     model.val_dataloader = model.val_dataloader__infinite
 
     # logger file to get meta
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, val_check_interval=check_interval)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        val_check_interval=check_interval,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     # verify training completed
@@ -648,6 +758,10 @@ def test_error_on_zero_len_dataloader(tmpdir):
             limit_train_batches=0.1,
             limit_val_batches=0.1,
             limit_test_batches=0.1,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
         )
         trainer.fit(model)
 
@@ -667,7 +781,16 @@ def test_warning_with_few_workers(_, tmpdir, ckpt_path, stage):
     val_dl = model.val_dataloader()
     val_dl.num_workers = 0
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_val_batches=0.1, limit_train_batches=0.2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_val_batches=0.1,
+        limit_train_batches=0.2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.warns(
         UserWarning,
@@ -706,7 +829,16 @@ def test_warning_with_few_workers_multi_loader(_, tmpdir, ckpt_path, stage):
     val_multi_dl = [val_dl, val_dl]
     test_multi_dl = [train_dl, train_dl]
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_val_batches=0.1, limit_train_batches=0.2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_val_batches=0.1,
+        limit_train_batches=0.2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.warns(
         UserWarning,
@@ -815,7 +947,16 @@ def test_auto_add_worker_init_fn_distributed(tmpdir, monkeypatch):
 
     dataloader = DataLoader(dataset, batch_size=batch_size, num_workers=num_workers)
     seed_everything(0, workers=True)
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, gpus=2, strategy="ddp_spawn")
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        gpus=2,
+        strategy="ddp_spawn",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     model = MultiProcessModel()
     model.val_dataloader = None
     trainer.fit(model, train_dataloaders=dataloader)
@@ -829,11 +970,28 @@ def test_warning_with_small_dataloader_and_logging_interval(tmpdir):
     model.train_dataloader = lambda: dataloader
 
     with pytest.warns(UserWarning, match=r"The number of training samples \(10\) is smaller than the logging interval"):
-        trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, log_every_n_steps=11)
+        trainer = Trainer(
+            default_root_dir=tmpdir,
+            max_epochs=1,
+            log_every_n_steps=11,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
+        )
         trainer.fit(model)
 
     with pytest.warns(UserWarning, match=r"The number of training samples \(1\) is smaller than the logging interval"):
-        trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, log_every_n_steps=2, limit_train_batches=1)
+        trainer = Trainer(
+            default_root_dir=tmpdir,
+            max_epochs=1,
+            log_every_n_steps=2,
+            limit_train_batches=1,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
+        )
         trainer.fit(model)
 
 
@@ -851,7 +1009,14 @@ def test_warning_with_iterable_dataset_and_len(tmpdir):
             return len(original_dataset)
 
     # with __len__ defined
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=3)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     dataloader = DataLoader(IterableWithLen(), batch_size=16)
     assert has_len_all_ranks(dataloader, trainer.training_type_plugin, model)
     assert has_iterable_dataset(dataloader)
@@ -865,7 +1030,14 @@ def test_warning_with_iterable_dataset_and_len(tmpdir):
         trainer.predict(model, dataloaders=[dataloader])
 
     # without __len__ defined
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=3)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     dataloader = DataLoader(IterableWithoutLen(), batch_size=16)
     assert not has_len_all_ranks(dataloader, trainer.training_type_plugin, model)
     assert has_iterable_dataset(dataloader)
@@ -900,6 +1072,9 @@ def test_iterable_dataset_stop_iteration_at_epoch_beginning(yield_at_all):
         default_root_dir=os.getcwd(),
         max_epochs=2,
         enable_model_summary=False,
+        enable_progress_bar=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model, train_dataloaders=train_dataloader)
     assert trainer.global_step == 2 * yield_at_all
@@ -942,6 +1117,10 @@ def test_dataloader_distributed_sampler(tmpdir):
         default_root_dir=tmpdir,
         max_steps=1,
         callbacks=[DistribSamplerCallback(expected_seeds=(123, 123, 123))],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     trainer.test(model)
@@ -970,6 +1149,10 @@ def test_dataloader_distributed_sampler_already_attached(tmpdir):
         max_steps=100,
         callbacks=[DistribSamplerCallback(expected_seeds=(11, 123, 0))],
         replace_sampler_ddp=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
     assert trainer.state.finished, "DDP Training failed"
@@ -1009,7 +1192,15 @@ def test_batch_size_smaller_than_num_gpus(tmpdir):
     model = CurrentTestModel(**hparams)
 
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=0.1, limit_val_batches=0, gpus=num_gpus
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_train_batches=0.1,
+        limit_val_batches=0,
+        gpus=num_gpus,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     # we expect the reduction for the metrics also to happen on the last batch
@@ -1019,8 +1210,7 @@ def test_batch_size_smaller_than_num_gpus(tmpdir):
 
 
 @pytest.mark.parametrize(
-    ["multiple_trainloader_mode", "num_training_batches"],
-    [("min_size", 5), ("max_size_cycle", 10)],
+    ["multiple_trainloader_mode", "num_training_batches"], [("min_size", 5), ("max_size_cycle", 10)]
 )
 def test_fit_multiple_train_loaders(tmpdir, multiple_trainloader_mode, num_training_batches):
     """Integration test for multple train loaders."""
@@ -1030,7 +1220,15 @@ def test_fit_multiple_train_loaders(tmpdir, multiple_trainloader_mode, num_train
     # todo: add also `train_dataloader__multiple_sequence`
     model.training_step = model.training_step__multiple_dataloaders
 
-    trainer = Trainer(max_epochs=1, default_root_dir=tmpdir, multiple_trainloader_mode=multiple_trainloader_mode)
+    trainer = Trainer(
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        multiple_trainloader_mode=multiple_trainloader_mode,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     # verify the num_training_batches according to the multiple_trainloader_mode
     assert num_training_batches == trainer.num_training_batches
@@ -1044,7 +1242,16 @@ def test_val_dataloader_not_implemented_error(tmpdir, check_interval):
     model.val_dataloader = model.val_dataloader__not_implemented_error
 
     # logger file to get meta
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=5, max_epochs=1, val_check_interval=check_interval)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=5,
+        max_epochs=1,
+        val_check_interval=check_interval,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     # verify training completed
     assert trainer.state.finished, f"Training failed with {trainer.state}"
@@ -1058,7 +1265,16 @@ def test_train_dataloader_not_implemented_error(tmpdir, check_interval):
     model.train_dataloader = model.train_dataloader__not_implemented_error
     model.val_dataloader = model.val_dataloader__not_implemented_error
 
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=5, max_epochs=1, val_check_interval=check_interval)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=5,
+        max_epochs=1,
+        val_check_interval=check_interval,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     # verify training completed
     assert trainer.state.finished, f"Training failed with {trainer.state}"
@@ -1069,7 +1285,16 @@ def test_train_dataloader_not_implemented_error_failed(tmpdir):
     model = EvalModelTemplate()
     model.train_dataloader = model.train_dataloader__not_implemented_error
 
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=5, max_epochs=1, val_check_interval=0.5)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=5,
+        max_epochs=1,
+        val_check_interval=0.5,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.raises(MisconfigurationException, match="using an IterableDataset"):
         trainer.fit(model)
@@ -1080,7 +1305,16 @@ def test_val_dataloader_not_implemented_error_failed(tmpdir):
     model = EvalModelTemplate()
     model.val_dataloader = model.val_dataloader__not_implemented_error
 
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=5, max_epochs=1, limit_val_batches=0.5)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=5,
+        max_epochs=1,
+        limit_val_batches=0.5,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.raises(MisconfigurationException, match="using an IterableDataset"):
         trainer.fit(model)
@@ -1091,7 +1325,16 @@ def test_test_dataloader_not_implemented_error_failed(tmpdir):
     model = EvalModelTemplate()
     model.test_dataloader = model.test_dataloader__not_implemented_error
 
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=5, max_epochs=1, limit_test_batches=0.5)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=5,
+        max_epochs=1,
+        limit_test_batches=0.5,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.raises(MisconfigurationException, match="using an IterableDataset"):
         trainer.test(model)
@@ -1109,7 +1352,16 @@ def test_dataloaders_load_only_once(tmpdir):
     tracker.attach_mock(model.val_dataloader, "val_dataloader")
     tracker.attach_mock(model.test_dataloader, "test_dataloader")
 
-    trainer = Trainer(default_root_dir=tmpdir, limit_train_batches=0.3, limit_val_batches=0.3, max_epochs=3)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_train_batches=0.3,
+        limit_val_batches=0.3,
+        max_epochs=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
     model.train_dataloader.assert_called_once()
@@ -1130,6 +1382,10 @@ def test_dataloaders_load_only_once_val_interval(tmpdir):
         val_check_interval=0.3,
         reload_dataloaders_every_n_epochs=1,
         max_epochs=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     tracker = Mock()
@@ -1169,7 +1425,15 @@ def test_dataloaders_load_only_once_no_sanity_check(tmpdir):
 
     # logger file to get meta
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_train_batches=0.3, limit_val_batches=0.3, num_sanity_val_steps=0, max_epochs=3
+        default_root_dir=tmpdir,
+        limit_train_batches=0.3,
+        limit_val_batches=0.3,
+        num_sanity_val_steps=0,
+        max_epochs=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     tracker = Mock()
@@ -1198,6 +1462,10 @@ def test_dataloaders_load_every_n_epochs(tmpdir, n):
         limit_val_batches=0.3,
         reload_dataloaders_every_n_epochs=n,
         max_epochs=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     tracker = Mock()
@@ -1249,6 +1517,9 @@ def test_dataloaders_load_every_epoch_no_sanity_check(tmpdir):
         reload_dataloaders_every_n_epochs=1,
         max_epochs=3,
         callbacks=[checkpoint_callback],
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        logger=False,
     )
 
     tracker = Mock()
@@ -1295,7 +1566,16 @@ def test_dataloaders_load_only_once_passed_loaders(tmpdir):
     model.val_dataloader = None
     model.test_dataloader = None
 
-    trainer = Trainer(default_root_dir=tmpdir, limit_train_batches=0.3, limit_val_batches=0.3, max_epochs=3)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_train_batches=0.3,
+        limit_val_batches=0.3,
+        max_epochs=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     trainer.reset_train_dataloader = Mock(wraps=trainer.reset_train_dataloader)
     trainer.reset_val_dataloader = Mock(wraps=trainer.reset_val_dataloader)
@@ -1335,6 +1615,10 @@ def test_dataloaders_reset_and_attach(tmpdir):
         limit_val_batches=1,
         limit_test_batches=1,
         limit_predict_batches=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     # 1st fit
@@ -1500,7 +1784,15 @@ def test_request_dataloader(tmpdir):
             self.on_val_batch_start_called = True
 
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_train_batches=2, limit_val_batches=2, limit_test_batches=2, max_epochs=1
+        default_root_dir=tmpdir,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        limit_test_batches=2,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     model = TestModel()
     trainer.fit(model)
@@ -1526,5 +1818,13 @@ def test_multiple_dataloaders_with_random_sampler_overfit_batches(num_loaders, t
 
         validation_step = None
 
-    trainer = Trainer(default_root_dir=tmpdir, overfit_batches=1.0, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        overfit_batches=1.0,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(TestModel())

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -172,7 +172,6 @@ def test_multiple_eval_dataloader(tmpdir, ckpt_path):
         limit_train_batches=100,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)
@@ -235,7 +234,6 @@ def test_dataloaders_passed_to_fn(tmpdir, ckpt_path, n):
         limit_train_batches=0.2,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model, train_dataloaders=model.dataloader(train=True), val_dataloaders=dataloaders)
@@ -788,7 +786,6 @@ def test_warning_with_few_workers(_, tmpdir, ckpt_path, stage):
         limit_train_batches=0.2,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
 
@@ -836,7 +833,6 @@ def test_warning_with_few_workers_multi_loader(_, tmpdir, ckpt_path, stage):
         limit_train_batches=0.2,
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
 
@@ -977,7 +973,6 @@ def test_warning_with_small_dataloader_and_logging_interval(tmpdir):
             enable_progress_bar=False,
             enable_model_summary=False,
             enable_checkpointing=False,
-            logger=False,
         )
         trainer.fit(model)
 
@@ -990,7 +985,6 @@ def test_warning_with_small_dataloader_and_logging_interval(tmpdir):
             enable_progress_bar=False,
             enable_model_summary=False,
             enable_checkpointing=False,
-            logger=False,
         )
         trainer.fit(model)
 

--- a/tests/trainer/test_supporters.py
+++ b/tests/trainer/test_supporters.py
@@ -220,9 +220,7 @@ def test_combined_loader_sequence_iterable_dataset(mode, use_multiple_dataloader
             torch.utils.data.DataLoader(TestIterableDataset(20), batch_size=2),
         ]
     else:
-        loaders = [
-            torch.utils.data.DataLoader(TestIterableDataset(10), batch_size=2),
-        ]
+        loaders = [torch.utils.data.DataLoader(TestIterableDataset(10), batch_size=2)]
 
     combined_loader = CombinedLoader(loaders, mode)
 
@@ -388,17 +386,14 @@ def test_combined_data_loader_with_max_size_cycle_and_ddp(replace_sampler_ddp, t
     trainer = Trainer(strategy="ddp", accelerator="auto", devices=2, replace_sampler_ddp=replace_sampler_ddp)
 
     dataloader = CombinedLoader(
-        {"a": DataLoader(RandomDataset(32, 8), batch_size=1), "b": DataLoader(RandomDataset(32, 8), batch_size=1)},
+        {"a": DataLoader(RandomDataset(32, 8), batch_size=1), "b": DataLoader(RandomDataset(32, 8), batch_size=1)}
     )
     dataloader = trainer.prepare_dataloader(dataloader, shuffle=False)
     assert len(dataloader) == 4 if replace_sampler_ddp else 8
 
     for a_length in [6, 8, 10]:
         dataloader = CombinedLoader(
-            {
-                "a": DataLoader(range(a_length), batch_size=1),
-                "b": DataLoader(range(8), batch_size=1),
-            },
+            {"a": DataLoader(range(a_length), batch_size=1), "b": DataLoader(range(8), batch_size=1)},
             mode="max_size_cycle",
         )
 
@@ -421,10 +416,7 @@ def test_combined_data_loader_with_max_size_cycle_and_ddp(replace_sampler_ddp, t
                 yield 1
 
     dataloader = CombinedLoader(
-        {
-            "a": DataLoader(InfiniteDataset(), batch_size=1),
-            "b": DataLoader(range(8), batch_size=1),
-        },
+        {"a": DataLoader(InfiniteDataset(), batch_size=1), "b": DataLoader(range(8), batch_size=1)},
         mode="max_size_cycle",
     )
     assert get_len(dataloader) == float("inf")

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -713,7 +713,6 @@ def test_tested_checkpoint_path(tmpdir, ckpt_path, save_top_k, fn):
         default_root_dir=tmpdir,
         callbacks=[ModelCheckpoint(monitor="foo", save_top_k=save_top_k)],
         enable_model_summary=False,
-        logger=False,
     )
     trainer.fit(model)
 
@@ -1433,7 +1432,6 @@ def test_log_every_n_steps(log_metrics_mock, tmpdir, train_batches, max_steps, l
         enable_progress_bar=False,
         enable_model_summary=False,
         enable_checkpointing=False,
-        logger=False,
     )
     trainer.fit(model)
     expected_calls = [call(metrics=ANY, step=s) for s in range(log_interval - 1, max_steps, log_interval)]
@@ -2007,15 +2005,14 @@ def test_on_load_checkpoint_missing_callbacks(tmpdir):
     """Test a warning appears when callbacks in the checkpoint don't match callbacks provided when resuming."""
 
     model = BoringModel()
-    chk = ModelCheckpoint(dirpath=tmpdir, save_last=True)
+    ckpt = ModelCheckpoint(dirpath=tmpdir, save_last=True)
 
     trainer = Trainer(
         default_root_dir=tmpdir,
         max_epochs=3,
-        callbacks=[chk, CustomCallbackOnLoadCheckpoint()],
+        callbacks=[ckpt, CustomCallbackOnLoadCheckpoint()],
         enable_progress_bar=False,
         enable_model_summary=False,
-        enable_checkpointing=False,
         logger=False,
     )
     trainer.fit(model)
@@ -2029,7 +2026,7 @@ def test_on_load_checkpoint_missing_callbacks(tmpdir):
         logger=False,
     )
     with pytest.warns(UserWarning, match="CustomCallbackOnLoadCheckpoint"):
-        trainer.fit(model, ckpt_path=chk.last_model_path)
+        trainer.fit(model, ckpt_path=ckpt.last_model_path)
 
 
 def test_module_current_fx_attributes_reset(tmpdir):

--- a/tests/tuner/test_lr_finder.py
+++ b/tests/tuner/test_lr_finder.py
@@ -40,7 +40,14 @@ def test_error_on_more_than_1_optimizer(tmpdir):
     model = CustomBoringModel(lr=1e-2)
 
     # logger file to get meta
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     with pytest.raises(MisconfigurationException, match="only works with single optimizer"):
         trainer.tuner.lr_find(model)
@@ -52,7 +59,14 @@ def test_model_reset_correctly(tmpdir):
     model = BoringModel()
 
     # logger file to get meta
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     before_state_dict = deepcopy(model.state_dict())
 
@@ -74,7 +88,14 @@ def test_trainer_reset_correctly(tmpdir):
     model = BoringModel()
 
     # logger file to get meta
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     changed_attributes = [
         "accumulate_grad_batches",
@@ -111,7 +132,15 @@ def test_trainer_arg_bool(tmpdir, use_hparams):
 
     before_lr = 1e-2
     model = CustomBoringModel(lr=before_lr)
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=2, auto_lr_find=True)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        auto_lr_find=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     trainer.tune(model)
     if use_hparams:
@@ -142,7 +171,15 @@ def test_trainer_arg_str(tmpdir, use_hparams):
 
     before_lr = 1e-2
     model = CustomBoringModel(my_fancy_lr=before_lr)
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=2, auto_lr_find="my_fancy_lr")
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        auto_lr_find="my_fancy_lr",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     trainer.tune(model)
     if use_hparams:
@@ -174,7 +211,14 @@ def test_call_to_trainer_method(tmpdir, opt):
 
     before_lr = 1e-2
     model = CustomBoringModel(1e-2)
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     lrfinder = trainer.tuner.lr_find(model, mode="linear")
     after_lr = lrfinder.suggestion()
@@ -195,7 +239,14 @@ def test_datamodule_parameter(tmpdir):
 
     before_lr = model.lr
     # logger file to get meta
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     lrfinder = trainer.tuner.lr_find(model, datamodule=dm)
     after_lr = lrfinder.suggestion()
@@ -239,7 +290,14 @@ def test_suggestion_parameters_work(tmpdir):
 
     # logger file to get meta
     model = CustomBoringModel(lr=1e-2)
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=3)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     lrfinder = trainer.tuner.lr_find(model)
     lr1 = lrfinder.suggestion(skip_begin=10)  # default
@@ -264,7 +322,14 @@ def test_suggestion_with_non_finite_values(tmpdir):
             return optimizer
 
     model = CustomBoringModel(lr=1e-2)
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=3)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=3,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     lrfinder = trainer.tuner.lr_find(model)
     before_lr = lrfinder.suggestion()
@@ -278,7 +343,15 @@ def test_suggestion_with_non_finite_values(tmpdir):
 
 def test_lr_finder_fails_fast_on_bad_config(tmpdir):
     """Test that tune fails if the model does not have a lr BEFORE running lr find."""
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=2, auto_lr_find=True)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=2,
+        auto_lr_find=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with pytest.raises(MisconfigurationException, match="should have one of these fields"):
         trainer.tune(BoringModel())
 
@@ -296,7 +369,16 @@ def test_lr_find_with_bs_scale(tmpdir):
     before_lr = model.hparams.learning_rate
 
     # logger file to get meta
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=3, auto_lr_find=True, auto_scale_batch_size=True)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=3,
+        auto_lr_find=True,
+        auto_scale_batch_size=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     result = trainer.tune(model)
     bs = result["scale_batch_size"]
     after_lr = result["lr_find"].suggestion()
@@ -348,7 +430,14 @@ def test_multiple_lr_find_calls_gives_same_results(tmpdir):
     seed_everything(1)
     model = BoringModel()
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=2)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=2,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     all_res = [trainer.tuner.lr_find(model).results for _ in range(3)]
 
     assert all(

--- a/tests/tuner/test_scale_batch_size.py
+++ b/tests/tuner/test_scale_batch_size.py
@@ -53,7 +53,16 @@ class BatchSizeModel(BoringModel):
 @pytest.mark.parametrize(["model_bs", "dm_bs"], [(2, -1), (2, 2), (2, None), (None, 2), (16, 16)])
 def test_scale_batch_size_method_with_model_or_datamodule(tmpdir, model_bs, dm_bs):
     """Test the tuner method `Tuner.scale_batch_size` with a datamodule."""
-    trainer = Trainer(default_root_dir=tmpdir, limit_train_batches=1, limit_val_batches=0, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        limit_train_batches=1,
+        limit_val_batches=0,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     tuner = Tuner(trainer)
 
     model = BatchSizeModel(model_bs)
@@ -79,7 +88,14 @@ def test_model_reset_correctly(tmpdir):
     model = BatchSizeModel(batch_size=2)
 
     # logger file to get meta
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     before_state_dict = deepcopy(model.state_dict())
 
@@ -102,7 +118,14 @@ def test_trainer_reset_correctly(tmpdir):
     model = BatchSizeModel(batch_size=2)
 
     # logger file to get meta
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     changed_attributes = [
         "callbacks",
@@ -127,7 +150,16 @@ def test_auto_scale_batch_size_trainer_arg(tmpdir, scale_arg):
     tutils.reset_seed()
     before_batch_size = 2
     model = BatchSizeModel(batch_size=before_batch_size)
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, auto_scale_batch_size=scale_arg, gpus=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        auto_scale_batch_size=scale_arg,
+        gpus=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.tune(model)
     after_batch_size = model.batch_size
     assert before_batch_size != after_batch_size, "Batch size was not altered after running auto scaling of batch size"
@@ -169,7 +201,16 @@ def test_auto_scale_batch_size_set_model_attribute(tmpdir, use_hparams):
     model_class = HparamsBatchSizeModel if use_hparams else BatchSizeModel
     model = model_class(**hparams)
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, auto_scale_batch_size=True, gpus=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        auto_scale_batch_size=True,
+        gpus=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.tune(model, datamodule_fit)
     after_batch_size = model.hparams.batch_size if use_hparams else model.batch_size
     assert trainer.datamodule == datamodule_fit
@@ -189,7 +230,16 @@ def test_auto_scale_batch_size_duplicate_attribute_warning(tmpdir):
             self.save_hyperparameters()
 
     model = TestModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=1, max_epochs=1000, auto_scale_batch_size=True)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+        max_epochs=1000,
+        auto_scale_batch_size=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     expected_message = "Field `model.batch_size` and `model.hparams.batch_size` are mutually exclusive!"
     with pytest.warns(UserWarning, match=expected_message):
         trainer.tune(model)
@@ -204,7 +254,14 @@ def test_call_to_trainer_method(tmpdir, scale_method):
     model = BatchSizeModel(batch_size=before_batch_size)
 
     # logger file to get meta
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
     after_batch_size = trainer.tuner.scale_batch_size(model, mode=scale_method, max_trials=5)
     model.batch_size = after_batch_size
@@ -225,12 +282,15 @@ def test_error_on_dataloader_passed_to_fit(tmpdir):
         limit_val_batches=0.1,
         limit_train_batches=0.2,
         auto_scale_batch_size="power",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     fit_options = dict(train_dataloaders=model.train_dataloader())
 
     with pytest.raises(
-        MisconfigurationException,
-        match="The batch scaling feature cannot be used with dataloaders passed directly",
+        MisconfigurationException, match="The batch scaling feature cannot be used with dataloaders passed directly"
     ):
         trainer.tune(model, **fit_options)
 
@@ -239,7 +299,17 @@ def test_error_on_dataloader_passed_to_fit(tmpdir):
 def test_auto_scale_batch_size_with_amp(tmpdir):
     before_batch_size = 2
     model = BatchSizeModel(batch_size=before_batch_size)
-    trainer = Trainer(default_root_dir=tmpdir, max_steps=1, auto_scale_batch_size=True, gpus=1, precision=16)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_steps=1,
+        auto_scale_batch_size=True,
+        gpus=1,
+        precision=16,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.tune(model)
     after_batch_size = model.batch_size
     assert trainer.amp_backend == AMPType.NATIVE
@@ -250,7 +320,15 @@ def test_auto_scale_batch_size_with_amp(tmpdir):
 def test_scale_batch_size_no_trials(tmpdir):
     """Check the result is correct even when no trials are run."""
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_val_batches=1, limit_train_batches=1, auto_scale_batch_size="power"
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_val_batches=1,
+        limit_train_batches=1,
+        auto_scale_batch_size="power",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     model = BatchSizeModel(batch_size=2)
     result = trainer.tuner.scale_batch_size(model, max_trials=0)
@@ -272,6 +350,10 @@ def test_scale_batch_size_fails_with_unavailable_mode(tmpdir):
         limit_val_batches=1,
         limit_train_batches=1,
         auto_scale_batch_size="ThisModeDoesNotExist",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     with pytest.raises(ValueError, match="could either be `power` or `binsearch`"):
@@ -286,7 +368,14 @@ def test_dataloader_reset_with_scale_batch_size(tmpdir, scale_method):
     model = BatchSizeModel(batch_size=16)
     scale_batch_size_kwargs = {"max_trials": 5, "init_val": 4, "mode": scale_method}
 
-    trainer = Trainer(max_epochs=2, auto_scale_batch_size=True)
+    trainer = Trainer(
+        max_epochs=2,
+        auto_scale_batch_size=True,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     new_batch_size = trainer.tune(model, scale_batch_size_kwargs=scale_batch_size_kwargs)["scale_batch_size"]
 
     assert trainer.train_dataloader.loaders.batch_size == new_batch_size

--- a/tests/utilities/test_all_gather_grad.py
+++ b/tests/utilities/test_all_gather_grad.py
@@ -105,6 +105,10 @@ def test_all_gather_collection(tmpdir):
         accumulate_grad_batches=2,
         gpus=2,
         strategy="ddp",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
 
     trainer.fit(model)

--- a/tests/utilities/test_auto_restart.py
+++ b/tests/utilities/test_auto_restart.py
@@ -695,10 +695,7 @@ def test_data_loading_wraps_dataset_and_samplers(_, tmpdir, use_fault_tolerant):
             }
 
         def training_step(self, batch, batch_idx):
-            assert batch == {
-                "a": [ANY, ANY, ANY],
-                "b": ANY,
-            }
+            assert batch == {"a": [ANY, ANY, ANY], "b": ANY}
 
         def validation_step(self, batch, batch_idx):
             assert isinstance(batch, torch.Tensor)
@@ -726,7 +723,16 @@ def test_data_loading_wraps_dataset_and_samplers(_, tmpdir, use_fault_tolerant):
     with mock.patch.dict(os.environ, {"PL_FAULT_TOLERANT_TRAINING": use_fault_tolerant}):
         model = TestModel()
         model.training_epoch_end = None
-        trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, limit_train_batches=1, callbacks=Check())
+        trainer = Trainer(
+            default_root_dir=tmpdir,
+            max_epochs=1,
+            limit_train_batches=1,
+            callbacks=Check(),
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
+        )
         trainer.fit(model)
 
 
@@ -1018,6 +1024,10 @@ def test_auto_restart_within_validation_loop(train_datasets, val_datasets, val_c
             max_epochs=1,
             val_check_interval=val_check_interval,
             num_sanity_val_steps=0,
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            enable_checkpointing=False,
+            logger=False,
         )
         if should_fail:
             with pytest.raises(CustomException):
@@ -1514,9 +1524,7 @@ class RandomFaultTolerantSampler(RandomSampler):
 
 @pytest.mark.parametrize(
     ["train_dataset_cls", "val_dataset_cls"],
-    [
-        ([RandomFaultTolerantDataset, RandomFaultTolerantDataset], [RandomFaultTolerantDataset]),
-    ],
+    [([RandomFaultTolerantDataset, RandomFaultTolerantDataset], [RandomFaultTolerantDataset])],
 )
 @pytest.mark.parametrize("val_check_interval", [0.5])
 @mock.patch.dict(os.environ, {"PL_FAULT_TOLERANT_TRAINING": "2"})
@@ -1573,7 +1581,15 @@ def test_fault_tolerant_manual_mode(val_check_interval, train_dataset_cls, val_d
 
     seed_everything(42)
     model = TestModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, val_check_interval=val_check_interval)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        val_check_interval=val_check_interval,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     total_batches = model.batches
     total_weight = deepcopy(model.layer.weight)
@@ -1581,7 +1597,15 @@ def test_fault_tolerant_manual_mode(val_check_interval, train_dataset_cls, val_d
 
     seed_everything(42)
     model = TestModel(should_fail=True)
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, val_check_interval=val_check_interval)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        val_check_interval=val_check_interval,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     with suppress(CustomException):
         trainer.fit(model)
     trainer.train_dataloader = None
@@ -1593,7 +1617,15 @@ def test_fault_tolerant_manual_mode(val_check_interval, train_dataset_cls, val_d
 
     seed_everything(42)
     model = TestModel()
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, val_check_interval=val_check_interval)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        val_check_interval=val_check_interval,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model, ckpt_path=checkpoint_path)
     trainer.train_dataloader = None
     restart_batches = model.batches

--- a/tests/utilities/test_cli.py
+++ b/tests/utilities/test_cli.py
@@ -233,7 +233,15 @@ def _model_builder(model_param: int) -> Model:
 def _trainer_builder(
     limit_train_batches: int, fast_dev_run: bool = False, callbacks: Optional[Union[List[Callback], Callback]] = None
 ) -> Trainer:
-    return Trainer(limit_train_batches=limit_train_batches, fast_dev_run=fast_dev_run, callbacks=callbacks)
+    return Trainer(
+        limit_train_batches=limit_train_batches,
+        fast_dev_run=fast_dev_run,
+        callbacks=callbacks,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
 
 
 @pytest.mark.parametrize(["trainer_class", "model_class"], [(Trainer, Model), (_trainer_builder, _model_builder)])
@@ -580,11 +588,7 @@ class EarlyExitTestModel(BoringModel):
 @pytest.mark.parametrize("logger", (False, True))
 @pytest.mark.parametrize(
     "trainer_kwargs",
-    (
-        dict(strategy="ddp_spawn"),
-        dict(strategy="ddp"),
-        pytest.param({"tpu_cores": 1}, marks=RunIf(tpu=True)),
-    ),
+    (dict(strategy="ddp_spawn"), dict(strategy="ddp"), pytest.param({"tpu_cores": 1}, marks=RunIf(tpu=True))),
 )
 def test_cli_distributed_save_config_callback(tmpdir, logger, trainer_kwargs):
     with mock.patch("sys.argv", ["any.py", "fit"]), pytest.raises(

--- a/tests/utilities/test_dtype_device_mixin.py
+++ b/tests/utilities/test_dtype_device_mixin.py
@@ -67,7 +67,17 @@ def test_submodules_device_and_dtype(dst_device, dst_dtype):
 @RunIf(min_gpus=2)
 def test_submodules_multi_gpu_dp(tmpdir):
     model = TopModule()
-    trainer = Trainer(default_root_dir=tmpdir, strategy="dp", gpus=2, callbacks=[DeviceAssertCallback()], max_steps=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        strategy="dp",
+        gpus=2,
+        callbacks=[DeviceAssertCallback()],
+        max_steps=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
 
@@ -75,7 +85,15 @@ def test_submodules_multi_gpu_dp(tmpdir):
 def test_submodules_multi_gpu_ddp_spawn(tmpdir):
     model = TopModule()
     trainer = Trainer(
-        default_root_dir=tmpdir, strategy="ddp_spawn", gpus=2, callbacks=[DeviceAssertCallback()], max_steps=1
+        default_root_dir=tmpdir,
+        strategy="ddp_spawn",
+        gpus=2,
+        callbacks=[DeviceAssertCallback()],
+        max_steps=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
     )
     trainer.fit(model)
 

--- a/tests/utilities/test_fetching.py
+++ b/tests/utilities/test_fetching.py
@@ -259,7 +259,14 @@ def test_fetching_dataloader_iter(automatic_optimization, tmpdir):
             assert self.count == 64
 
     model = TestModel(automatic_optimization=automatic_optimization)
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
 
 
@@ -314,7 +321,14 @@ class AsyncBoringModel(BoringModel):
 
 def test_training_step_with_dataloader_access(tmpdir) -> None:
     """A baseline functional test for `training_step` with dataloader access."""
-    trainer = Trainer(max_epochs=1, default_root_dir=tmpdir)
+    trainer = Trainer(
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     m = AsyncBoringModel()
     trainer.fit(m)
     assert m.num_batches_processed == DATASET_LEN, f"Expect all {DATASET_LEN} batches to be processed."
@@ -342,7 +356,14 @@ def test_stop_iteration(trigger_stop_iteration, tmpdir):
                 return DataLoader(RandomDataset(BATCH_SIZE, 2 * EXPECT_NUM_BATCHES_PROCESSED))
             return DataLoader(RandomDataset(BATCH_SIZE, EXPECT_NUM_BATCHES_PROCESSED))
 
-    trainer = Trainer(max_epochs=1, default_root_dir=tmpdir)
+    trainer = Trainer(
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     m = TestModel(trigger_stop_iteration)
     trainer.fit(m)
     expected = EXPECT_NUM_BATCHES_PROCESSED
@@ -359,7 +380,14 @@ def test_on_train_batch_start_overridden(tmpdir) -> None:
         def on_train_batch_start(self, batch, batch_idx):
             pass
 
-    trainer = Trainer(max_epochs=1, default_root_dir=tmpdir)
+    trainer = Trainer(
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     m = InvalidModel()
     with pytest.raises(MisconfigurationException, match="The model hook `on_train_batch_start` is not compatible with"):
         trainer.fit(m)
@@ -373,7 +401,14 @@ def test_on_train_batch_end_overridden(tmpdir) -> None:
         def on_train_batch_end(self, outputs, batch, batch_idx):
             pass
 
-    trainer = Trainer(max_epochs=1, default_root_dir=tmpdir)
+    trainer = Trainer(
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     m = InvalidModel()
     with pytest.raises(MisconfigurationException, match="The model hook `on_train_batch_end` is not compatible with"):
         trainer.fit(m)
@@ -388,7 +423,14 @@ def test_tbptt_split_batch_overridden(tmpdir) -> None:
             super().__init__()
             self.truncated_bptt_steps = 2
 
-    trainer = Trainer(max_epochs=1, default_root_dir=tmpdir)
+    trainer = Trainer(
+        max_epochs=1,
+        default_root_dir=tmpdir,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     m = InvalidModel()
     with pytest.raises(MisconfigurationException, match="is incompatible with `truncated_bptt_steps > 0`."):
         trainer.fit(m)
@@ -435,7 +477,15 @@ def test_transfer_hooks_with_unpacking(tmpdir):
             x, _ = batch
             return super().validation_step(x, batch_idx)
 
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, num_sanity_val_steps=0)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        num_sanity_val_steps=0,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     dm = BoringDataModule()
     trainer.fit(TestModel(), datamodule=dm)
     assert dm.count_called_on_before_batch_transfer == 4

--- a/tests/utilities/test_grads.py
+++ b/tests/utilities/test_grads.py
@@ -23,10 +23,7 @@ from pytorch_lightning.utilities import grad_norm
 @pytest.mark.parametrize(
     "norm_type,expected",
     [
-        (
-            1,
-            {"grad_1.0_norm/param0": 1 + 2 + 3, "grad_1.0_norm/param1": 4 + 5, "grad_1.0_norm_total": 15.0},
-        ),
+        (1, {"grad_1.0_norm/param0": 1 + 2 + 3, "grad_1.0_norm/param1": 4 + 5, "grad_1.0_norm_total": 15.0}),
         (
             2,
             {

--- a/tests/utilities/test_model_summary.py
+++ b/tests/utilities/test_model_summary.py
@@ -301,7 +301,17 @@ def test_model_size_precision(tmpdir):
     model = PreCalculatedModel()
 
     # fit model
-    trainer = Trainer(default_root_dir=tmpdir, gpus=1, max_steps=1, max_epochs=1, precision=32)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        gpus=1,
+        max_steps=1,
+        max_epochs=1,
+        precision=32,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        logger=False,
+    )
     trainer.fit(model)
     summary = summarize(model)
     assert model.pre_calculated_model_size == summary.model_size

--- a/tests/utilities/test_remote_filesystem.py
+++ b/tests/utilities/test_remote_filesystem.py
@@ -51,6 +51,8 @@ def test_gcs_model_checkpoint_contents(tmpdir):
         limit_val_batches=10,
         max_epochs=2,
         logger=False,
+        enable_progress_bar=False,
+        enable_model_summary=False,
     )
 
     trainer.fit(model)
@@ -96,7 +98,14 @@ def test_gcs_save_hparams_to_yaml_file(tmpdir):
 
     model = BoringModel()
     logger = TensorBoardLogger(save_dir=dir_path, default_hp_metric=False)
-    trainer = Trainer(max_steps=1, default_root_dir=dir_path, logger=logger)
+    trainer = Trainer(
+        max_steps=1,
+        default_root_dir=dir_path,
+        logger=logger,
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+    )
     assert trainer.log_dir == trainer.logger.log_dir
     trainer.fit(model)
 


### PR DESCRIPTION
## What does this PR do?

Automatically disable these flags for faster runs and less verbose logs: `Trainer(enable_checkpointing=False, logger=False, enable_model_summary=False, enable_progress_bar=False)`

Fixes #11083

<details>

<summary>Script used</summary>

```python
from typing import Any, Dict, List, Tuple, Union


def find_trainers(code: str) -> List[Tuple[int, int]]:
    trainer = "Trainer("
    t = len(trainer)
    i = 0
    arg_start = None
    parentheses = 0
    n = len(code)
    found = []

    while i < n - t:
        if code[i : i + t] == trainer:
            # Trainer found
            i += t
            arg_start = i
            parentheses += 1
        elif arg_start is not None:
            # keep a stack of parentheses used
            if code[i] == "(":
                parentheses += 1
            elif code[i] == ")":
                parentheses -= 1
                # closed Trainer instantiation
                if parentheses == 0:
                    found.append((arg_start, i))
                    arg_start = None
            i += 1
        else:
            i += 1
            parentheses = 0

    return found


def add_arguments(code: str, indices: List[Tuple[int, int]], changes: Dict[str, Any]) -> str:
    # loop in reverse because additions will mess up the indices
    for start, end in reversed(indices):
        # parsing comments would be too difficult. assume there will be a trailing comma if it has a comment
        if "#" not in code[start:end]:
            # add a trailing comma if necessary
            for i in range(end - 1, start - 1, -1):
                if not code[i].isspace():
                    if code[i] != ",":
                        code = code[:end] + "," + code[end:]
                        end += 1
                    break

        args = code[start:end]

        if not (
            "limit_train_batches" in args
            or "limit_val_batches" in args
            or "limit_test_batches" in args
            or "limit_predict_batches" in args
            or "max_epochs" in args
            or "max_steps" in args
            or "max_time" in args
        ):
            # heuristic: filter out trainers that will not run. a better solution would be to check that this trainer
            # instance will run `.fit`, `.test`, ... but that'd be much more complex
            continue

        # add the arguments
        for arg, value in changes.items():
            if arg in args:
                # already set
                continue
            if arg == "enable_checkpointing" and ("ModelCheckpoint" in args or "checkpoint" in args or "ckpt" in args):
                # heuristic: ModelCheckpoint was passed
                continue
            if arg == "enable_model_summary" and "ModelSummary" in args:
                # heuristic: ModelSummary was passed
                continue
            if arg == "enable_progress_bar" and ("ProgressBar" in args or "progress_bar" in args or "pbar" in args):
                # heuristic: ModelSummary was passed
                continue

            code = code[:end] + f"{arg}={value}," + code[end:]

    return code


def format(code: str) -> str:
    import black

    try:
        return black.format_str(code, mode=black.Mode(line_length=120, magic_trailing_comma=False))
    except black.parsing.InvalidInput:
        print(code)
        raise


def main(code: str) -> str:
    indices = find_trainers(code)
    code = add_arguments(
        code,
        indices,
        {"logger": False, "enable_checkpointing": False, "enable_model_summary": False, "enable_progress_bar": False},
    )
    code = format(code)
    return code


def update_file(filepath: str) -> None:
    with open(filepath) as fp:
        code = fp.read()

    try:
        code = main(code)
    except:
        print("Problem parsing", filepath)
        raise

    with open(filepath, "w") as fp:
        fp.write(code)


if __name__ == "__main__":
    import os

    import jsonargparse
    from jsonargparse.typing import Path_drw, Path_dw

    parser = jsonargparse.ArgumentParser()
    parser.add_argument("path", type=Union[Path_dw, Path_drw], default="tests")
    args = parser.parse_args()

    for root, dirs, files in os.walk(args.path):
        for file in files:
            if not file.endswith(".py"):
                continue
            update_file(os.path.join(root, file))
```

</details>

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [n/a] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [n/a] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified