### PR TITLE
Update requirements.txt for `pyDeprecate` version flexibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ PyYAML>=5.4
 fsspec[http]>=2021.05.0, !=2021.06.0
 tensorboard>=2.2.0
 torchmetrics>=0.4.1
-pyDeprecate==0.3.1
+pyDeprecate>=0.3.1, <0.4.0
 packaging>=17.0
 typing-extensions>=4.0.0


### PR DESCRIPTION
## What does this PR do?

It introduces flexibility of version installation for the `pyDeprecate` included in the requirements.txt

Fixes #11600 