### PR TITLE
Reset the total fit-validation batch progress on epoch

### DIFF
--- a/pytorch_lightning/loops/epoch/training_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/training_epoch_loop.py
@@ -126,6 +126,9 @@ class TrainingEpochLoop(loops.Loop[_OUTPUTS_TYPE]):
             self.batch_progress.reset_on_run()
             self.scheduler_progress.reset_on_run()
             self.batch_loop.optimizer_loop.optim_progress.reset_on_run()
+            # when the epoch starts, the total val batch progress should be reset as it's supposed to count the batches
+            # seen per epoch, this is useful for tracking when validation is run multiple times per epoch
+            self.val_loop.epoch_loop.batch_progress.total.reset()
 
         self._outputs = []
 

--- a/tests/loops/test_loop_state_dict.py
+++ b/tests/loops/test_loop_state_dict.py
@@ -77,7 +77,9 @@ def test_loops_state_dict_structure():
             },
             "epoch_loop.val_loop.epoch_loop.state_dict": {},
             "epoch_loop.val_loop.epoch_loop.batch_progress": {
+                # number of batches across validation runs per epoch
                 "total": {"ready": 0, "started": 0, "processed": 0, "completed": 0},
+                # number of batches for this validation run
                 "current": {"ready": 0, "started": 0, "processed": 0, "completed": 0},
                 "is_last_batch": False,
             },
@@ -107,7 +109,9 @@ def test_loops_state_dict_structure():
             "dataloader_progress": {"total": {"ready": 0, "completed": 0}, "current": {"ready": 0, "completed": 0}},
             "epoch_loop.state_dict": {},
             "epoch_loop.batch_progress": {
+                # total batches run by `validate`
                 "total": {"ready": 0, "started": 0, "processed": 0, "completed": 0},
+                # number of batches run by this `validate` call
                 "current": {"ready": 0, "started": 0, "processed": 0, "completed": 0},
                 "is_last_batch": False,
             },

--- a/tests/loops/test_loops.py
+++ b/tests/loops/test_loops.py
@@ -344,7 +344,8 @@ def test_loop_restart_progress_multiple_dataloaders(tmpdir, n_dataloaders, stop_
     trainer.fit_loop.load_state_dict(checkpoint)
 
     # `nbe_`: non-breaking epoch, as in, no exception will be raised. `be_`: breaking epoch
-    nbe_total_val_batch = stop_epoch * n_dataloaders * n_batches
+    # the fit-validation total batch progress is reset per epoch so it's not counted for the total value.
+    nbe_total_val_batch = 0  # stop_epoch * n_dataloaders * n_batches
     be_total_val_batch = stop_dataloader * n_batches + stop_batch
     total_val_batch = nbe_total_val_batch + be_total_val_batch
     expected = {


### PR DESCRIPTION
## What does this PR do?

The fit-loop validation total counters are supposed to count the total number of batches per epoch. This PR fixes it.

Note that we don't want the same behavior for the validate-loop validation.

This is necessary for #11213 where the total value will be used to update the progress bar.

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @borda @carmocca @awaelchli