### PR TITLE
Remove `Strategy.on_tpu` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -413,7 +413,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed `Strategy.on_gpu` ([#11537](https://github.com/PyTorchLightning/pytorch-lightning/pull/11537))
 
 
-- Removed `Strategy.on_tpu` property ([]())
+- Removed `Strategy.on_tpu` property ([#11536](https://github.com/PyTorchLightning/pytorch-lightning/pull/11536))
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -413,6 +413,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed `Strategy.on_gpu` ([#11537](https://github.com/PyTorchLightning/pytorch-lightning/pull/11537))
 
 
+- Removed `Strategy.on_tpu` property ([]())
+
+
 ### Fixed
 
 - Fixed security vulnerabilities CVE-2020-1747 and CVE-2020-14343 caused by the `PyYAML` dependency ([#11099](https://github.com/PyTorchLightning/pytorch-lightning/pull/11099))

--- a/pytorch_lightning/strategies/parallel.py
+++ b/pytorch_lightning/strategies/parallel.py
@@ -25,7 +25,6 @@ from pytorch_lightning.plugins.environments.cluster_environment import ClusterEn
 from pytorch_lightning.plugins.io.checkpoint_plugin import CheckpointIO
 from pytorch_lightning.plugins.precision import PrecisionPlugin
 from pytorch_lightning.strategies.strategy import Strategy
-from pytorch_lightning.utilities import _XLA_AVAILABLE
 from pytorch_lightning.utilities.distributed import all_gather_ddp_if_available, ReduceOp
 
 
@@ -48,10 +47,6 @@ class ParallelStrategy(Strategy, ABC):
     @abstractmethod
     def root_device(self) -> torch.device:
         """Return the root device."""
-
-    @property
-    def on_tpu(self) -> bool:
-        return self.root_device.type == "xla" and _XLA_AVAILABLE
 
     @property
     def lightning_module(self) -> Optional["pl.LightningModule"]:

--- a/pytorch_lightning/strategies/single_device.py
+++ b/pytorch_lightning/strategies/single_device.py
@@ -21,7 +21,6 @@ import pytorch_lightning as pl
 from pytorch_lightning.plugins.io.checkpoint_plugin import CheckpointIO
 from pytorch_lightning.plugins.precision import PrecisionPlugin
 from pytorch_lightning.strategies.strategy import Strategy
-from pytorch_lightning.utilities import _XLA_AVAILABLE
 from pytorch_lightning.utilities.types import _DEVICE
 
 
@@ -40,10 +39,6 @@ class SingleDeviceStrategy(Strategy):
         self.global_rank = 0
         self.local_rank = 0
         self.world_size = 1
-
-    @property
-    def on_tpu(self) -> bool:
-        return self.root_device.type == "xla" and _XLA_AVAILABLE
 
     def reduce(self, tensor: Any | torch.Tensor, *args: Any, **kwargs: Any) -> Any | torch.Tensor:
         """Reduces a tensor from several distributed processes to one aggregated tensor. As this plugin only

--- a/pytorch_lightning/strategies/strategy.py
+++ b/pytorch_lightning/strategies/strategy.py
@@ -230,11 +230,6 @@ class Strategy(ABC):
 
     @property
     @abstractmethod
-    def on_tpu(self) -> bool:
-        """Returns whether the current process is done on TPU."""
-
-    @property
-    @abstractmethod
     def root_device(self) -> torch.device:
         """Returns the root device."""
 

--- a/tests/strategies/test_ddp_spawn_strategy.py
+++ b/tests/strategies/test_ddp_spawn_strategy.py
@@ -57,7 +57,6 @@ def test_ddp_cpu():
     # assert training type plugin attributes for device setting
 
     assert isinstance(trainer.strategy, DDPSpawnStrategy)
-    assert not trainer.strategy.on_tpu
     assert trainer.strategy.root_device == torch.device("cpu")
 
     model = BoringModelDDPCPU()

--- a/tests/strategies/test_ddp_strategy.py
+++ b/tests/strategies/test_ddp_strategy.py
@@ -39,7 +39,6 @@ def test_ddp_with_2_gpus():
     trainer = Trainer(gpus=2, strategy="ddp", fast_dev_run=True)
     # assert training type plugin attributes for device setting
     assert isinstance(trainer.strategy, DDPStrategy)
-    assert not trainer.strategy.on_tpu
     local_rank = trainer.strategy.local_rank
     assert trainer.strategy.root_device == torch.device(f"cuda:{local_rank}")
 

--- a/tests/strategies/test_single_device_strategy.py
+++ b/tests/strategies/test_single_device_strategy.py
@@ -23,10 +23,9 @@ from tests.helpers.runif import RunIf
 
 
 def test_single_cpu():
-    """Tests if on_tpu is set correctly for single CPU strategy."""
+    """Tests if device is set correctly for single CPU strategy."""
     trainer = Trainer()
     assert isinstance(trainer.strategy, SingleDeviceStrategy)
-    assert not trainer.strategy.on_tpu
     assert trainer.strategy.root_device == torch.device("cpu")
 
 
@@ -43,7 +42,6 @@ def test_single_gpu():
     trainer = Trainer(gpus=1, fast_dev_run=True)
     # assert training strategy attributes for device setting
     assert isinstance(trainer.strategy, SingleDeviceStrategy)
-    assert not trainer.strategy.on_tpu
     assert trainer.strategy.root_device == torch.device("cuda:0")
 
     model = BoringModelGPU()

--- a/tests/strategies/test_tpu_spawn.py
+++ b/tests/strategies/test_tpu_spawn.py
@@ -96,7 +96,6 @@ def test_model_tpu_one_core():
     trainer = Trainer(tpu_cores=1, fast_dev_run=True, strategy=TPUSpawnStrategy(debug=True))
     # assert training strategy attributes for device setting
     assert isinstance(trainer.strategy, TPUSpawnStrategy)
-    assert trainer.strategy.on_tpu
     assert trainer.strategy.root_device == torch.device("xla", index=1)
     model = BoringModelTPU()
     trainer.fit(model)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Part of #10416 

Reasons for removal:
- This can be deduced from the `root_device` property. The property `on_tpu` is redundant yet it's also an `abstractmethod`. Requiring every strategy class to implement this is boilerplate.
- We don't offer `on_ipu` or `on_X` for existing accelerator implementations
- Given the Accelerator is also customizable/pluggable, the pattern of offering `on_gpu` and `on_tpu` flags doesn't scale.

### Does your PR introduce any breaking changes? If yes, please list them.

Yes: removes the `on_tpu` property from the Strategy base class.
Reason: The strategy is still an experimental API, and this is part of making it stable

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
