### PR TITLE
Safely disable profiler

### DIFF
--- a/pytorch_lightning/profiler/pytorch.py
+++ b/pytorch_lightning/profiler/pytorch.py
@@ -377,10 +377,8 @@ class PyTorchProfiler(BaseProfiler):
 
             # close profiler if it is already opened. might happen if 2 profilers
             # are created and the first one did not call `describe`
-            try:
+            if torch.autograd._profiler_enabled():
                 torch.autograd._disable_profiler()
-            except (AttributeError, RuntimeError):
-                pass
 
             if self._schedule is not None:
                 self._schedule.setup(action_name)


### PR DESCRIPTION
In pytorch nightly build, the torch.autograd._disable_profiler would crash with the following errors screenshot.
![image](https://user-images.githubusercontent.com/62738430/146736616-e7d951d7-05af-47fd-b8c4-a0872a2056dd.png)
which cannot be catched by 'try' statement.
So we check it before disable_profiler.
related issue: https://github.com/PyTorchLightning/pytorch-lightning/issues/11168



## Before submitting
- [ ] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [ ] Did you make sure to update the documentation with your changes? (if necessary)
- [ ] Did you write any new necessary tests? (not for typos and docs)
- [ ] Did you verify new and existing tests pass locally with your changes?
- [ ] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [ ] Is this pull request ready for review? (if not, please submit in draft mode)
 - [ ] Check that all items from **Before submitting** are resolved
 - [ ] Make sure the title is self-explanatory and the description concisely explains the PR
 - [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
