### PR TITLE
Avoid non-blocking GPU->CPU copies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -385,6 +385,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed data fetcher selection ([#11294](https://github.com/PyTorchLightning/pytorch-lightning/pull/11294))
 
 
+- Fixed a race that could result in incorrect (zero) values being observed in prediction writer callbacks. ([#11287](https://github.com/PyTorchLightning/pytorch-lightning/pull/11287))
+
+
 ## [1.5.7] - 2021-12-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -385,7 +385,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed data fetcher selection ([#11294](https://github.com/PyTorchLightning/pytorch-lightning/pull/11294))
 
 
-- Fixed a race that could result in incorrect (zero) values being observed in prediction writer callbacks. ([#11287](https://github.com/PyTorchLightning/pytorch-lightning/pull/11287))
+- Fixed a race condition that could result in incorrect (zero) values being observed in prediction writer callbacks ([#11288](https://github.com/PyTorchLightning/pytorch-lightning/pull/11288))
 
 
 ## [1.5.7] - 2021-12-21

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -35,6 +35,9 @@ else:
     Batch = type(None)
 
 
+CPU_DEVICES = [None, "cpu", torch.device("cpu")]
+
+
 def to_dtype_tensor(
     value: Union[int, float, List[Union[int, float]]], dtype: torch.dtype, device: Union[str, torch.device]
 ) -> torch.Tensor:
@@ -274,7 +277,10 @@ def move_data_to_device(batch: Any, device: Union[str, torch.device]) -> Any:
                 setattr(device_data, field, device_field)
             return device_data
 
-        kwargs = dict(non_blocking=True) if isinstance(data, torch.Tensor) else {}
+        kwargs = {}
+        # Don't issue non-blocking transfers to CPU. #11287
+        if isinstance(data, torch.Tensor) and device not in CPU_DEVICES:
+            kwargs["non_blocking"] = True
         data_output = data.to(device, **kwargs)
         if data_output is not None:
             return data_output

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -35,7 +35,7 @@ else:
     Batch = type(None)
 
 
-CPU_DEVICES = (None, "cpu", torch.device("cpu"))
+CPU_DEVICES = ("cpu", torch.device("cpu"))
 
 
 def to_dtype_tensor(

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -35,7 +35,7 @@ else:
     Batch = type(None)
 
 
-CPU_DEVICES = ("cpu", torch.device("cpu"))
+_CPU_DEVICES = ("cpu", torch.device("cpu"))
 
 
 def to_dtype_tensor(
@@ -278,8 +278,8 @@ def move_data_to_device(batch: Any, device: Union[str, torch.device]) -> Any:
             return device_data
 
         kwargs = {}
-        # Don't issue non-blocking transfers to CPU. #11287
-        if isinstance(data, torch.Tensor) and device not in CPU_DEVICES:
+        # Don't issue non-blocking transfers to CPU
+        if isinstance(data, torch.Tensor) and device not in _CPU_DEVICES:
             kwargs["non_blocking"] = True
         data_output = data.to(device, **kwargs)
         if data_output is not None:

--- a/pytorch_lightning/utilities/apply_func.py
+++ b/pytorch_lightning/utilities/apply_func.py
@@ -35,7 +35,7 @@ else:
     Batch = type(None)
 
 
-CPU_DEVICES = [None, "cpu", torch.device("cpu")]
+CPU_DEVICES = (None, "cpu", torch.device("cpu"))
 
 
 def to_dtype_tensor(


### PR DESCRIPTION
Non-blocking GPU->CPU transfers can create race windows where tensor contents are observed to have incorrect values.

Fixes #11287. See #11287 for detailed mechanics of the issue this resolves.

Verified that this change fixes the behavior in the reproduce script from #11287.

### Does your PR introduce any breaking changes? If yes, please list them.

No

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
   - see discussion on the issue thread for challenges with contbuild tests for this. I did test that this resolves the reproduce script in #11287
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified
  - can't seem to do this, and the review guidelines wiki page no longer loads for me

## Did you have fun?

Fixing: yes. Root causing the bug: no. It's subtle, and many log statements you add to debug the issue fix the issue (by observing the value of GPU tensors, forcing a CUDA sync), which is frustrating if you don't know that this is the nature of the issue.

I also had some trouble getting tests to run in my environment. It looks to me like some tests fail in GPU environments but pass in non-GPU environments. Others fail when run on slurm environments, which is the only way I can easily access GPUs.