### PR TITLE
Simplify data fetching

### DIFF
--- a/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
@@ -20,7 +20,6 @@ from typing import Any, Dict, Iterator, Optional, Union
 from deprecate import void
 
 from pytorch_lightning.loops.base import Loop
-from pytorch_lightning.loops.utilities import _update_dataloader_iter
 from pytorch_lightning.trainer.progress import BatchProgress
 from pytorch_lightning.trainer.states import TrainerFn
 from pytorch_lightning.trainer.supporters import CombinedLoader
@@ -88,7 +87,7 @@ class EvaluationEpochLoop(Loop):
         self._data_fetcher = data_fetcher
 
         self._reload_dataloader_state_dict(data_fetcher)
-        self._dataloader_iter = _update_dataloader_iter(data_fetcher, self.batch_progress.current.ready)
+        self._dataloader_iter = iter(data_fetcher)
 
     def advance(  # type: ignore[override]
         self, data_fetcher: AbstractDataFetcher, dataloader_idx: Optional[int], dl_max_batches: int
@@ -106,7 +105,8 @@ class EvaluationEpochLoop(Loop):
         void(dl_max_batches)
 
         assert self._dataloader_iter is not None
-        batch_idx, (batch, self.batch_progress.is_last_batch) = next(self._dataloader_iter)
+        batch_idx = self.batch_progress.current.ready
+        batch, self.batch_progress.is_last_batch = next(self._dataloader_iter)
 
         if batch is None:
             raise StopIteration

--- a/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
@@ -111,12 +111,10 @@ class EvaluationEpochLoop(Loop):
         if batch is None:
             raise StopIteration
 
-        if not data_fetcher.store_on_device:
-            batch = self.trainer._call_strategy_hook("batch_to_device", batch, dataloader_idx=(dataloader_idx or 0))
-
         self.batch_progress.increment_ready()
 
         # configure step_kwargs
+        # TODO: each loop should construct its own kwargs, so we avoid the dataloader_idx reference here
         kwargs = self._build_kwargs(batch, batch_idx, dataloader_idx)
 
         # hook

--- a/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
@@ -105,17 +105,15 @@ class EvaluationEpochLoop(Loop):
         void(dl_max_batches)
 
         assert self._dataloader_iter is not None
-        batch_idx = self.batch_progress.current.ready
         batch, self.batch_progress.is_last_batch = next(self._dataloader_iter)
-
         if batch is None:
             raise StopIteration
 
-        self.batch_progress.increment_ready()
-
         # configure step_kwargs
         # TODO: each loop should construct its own kwargs, so we avoid the dataloader_idx reference here
-        kwargs = self._build_kwargs(batch, batch_idx, dataloader_idx)
+        kwargs = self._build_kwargs(batch, self.batch_progress.current.ready, dataloader_idx)
+
+        self.batch_progress.increment_ready()
 
         # hook
         self._on_evaluation_batch_start(**kwargs)

--- a/pytorch_lightning/loops/epoch/training_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/training_epoch_loop.py
@@ -149,9 +149,6 @@ class TrainingEpochLoop(loops.Loop[_OUTPUTS_TYPE]):
         assert self._dataloader_iter is not None
         batch_idx, (batch, self.batch_progress.is_last_batch) = next(self._dataloader_iter)
 
-        if not data_fetcher.store_on_device:
-            batch = self.trainer._call_strategy_hook("batch_to_device", batch)
-
         self.batch_progress.increment_ready()
 
         self.trainer.logger_connector.on_batch_start(batch, batch_idx)

--- a/pytorch_lightning/loops/epoch/training_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/training_epoch_loop.py
@@ -226,9 +226,8 @@ class TrainingEpochLoop(loops.Loop[_OUTPUTS_TYPE]):
         self.trainer.logger_connector.update_train_step_metrics()
 
     def on_advance_end(self) -> None:
-        """Runs validation and Checkpointing if necessary."""
         # -----------------------------------------
-        # VALIDATE IF NEEDED + CHECKPOINT CALLBACK
+        # VALIDATE IF NEEDED
         # -----------------------------------------
         should_check_val = self._should_check_val_fx(self.batch_idx, self.batch_progress.is_last_batch)
         if should_check_val:

--- a/pytorch_lightning/loops/epoch/training_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/training_epoch_loop.py
@@ -20,14 +20,14 @@ import torch
 from pytorch_lightning import loops  # import as loops to avoid circular imports
 from pytorch_lightning.loops.batch import TrainingBatchLoop
 from pytorch_lightning.loops.batch.training_batch_loop import _OUTPUTS_TYPE as _BATCH_OUTPUTS_TYPE
-from pytorch_lightning.loops.utilities import _get_active_optimizers, _is_max_limit_reached, _update_dataloader_iter
+from pytorch_lightning.loops.utilities import _get_active_optimizers, _is_max_limit_reached
 from pytorch_lightning.trainer.connectors.logger_connector.result import _ResultCollection
 from pytorch_lightning.trainer.progress import BatchProgress, SchedulerProgress
 from pytorch_lightning.utilities import rank_zero_warn
 from pytorch_lightning.utilities.apply_func import apply_to_collection
 from pytorch_lightning.utilities.auto_restart import _collect_states_on_rank_zero_over_collection
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities.fetching import AbstractDataFetcher
+from pytorch_lightning.utilities.fetching import AbstractDataFetcher, DataLoaderIterDataFetcher
 from pytorch_lightning.utilities.model_helpers import is_overridden
 from pytorch_lightning.utilities.signature_utils import is_param_in_hook_signature
 from pytorch_lightning.utilities.warnings import rank_zero_deprecation, WarningCache
@@ -134,7 +134,7 @@ class TrainingEpochLoop(loops.Loop[_OUTPUTS_TYPE]):
 
     def on_run_start(self, data_fetcher: AbstractDataFetcher) -> None:  # type: ignore[override]
         self._reload_dataloader_state_dict(data_fetcher)
-        self._dataloader_iter = _update_dataloader_iter(data_fetcher, self.batch_idx + 1)
+        self._dataloader_iter = iter(data_fetcher)
 
     def advance(self, data_fetcher: AbstractDataFetcher) -> None:  # type: ignore[override]
         """Runs a single training batch.
@@ -147,7 +147,11 @@ class TrainingEpochLoop(loops.Loop[_OUTPUTS_TYPE]):
             return
 
         assert self._dataloader_iter is not None
-        batch_idx, (batch, self.batch_progress.is_last_batch) = next(self._dataloader_iter)
+        if not isinstance(data_fetcher, DataLoaderIterDataFetcher):
+            batch_idx = self.batch_idx + 1
+            batch, self.batch_progress.is_last_batch = next(self._dataloader_iter)
+        else:
+            batch_idx, (batch, self.batch_progress.is_last_batch) = next(self._dataloader_iter)
 
         self.batch_progress.increment_ready()
 
@@ -222,11 +226,7 @@ class TrainingEpochLoop(loops.Loop[_OUTPUTS_TYPE]):
         self.trainer.logger_connector.update_train_step_metrics()
 
     def on_advance_end(self) -> None:
-        """Runs validation and Checkpointing if necessary.
-
-        Raises:
-            StopIteration: if :attr:`done` evaluates to ``True`` to finish this epoch
-        """
+        """Runs validation and Checkpointing if necessary."""
         # -----------------------------------------
         # VALIDATE IF NEEDED + CHECKPOINT CALLBACK
         # -----------------------------------------

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -244,7 +244,7 @@ class FitLoop(Loop[None]):
         log.detail(f"{self.__class__.__name__}: advancing loop")
         assert self.trainer.train_dataloader is not None
         dataloader = self.trainer.strategy.process_dataloader(self.trainer.train_dataloader)
-        data_fetcher = self.trainer._data_connector.get_profiled_dataloader(dataloader)
+        data_fetcher = self.trainer._data_connector.get_profiled_dataloader(dataloader, 0)
 
         with self.trainer.profiler.profile("run_training_epoch"):
             self._outputs = self.epoch_loop.run(data_fetcher)

--- a/pytorch_lightning/loops/optimization/optimizer_loop.py
+++ b/pytorch_lightning/loops/optimization/optimizer_loop.py
@@ -419,8 +419,6 @@ class OptimizerLoop(Loop[_OUTPUTS_TYPE]):
             training_step_output = self.trainer._call_strategy_hook("training_step", *step_kwargs.values())
             self.trainer.strategy.post_training_step()
 
-            del step_kwargs
-
             model_output = self.trainer._call_lightning_module_hook("training_step_end", training_step_output)
             strategy_output = self.trainer._call_strategy_hook("training_step_end", training_step_output)
             training_step_output = strategy_output if model_output is None else model_output

--- a/pytorch_lightning/loops/utilities.py
+++ b/pytorch_lightning/loops/utilities.py
@@ -15,7 +15,7 @@ from collections import OrderedDict
 from contextlib import contextmanager
 from datetime import timedelta
 from functools import lru_cache
-from typing import Any, Dict, Generator, Iterator, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Sequence, Tuple, Union
 
 import numpy as np
 import torch
@@ -27,7 +27,6 @@ from pytorch_lightning.strategies import ParallelStrategy
 from pytorch_lightning.trainer.progress import BaseProgress
 from pytorch_lightning.utilities import rank_zero_warn
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities.fetching import AbstractDataFetcher, DataLoaderIterDataFetcher
 from pytorch_lightning.utilities.memory import recursive_detach
 from pytorch_lightning.utilities.signature_utils import is_param_in_hook_signature
 from pytorch_lightning.utilities.types import STEP_OUTPUT
@@ -150,15 +149,6 @@ def _build_training_step_kwargs(
         step_kwargs["hiddens"] = hiddens
 
     return step_kwargs
-
-
-def _update_dataloader_iter(data_fetcher: AbstractDataFetcher, batch_idx: int) -> Iterator:
-    """Attach the dataloader."""
-    if not isinstance(data_fetcher, DataLoaderIterDataFetcher):
-        # restore iteration
-        return enumerate(data_fetcher, batch_idx)
-    else:
-        return iter(data_fetcher)
 
 
 @contextmanager

--- a/pytorch_lightning/trainer/connectors/data_connector.py
+++ b/pytorch_lightning/trainer/connectors/data_connector.py
@@ -143,7 +143,7 @@ class DataConnector:
             return InterBatchParallelDataFetcher()
         return DataFetcher()
 
-    def get_profiled_dataloader(self, dataloader: Iterable, dataloader_idx: int = 0) -> Iterable:
+    def get_profiled_dataloader(self, dataloader: Iterable, dataloader_idx: int) -> Iterable:
         stage: str = self.trainer.state.stage.value
         data_fetcher = getattr(self, f"{stage}_data_fetcher", None) or self._select_data_fetcher()
         data_fetcher.setup(

--- a/pytorch_lightning/trainer/connectors/data_connector.py
+++ b/pytorch_lightning/trainer/connectors/data_connector.py
@@ -148,9 +148,7 @@ class DataConnector:
         data_fetcher = getattr(self, f"{stage}_data_fetcher", None) or self._select_data_fetcher()
         data_fetcher.setup(
             dataloader,
-            stage=stage,
-            batch_to_device=partial(self.trainer.strategy.batch_to_device, dataloader_idx=dataloader_idx),
-            profiler=self.trainer.profiler,
+            batch_to_device=partial(self.trainer._call_strategy_hook, "batch_to_device", dataloader_idx=dataloader_idx),
         )
         setattr(self, f"{stage}_data_fetcher", data_fetcher)
         return data_fetcher

--- a/pytorch_lightning/trainer/connectors/data_connector.py
+++ b/pytorch_lightning/trainer/connectors/data_connector.py
@@ -23,6 +23,7 @@ from torch.utils.data.dataset import IterableDataset
 from torch.utils.data.distributed import DistributedSampler
 
 import pytorch_lightning as pl
+from pytorch_lightning.accelerators import GPUAccelerator
 from pytorch_lightning.overrides.distributed import UnrepeatedDistributedSampler
 from pytorch_lightning.trainer.states import RunningStage
 from pytorch_lightning.trainer.supporters import CombinedLoader, CycleIterator
@@ -126,23 +127,20 @@ class DataConnector:
         self.trainer._is_data_prepared = False
 
     def _select_data_fetcher(self) -> AbstractDataFetcher:
-        if self.trainer.sanity_checking:
+        if not self.trainer.training:
             return DataFetcher()
 
         training_step_fx = getattr(self.trainer.lightning_module, "training_step")
-        if self.trainer.training and is_param_in_hook_signature(training_step_fx, "dataloader_iter", explicit=True):
+        if is_param_in_hook_signature(training_step_fx, "dataloader_iter", explicit=True):
             rank_zero_warn(
                 "Found `dataloader_iter` argument in the `training_step`. Note that the support for "
                 "this signature is experimental and the behavior is subject to change."
             )
             return DataLoaderIterDataFetcher()
-
-        elif self.trainer.training and os.getenv("PL_INTER_BATCH_PARALLELISM", "0") == "1":
-            # note: this is an experimental feature
-            if not self.trainer.strategy.on_gpu:
+        elif os.getenv("PL_INTER_BATCH_PARALLELISM", "0") == "1":
+            if not isinstance(self.trainer.accelerator, GPUAccelerator):
                 raise MisconfigurationException("Inter batch parallelism is available only when using Nvidia GPUs.")
             return InterBatchParallelDataFetcher()
-
         return DataFetcher()
 
     def get_profiled_dataloader(self, dataloader: Iterable, dataloader_idx: int = 0) -> Iterable:

--- a/pytorch_lightning/utilities/fetching.py
+++ b/pytorch_lightning/utilities/fetching.py
@@ -301,11 +301,6 @@ class DataFetcher(AbstractDataFetcher):
                 self.fetched += 1
                 self.on_fetch_end(batch, data)
 
-    def _consume_prefetched_batches(self) -> Generator:
-        self.done = True
-        while self.batches:
-            yield from self._yield_batch()
-
     def _get_queued_batch(self) -> Tuple[Any, bool]:
         self.wait()
         batch = self.batches.pop(0)
@@ -314,7 +309,6 @@ class DataFetcher(AbstractDataFetcher):
 
     def move_to_device(self, batch: Any) -> Any:
         if self.store_on_device and self.batch_to_device is not None:
-            # FIXME: what about call_hook?
             with self.apply_profiler(f"move_{self.stage}_batch_to_device"):
                 batch = self.batch_to_device(batch)
         return batch

--- a/pytorch_lightning/utilities/fetching.py
+++ b/pytorch_lightning/utilities/fetching.py
@@ -300,18 +300,15 @@ class InterBatchParallelDataFetcher(DataFetcher):
         self.cuda_stream = torch.cuda.Stream()
         self.events: List[torch.cuda.Event] = []
 
-    def _fetch_next_batch(self):
+    def move_to_device(self, batch):
         with torch.cuda.stream(self.cuda_stream):
-            super()._fetch_next_batch()
+            return super().move_to_device(batch)
 
     def on_fetch_start(self) -> "torch.cuda.Event":
         # create a cuda event used to record the async stream of data to device.
         return torch.cuda.Event()
 
     def on_fetch_end(self, batch, event: torch.cuda.Event) -> None:
-        # move the batch to device and store it
-        # FIXME: will this move twice?
-        batch = self.move_to_device(batch)
         super().on_fetch_end(batch)
 
         # record event and store the event

--- a/pytorch_lightning/utilities/fetching.py
+++ b/pytorch_lightning/utilities/fetching.py
@@ -243,8 +243,6 @@ class DataFetcher(AbstractDataFetcher):
             try:
                 yield_batch = self.batches.pop(0)
                 self._fetch_next_batch()
-
-                # TODO: move `wait` into `move_to_device`?
                 # wait for batch to be available.
                 self.wait()
                 # yield last and has next

--- a/pytorch_lightning/utilities/fetching.py
+++ b/pytorch_lightning/utilities/fetching.py
@@ -55,7 +55,7 @@ class AbstractDataFetcher(ABC):
         """Override with your own fetching logic."""
 
     @abstractmethod
-    def prefetching(self, prefetch_batches: int) -> None:
+    def prefetching(self) -> None:
         """Override with your own pre-fetching logic."""
 
     def __init__(self, prefetch_batches: int = 0) -> None:
@@ -181,7 +181,7 @@ class AbstractDataFetcher(ABC):
         _patch_dataloader_get_iterators()
         self.dataloader_iter = iter(self.dataloader)
         self._apply_patch()
-        self.prefetching(self.prefetch_batches)
+        self.prefetching()
         return self
 
     def __next__(self):
@@ -227,8 +227,8 @@ class DataFetcher(AbstractDataFetcher):
     def wait(self) -> None:
         """Hook to override to indicate the `DataFetcher` to wait for an event."""
 
-    def prefetching(self, prefetch_batches: int) -> None:
-        for _ in range(prefetch_batches):
+    def prefetching(self) -> None:
+        for _ in range(self.prefetch_batches):
             try:
                 self._fetch_next_batch()
             except StopIteration:
@@ -369,7 +369,7 @@ class DataLoaderIterDataFetcher(AbstractDataFetcher):
         super().__init__()
         self.store_on_device = False
 
-    def prefetching(self, prefetch_batches: int) -> None:
+    def prefetching(self) -> None:
         self.iterator = iter(StepFuncDataLoaderIter(self.dataloader_iter, self))
 
     def fetching_function(self):

--- a/tests/utilities/test_fetching.py
+++ b/tests/utilities/test_fetching.py
@@ -40,7 +40,7 @@ def test_prefetch_iterator(use_combined_loader):
             yield 2
             yield 3
 
-    for prefetch_batches in range(0, 4):
+    for prefetch_batches in range(1, 5):
         if use_combined_loader:
             loader = CombinedLoader([DataLoader(IterDataset()), DataLoader(IterDataset())])
             expected = [
@@ -52,7 +52,6 @@ def test_prefetch_iterator(use_combined_loader):
             loader = DataLoader(IterDataset())
             expected = [(1, False), (2, False), (3, True)]
         iterator = DataFetcher(prefetch_batches=prefetch_batches)
-        prefetch_batches += 1
         assert iterator.prefetch_batches == prefetch_batches
         iterator.setup(loader)
 

--- a/tests/utilities/test_fetching.py
+++ b/tests/utilities/test_fetching.py
@@ -216,7 +216,7 @@ def test_trainer_num_prefetch_batches(tmpdir):
 
     assert global_step == trainer.global_step == 4
     ratio = regular_duration / inter_batch_duration
-    assert False > 1.1, (regular_duration, inter_batch_duration, ratio)
+    assert ratio > 1.1, (regular_duration, inter_batch_duration, ratio)
 
 
 @pytest.mark.parametrize("automatic_optimization", [False, True])


### PR DESCRIPTION
## What does this PR do?

Refactors code introduced in #9047

- Remove (some) unnecessary abstractions and methods
- Removed some dead code
- Remove profiling, it's not necessary at the fetching level for now, `batch_to_device` is still profiled by `call_hook`.
- Removes hack to move the batches to device caused by an esoteric bug(?) where `enumerate` was keeping a reference to the batch alive after `training_step`. See https://github.com/PyTorchLightning/pytorch-lightning/pull/11466#discussion_r785254597

Possible follow-ups:
- Each loop should construct its own `step_kwargs`
- We can simplify further, there's really no need for an abstract interface at the moment.

Simplification is good just to reduce complexity, have faster code, and improve unit-testability which this area lacks.

Some average times over 3 runs using a dumb benchmark:

| Branch | Regular training (s) | InterBatchParallelism (s) | Speedup      |
|--------|----------------------|---------------------------|--------------|
| Master | 1.8212               | 1.3283                    | 1.3711       |
| #11466 | 1.8087               | 1.2795                    | 1.4136       |

which makes it 4.24% faster. Code:

<details>

```python
import os
from time import time
from typing import Any
from unittest import mock

import torch
from torch.utils.data import DataLoader, Dataset

from pytorch_lightning import Trainer
from tests.helpers import BoringModel


def get_cycles_per_ms() -> float:
    def measure() -> float:
        start = torch.cuda.Event(enable_timing=True)
        end = torch.cuda.Event(enable_timing=True)
        start.record()
        torch.cuda._sleep(1000000)
        end.record()
        end.synchronize()
        cycles_per_ms = 1000000 / start.elapsed_time(end)
        return cycles_per_ms

    num = 10
    vals = []
    for _ in range(num):
        vals.append(measure())
    vals = sorted(vals)
    stats = vals[2 : num - 2]
    return sum(stats) / len(stats)


BATCH_SIZE = 32
DATASET_LEN = 64
EMB_SZ = 100
EMB_DIM = 64


class RandomIndicesDataset(Dataset):
    def __getitem__(self, index):
        return torch.randint(EMB_DIM, [BATCH_SIZE])

    def __len__(self):
        return 16


class RecommenderModel(BoringModel):
    def __init__(self):
        super().__init__()
        self.layer = None
        self.local_embedding = torch.nn.Embedding(EMB_SZ, EMB_DIM)
        self.CYCLES_PER_MS = int(get_cycles_per_ms())

    def forward(self, indices: torch.Tensor):
        result = self.local_embedding(indices)
        return result

    def on_after_batch_transfer(self, batch: Any, dataloader_idx: int) -> Any:
        # emulate heavy routine
        torch.cuda._sleep(self.CYCLES_PER_MS * 50)
        return batch

    def training_step_end(self, training_step_outputs):
        # emulate heavy routine
        torch.cuda._sleep(self.CYCLES_PER_MS * 50)
        return training_step_outputs

    def configure_optimizers(self):
        return torch.optim.SGD(self.parameters(), lr=0.1)

    def train_dataloader(self):
        return DataLoader(RandomIndicesDataset(), batch_size=4)

    def val_dataloader(self):
        return DataLoader(RandomIndicesDataset(), batch_size=4)

    def test_dataloader(self):
        return DataLoader(RandomIndicesDataset(), batch_size=4)


model = RecommenderModel()

trainer_kwargs = dict(
    max_epochs=3,
    accelerator="gpu",
    devices=1,
    num_sanity_val_steps=0,
    enable_progress_bar=0,
    enable_checkpointing=False,
    logger=False,
    enable_model_summary=False,
)

trainer = Trainer(**trainer_kwargs)
with mock.patch.dict(os.environ, {"PL_INTER_BATCH_PARALLELISM": "1"}):
    t0 = time()
    trainer.fit(model)
    t1 = time()
inter_batch_duration = t1 - t0
global_step = trainer.global_step

torch.cuda.synchronize()

trainer = Trainer(**trainer_kwargs)
t2 = time()
trainer.fit(model)
t3 = time()
regular_duration = t3 - t2

print(regular_duration, inter_batch_duration, regular_duration / inter_batch_duration)
```

</details>

### Does your PR introduce any breaking changes? If yes, please list them.

All the data fetching implementations are experimental, so no.
But if you were using them, I definitely broke your code 🙈

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified


cc @justusschock @awaelchli @akihironitta @rohitgr7 @ninginthecloud @borda