### PR TITLE
Remove ignore F401

### DIFF
--- a/pytorch_lightning/accelerators/__init__.py
+++ b/pytorch_lightning/accelerators/__init__.py
@@ -10,8 +10,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pytorch_lightning.accelerators.accelerator import Accelerator  # noqa: F401
-from pytorch_lightning.accelerators.cpu import CPUAccelerator  # noqa: F401
-from pytorch_lightning.accelerators.gpu import GPUAccelerator  # noqa: F401
-from pytorch_lightning.accelerators.ipu import IPUAccelerator  # noqa: F401
-from pytorch_lightning.accelerators.tpu import TPUAccelerator  # noqa: F401
+from pytorch_lightning.accelerators.accelerator import Accelerator
+from pytorch_lightning.accelerators.cpu import CPUAccelerator
+from pytorch_lightning.accelerators.gpu import GPUAccelerator
+from pytorch_lightning.accelerators.ipu import IPUAccelerator
+from pytorch_lightning.accelerators.tpu import TPUAccelerator
+
+__all__ = [
+    "Accelerator",
+    "CPUAccelerator",
+    "GPUAccelerator",
+    "IPUAccelerator",
+    "TPUAccelerator",
+]


### PR DESCRIPTION
## What does this PR do?

Remove `F401` Ignoring part in `__init__.py`. Instead we use `__all__` to avoid it.

Relates to #11592