### PR TITLE
Describe the behavior with `limit_*_batches=1|1.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Added a `LOGGER_REGISTRY` instance to register custom loggers to the `LightningCLI` ([#11533](https://github.com/PyTorchLightning/pytorch-lightning/pull/11533))
 
 
+- Added info message when the `Trainer` arguments `limit_*_batches`, `overfit_batches`, or `val_check_interval` are set to `1` or `1.0` ([#11950](https://github.com/PyTorchLightning/pytorch-lightning/pull/11950))
+
 - Added a `PrecisionPlugin.teardown` method ([#10990](https://github.com/PyTorchLightning/pytorch-lightning/pull/10990))
 
 

--- a/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/prediction_epoch_loop.py
@@ -164,7 +164,11 @@ class PredictionEpochLoop(Loop):
         """Returns a reference to the seen batch indices if the dataloader has a batch sampler wrapped by our
         :class:`~pytorch_lightning.overrides.distributed.IndexBatchSamplerWrapper`."""
         # the batch_sampler is not be defined in case of CombinedDataLoaders
-        batch_sampler = getattr(self.trainer.predict_dataloaders[dataloader_idx], "batch_sampler", None)
+        batch_sampler = getattr(
+            self.trainer.predict_dataloaders[dataloader_idx],  # type: ignore[has-type]
+            "batch_sampler",
+            None,
+        )
         if isinstance(batch_sampler, IndexBatchSamplerWrapper) and self.should_store_predictions:
             return batch_sampler.seen_batch_indices
 

--- a/pytorch_lightning/loops/fit_loop.py
+++ b/pytorch_lightning/loops/fit_loop.py
@@ -263,6 +263,7 @@ class FitLoop(Loop[None]):
         log.detail(f"{self.__class__.__name__}: advancing loop")
         assert self.trainer.train_dataloader is not None
         dataloader = self.trainer.strategy.process_dataloader(self.trainer.train_dataloader)
+        assert self._data_fetcher is not None
         self._data_fetcher.setup(
             dataloader, batch_to_device=partial(self.trainer._call_strategy_hook, "batch_to_device", dataloader_idx=0)
         )

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -2647,10 +2647,25 @@ def _determine_batch_limits(batches: Optional[Union[int, float]], name: str) -> 
         # batches is optional to know if the user passed a value so that we can show the above info messages only to the
         # users that set a value explicitly
         return 1.0
+
+    # differentiating based on the type can be error-prone for users. show a message describing the chosen behaviour
     if isinstance(batches, int) and batches == 1:
-        log.info(f"`Trainer({name}=1)` was configured so 1 batch per epoch will be used.")
+        if name == "limit_train_batches":
+            message = "1 batch per epoch will be used."
+        elif name == "val_check_interval":
+            message = "validation will run after every batch."
+        else:
+            message = "1 batch will be used."
+        log.info(f"`Trainer({name}=1)` was configured so {message}")
     elif isinstance(batches, float) and batches == 1.0:
-        log.info(f"`Trainer({name}=1.0)` was configured so 100% of the batches per epoch will be used.")
+        if name == "limit_train_batches":
+            message = "100% of the batches per epoch will be used."
+        elif name == "val_check_interval":
+            message = "validation will run at the end of the training epoch."
+        else:
+            message = "100% of the batches will be used."
+        log.info(f"`Trainer({name}=1.0)` was configured so {message}.")
+
     if 0 <= batches <= 1:
         return batches
     if batches > 1 and batches % 1.0 == 0:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -147,7 +147,7 @@ class Trainer(
         log_gpu_memory: Optional[str] = None,  # TODO: Remove in 1.7
         progress_bar_refresh_rate: Optional[int] = None,  # TODO: remove in v1.7
         enable_progress_bar: bool = True,
-        overfit_batches: Union[int, float] = 0.0,
+        overfit_batches: Optional[Union[int, float]] = None,
         track_grad_norm: Union[int, float, str] = -1,
         check_val_every_n_epoch: int = 1,
         fast_dev_run: Union[int, bool] = False,
@@ -157,11 +157,11 @@ class Trainer(
         max_steps: int = -1,
         min_steps: Optional[int] = None,
         max_time: Optional[Union[str, timedelta, Dict[str, int]]] = None,
-        limit_train_batches: Union[int, float] = 1.0,
-        limit_val_batches: Union[int, float] = 1.0,
-        limit_test_batches: Union[int, float] = 1.0,
-        limit_predict_batches: Union[int, float] = 1.0,
-        val_check_interval: Union[int, float] = 1.0,
+        limit_train_batches: Optional[Union[int, float]] = None,
+        limit_val_batches: Optional[Union[int, float]] = None,
+        limit_test_batches: Optional[Union[int, float]] = None,
+        limit_predict_batches: Optional[Union[int, float]] = None,
+        val_check_interval: Optional[Union[int, float]] = None,
         flush_logs_every_n_steps: Optional[int] = None,
         log_every_n_steps: int = 50,
         accelerator: Optional[Union[str, Accelerator]] = None,
@@ -512,6 +512,7 @@ class Trainer(
         self._call_callback_hooks("on_init_start")
 
         # init data flags
+        self.check_val_every_n_epoch: int
         self._data_connector.on_trainer_init(
             check_val_every_n_epoch,
             reload_dataloaders_every_n_epochs,
@@ -569,6 +570,7 @@ class Trainer(
         self.logger_connector.on_trainer_init(logger, flush_logs_every_n_steps, log_every_n_steps, move_metrics_to_cpu)
 
         # init debugging flags
+        self.val_check_interval: Union[int, float]
         self._init_debugging_flags(
             limit_train_batches,
             limit_val_batches,
@@ -584,14 +586,14 @@ class Trainer(
 
     def _init_debugging_flags(
         self,
-        limit_train_batches,
-        limit_val_batches,
-        limit_test_batches,
-        limit_predict_batches,
-        val_check_interval,
-        overfit_batches,
-        fast_dev_run,
-    ):
+        limit_train_batches: Optional[Union[int, float]],
+        limit_val_batches: Optional[Union[int, float]],
+        limit_test_batches: Optional[Union[int, float]],
+        limit_predict_batches: Optional[Union[int, float]],
+        val_check_interval: Optional[Union[int, float]],
+        overfit_batches: Optional[Union[int, float]],
+        fast_dev_run: Union[int, bool],
+    ) -> None:
         if isinstance(fast_dev_run, int) and (fast_dev_run < 0):
             raise MisconfigurationException(
                 f"fast_dev_run={fast_dev_run} is not a valid configuration. It should be >= 0."
@@ -2640,10 +2642,18 @@ class Trainer(
         self._terminate_on_nan = val  # : 212
 
 
-def _determine_batch_limits(batches: Union[int, float], name: str) -> Union[int, float]:
+def _determine_batch_limits(batches: Optional[Union[int, float]], name: str) -> Union[int, float]:
+    if isinstance(batches, int) and batches == 1:
+        log.info(f"`Trainer({name}=1)` was configured so 1 batch per epoch will be used.")
+    elif isinstance(batches, float) and batches == 1.0:
+        log.info(f"`Trainer({name}=1.0)` was configured so 100% of the batches per epoch will be used.")
+    elif batches is None:
+        # batches is optional to know if the user passed a value so that we can show the above info messages only to the
+        # users that set a value explicitly
+        return 1.0
     if 0 <= batches <= 1:
         return batches
-    if batches > 1 and batches % 1.0 == 0:
+    if batches > 1:
         return int(batches)
     raise MisconfigurationException(
         f"You have passed invalid value {batches} for {name}, it has to be in [0.0, 1.0] or an int."

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -2653,7 +2653,7 @@ def _determine_batch_limits(batches: Optional[Union[int, float]], name: str) -> 
         return 1.0
     if 0 <= batches <= 1:
         return batches
-    if batches > 1:
+    if batches > 1 and batches % 1.0 == 0:
         return int(batches)
     raise MisconfigurationException(
         f"You have passed invalid value {batches} for {name}, it has to be in [0.0, 1.0] or an int."

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -147,7 +147,7 @@ class Trainer(
         log_gpu_memory: Optional[str] = None,  # TODO: Remove in 1.7
         progress_bar_refresh_rate: Optional[int] = None,  # TODO: remove in v1.7
         enable_progress_bar: bool = True,
-        overfit_batches: Optional[Union[int, float]] = None,
+        overfit_batches: Union[int, float] = 0.0,
         track_grad_norm: Union[int, float, str] = -1,
         check_val_every_n_epoch: int = 1,
         fast_dev_run: Union[int, bool] = False,
@@ -591,7 +591,7 @@ class Trainer(
         limit_test_batches: Optional[Union[int, float]],
         limit_predict_batches: Optional[Union[int, float]],
         val_check_interval: Optional[Union[int, float]],
-        overfit_batches: Optional[Union[int, float]],
+        overfit_batches: Union[int, float],
         fast_dev_run: Union[int, bool],
     ) -> None:
         if isinstance(fast_dev_run, int) and (fast_dev_run < 0):
@@ -2643,14 +2643,14 @@ class Trainer(
 
 
 def _determine_batch_limits(batches: Optional[Union[int, float]], name: str) -> Union[int, float]:
+    if batches is None:
+        # batches is optional to know if the user passed a value so that we can show the above info messages only to the
+        # users that set a value explicitly
+        return 1.0
     if isinstance(batches, int) and batches == 1:
         log.info(f"`Trainer({name}=1)` was configured so 1 batch per epoch will be used.")
     elif isinstance(batches, float) and batches == 1.0:
         log.info(f"`Trainer({name}=1.0)` was configured so 100% of the batches per epoch will be used.")
-    elif batches is None:
-        # batches is optional to know if the user passed a value so that we can show the above info messages only to the
-        # users that set a value explicitly
-        return 1.0
     if 0 <= batches <= 1:
         return batches
     if batches > 1 and batches % 1.0 == 0:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -2656,7 +2656,7 @@ def _determine_batch_limits(batches: Optional[Union[int, float]], name: str) -> 
             message = "validation will run after every batch."
         else:
             message = "1 batch will be used."
-        log.info(f"`Trainer({name}=1)` was configured so {message}")
+        rank_zero_info(f"`Trainer({name}=1)` was configured so {message}")
     elif isinstance(batches, float) and batches == 1.0:
         if name == "limit_train_batches":
             message = "100% of the batches per epoch will be used."
@@ -2664,7 +2664,7 @@ def _determine_batch_limits(batches: Optional[Union[int, float]], name: str) -> 
             message = "validation will run at the end of the training epoch."
         else:
             message = "100% of the batches will be used."
-        log.info(f"`Trainer({name}=1.0)` was configured so {message}.")
+        rank_zero_info(f"`Trainer({name}=1.0)` was configured so {message}.")
 
     if 0 <= batches <= 1:
         return batches

--- a/tests/trainer/flags/test_limit_batches.py
+++ b/tests/trainer/flags/test_limit_batches.py
@@ -75,7 +75,7 @@ def test_eval_limit_batches(stage, mode, limit_batches):
 )
 @pytest.mark.parametrize("value", (1, 1.0))
 def test_limit_batches_info_message(caplog, argument, value):
-    with caplog.at_level(logging.INFO, logger="pytorch_lightning.trainer.trainer"):
+    with caplog.at_level(logging.INFO):
         Trainer(**{argument: value})
     assert f"`Trainer({argument}={value})` was configured" in caplog.text
     message = f"configured so {'1' if isinstance(value, int) else '100%'}"
@@ -84,6 +84,6 @@ def test_limit_batches_info_message(caplog, argument, value):
     caplog.clear()
 
     # the message should not appear by default
-    with caplog.at_level(logging.INFO, logger="pytorch_lightning.trainer.trainer"):
+    with caplog.at_level(logging.INFO):
         Trainer()
     assert message not in caplog.text

--- a/tests/trainer/flags/test_limit_batches.py
+++ b/tests/trainer/flags/test_limit_batches.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 
 import pytest
 
@@ -66,3 +67,23 @@ def test_eval_limit_batches(stage, mode, limit_batches):
     expected_batches = int(limit_batches * len(eval_loader)) if isinstance(limit_batches, float) else limit_batches
     assert loader_num_batches[0] == expected_batches
     assert len(dataloaders[0]) == len(eval_loader)
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ("limit_train_batches", "limit_test_batches", "limit_predict_batches", "overfit_batches", "val_check_interval"),
+)
+@pytest.mark.parametrize("value", (1, 1.0))
+def test_limit_batches_info_message(caplog, flag, value):
+    with caplog.at_level(logging.INFO, logger="pytorch_lightning.trainer.trainer"):
+        Trainer(**{flag: value})
+    assert f"`Trainer({flag}={value})` was configured" in caplog.text
+    message = f"configured so {'1' if isinstance(value, int) else '100%'}"
+    assert message in caplog.text
+
+    caplog.clear()
+
+    # the message should not appear by default
+    with caplog.at_level(logging.INFO, logger="pytorch_lightning.trainer.trainer"):
+        Trainer()
+    assert message not in caplog.text

--- a/tests/trainer/flags/test_limit_batches.py
+++ b/tests/trainer/flags/test_limit_batches.py
@@ -70,14 +70,14 @@ def test_eval_limit_batches(stage, mode, limit_batches):
 
 
 @pytest.mark.parametrize(
-    "flag",
-    ("limit_train_batches", "limit_test_batches", "limit_predict_batches", "overfit_batches", "val_check_interval"),
+    "argument",
+    ("limit_train_batches", "limit_val_batches", "limit_test_batches", "limit_predict_batches", "overfit_batches"),
 )
 @pytest.mark.parametrize("value", (1, 1.0))
-def test_limit_batches_info_message(caplog, flag, value):
+def test_limit_batches_info_message(caplog, argument, value):
     with caplog.at_level(logging.INFO, logger="pytorch_lightning.trainer.trainer"):
-        Trainer(**{flag: value})
-    assert f"`Trainer({flag}={value})` was configured" in caplog.text
+        Trainer(**{argument: value})
+    assert f"`Trainer({argument}={value})` was configured" in caplog.text
     message = f"configured so {'1' if isinstance(value, int) else '100%'}"
     assert message in caplog.text
 

--- a/tests/trainer/flags/test_val_check_interval.py
+++ b/tests/trainer/flags/test_val_check_interval.py
@@ -45,7 +45,7 @@ def test_val_check_interval(tmpdir, max_epochs, denominator):
 
 @pytest.mark.parametrize("value", (1, 1.0))
 def test_val_check_interval_info_message(caplog, value):
-    with caplog.at_level(logging.INFO, logger="pytorch_lightning.trainer.trainer"):
+    with caplog.at_level(logging.INFO):
         Trainer(val_check_interval=value)
     assert f"`Trainer(val_check_interval={value})` was configured" in caplog.text
     message = "configured so validation will run"
@@ -54,6 +54,6 @@ def test_val_check_interval_info_message(caplog, value):
     caplog.clear()
 
     # the message should not appear by default
-    with caplog.at_level(logging.INFO, logger="pytorch_lightning.trainer.trainer"):
+    with caplog.at_level(logging.INFO):
         Trainer()
     assert message not in caplog.text

--- a/tests/trainer/flags/test_val_check_interval.py
+++ b/tests/trainer/flags/test_val_check_interval.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
+
 import pytest
 
 from pytorch_lightning.trainer import Trainer
@@ -39,3 +41,19 @@ def test_val_check_interval(tmpdir, max_epochs, denominator):
 
     assert model.train_epoch_calls == max_epochs
     assert model.val_epoch_calls == max_epochs * denominator
+
+
+@pytest.mark.parametrize("value", (1, 1.0))
+def test_val_check_interval_info_message(caplog, value):
+    with caplog.at_level(logging.INFO, logger="pytorch_lightning.trainer.trainer"):
+        Trainer(val_check_interval=value)
+    assert f"`Trainer(val_check_interval={value})` was configured" in caplog.text
+    message = "configured so validation will run"
+    assert message in caplog.text
+
+    caplog.clear()
+
+    # the message should not appear by default
+    with caplog.at_level(logging.INFO, logger="pytorch_lightning.trainer.trainer"):
+        Trainer()
+    assert message not in caplog.text


### PR DESCRIPTION
## What does this PR do?

The behavior for `limit_*_batches` is wildly different when the user passes `1` vs `1.0`. This can be a footgun.
This PR aims to increase transparency by showing a message clarifying the behavior.

In reaction to https://twitter.com/jxmnop/status/1494007900494303243 cc @borda @jxmorris12

Proposed by @williamFalcon 

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [n/a] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified