### PR TITLE
Suppress Warning in `PredictionEpochLoop`

### DIFF
--- a/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
@@ -69,6 +69,7 @@ class PredictionEpochLoop(Loop):
         self._dl_max_batches = dl_max_batches
         self._num_dataloaders = num_dataloaders
         self.return_predictions = return_predictions
+        # this call requires that `self.return_predictions` is set
         self._seen_batch_indices = self._get_batch_indices(dataloader_idx)
 
     def advance(  # type: ignore[override]

--- a/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
@@ -68,8 +68,8 @@ class PredictionEpochLoop(Loop):
         void(dataloader_iter, dataloader_idx)
         self._dl_max_batches = dl_max_batches
         self._num_dataloaders = num_dataloaders
-        self._seen_batch_indices = self._get_batch_indices(dataloader_idx)
         self.return_predictions = return_predictions
+        self._seen_batch_indices = self._get_batch_indices(dataloader_idx)
 
     def advance(  # type: ignore[override]
         self,


### PR DESCRIPTION
## What does this PR do?

This PR gets rid of a warning that is emitted every time `on_run_start` is run on the `PredictionEpochLoop`. At the time of the call to `_get_batch_indices`, the parameter `return_predictions` passed to `on_run_start` has not been set and the following warning is emitted in any case: `"Lightning couldn't infer the indices fetched for your dataloader."`

-- no issue opened

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
