### PR TITLE
Support no pre-fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `LightningModule.lr_scheduler_step` ([#10249](https://github.com/PyTorchLightning/pytorch-lightning/pull/10249))
 
 
-- Added support for no pre-fetching to `class DataFetcher(AbstractDataFetcher)`
+- Added support for no pre-fetching to `DataFetcher` ([#11606](https://github.com/PyTorchLightning/pytorch-lightning/pull/11606))
 
 
 - Added `opt_idx` to scheduler config if not assigned by user ([#11247](https://github.com/PyTorchLightning/pytorch-lightning/pull/11247))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added `LightningModule.lr_scheduler_step` ([#10249](https://github.com/PyTorchLightning/pytorch-lightning/pull/10249))
 
 
+- Added support for no pre-fetching to `class DataFetcher(AbstractDataFetcher)`
+
+
 - Added `opt_idx` to scheduler config if not assigned by user ([#11247](https://github.com/PyTorchLightning/pytorch-lightning/pull/11247))
 
 

--- a/pytorch_lightning/utilities/fetching.py
+++ b/pytorch_lightning/utilities/fetching.py
@@ -237,18 +237,28 @@ class DataFetcher(AbstractDataFetcher):
 
     def fetching_function(self) -> Tuple[Any, bool]:
         if self.batches:
+            # we pre-fetched, consume one
             batch = self.batches.pop(0)
-        else:
-            # empty iterator, no prefetching done
-            raise StopIteration
-        if not self.done:
-            assert self.dataloader_iter is not None
             try:
+                # and replace it
                 self._fetch_next_batch(self.dataloader_iter)
             except StopIteration:
+                self.done = not self.batches
+
+        elif not self.done:
+            # we did not prefetch at all
+            try:
+                self._fetch_next_batch(self.dataloader_iter)
+                batch = self.batches.pop(0)
+            except StopIteration as e:
                 self.done = True
+                raise e
+
+        else:
+            raise StopIteration
+
         self.wait()
-        return self.move_to_device(batch), len(self.batches) == 0
+        return self.move_to_device(batch), self.done
 
     def _fetch_next_batch(self, iterator: Iterator) -> None:
         start_output = self.on_fetch_start()

--- a/pytorch_lightning/utilities/fetching.py
+++ b/pytorch_lightning/utilities/fetching.py
@@ -236,22 +236,26 @@ class DataFetcher(AbstractDataFetcher):
     def fetching_function(self) -> Tuple[Any, bool]:
         assert self.dataloader_iter is not None
         if self.batches:
-            # we pre-fetched, consume one
+            # there are pre-fetched batches already from a previous `prefetching` call.
+            # consume one
             batch = self.batches.pop(0)
             try:
-                # and replace it
+                # refill the consumed batch
                 self._fetch_next_batch(self.dataloader_iter)
             except StopIteration:
+                # no more batches to fetch. we are done only if all pre-fetched batches were returned
                 self.done = not self.batches
         elif not self.done:
-            # we did not prefetch at all
+            # this will run only when no pre-fetching was done.
             try:
                 self._fetch_next_batch(self.dataloader_iter)
+                # consume the batch we just fetched
                 batch = self.batches.pop(0)
             except StopIteration as e:
                 self.done = True
                 raise e
         else:
+            # the iterator is empty
             raise StopIteration
         self.wait()
         return self.move_to_device(batch), self.done

--- a/pytorch_lightning/utilities/fetching.py
+++ b/pytorch_lightning/utilities/fetching.py
@@ -203,13 +203,11 @@ class AbstractDataFetcher(ABC):
 
 
 class DataFetcher(AbstractDataFetcher):
-
-    """This class is used to control batch fetching flow. By default, the ``fetching_function`` will pre-fetch a
-    batch in advance to detect the end of the iteration.
+    """This class is used to control batch fetching flow.
 
     Args:
-        prefetch_batches: Number of batches to be pre-fetched. Lightning will pre-fetch
-            at least 1 batch for tracking the latest batch.
+        prefetch_batches: Number of batches to pre-fetch. Pre-fetching at least 1 batch is necessasry to properly track
+            whether a batch is the last one (available with :attr:`self.done`).
         store_on_device: Whether to store the pre-fetched batches on device.
     """
 

--- a/pytorch_lightning/utilities/fetching.py
+++ b/pytorch_lightning/utilities/fetching.py
@@ -206,7 +206,7 @@ class DataFetcher(AbstractDataFetcher):
     """This class is used to control batch fetching flow.
 
     Args:
-        prefetch_batches: Number of batches to pre-fetch. Pre-fetching at least 1 batch is necessasry to properly track
+        prefetch_batches: Number of batches to pre-fetch. Pre-fetching at least 1 batch is necessary to properly track
             whether a batch is the last one (available with :attr:`self.done`).
         store_on_device: Whether to store the pre-fetched batches on device.
     """

--- a/pytorch_lightning/utilities/fetching.py
+++ b/pytorch_lightning/utilities/fetching.py
@@ -210,8 +210,6 @@ class DataFetcher(AbstractDataFetcher):
     """
 
     def __init__(self, prefetch_batches: int = 1, store_on_device: bool = True) -> None:
-        if prefetch_batches < 1:
-            raise MisconfigurationException("`prefetch_batches` should at least be 1.")
         super().__init__(prefetch_batches=prefetch_batches)
         self.store_on_device = store_on_device
         self.batch_to_device: Callable[[Any], Any] = _no_op_batch_to_device

--- a/pytorch_lightning/utilities/fetching.py
+++ b/pytorch_lightning/utilities/fetching.py
@@ -234,6 +234,7 @@ class DataFetcher(AbstractDataFetcher):
                 break
 
     def fetching_function(self) -> Tuple[Any, bool]:
+        assert self.dataloader_iter is not None
         if self.batches:
             # we pre-fetched, consume one
             batch = self.batches.pop(0)
@@ -242,7 +243,6 @@ class DataFetcher(AbstractDataFetcher):
                 self._fetch_next_batch(self.dataloader_iter)
             except StopIteration:
                 self.done = not self.batches
-
         elif not self.done:
             # we did not prefetch at all
             try:
@@ -251,10 +251,8 @@ class DataFetcher(AbstractDataFetcher):
             except StopIteration as e:
                 self.done = True
                 raise e
-
         else:
             raise StopIteration
-
         self.wait()
         return self.move_to_device(batch), self.done
 

--- a/tests/utilities/test_fetching.py
+++ b/tests/utilities/test_fetching.py
@@ -51,18 +51,21 @@ def test_prefetch_iterator(use_combined_loader):
         iterator.setup(loader)
 
         def generate():
-            generated = []
-            for idx, data in enumerate(iterator, prefetch_batches + 1):
-                assert iterator.fetched == 3 if iterator.done else idx
-                generated.append(data)
+            generated = [(iterator.fetched, *data) for i, data in enumerate(iterator, prefetch_batches + 1)]
+            assert iterator.fetched == 3
+            assert iterator.done
             return generated
 
         is_last_batch = [False, False, prefetch_batches > 0]
+        fetched = list(range(prefetch_batches + 1, 4))
+        fetched += [3] * (3 - len(fetched))
         if use_combined_loader:
             batches = [[tensor(1), tensor(1)], [tensor(2), tensor(2)], [tensor(3), tensor(3)]]
         else:
             batches = [1, 2, 3]
-        expected = list(zip(batches, is_last_batch))
+        expected = list(zip(fetched, batches, is_last_batch))
+        assert len(expected) == 3
+
         assert generate() == expected
         # validate reset works properly.
         assert generate() == expected
@@ -72,9 +75,9 @@ def test_prefetch_iterator(use_combined_loader):
         def __iter__(self):
             return iter([])
 
-    dataloader = DataLoader(EmptyIterDataset())
+    loader = DataLoader(EmptyIterDataset())
     iterator = DataFetcher()
-    iterator.setup(dataloader)
+    iterator.setup(loader)
     assert not list(iterator)
 
 


### PR DESCRIPTION
## What does this PR do?

Adds support for no-prefetching.
This was proposed by @justusschock in https://github.com/PyTorchLightning/pytorch-lightning/pull/11516#discussion_r786558553.
Also means users do not need to patch the Loops to disable it as it is done by some `ffcv` users.

One drawback is that `is_last_batch` will not be correctly set in this case.

Part of #11538 

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @borda @justusschock @awaelchli @ninginthecloud