### PR TITLE
Update `tests/checkpointing/*.py` to use `devices` instead of `gpus` or `ipus`

### DIFF
--- a/tests/checkpointing/test_checkpoint_callback_frequency.py
+++ b/tests/checkpointing/test_checkpoint_callback_frequency.py
@@ -115,7 +115,8 @@ def test_top_k_ddp(save_mock, tmpdir, k, epochs, val_check_interval, expected):
         enable_model_summary=False,
         val_check_interval=val_check_interval,
         strategy="ddp",
-        gpus=2,
+        accelerator="gpu",
+        devices=2,
         limit_train_batches=64,
         limit_val_batches=32,
     )

--- a/tests/checkpointing/test_legacy_checkpoints.py
+++ b/tests/checkpointing/test_legacy_checkpoints.py
@@ -75,9 +75,11 @@ def test_resume_legacy_checkpoints(tmpdir, pl_version: str):
         model = ClassificationModel()
         es = EarlyStopping(monitor="val_acc", mode="max", min_delta=0.005)
         stop = LimitNbEpochs(1)
+
         trainer = Trainer(
             default_root_dir=str(tmpdir),
-            gpus=int(torch.cuda.is_available()),
+            accelerator="gpu" if torch.cuda.is_available() else "cpu",
+            devices=1,
             precision=(16 if torch.cuda.is_available() else 32),
             callbacks=[es, stop],
             max_epochs=21,

--- a/tests/checkpointing/test_legacy_checkpoints.py
+++ b/tests/checkpointing/test_legacy_checkpoints.py
@@ -78,7 +78,7 @@ def test_resume_legacy_checkpoints(tmpdir, pl_version: str):
 
         trainer = Trainer(
             default_root_dir=str(tmpdir),
-            accelerator="gpu" if torch.cuda.is_available() else "cpu",
+            accelerator="auto",
             devices=1,
             precision=(16 if torch.cuda.is_available() else 32),
             callbacks=[es, stop],

--- a/tests/checkpointing/test_model_checkpoint.py
+++ b/tests/checkpointing/test_model_checkpoint.py
@@ -396,7 +396,8 @@ def test_model_checkpoint_no_extraneous_invocations(tmpdir):
     model_checkpoint = ModelCheckpointTestInvocations(monitor="early_stop_on", expected_count=num_epochs, save_top_k=-1)
     trainer = Trainer(
         strategy="ddp_spawn",
-        num_processes=2,
+        accelerator="cpu",
+        devices=2,
         default_root_dir=tmpdir,
         callbacks=[model_checkpoint],
         max_epochs=num_epochs,

--- a/tests/checkpointing/test_torch_saving.py
+++ b/tests/checkpointing/test_torch_saving.py
@@ -40,7 +40,7 @@ def test_model_torch_save_ddp_cpu(tmpdir):
     model = BoringModel()
     num_epochs = 1
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=num_epochs, strategy="ddp_spawn", num_processes=2, logger=False
+        default_root_dir=tmpdir, max_epochs=num_epochs, strategy="ddp_spawn", accelerator="cpu", devices=2, logger=False
     )
     temp_path = os.path.join(tmpdir, "temp.pt")
     trainer.fit(model)
@@ -55,7 +55,9 @@ def test_model_torch_save_ddp_cuda(tmpdir):
     """Test to ensure torch save does not fail for model and trainer using gpu ddp."""
     model = BoringModel()
     num_epochs = 1
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=num_epochs, strategy="ddp_spawn", gpus=2)
+    trainer = Trainer(
+        default_root_dir=tmpdir, max_epochs=num_epochs, strategy="ddp_spawn", accelerator="gpu", devices=2
+    )
     temp_path = os.path.join(tmpdir, "temp.pt")
     trainer.fit(model)
 


### PR DESCRIPTION
## What does this PR do?

Update test to deprecate `num_processes`, `gpus`, `tpu_cores`, and `ipus` from the Trainer constructor

Part of [Pull 11040](https://github.com/PyTorchLightning/pytorch-lightning/pull/11040).

🌳 [Trello Board Link](https://trello.com/b/He49BfCc/pl-tests)

### Does your PR introduce any breaking changes? If yes, please list them.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
