### PR TITLE
Rename `restore_checkpoint_after_pre_dispatch` to `restore_checkpoint_after_setup`

### DIFF
--- a/pytorch_lightning/plugins/training_type/deepspeed.py
+++ b/pytorch_lightning/plugins/training_type/deepspeed.py
@@ -365,7 +365,7 @@ class DeepSpeedPlugin(DDPPlugin):
         os.environ["LOCAL_RANK"] = str(self.local_rank)
 
     @property
-    def restore_checkpoint_after_pre_dispatch(self) -> bool:
+    def restore_checkpoint_after_setup(self) -> bool:
         return True
 
     def pre_dispatch(self, trainer: "pl.Trainer") -> None:

--- a/pytorch_lightning/plugins/training_type/training_type_plugin.py
+++ b/pytorch_lightning/plugins/training_type/training_type_plugin.py
@@ -381,7 +381,7 @@ class TrainingTypePlugin(ABC):
         return trainer.init_optimizers(model)
 
     @property
-    def restore_checkpoint_after_pre_dispatch(self) -> bool:
+    def restore_checkpoint_after_setup(self) -> bool:
         """Override to delay restoring from checkpoint till after pre-dispatch. This is useful when the plugin
         requires all the setup hooks to run before loading checkpoint.
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1107,7 +1107,7 @@ class Trainer(
         self._call_setup_hook()  # allow user to setup lightning_module in accelerator environment
 
         # check if we should delay restoring checkpoint till later
-        if not self.training_type_plugin.restore_checkpoint_after_pre_dispatch:
+        if not self.training_type_plugin.restore_checkpoint_after_setup:
             self._restore_modules_and_callbacks(ckpt_path)
 
         self._call_configure_sharded_model()  # allow user to setup in model sharded environment
@@ -1153,7 +1153,7 @@ class Trainer(
         # plugin will move model to device
         self._pre_dispatch()
 
-        if self.training_type_plugin.restore_checkpoint_after_pre_dispatch:
+        if self.training_type_plugin.restore_checkpoint_after_setup:
             self._restore_modules_and_callbacks(ckpt_path)
 
         # restore optimizers, etc.

--- a/tests/accelerators/test_cpu.py
+++ b/tests/accelerators/test_cpu.py
@@ -14,17 +14,17 @@ from pytorch_lightning.plugins.precision.precision_plugin import PrecisionPlugin
 from tests.helpers.boring_model import BoringModel
 
 
-def test_restore_checkpoint_after_pre_dispatch_default():
-    """Assert default for restore_checkpoint_after_pre_dispatch is False."""
+def test_restore_checkpoint_after_pre_setup_default():
+    """Assert default for restore_checkpoint_after_setup is False."""
     plugin = SingleDevicePlugin(
         accelerator=CPUAccelerator(), device=torch.device("cpu"), precision_plugin=PrecisionPlugin()
     )
-    assert not plugin.restore_checkpoint_after_pre_dispatch
+    assert not plugin.restore_checkpoint_after_setup
 
 
-@pytest.mark.parametrize("restore_after_pre_dispatch", [True, False])
-def test_restore_checkpoint_after_pre_dispatch(tmpdir, restore_after_pre_dispatch):
-    """Test to ensure that if restore_checkpoint_after_pre_dispatch is True, then we only load the state after pre-
+@pytest.mark.parametrize("restore_after_pre_setup", [True, False])
+def test_restore_checkpoint_after_pre_setup(tmpdir, restore_after_pre_setup):
+    """Test to ensure that if restore_checkpoint_after_setup is True, then we only load the state after pre-
     dispatch is called."""
 
     class TestPlugin(SingleDevicePlugin):
@@ -35,11 +35,11 @@ def test_restore_checkpoint_after_pre_dispatch(tmpdir, restore_after_pre_dispatc
             self.predispatched_called = True
 
         @property
-        def restore_checkpoint_after_pre_dispatch(self) -> bool:
-            return restore_after_pre_dispatch
+        def restore_checkpoint_after_setup(self) -> bool:
+            return restore_after_pre_setup
 
         def load_checkpoint(self, checkpoint_path: Union[str, Path]) -> Dict[str, Any]:
-            assert self.predispatched_called == restore_after_pre_dispatch
+            assert self.predispatched_called == restore_after_pre_setup
             return super().load_checkpoint(checkpoint_path)
 
     model = BoringModel()
@@ -55,7 +55,7 @@ def test_restore_checkpoint_after_pre_dispatch(tmpdir, restore_after_pre_dispatc
         device=torch.device("cpu"),
         checkpoint_io=TorchCheckpointIO(),
     )
-    assert plugin.restore_checkpoint_after_pre_dispatch == restore_after_pre_dispatch
+    assert plugin.restore_checkpoint_after_setup == restore_after_pre_setup
 
     trainer = Trainer(default_root_dir=tmpdir, strategy=plugin, fast_dev_run=True)
     trainer.fit(model, ckpt_path=checkpoint_path)


### PR DESCRIPTION
## What does this PR do?

Follow up to #11137
Fixes #10987

The two TTP methods `pre_dispatch` and `setup` were merged in #11137. Accordingly, the related property `restore_checkpoint_after_pre_dispatch` should now be renamed to `restore_checkpoint_after_setup`.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃

Part of #1 (it's a lie, this is just here to avoid noisy GitHub bot)


cc @borda @justusschock @awaelchli @akihironitta @SeanNaren