### PR TITLE
Update `tests/trainer/*.py` to use `devices` instead of `gpus` or `ipus`

### DIFF
--- a/tests/trainer/flags/test_env_vars.py
+++ b/tests/trainer/flags/test_env_vars.py
@@ -48,9 +48,9 @@ def test_passing_env_variables_defaults():
 @mock.patch.dict(os.environ, {"CUDA_VISIBLE_DEVICES": "0,1", "PL_TRAINER_GPUS": "2"})
 @mock.patch("torch.cuda.device_count", return_value=2)
 @mock.patch("torch.cuda.is_available", return_value=True)
-def test_passing_env_variables_gpus(cuda_available_mock, device_count_mock):
+def test_passing_env_variables_devices(cuda_available_mock, device_count_mock):
     """Testing overwriting trainer arguments."""
     trainer = Trainer()
-    assert trainer.gpus == 2
+    assert trainer.devices == 2
     trainer = Trainer(accelerator="gpu", devices=1)
-    assert trainer.gpus == 1
+    assert trainer.devices == 1

--- a/tests/trainer/flags/test_env_vars.py
+++ b/tests/trainer/flags/test_env_vars.py
@@ -52,5 +52,5 @@ def test_passing_env_variables_gpus(cuda_available_mock, device_count_mock):
     """Testing overwriting trainer arguments."""
     trainer = Trainer()
     assert trainer.gpus == 2
-    trainer = Trainer(gpus=1)
+    trainer = Trainer(accelerator="gpu", devices=1)
     assert trainer.gpus == 1

--- a/tests/trainer/flags/test_overfit_batches.py
+++ b/tests/trainer/flags/test_overfit_batches.py
@@ -127,8 +127,9 @@ def test_distributed_sampler_with_overfit_batches():
     model = BoringModel()
     trainer = Trainer(
         overfit_batches=1,
+        accelerator="cpu",
+        devices=2,
         strategy="ddp_spawn",
-        num_processes=2,
     )
     model.trainer = trainer
     trainer.model = model

--- a/tests/trainer/logging_/test_distributed_logging.py
+++ b/tests/trainer/logging_/test_distributed_logging.py
@@ -65,8 +65,9 @@ def test_all_rank_logging_ddp_cpu(tmpdir):
     model = TestModel()
     all_rank_logger = AllRankLogger()
     trainer = Trainer(
+        accelerator="cpu",
+        devices=2,
         strategy="ddp_spawn",
-        num_processes=2,
         default_root_dir=tmpdir,
         limit_train_batches=1,
         limit_val_batches=1,

--- a/tests/trainer/logging_/test_distributed_logging.py
+++ b/tests/trainer/logging_/test_distributed_logging.py
@@ -86,7 +86,8 @@ def test_all_rank_logging_ddp_spawn(tmpdir):
     model.training_epoch_end = None
     trainer = Trainer(
         strategy="ddp_spawn",
-        gpus=2,
+        accelerator="gpu",
+        devices=2,
         default_root_dir=tmpdir,
         limit_train_batches=1,
         limit_val_batches=1,

--- a/tests/trainer/logging_/test_eval_loop_logging.py
+++ b/tests/trainer/logging_/test_eval_loop_logging.py
@@ -707,7 +707,7 @@ def test_evaluation_move_metrics_to_cpu_and_outputs(tmpdir):
             assert self.trainer.callback_metrics["foo"].device.type == "cpu"
 
     model = TestModel()
-    trainer = Trainer(default_root_dir=tmpdir, limit_val_batches=2, move_metrics_to_cpu=True, gpus=1)
+    trainer = Trainer(default_root_dir=tmpdir, limit_val_batches=2, move_metrics_to_cpu=True, accelerator="gpu", devices=1)
     trainer.validate(model, verbose=False)
 
 

--- a/tests/trainer/logging_/test_eval_loop_logging.py
+++ b/tests/trainer/logging_/test_eval_loop_logging.py
@@ -707,7 +707,9 @@ def test_evaluation_move_metrics_to_cpu_and_outputs(tmpdir):
             assert self.trainer.callback_metrics["foo"].device.type == "cpu"
 
     model = TestModel()
-    trainer = Trainer(default_root_dir=tmpdir, limit_val_batches=2, move_metrics_to_cpu=True, accelerator="gpu", devices=1)
+    trainer = Trainer(
+        default_root_dir=tmpdir, limit_val_batches=2, move_metrics_to_cpu=True, accelerator="gpu", devices=1
+    )
     trainer.validate(model, verbose=False)
 
 

--- a/tests/trainer/logging_/test_logger_connector.py
+++ b/tests/trainer/logging_/test_logger_connector.py
@@ -335,7 +335,13 @@ def test_epoch_results_cache_dp(tmpdir):
 
     model = TestModel()
     trainer = Trainer(
-        default_root_dir=tmpdir, strategy="dp", accelerator="gpu", devices=2, limit_train_batches=2, limit_val_batches=2, max_epochs=1
+        default_root_dir=tmpdir,
+        strategy="dp",
+        accelerator="gpu",
+        devices=2,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        max_epochs=1,
     )
     trainer.fit(model)
     trainer.test(model)

--- a/tests/trainer/logging_/test_logger_connector.py
+++ b/tests/trainer/logging_/test_logger_connector.py
@@ -335,7 +335,7 @@ def test_epoch_results_cache_dp(tmpdir):
 
     model = TestModel()
     trainer = Trainer(
-        default_root_dir=tmpdir, strategy="dp", gpus=2, limit_train_batches=2, limit_val_batches=2, max_epochs=1
+        default_root_dir=tmpdir, strategy="dp", accelerator="gpu", devices=2, limit_train_batches=2, limit_val_batches=2, max_epochs=1
     )
     trainer.fit(model)
     trainer.test(model)

--- a/tests/trainer/logging_/test_train_loop_logging.py
+++ b/tests/trainer/logging_/test_train_loop_logging.py
@@ -467,7 +467,8 @@ def test_logging_sync_dist_true_ddp(tmpdir):
         max_epochs=2,
         enable_model_summary=False,
         strategy="ddp",
-        gpus=2,
+        accelerator="gpu",
+        devices=2,
         profiler="pytorch",
     )
     trainer.fit(model)
@@ -589,7 +590,8 @@ def test_metric_are_properly_reduced(tmpdir):
     model = TestingModel()
     trainer = Trainer(
         default_root_dir=tmpdir,
-        gpus=1,
+        accelerator="gpu",
+        devices=1,
         max_epochs=2,
         limit_train_batches=5,
         limit_val_batches=32,
@@ -710,7 +712,8 @@ def test_move_metrics_to_cpu(tmpdir):
         amp_backend="native",
         precision=16,
         move_metrics_to_cpu=True,
-        gpus=1,
+        accelerator="gpu",
+        devices=1,
     )
     trainer.fit(TestModel())
 

--- a/tests/trainer/optimization/test_manual_optimization.py
+++ b/tests/trainer/optimization/test_manual_optimization.py
@@ -67,9 +67,9 @@ class ManualOptModel(BoringModel):
     "kwargs",
     [
         {},
-        pytest.param({"devices": 1, "precision": 16, "amp_backend": "native"}, marks=RunIf(min_gpus=1)),
+        pytest.param({"accelerator": "gpu", "devices": 1, "precision": 16, "amp_backend": "native"}, marks=RunIf(min_gpus=1)),
         pytest.param(
-            {"devices": 1, "precision": 16, "amp_backend": "apex", "amp_level": "O2"},
+            {"accelerator": "gpu", "devices": 1, "precision": 16, "amp_backend": "apex", "amp_level": "O2"},
             marks=RunIf(amp_apex=True, min_gpus=1),
         ),
     ],
@@ -118,7 +118,6 @@ def test_multiple_optimizers_manual_no_return(tmpdir, kwargs):
         max_epochs=1,
         log_every_n_steps=1,
         enable_model_summary=False,
-        accelerator="gpu",
         **kwargs,
     )
 

--- a/tests/trainer/optimization/test_manual_optimization.py
+++ b/tests/trainer/optimization/test_manual_optimization.py
@@ -67,9 +67,9 @@ class ManualOptModel(BoringModel):
     "kwargs",
     [
         {},
-        pytest.param({"gpus": 1, "precision": 16, "amp_backend": "native"}, marks=RunIf(min_gpus=1)),
+        pytest.param({"devices": 1, "precision": 16, "amp_backend": "native"}, marks=RunIf(min_gpus=1)),
         pytest.param(
-            {"gpus": 1, "precision": 16, "amp_backend": "apex", "amp_level": "O2"},
+            {"devices": 1, "precision": 16, "amp_backend": "apex", "amp_level": "O2"},
             marks=RunIf(amp_apex=True, min_gpus=1),
         ),
     ],
@@ -118,6 +118,7 @@ def test_multiple_optimizers_manual_no_return(tmpdir, kwargs):
         max_epochs=1,
         log_every_n_steps=1,
         enable_model_summary=False,
+        accelerator="gpu",
         **kwargs,
     )
 
@@ -209,7 +210,8 @@ def test_multiple_optimizers_manual_native_amp(tmpdir):
         log_every_n_steps=1,
         enable_model_summary=False,
         precision=16,
-        gpus=1,
+        accelerator="gpu",
+        devices=1,
     )
 
     with mock.patch.object(Strategy, "backward", wraps=trainer.strategy.backward) as bwd_mock:
@@ -296,7 +298,8 @@ def test_manual_optimization_and_return_tensor(tmpdir):
         precision=16,
         amp_backend="native",
         strategy="ddp_spawn",
-        gpus=2,
+        accelerator="gpu",
+        devices=2,
     )
     trainer.fit(model)
 
@@ -383,7 +386,8 @@ def test_manual_optimization_and_accumulated_gradient(tmpdir):
         limit_val_batches=0,
         precision=16,
         amp_backend="native",
-        gpus=1,
+        accelerator="gpu",
+        devices=1,
     )
     trainer.fit(model)
 
@@ -466,7 +470,8 @@ def test_multiple_optimizers_step(tmpdir):
         enable_model_summary=False,
         precision=16,
         amp_backend="native",
-        gpus=1,
+        accelerator="gpu",
+        devices=1,
         track_grad_norm=2,
     )
 
@@ -830,7 +835,8 @@ def train_manual_optimization(tmpdir, strategy, model_cls=TesManualOptimizationD
         limit_val_batches=2,
         max_epochs=1,
         log_every_n_steps=1,
-        gpus=2,
+        accelerator="gpu",
+        devices=2,
         strategy=strategy,
     )
 
@@ -1074,7 +1080,8 @@ def test_multiple_optimizers_logging(precision, tmpdir):
         max_epochs=1,
         log_every_n_steps=1,
         enable_model_summary=False,
-        gpus=1,
+        accelerator="gpu",
+        devices=1,
         precision=precision,
     )
 

--- a/tests/trainer/optimization/test_manual_optimization.py
+++ b/tests/trainer/optimization/test_manual_optimization.py
@@ -67,7 +67,9 @@ class ManualOptModel(BoringModel):
     "kwargs",
     [
         {},
-        pytest.param({"accelerator": "gpu", "devices": 1, "precision": 16, "amp_backend": "native"}, marks=RunIf(min_gpus=1)),
+        pytest.param(
+            {"accelerator": "gpu", "devices": 1, "precision": 16, "amp_backend": "native"}, marks=RunIf(min_gpus=1)
+        ),
         pytest.param(
             {"accelerator": "gpu", "devices": 1, "precision": 16, "amp_backend": "apex", "amp_level": "O2"},
             marks=RunIf(amp_apex=True, min_gpus=1),

--- a/tests/trainer/properties/test_get_model.py
+++ b/tests/trainer/properties/test_get_model.py
@@ -49,8 +49,9 @@ def test_get_model_ddp_cpu(tmpdir):
         limit_train_batches=limit_train_batches,
         limit_val_batches=2,
         max_epochs=1,
+        accelerator="cpu",
+        devices=2,
         strategy="ddp_spawn",
-        num_processes=2,
     )
     trainer.fit(model)
 

--- a/tests/trainer/properties/test_get_model.py
+++ b/tests/trainer/properties/test_get_model.py
@@ -64,6 +64,11 @@ def test_get_model_gpu(tmpdir):
 
     limit_train_batches = 2
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_train_batches=limit_train_batches, limit_val_batches=2, max_epochs=1, accelerator="gpu", devices=1
+        default_root_dir=tmpdir,
+        limit_train_batches=limit_train_batches,
+        limit_val_batches=2,
+        max_epochs=1,
+        accelerator="gpu",
+        devices=1,
     )
     trainer.fit(model)

--- a/tests/trainer/properties/test_get_model.py
+++ b/tests/trainer/properties/test_get_model.py
@@ -63,6 +63,6 @@ def test_get_model_gpu(tmpdir):
 
     limit_train_batches = 2
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_train_batches=limit_train_batches, limit_val_batches=2, max_epochs=1, gpus=1
+        default_root_dir=tmpdir, limit_train_batches=limit_train_batches, limit_val_batches=2, max_epochs=1, accelerator="gpu", devices=1
     )
     trainer.fit(model)

--- a/tests/trainer/test_data_loading.py
+++ b/tests/trainer/test_data_loading.py
@@ -87,7 +87,7 @@ def test_replace_distributed_sampler(tmpdir, mode):
     model.test_epoch_end = None
 
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_test_batches=2, strategy="ddp_find_unused_parameters_false", num_processes=1
+        default_root_dir=tmpdir, limit_test_batches=2, accelerator="cpu", devices=1, strategy="ddp_find_unused_parameters_false",
     )
     trainer.test(model)
 
@@ -128,7 +128,7 @@ class TestSpawnBoringModel(BoringModel):
 @RunIf(skip_windows=True, skip_49370=True)
 @pytest.mark.parametrize("num_workers", [0, 1])
 def test_dataloader_warnings(tmpdir, num_workers):
-    trainer = Trainer(default_root_dir=tmpdir, strategy="ddp_spawn", num_processes=2, fast_dev_run=4)
+    trainer = Trainer(default_root_dir=tmpdir, accelerator="cpu", devices=2, strategy="ddp_spawn", fast_dev_run=4)
     assert trainer._accelerator_connector._strategy_type == _StrategyType.DDP_SPAWN
     trainer.fit(TestSpawnBoringModel(num_workers))
 
@@ -243,7 +243,7 @@ def test_dataloader_reinit_for_subclass():
             self.dummy_kwarg = dummy_kwarg
             self.something_unrelated = 1
 
-    trainer = Trainer(num_processes=2, strategy="ddp_spawn")
+    trainer = Trainer(accelerator="cpu", devices=2, strategy="ddp_spawn")
 
     class CustomDummyObj:
         sampler = None

--- a/tests/trainer/test_data_loading.py
+++ b/tests/trainer/test_data_loading.py
@@ -87,7 +87,11 @@ def test_replace_distributed_sampler(tmpdir, mode):
     model.test_epoch_end = None
 
     trainer = Trainer(
-        default_root_dir=tmpdir, limit_test_batches=2, accelerator="cpu", devices=1, strategy="ddp_find_unused_parameters_false",
+        default_root_dir=tmpdir,
+        limit_test_batches=2,
+        accelerator="cpu",
+        devices=1,
+        strategy="ddp_find_unused_parameters_false",
     )
     trainer.test(model)
 

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -914,7 +914,12 @@ def test_batch_size_smaller_than_num_gpus(tmpdir):
     model = CurrentTestModel(batch_size=batch_size)
 
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=0.1, limit_val_batches=0, accelerator="gpu", devices=num_gpus
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_train_batches=0.1,
+        limit_val_batches=0,
+        accelerator="gpu",
+        devices=num_gpus,
     )
 
     # we expect the reduction for the metrics also to happen on the last batch

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -721,7 +721,7 @@ def test_auto_add_worker_init_fn_distributed(tmpdir, monkeypatch):
 
     dataloader = DataLoader(dataset, batch_size=batch_size, num_workers=num_workers)
     seed_everything(0, workers=True)
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, gpus=2, strategy="ddp_spawn")
+    trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, accelerator="gpu", devices=2, strategy="ddp_spawn")
     model = MultiProcessModel()
     model.val_dataloader = None
     trainer.fit(model, train_dataloaders=dataloader)
@@ -842,7 +842,8 @@ def test_dataloader_distributed_sampler(tmpdir):
     seed_everything(123)
     model = BoringModel()
     trainer = Trainer(
-        gpus=[0, 1],
+        accelerator="gpu",
+        devices=[0, 1],
         num_nodes=1,
         strategy="ddp_spawn",
         default_root_dir=tmpdir,
@@ -867,7 +868,8 @@ def test_dataloader_distributed_sampler_already_attached(tmpdir):
     seed_everything(123)
     model = ModelWithDataLoaderDistributedSampler()
     trainer = Trainer(
-        gpus=[0, 1],
+        accelerator="gpu",
+        devices=[0, 1],
         num_nodes=1,
         strategy="ddp_spawn",
         default_root_dir=tmpdir,
@@ -912,7 +914,7 @@ def test_batch_size_smaller_than_num_gpus(tmpdir):
     model = CurrentTestModel(batch_size=batch_size)
 
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=0.1, limit_val_batches=0, gpus=num_gpus
+        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=0.1, limit_val_batches=0, accelerator="gpu", devices=num_gpus
     )
 
     # we expect the reduction for the metrics also to happen on the last batch

--- a/tests/trainer/test_supporters.py
+++ b/tests/trainer/test_supporters.py
@@ -349,7 +349,7 @@ def test_combined_data_loader_validation_test(
 
     with mock.patch.dict(os.environ, {"PL_FAULT_TOLERANT_TRAINING": str(int(use_fault_tolerant))}):
 
-        trainer = Trainer(replace_sampler_ddp=replace_sampler_ddp, strategy="ddp", gpus=2)
+        trainer = Trainer(replace_sampler_ddp=replace_sampler_ddp, strategy="ddp", accelerator="gpu", devices=2)
         dataloader = trainer._data_connector._prepare_dataloader(dataloader, shuffle=True)
         _count = 0
         _has_fastforward_sampler = False

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1097,7 +1097,7 @@ def test_gpu_choice(tmpdir):
     num_gpus = torch.cuda.device_count()
     Trainer(**trainer_options, accelerator="gpu", devices=num_gpus, auto_select_gpus=True)
 
-    with pytest.raises(RuntimeError, match=r".*But your machine only has.*"):
+    with pytest.raises(MisconfigurationException, match=r".*But your machine only has.*"):
         Trainer(**trainer_options, accelerator="gpu", devices=num_gpus + 1, auto_select_gpus=True)
 
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1175,7 +1175,7 @@ def test_num_sanity_val_steps_neg_one(tmpdir, limit_val_batches):
         assert mocked.call_count == sum(trainer.num_val_batches)
 
 
-@pytest.mark.parametrize( # TODO: please update tests, @daniellepintz
+@pytest.mark.parametrize(  # TODO: please update tests, @daniellepintz
     "trainer_kwargs,expected",
     [
         (
@@ -1309,7 +1309,10 @@ def test_trainer_subclassing():
 
 
 @RunIf(omegaconf=True)
-@pytest.mark.parametrize("trainer_params", [{"max_epochs": 1, "accelerator":"gpu", "devices": 1}, {"max_epochs": 1, "accelerator":"gpu", "devices": [0]}])
+@pytest.mark.parametrize(
+    "trainer_params",
+    [{"max_epochs": 1, "accelerator": "gpu", "devices": 1}, {"max_epochs": 1, "accelerator": "gpu", "devices": [0]}],
+)
 @mock.patch("torch.cuda.device_count", return_value=1)
 def test_trainer_omegaconf(_, trainer_params):
     config = OmegaConf.create(trainer_params)
@@ -1918,7 +1921,13 @@ def test_ddp_terminate_when_deadlock_is_detected(tmpdir):
     model = TestModel()
 
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=5, num_sanity_val_steps=0, accelerator="gpu", devices=2, strategy="ddp"
+        default_root_dir=tmpdir,
+        max_epochs=1,
+        limit_train_batches=5,
+        num_sanity_val_steps=0,
+        accelerator="gpu",
+        devices=2,
+        strategy="ddp",
     )
 
     # simulate random failure in training_step on rank 0
@@ -2091,7 +2100,7 @@ def test_detect_anomaly_nan(tmpdir):
             trainer.fit(model)
 
 
-@pytest.mark.parametrize( # TODO: please update tests, @daniellepintz
+@pytest.mark.parametrize(  # TODO: please update tests, @daniellepintz
     "trainer_kwargs,expected",
     [
         (

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1098,10 +1098,10 @@ def test_gpu_choice(tmpdir):
         return
 
     num_gpus = torch.cuda.device_count()
-    Trainer(**trainer_options, gpus=num_gpus, auto_select_gpus=True)
+    Trainer(**trainer_options, accelerator="gpu", devices=num_gpus, auto_select_gpus=True)
 
     with pytest.raises(RuntimeError, match=r".*No GPUs available.*"):
-        Trainer(**trainer_options, gpus=num_gpus + 1, auto_select_gpus=True)
+        Trainer(**trainer_options, accelerator="gpu", devices=num_gpus + 1, auto_select_gpus=True)
 
 
 @pytest.mark.parametrize("limit_val_batches", [0.0, 1, 1.0, 0.5, 5])
@@ -1175,7 +1175,7 @@ def test_num_sanity_val_steps_neg_one(tmpdir, limit_val_batches):
         assert mocked.call_count == sum(trainer.num_val_batches)
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize( # TODO: please update tests, @daniellepintz
     "trainer_kwargs,expected",
     [
         (
@@ -1309,7 +1309,7 @@ def test_trainer_subclassing():
 
 
 @RunIf(omegaconf=True)
-@pytest.mark.parametrize("trainer_params", [{"max_epochs": 1, "gpus": 1}, {"max_epochs": 1, "gpus": [0]}])
+@pytest.mark.parametrize("trainer_params", [{"max_epochs": 1, "accelerator":"gpu", "devices": 1}, {"max_epochs": 1, "accelerator":"gpu", "devices": [0]}])
 @mock.patch("torch.cuda.device_count", return_value=1)
 def test_trainer_omegaconf(_, trainer_params):
     config = OmegaConf.create(trainer_params)
@@ -1673,7 +1673,7 @@ def test_setup_hook_move_to_device_correctly(tmpdir):
 
     # model
     model = TestModel()
-    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=True, gpus=1)
+    trainer = Trainer(default_root_dir=tmpdir, fast_dev_run=True, accelerator="gpu", devices=1)
     trainer.fit(model, train_data)
 
 
@@ -1918,7 +1918,7 @@ def test_ddp_terminate_when_deadlock_is_detected(tmpdir):
     model = TestModel()
 
     trainer = Trainer(
-        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=5, num_sanity_val_steps=0, gpus=2, strategy="ddp"
+        default_root_dir=tmpdir, max_epochs=1, limit_train_batches=5, num_sanity_val_steps=0, accelerator="gpu", devices=2, strategy="ddp"
     )
 
     # simulate random failure in training_step on rank 0
@@ -1954,7 +1954,8 @@ def test_multiple_trainer_constant_memory_allocated(tmpdir):
     trainer_kwargs = dict(
         default_root_dir=tmpdir,
         fast_dev_run=True,
-        gpus=1,
+        accelerator="gpu",
+        devices=1,
         strategy="ddp",
         enable_progress_bar=False,
         callbacks=Check(),
@@ -2090,7 +2091,7 @@ def test_detect_anomaly_nan(tmpdir):
             trainer.fit(model)
 
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize( # TODO: please update tests, @daniellepintz
     "trainer_kwargs,expected",
     [
         (

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1309,12 +1309,10 @@ def test_trainer_subclassing():
 
 
 @RunIf(omegaconf=True)
-@pytest.mark.parametrize(
-    "trainer_params",
-    [{"max_epochs": 1, "accelerator": "gpu", "devices": 1}, {"max_epochs": 1, "accelerator": "gpu", "devices": [0]}],
-)
+@pytest.mark.parametrize("trainer_params", [{"max_epochs": 1, "accelerator": "gpu", "devices": 1}, {"max_epochs": 1, "accelerator": "gpu", "devices": [0]}])
+@mock.patch("torch.cuda.is_available", return_value=True)
 @mock.patch("torch.cuda.device_count", return_value=1)
-def test_trainer_omegaconf(_, trainer_params):
+def test_trainer_omegaconf(_, __, trainer_params):
     config = OmegaConf.create(trainer_params)
     Trainer(**config)
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1097,7 +1097,7 @@ def test_gpu_choice(tmpdir):
     num_gpus = torch.cuda.device_count()
     Trainer(**trainer_options, accelerator="gpu", devices=num_gpus, auto_select_gpus=True)
 
-    with pytest.raises(RuntimeError, match=r".*No GPUs available.*"):
+    with pytest.raises(RuntimeError, match=r".*But your machine only has.*"):
         Trainer(**trainer_options, accelerator="gpu", devices=num_gpus + 1, auto_select_gpus=True)
 
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1309,7 +1309,10 @@ def test_trainer_subclassing():
 
 
 @RunIf(omegaconf=True)
-@pytest.mark.parametrize("trainer_params", [{"max_epochs": 1, "accelerator": "gpu", "devices": 1}, {"max_epochs": 1, "accelerator": "gpu", "devices": [0]}])
+@pytest.mark.parametrize(
+    "trainer_params",
+    [{"max_epochs": 1, "accelerator": "gpu", "devices": 1}, {"max_epochs": 1, "accelerator": "gpu", "devices": [0]}],
+)
 @mock.patch("torch.cuda.is_available", return_value=True)
 @mock.patch("torch.cuda.device_count", return_value=1)
 def test_trainer_omegaconf(_, __, trainer_params):

--- a/tests/trainer/test_trainer_cli.py
+++ b/tests/trainer/test_trainer_cli.py
@@ -165,6 +165,7 @@ def test_argparse_args_parsing_fast_dev_run(cli_args, expected):
     ["cli_args", "expected_parsed", "expected_device_ids"],
     [("", None, None), ("--devices 1", 1, [0]), ("--devices 0,", "0,", [0])],
 )
+@RunIf(min_gpus=1)
 def test_argparse_args_parsing_gpus(cli_args, expected_parsed, expected_device_ids):
     """Test multi type argument with bool."""
     cli_args = cli_args.split(" ") if cli_args else []
@@ -172,7 +173,7 @@ def test_argparse_args_parsing_gpus(cli_args, expected_parsed, expected_device_i
         parser = ArgumentParser(add_help=False)
         parser = Trainer.add_argparse_args(parent_parser=parser)
         args = Trainer.parse_argparser(parser)
-
+    
     assert args.gpus == expected_parsed
     trainer = Trainer.from_argparse_args(args)
     assert trainer.data_parallel_device_ids == expected_device_ids

--- a/tests/trainer/test_trainer_cli.py
+++ b/tests/trainer/test_trainer_cli.py
@@ -163,7 +163,7 @@ def test_argparse_args_parsing_fast_dev_run(cli_args, expected):
 
 @pytest.mark.parametrize(
     ["cli_args", "expected_parsed", "expected_device_ids"],
-    [("", None, None), ("--devices 1", 1, [0]), ("--devices 0,", "0,", [0])],
+    [("", None, None), ("--accelerator gpu --devices 1", "1", [0]), ("--accelerator gpu --devices 0,", "0,", [0])],
 )
 @RunIf(min_gpus=1)
 def test_argparse_args_parsing_devices(cli_args, expected_parsed, expected_device_ids):

--- a/tests/trainer/test_trainer_cli.py
+++ b/tests/trainer/test_trainer_cli.py
@@ -163,9 +163,8 @@ def test_argparse_args_parsing_fast_dev_run(cli_args, expected):
 
 @pytest.mark.parametrize(
     ["cli_args", "expected_parsed", "expected_device_ids"],
-    [("", None, None), ("--gpus 1", 1, [0]), ("--gpus 0,", "0,", [0])],
+    [("", None, None), ("--devices 1", 1, [0]), ("--devices 0,", "0,", [0])],
 )
-@RunIf(min_gpus=1)
 def test_argparse_args_parsing_gpus(cli_args, expected_parsed, expected_device_ids):
     """Test multi type argument with bool."""
     cli_args = cli_args.split(" ") if cli_args else []

--- a/tests/trainer/test_trainer_cli.py
+++ b/tests/trainer/test_trainer_cli.py
@@ -173,7 +173,7 @@ def test_argparse_args_parsing_gpus(cli_args, expected_parsed, expected_device_i
         parser = ArgumentParser(add_help=False)
         parser = Trainer.add_argparse_args(parent_parser=parser)
         args = Trainer.parse_argparser(parser)
-    
+
     assert args.gpus == expected_parsed
     trainer = Trainer.from_argparse_args(args)
     assert trainer.data_parallel_device_ids == expected_device_ids

--- a/tests/trainer/test_trainer_cli.py
+++ b/tests/trainer/test_trainer_cli.py
@@ -166,7 +166,7 @@ def test_argparse_args_parsing_fast_dev_run(cli_args, expected):
     [("", None, None), ("--devices 1", 1, [0]), ("--devices 0,", "0,", [0])],
 )
 @RunIf(min_gpus=1)
-def test_argparse_args_parsing_gpus(cli_args, expected_parsed, expected_device_ids):
+def test_argparse_args_parsing_devices(cli_args, expected_parsed, expected_device_ids):
     """Test multi type argument with bool."""
     cli_args = cli_args.split(" ") if cli_args else []
     with mock.patch("argparse._sys.argv", ["any.py"] + cli_args):
@@ -174,7 +174,7 @@ def test_argparse_args_parsing_gpus(cli_args, expected_parsed, expected_device_i
         parser = Trainer.add_argparse_args(parent_parser=parser)
         args = Trainer.parse_argparser(parser)
 
-    assert args.gpus == expected_parsed
+    assert args.devices == expected_parsed
     trainer = Trainer.from_argparse_args(args)
     assert trainer.data_parallel_device_ids == expected_device_ids
 


### PR DESCRIPTION
## What does this PR do?

Update test to deprecate `num_processes`, `gpus`, `tpu_cores`, and `ipus` from the Trainer constructor

Part of [Pull 11040](https://github.com/PyTorchLightning/pytorch-lightning/pull/11040).

🌳 [Trello Board Link](https://trello.com/b/He49BfCc/pl-tests)

### Does your PR introduce any breaking changes? If yes, please list them.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
