### PR TITLE
[CLI] Fix bug that forces overriding `configure_optimizers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -445,6 +445,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed the format of the configuration saved automatically by the CLI's `SaveConfigCallback` ([#11532](https://github.com/PyTorchLightning/pytorch-lightning/pull/11532))
 
 
+- Fixed bug that forced overriding `configure_optimizers` with the CLI ([#11672](https://github.com/PyTorchLightning/pytorch-lightning/pull/11672))
+
+
 - Fixed type promotion when tensors of higher category than float are logged ([#11401](https://github.com/PyTorchLightning/pytorch-lightning/pull/11401))
 
 

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -792,7 +792,7 @@ class LightningCLI:
         optimizer = instantiate_class(self.model.parameters(), optimizer_init)
         lr_scheduler = instantiate_class(optimizer, lr_scheduler_init) if lr_scheduler_init else None
         fn = partial(self.configure_optimizers, optimizer=optimizer, lr_scheduler=lr_scheduler)
-        update_wrapper(fn, self.model.configure_optimizers)  # necessary for `is_overridden`
+        update_wrapper(fn, self.configure_optimizers)  # necessary for `is_overridden`
         # override the existing method
         self.model.configure_optimizers = MethodType(fn, self.model)
 

--- a/tests/utilities/test_cli.py
+++ b/tests/utilities/test_cli.py
@@ -1464,6 +1464,5 @@ def test_cli_no_need_configure_optimizers():
         wraps=__verify_train_val_loop_configuration,
     ) as verify:
         cli = LightningCLI(BoringModel)
-    # `__verify_train_val_loop_configuration` should have been called
     run.assert_called_once()
     verify.assert_called_once_with(cli.trainer, cli.model)

--- a/tests/utilities/test_cli.py
+++ b/tests/utilities/test_cli.py
@@ -659,6 +659,33 @@ def test_lightning_cli_optimizer_and_lr_scheduler(tmpdir):
     assert cli.trainer.lr_scheduler_configs[0].scheduler.gamma == 0.8
 
 
+def test_cli_no_need_configure_optimizers():
+    class BoringModel(LightningModule):
+        def __init__(self):
+            super().__init__()
+            self.layer = torch.nn.Linear(32, 2)
+
+        def training_step(self, *_):
+            ...
+
+        def train_dataloader(self):
+            ...
+
+        # did not define `configure_optimizers`
+
+    from pytorch_lightning.trainer.configuration_validator import __verify_train_val_loop_configuration
+
+    with mock.patch("sys.argv", ["any.py", "fit", "--optimizer=Adam"]), mock.patch(
+        "pytorch_lightning.Trainer._run_train"
+    ) as run, mock.patch(
+        "pytorch_lightning.trainer.configuration_validator.__verify_train_val_loop_configuration",
+        wraps=__verify_train_val_loop_configuration,
+    ) as verify:
+        cli = LightningCLI(BoringModel)
+    run.assert_called_once()
+    verify.assert_called_once_with(cli.trainer, cli.model)
+
+
 def test_lightning_cli_optimizer_and_lr_scheduler_subclasses(tmpdir):
     class MyLightningCLI(LightningCLI):
         def add_arguments_to_parser(self, parser):
@@ -1439,30 +1466,3 @@ def test_cli_parameter_with_lazy_instance_default():
         assert isinstance(cli.model.activation, torch.nn.LeakyReLU)
         assert cli.model.activation.negative_slope == 0.05
         assert cli.model.activation is not model.activation
-
-
-def test_cli_no_need_configure_optimizers():
-    class BoringModel(LightningModule):
-        def __init__(self):
-            super().__init__()
-            self.layer = torch.nn.Linear(32, 2)
-
-        def training_step(self, *_):
-            ...
-
-        def train_dataloader(self):
-            ...
-
-        # did not define `configure_optimizers`
-
-    from pytorch_lightning.trainer.configuration_validator import __verify_train_val_loop_configuration
-
-    with mock.patch("sys.argv", ["any.py", "fit", "--optimizer=Adam"]), mock.patch(
-        "pytorch_lightning.Trainer._run_train"
-    ) as run, mock.patch(
-        "pytorch_lightning.trainer.configuration_validator.__verify_train_val_loop_configuration",
-        wraps=__verify_train_val_loop_configuration,
-    ) as verify:
-        cli = LightningCLI(BoringModel)
-    run.assert_called_once()
-    verify.assert_called_once_with(cli.trainer, cli.model)

--- a/tests/utilities/test_cli.py
+++ b/tests/utilities/test_cli.py
@@ -1465,5 +1465,5 @@ def test_cli_no_need_configure_optimizers():
     ) as verify:
         cli = LightningCLI(BoringModel)
     # `__verify_train_val_loop_configuration` should have been called
-    assert run.called
+    run.assert_called_once()
     verify.assert_called_once_with(cli.trainer, cli.model)


### PR DESCRIPTION
## What does this PR do?

Fixes the `__wrapped__` reference on the patched `configure_optimizers` by the CLI.

Noticed while checking #11628

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @borda @carmocca @mauvilsa