### PR TITLE
bug fix: restore_optimizers correctly handles non-mapping values in optimizer.state.values()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -532,6 +532,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The `RichProgressBar` now correctly shows the `on_epoch` logged values on train epoch end ([#11689](https://github.com/PyTorchLightning/pytorch-lightning/pull/11689))
 
 
+- Fixed `restore_optimizers` for mapping states ([#11757](https://github.com/PyTorchLightning/pytorch-lightning/pull/11757))
+
+
 - Fixed check for available modules ([#11526](https://github.com/PyTorchLightning/pytorch-lightning/pull/11526))
 
 

--- a/pytorch_lightning/trainer/connectors/checkpoint_connector.py
+++ b/pytorch_lightning/trainer/connectors/checkpoint_connector.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import logging
 import os
 import re
@@ -282,7 +281,7 @@ class CheckpointConnector:
             # avoids OOM
             if self.trainer.root_gpu is not None:
                 for param, state in optimizer.state.items():
-                    if isinstance(state, collections.Mapping):
+                    if isinstance(state, dict):
                         for k, v in state.items():
                             if isinstance(v, torch.Tensor):
                                 state[k] = v.cuda(self.trainer.root_gpu)


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

* This PR fixed the bug reported in https://github.com/PyTorchLightning/pytorch-lightning/issues/11741
* To reproduce this bug (and this is exactly what the test code below does): 1) use MADGRAD optmizer 2) use multiple GPUs for training, then resume training
* The main root cause for this bug to exist is because the original restore_optimizers() method cannot correctly handles non-mapping values in optmizer.state.values().

The test code is provided below:

```python
import os

import torch
from torch import nn
from torch.nn import functional as F
from torch.utils.data import DataLoader
from torchvision import transforms
from torchvision.datasets import MNIST
from pytorch_lightning import Trainer
from pytorch_lightning.callbacks import ModelCheckpoint
from pytorch_lightning.core.lightning import LightningModule

from madgrad import MADGRAD


class LitMNIST(LightningModule):
    def __init__(self):
        super().__init__()

        # mnist images are (1, 28, 28) (channels, height, width)
        self.layer_1 = nn.Linear(28 * 28, 128)
        self.layer_2 = nn.Linear(128, 256)
        self.layer_3 = nn.Linear(256, 10)

    def forward(self, x):
        batch_size, channels, height, width = x.size()

        # (b, 1, 28, 28) -> (b, 1*28*28)
        x = x.view(batch_size, -1)
        x = self.layer_1(x)
        x = F.relu(x)
        x = self.layer_2(x)
        x = F.relu(x)
        x = self.layer_3(x)

        x = F.log_softmax(x, dim=1)
        return x

    def training_step(self, batch, batch_idx):
        x, y = batch
        logits = self(x)
        loss = F.nll_loss(logits, y)
        return loss 

    def configure_optimizers(self):
        return MADGRAD(self.parameters(), lr=1e-6)

    def train_dataloader(self):
        # transforms
        # prepare transforms standard to MNIST
        transform=transforms.Compose([transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))])
        # data
        mnist_train = MNIST(os.getcwd(), train=True, download=True, transform=transform)
        return DataLoader(mnist_train, batch_size=64)


model = LitMNIST()
checkpoint_callback = ModelCheckpoint(save_last=True, save_top_k=1, monitor="loss", mode="min", filename="best")
trainer1 = Trainer(gpus=-1, strategy="dp", max_epochs=1, callbacks=[checkpoint_callback])
trainer1.fit(model)
trainer2 = Trainer(gpus=-1, strategy="dp", max_epochs=2, callbacks=[checkpoint_callback])
trainer2.fit(model, ckpt_path=checkpoint_callback.last_model_path)
```

(Notice that the madgrad.py being used in the test code can be freely downloaded from the official repo: https://github.com/facebookresearch/madgrad/blob/main/madgrad/madgrad.py)

Without this bug fix, the test code will fail and report error message as:
![image](https://user-images.githubusercontent.com/5665980/152649369-3c013fa6-2c1e-478d-82e6-71d3d4cfa06f.png)

Fixes #11741

### Does your PR introduce any breaking changes? If yes, please list them.

No.

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
