### PR TITLE
Refactor plugin tests whose assertions don't need to run in `on_fit_start` hook

### DIFF
--- a/tests/accelerators/test_accelerator_connector.py
+++ b/tests/accelerators/test_accelerator_connector.py
@@ -100,23 +100,15 @@ def test_accelerator_choice_ddp_spawn(cuda_available_mock, device_count_mock):
 @mock.patch("torch.cuda.set_device")
 @mock.patch("torch.cuda.device_count", return_value=2)
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
-def test_accelerator_choice_ddp_slurm(set_device_mock, device_count_mock, setup_distributed_mock):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert trainer._accelerator_connector._is_slurm_managing_tasks()
-            assert isinstance(trainer.accelerator, GPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDPPlugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, SLURMEnvironment)
-            assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
-            assert trainer.training_type_plugin.local_rank == 1
-            raise SystemExit()
-
-    model = BoringModel()
+def test_accelerator_choice_ddp_slurm(*_):
     with pytest.deprecated_call(match=r"accelerator='ddp'\)` has been deprecated in v1.5"):
-        trainer = Trainer(fast_dev_run=True, accelerator="ddp", gpus=2, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
+        trainer = Trainer(fast_dev_run=True, accelerator="ddp", gpus=2)
+    assert trainer._accelerator_connector._is_slurm_managing_tasks()
+    assert isinstance(trainer.accelerator, GPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDPPlugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, SLURMEnvironment)
+    assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
+    assert trainer.training_type_plugin.local_rank == 1
 
 
 @mock.patch.dict(
@@ -133,25 +125,15 @@ def test_accelerator_choice_ddp_slurm(set_device_mock, device_count_mock, setup_
 @mock.patch("torch.cuda.set_device")
 @mock.patch("torch.cuda.device_count", return_value=2)
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
-def test_accelerator_choice_ddp2_slurm(set_device_mock, device_count_mock, setup_distributed_mock):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert trainer._accelerator_connector._is_slurm_managing_tasks()
-            assert isinstance(trainer.accelerator, GPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDP2Plugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, SLURMEnvironment)
-            assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
-            assert trainer.training_type_plugin.local_rank == 1
-            raise SystemExit()
-
-    model = BoringModel()
+def test_accelerator_choice_ddp2_slurm(*_):
     with pytest.deprecated_call(match=r"accelerator='ddp2'\)` has been deprecated in v1.5"):
-        trainer = Trainer(fast_dev_run=True, accelerator="ddp2", gpus=2, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
-
-    set_device_mock.assert_called_once()
+        trainer = Trainer(fast_dev_run=True, accelerator="ddp2", gpus=2)
+    assert trainer._accelerator_connector._is_slurm_managing_tasks()
+    assert isinstance(trainer.accelerator, GPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDP2Plugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, SLURMEnvironment)
+    assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
+    assert trainer.training_type_plugin.local_rank == 1
 
 
 @mock.patch.dict(
@@ -168,24 +150,14 @@ def test_accelerator_choice_ddp2_slurm(set_device_mock, device_count_mock, setup
 @mock.patch("torch.cuda.set_device")
 @mock.patch("torch.cuda.device_count", return_value=1)
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
-def test_accelerator_choice_ddp_te(set_device_mock, device_count_mock, setup_distributed_mock):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert isinstance(trainer.accelerator, GPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDPPlugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, TorchElasticEnvironment)
-            assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
-            assert trainer.training_type_plugin.local_rank == 1
-            raise SystemExit()
-
-    model = BoringModel()
+def test_accelerator_choice_ddp_te(*_):
     with pytest.deprecated_call(match=r"accelerator='ddp'\)` has been deprecated in v1.5"):
-        trainer = Trainer(fast_dev_run=True, accelerator="ddp", gpus=2, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
-
-    set_device_mock.assert_called_once()
+        trainer = Trainer(fast_dev_run=True, accelerator="ddp", gpus=2)
+    assert isinstance(trainer.accelerator, GPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDPPlugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, TorchElasticEnvironment)
+    assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
+    assert trainer.training_type_plugin.local_rank == 1
 
 
 @mock.patch.dict(
@@ -202,24 +174,14 @@ def test_accelerator_choice_ddp_te(set_device_mock, device_count_mock, setup_dis
 @mock.patch("torch.cuda.set_device")
 @mock.patch("torch.cuda.device_count", return_value=1)
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
-def test_accelerator_choice_ddp2_te(set_device_mock, device_count_mock, setup_distributed_mock):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert isinstance(trainer.accelerator, GPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDP2Plugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, TorchElasticEnvironment)
-            assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
-            assert trainer.training_type_plugin.local_rank == 1
-            raise SystemExit()
-
-    model = BoringModel()
+def test_accelerator_choice_ddp2_te(*_):
     with pytest.deprecated_call(match=r"accelerator='ddp2'\)` has been deprecated in v1.5"):
-        trainer = Trainer(fast_dev_run=True, accelerator="ddp2", gpus=2, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
-
-    set_device_mock.assert_called_once()
+        trainer = Trainer(fast_dev_run=True, accelerator="ddp2", gpus=2)
+    assert isinstance(trainer.accelerator, GPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDP2Plugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, TorchElasticEnvironment)
+    assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
+    assert trainer.training_type_plugin.local_rank == 1
 
 
 @mock.patch.dict(
@@ -227,21 +189,13 @@ def test_accelerator_choice_ddp2_te(set_device_mock, device_count_mock, setup_di
 )
 @mock.patch("torch.cuda.device_count", return_value=0)
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
-def test_accelerator_choice_ddp_cpu_te(device_count_mock, setup_distributed_mock):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert isinstance(trainer.accelerator, CPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDPPlugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, TorchElasticEnvironment)
-            assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
-            assert trainer.training_type_plugin.local_rank == 1
-            raise SystemExit()
-
-    model = BoringModel()
-    trainer = Trainer(fast_dev_run=True, accelerator="ddp_cpu", num_processes=2, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
+def test_accelerator_choice_ddp_cpu_te(*_):
+    trainer = Trainer(fast_dev_run=True, accelerator="ddp_cpu", num_processes=2)
+    assert isinstance(trainer.accelerator, CPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDPPlugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, TorchElasticEnvironment)
+    assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
+    assert trainer.training_type_plugin.local_rank == 1
 
 
 @mock.patch.dict(
@@ -258,24 +212,14 @@ def test_accelerator_choice_ddp_cpu_te(device_count_mock, setup_distributed_mock
 @mock.patch("torch.cuda.set_device")
 @mock.patch("torch.cuda.device_count", return_value=1)
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
-def test_accelerator_choice_ddp_kubeflow(set_device_mock, device_count_mock, setup_distributed_mock):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert isinstance(trainer.accelerator, GPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDPPlugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, KubeflowEnvironment)
-            assert trainer.training_type_plugin.cluster_environment.local_rank() == 0
-            assert trainer.training_type_plugin.local_rank == 0
-            raise SystemExit()
-
-    model = BoringModel()
+def test_accelerator_choice_ddp_kubeflow(*_):
     with pytest.deprecated_call(match=r"accelerator='ddp'\)` has been deprecated in v1.5"):
-        trainer = Trainer(fast_dev_run=True, accelerator="ddp", gpus=1, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
-
-    set_device_mock.assert_called_once()
+        trainer = Trainer(fast_dev_run=True, accelerator="ddp", gpus=1)
+    assert isinstance(trainer.accelerator, GPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDPPlugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, KubeflowEnvironment)
+    assert trainer.training_type_plugin.cluster_environment.local_rank() == 0
+    assert trainer.training_type_plugin.local_rank == 0
 
 
 @mock.patch.dict(
@@ -290,21 +234,13 @@ def test_accelerator_choice_ddp_kubeflow(set_device_mock, device_count_mock, set
 )
 @mock.patch("torch.cuda.device_count", return_value=0)
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
-def test_accelerator_choice_ddp_cpu_kubeflow(device_count_mock, setup_distributed_mock):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert isinstance(trainer.accelerator, CPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDPPlugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, KubeflowEnvironment)
-            assert trainer.training_type_plugin.cluster_environment.local_rank() == 0
-            assert trainer.training_type_plugin.local_rank == 0
-            raise SystemExit()
-
-    model = BoringModel()
-    trainer = Trainer(fast_dev_run=True, accelerator="ddp_cpu", num_processes=1, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
+def test_accelerator_choice_ddp_cpu_kubeflow(*_):
+    trainer = Trainer(fast_dev_run=True, accelerator="ddp_cpu", num_processes=1)
+    assert isinstance(trainer.accelerator, CPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDPPlugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, KubeflowEnvironment)
+    assert trainer.training_type_plugin.cluster_environment.local_rank() == 0
+    assert trainer.training_type_plugin.local_rank == 0
 
 
 @mock.patch.dict(
@@ -320,21 +256,13 @@ def test_accelerator_choice_ddp_cpu_kubeflow(device_count_mock, setup_distribute
 )
 @mock.patch("torch.cuda.device_count", return_value=0)
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
-def test_accelerator_choice_ddp_cpu_slurm(device_count_mock, setup_distributed_mock):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert trainer._accelerator_connector._is_slurm_managing_tasks()
-            assert isinstance(trainer.accelerator, CPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDPPlugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, SLURMEnvironment)
-            assert trainer.training_type_plugin.local_rank == 0
-            raise SystemExit()
-
-    model = BoringModel()
-    trainer = Trainer(fast_dev_run=True, accelerator="ddp_cpu", num_processes=2, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
+def test_accelerator_choice_ddp_cpu_slurm(*_):
+    trainer = Trainer(fast_dev_run=True, accelerator="ddp_cpu", num_processes=2)
+    assert trainer._accelerator_connector._is_slurm_managing_tasks()
+    assert isinstance(trainer.accelerator, CPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDPPlugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, SLURMEnvironment)
+    assert trainer.training_type_plugin.local_rank == 0
 
 
 @RunIf(skip_windows=True, standalone=True)
@@ -449,19 +377,11 @@ def test_custom_accelerator(device_count_mock, setup_distributed_mock):
 )
 @mock.patch("torch.cuda.device_count", return_value=0)
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
-def test_dist_backend_accelerator_mapping(device_count_mock, setup_distributed_mock):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert isinstance(trainer.accelerator, CPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDPPlugin)
-            assert trainer.training_type_plugin.local_rank == 0
-            raise SystemExit()
-
-    model = BoringModel()
-    trainer = Trainer(fast_dev_run=True, strategy="ddp_spawn", num_processes=2, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
+def test_dist_backend_accelerator_mapping(*_):
+    trainer = Trainer(fast_dev_run=True, strategy="ddp_spawn", num_processes=2)
+    assert isinstance(trainer.accelerator, CPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDPPlugin)
+    assert trainer.training_type_plugin.local_rank == 0
 
 
 @mock.patch("pytorch_lightning.utilities._IS_INTERACTIVE", return_value=True)
@@ -792,21 +712,13 @@ def test_strategy_choice_ddp_spawn(cuda_available_mock, device_count_mock):
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
 @pytest.mark.parametrize("strategy", ["ddp", DDPPlugin()])
 def test_strategy_choice_ddp_slurm(setup_distributed_mock, strategy):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert trainer._accelerator_connector._is_slurm_managing_tasks()
-            assert isinstance(trainer.accelerator, GPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDPPlugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, SLURMEnvironment)
-            assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
-            assert trainer.training_type_plugin.local_rank == 1
-            raise SystemExit()
-
-    model = BoringModel()
-    trainer = Trainer(fast_dev_run=True, strategy=strategy, gpus=2, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
+    trainer = Trainer(fast_dev_run=True, strategy=strategy, gpus=2)
+    assert trainer._accelerator_connector._is_slurm_managing_tasks()
+    assert isinstance(trainer.accelerator, GPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDPPlugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, SLURMEnvironment)
+    assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
+    assert trainer.training_type_plugin.local_rank == 1
 
 
 @mock.patch.dict(
@@ -825,23 +737,13 @@ def test_strategy_choice_ddp_slurm(setup_distributed_mock, strategy):
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
 @pytest.mark.parametrize("strategy", ["ddp2", DDP2Plugin()])
 def test_strategy_choice_ddp2_slurm(set_device_mock, device_count_mock, setup_distributed_mock, strategy):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert trainer._accelerator_connector._is_slurm_managing_tasks()
-            assert isinstance(trainer.accelerator, GPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDP2Plugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, SLURMEnvironment)
-            assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
-            assert trainer.training_type_plugin.local_rank == 1
-            raise SystemExit()
-
-    model = BoringModel()
-    trainer = Trainer(fast_dev_run=True, strategy=strategy, gpus=2, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
-
-    set_device_mock.assert_called_once()
+    trainer = Trainer(fast_dev_run=True, strategy=strategy, gpus=2)
+    assert trainer._accelerator_connector._is_slurm_managing_tasks()
+    assert isinstance(trainer.accelerator, GPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDP2Plugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, SLURMEnvironment)
+    assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
+    assert trainer.training_type_plugin.local_rank == 1
 
 
 @mock.patch.dict(
@@ -858,23 +760,13 @@ def test_strategy_choice_ddp2_slurm(set_device_mock, device_count_mock, setup_di
 @mock.patch("torch.cuda.set_device")
 @mock.patch("torch.cuda.device_count", return_value=2)
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
-def test_strategy_choice_ddp_te(set_device_mock, device_count_mock, setup_distributed_mock):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert isinstance(trainer.accelerator, GPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDPPlugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, TorchElasticEnvironment)
-            assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
-            assert trainer.training_type_plugin.local_rank == 1
-            raise SystemExit()
-
-    model = BoringModel()
-    trainer = Trainer(fast_dev_run=True, strategy="ddp", gpus=2, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
-
-    set_device_mock.assert_called_once()
+def test_strategy_choice_ddp_te(*_):
+    trainer = Trainer(fast_dev_run=True, strategy="ddp", gpus=2)
+    assert isinstance(trainer.accelerator, GPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDPPlugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, TorchElasticEnvironment)
+    assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
+    assert trainer.training_type_plugin.local_rank == 1
 
 
 @mock.patch.dict(
@@ -891,23 +783,13 @@ def test_strategy_choice_ddp_te(set_device_mock, device_count_mock, setup_distri
 @mock.patch("torch.cuda.set_device")
 @mock.patch("torch.cuda.device_count", return_value=2)
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
-def test_strategy_choice_ddp2_te(set_device_mock, device_count_mock, setup_distributed_mock):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert isinstance(trainer.accelerator, GPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDP2Plugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, TorchElasticEnvironment)
-            assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
-            assert trainer.training_type_plugin.local_rank == 1
-            raise SystemExit()
-
-    model = BoringModel()
-    trainer = Trainer(fast_dev_run=True, strategy="ddp2", gpus=2, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
-
-    set_device_mock.assert_called_once()
+def test_strategy_choice_ddp2_te(*_):
+    trainer = Trainer(fast_dev_run=True, strategy="ddp2", gpus=2)
+    assert isinstance(trainer.accelerator, GPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDP2Plugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, TorchElasticEnvironment)
+    assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
+    assert trainer.training_type_plugin.local_rank == 1
 
 
 @mock.patch.dict(
@@ -915,21 +797,13 @@ def test_strategy_choice_ddp2_te(set_device_mock, device_count_mock, setup_distr
 )
 @mock.patch("torch.cuda.device_count", return_value=0)
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
-def test_strategy_choice_ddp_cpu_te(device_count_mock, setup_distributed_mock):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert isinstance(trainer.accelerator, CPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDPPlugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, TorchElasticEnvironment)
-            assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
-            assert trainer.training_type_plugin.local_rank == 1
-            raise SystemExit()
-
-    model = BoringModel()
-    trainer = Trainer(fast_dev_run=True, strategy="ddp_spawn", num_processes=2, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
+def test_strategy_choice_ddp_cpu_te(*_):
+    trainer = Trainer(fast_dev_run=True, strategy="ddp_spawn", num_processes=2)
+    assert isinstance(trainer.accelerator, CPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDPPlugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, TorchElasticEnvironment)
+    assert trainer.training_type_plugin.cluster_environment.local_rank() == 1
+    assert trainer.training_type_plugin.local_rank == 1
 
 
 @mock.patch.dict(
@@ -946,23 +820,13 @@ def test_strategy_choice_ddp_cpu_te(device_count_mock, setup_distributed_mock):
 @mock.patch("torch.cuda.set_device")
 @mock.patch("torch.cuda.device_count", return_value=1)
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
-def test_strategy_choice_ddp_kubeflow(set_device_mock, device_count_mock, setup_distributed_mock):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert isinstance(trainer.accelerator, GPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDPPlugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, KubeflowEnvironment)
-            assert trainer.training_type_plugin.cluster_environment.local_rank() == 0
-            assert trainer.training_type_plugin.local_rank == 0
-            raise SystemExit()
-
-    model = BoringModel()
-    trainer = Trainer(fast_dev_run=True, strategy="ddp", gpus=1, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
-
-    set_device_mock.assert_called_once()
+def test_strategy_choice_ddp_kubeflow(*_):
+    trainer = Trainer(fast_dev_run=True, strategy="ddp", gpus=1)
+    assert isinstance(trainer.accelerator, GPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDPPlugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, KubeflowEnvironment)
+    assert trainer.training_type_plugin.cluster_environment.local_rank() == 0
+    assert trainer.training_type_plugin.local_rank == 0
 
 
 @mock.patch.dict(
@@ -977,21 +841,13 @@ def test_strategy_choice_ddp_kubeflow(set_device_mock, device_count_mock, setup_
 )
 @mock.patch("torch.cuda.device_count", return_value=0)
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
-def test_strategy_choice_ddp_cpu_kubeflow(device_count_mock, setup_distributed_mock):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert isinstance(trainer.accelerator, CPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDPPlugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, KubeflowEnvironment)
-            assert trainer.training_type_plugin.cluster_environment.local_rank() == 0
-            assert trainer.training_type_plugin.local_rank == 0
-            raise SystemExit()
-
-    model = BoringModel()
-    trainer = Trainer(fast_dev_run=True, strategy="ddp_spawn", num_processes=2, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
+def test_strategy_choice_ddp_cpu_kubeflow(*_):
+    trainer = Trainer(fast_dev_run=True, strategy="ddp_spawn", num_processes=2)
+    assert isinstance(trainer.accelerator, CPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDPPlugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, KubeflowEnvironment)
+    assert trainer.training_type_plugin.cluster_environment.local_rank() == 0
+    assert trainer.training_type_plugin.local_rank == 0
 
 
 @mock.patch.dict(
@@ -1009,20 +865,11 @@ def test_strategy_choice_ddp_cpu_kubeflow(device_count_mock, setup_distributed_m
 @mock.patch("pytorch_lightning.plugins.DDPPlugin.setup_distributed", autospec=True)
 @pytest.mark.parametrize("strategy", ["ddp", DDPPlugin()])
 def test_strategy_choice_ddp_cpu_slurm(device_count_mock, setup_distributed_mock, strategy):
-    class CB(Callback):
-        def on_fit_start(self, trainer, pl_module):
-            assert trainer._accelerator_connector._is_slurm_managing_tasks()
-            assert isinstance(trainer.accelerator, CPUAccelerator)
-            assert isinstance(trainer.training_type_plugin, DDPPlugin)
-            assert isinstance(trainer.training_type_plugin.cluster_environment, SLURMEnvironment)
-            assert trainer.training_type_plugin.local_rank == 0
-            raise SystemExit()
-
-    model = BoringModel()
-    trainer = Trainer(fast_dev_run=True, strategy=strategy, num_processes=2, callbacks=[CB()])
-
-    with pytest.raises(SystemExit):
-        trainer.fit(model)
+    trainer = Trainer(fast_dev_run=True, strategy=strategy, num_processes=2)
+    assert isinstance(trainer.accelerator, CPUAccelerator)
+    assert isinstance(trainer.training_type_plugin, DDPPlugin)
+    assert isinstance(trainer.training_type_plugin.cluster_environment, SLURMEnvironment)
+    assert trainer.training_type_plugin.local_rank == 0
 
 
 def test_unsupported_tpu_choice(monkeypatch):

--- a/tests/accelerators/test_accelerator_connector.py
+++ b/tests/accelerators/test_accelerator_connector.py
@@ -24,7 +24,6 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.accelerators.accelerator import Accelerator
 from pytorch_lightning.accelerators.cpu import CPUAccelerator
 from pytorch_lightning.accelerators.gpu import GPUAccelerator
-from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.plugins import (
     DataParallelPlugin,
     DDP2Plugin,
@@ -45,7 +44,6 @@ from pytorch_lightning.plugins.environments import (
 )
 from pytorch_lightning.utilities import _AcceleratorType, _StrategyType
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from tests.helpers.boring_model import BoringModel
 from tests.helpers.runif import RunIf
 
 

--- a/tests/accelerators/test_gpu.py
+++ b/tests/accelerators/test_gpu.py
@@ -1,6 +1,10 @@
+from unittest import mock
+
 import torch
 
+from pytorch_lightning import Trainer
 from pytorch_lightning.accelerators import GPUAccelerator
+from tests.helpers import BoringModel
 from tests.helpers.runif import RunIf
 
 
@@ -26,3 +30,12 @@ def test_get_nvidia_gpu_stats(tmpdir):
 
     for f in fields:
         assert any(f in h for h in gpu_stats.keys())
+
+
+@RunIf(gpus=1)
+@mock.patch("torch.cuda.set_device")
+def test_set_cuda_device(set_device_mock, tmpdir):
+    model = BoringModel()
+    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=True, accelerator="gpu", devices=1, enable_checkpointing=False, enable_model_summary=False, enable_progress_bar=False)
+    trainer.fit(model)
+    set_device_mock.assert_called_once()

--- a/tests/accelerators/test_gpu.py
+++ b/tests/accelerators/test_gpu.py
@@ -1,3 +1,16 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from unittest import mock
 
 import torch

--- a/tests/accelerators/test_gpu.py
+++ b/tests/accelerators/test_gpu.py
@@ -45,7 +45,7 @@ def test_get_nvidia_gpu_stats(tmpdir):
         assert any(f in h for h in gpu_stats.keys())
 
 
-@RunIf(gpus=1)
+@RunIf(min_gpus=1)
 @mock.patch("torch.cuda.set_device")
 def test_set_cuda_device(set_device_mock, tmpdir):
     model = BoringModel()

--- a/tests/accelerators/test_gpu.py
+++ b/tests/accelerators/test_gpu.py
@@ -36,6 +36,14 @@ def test_get_nvidia_gpu_stats(tmpdir):
 @mock.patch("torch.cuda.set_device")
 def test_set_cuda_device(set_device_mock, tmpdir):
     model = BoringModel()
-    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=True, accelerator="gpu", devices=1, enable_checkpointing=False, enable_model_summary=False, enable_progress_bar=False)
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        fast_dev_run=True,
+        accelerator="gpu",
+        devices=1,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=False,
+    )
     trainer.fit(model)
     set_device_mock.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

Preparation for #11137 

There are a number of tests of this form:

```python
class CB(Callback):
    def on_fit_start(self, trainer):
        assert "something that doesn't require fit()"
        raise Error()

trainer = Trainer(callbacks=CB()) 
with pytest.raises(Error):
    trainer.fit()
```
These can actually be written without relying on the on_fit_start hook, like so:
```python
trainer = Trainer(callbacks=CB()) 
assert "something that doesn't require fit()"
```

The tests are a prehistoric artifact from a time when many accelerator related settings like global_rank etc. were not available upon trainer instantiation. 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃

Part of #1 (it's a lie, this is just here to avoid noisy GitHub bot)



cc @justusschock @awaelchli @akihironitta @borda