### PR TITLE
Update optimizer configuration info message in `DeepSpeedStrategy`

### DIFF
--- a/pytorch_lightning/strategies/deepspeed.py
+++ b/pytorch_lightning/strategies/deepspeed.py
@@ -463,12 +463,12 @@ class DeepSpeedStrategy(DDPStrategy):
 
     def _initialize_deepspeed_train(self, model):
         if "optimizer" in self.config:
+            rank_zero_info(
+                "You have specified an optimizer and/or scheduler within the DeepSpeed config."
+                " It is recommended to define it in `LightningModule.configure_optimizers`."
+            )
             optimizer, lr_scheduler = None, _get_default_scheduler_config()
         else:
-            rank_zero_info(
-                "You have not specified an optimizer or scheduler within the DeepSpeed config."
-                " Using `configure_optimizers` to define optimizer and scheduler."
-            )
             optimizer, lr_scheduler, _ = self._init_optimizers()
 
         scheduler = lr_scheduler["scheduler"]


### PR DESCRIPTION
## What does this PR do?

The recommended way to configure optimizers and schedulers is through the LightningModule hook. The current info message in DeepSpeedStrategy is slightly misleading. From now on, we print the info message only when optimizers are configured through the configuration file.

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃

Part of #1 (it's a lie, this is just here to avoid noisy GitHub bot)


cc @borda @SeanNaren @awaelchli @rohitgr7