### PR TITLE
Fix `SaveConfigCallback` with ddp spawn

### DIFF
--- a/pytorch_lightning/callbacks/base.py
+++ b/pytorch_lightning/callbacks/base.py
@@ -325,3 +325,6 @@ class Callback:
 
     def on_before_zero_grad(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", optimizer: Optimizer) -> None:
         """Called before ``optimizer.zero_grad()``."""
+
+    def _on_before_launch(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
+        """For internal use."""

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -670,6 +670,9 @@ class Trainer(
         """
         try:
             if self.strategy.launcher is not None:
+                # used in the CLI's `SaveConfigCallback` so that it still works with DDP spawn
+                self._call_callback_hooks("_on_before_launch")
+
                 return self.strategy.launcher.launch(trainer_fn, *args, trainer=self, **kwargs)
             else:
                 return trainer_fn(*args, **kwargs)

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -447,7 +447,11 @@ class SaveConfigCallback(Callback):
 
     def __reduce__(self) -> Tuple[Type["SaveConfigCallback"], Tuple, Dict]:
         # `ArgumentParser` is un-pickleable. Drop it
-        return self.__class__, (None, self.config, self.config_filename), {}
+        return (
+            self.__class__,
+            (None, self.config, self.config_filename),
+            {"overwrite": self.overwrite, "multifile": self.multifile},
+        )
 
 
 class LightningCLI:

--- a/tests/utilities/test_cli.py
+++ b/tests/utilities/test_cli.py
@@ -28,7 +28,6 @@ import pytest
 import torch
 import yaml
 from packaging import version
-from torch.multiprocessing import ProcessRaisedException
 from torch.optim import SGD
 from torch.optim.lr_scheduler import ReduceLROnPlateau, StepLR
 
@@ -51,7 +50,7 @@ from pytorch_lightning.utilities.cli import (
     SaveConfigCallback,
 )
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities.imports import _TORCHVISION_AVAILABLE
+from pytorch_lightning.utilities.imports import _TORCH_GREATER_EQUAL_1_8, _TORCHVISION_AVAILABLE
 from tests.helpers import BoringDataModule, BoringModel
 from tests.helpers.utils import no_warning_call
 
@@ -579,6 +578,11 @@ class EarlyExitTestModel(BoringModel):
 @pytest.mark.parametrize("logger", (False, True))
 @pytest.mark.parametrize("strategy", ("ddp_spawn", "ddp"))
 def test_cli_distributed_save_config_callback(tmpdir, logger, strategy):
+    if _TORCH_GREATER_EQUAL_1_8:
+        from torch.multiprocessing import ProcessRaisedException
+    else:
+        ProcessRaisedException = Exception
+
     with mock.patch("sys.argv", ["any.py", "fit"]), pytest.raises(
         (MisconfigurationException, ProcessRaisedException), match=r"Error on fit start"
     ):

--- a/tests/utilities/test_cli.py
+++ b/tests/utilities/test_cli.py
@@ -28,6 +28,7 @@ import pytest
 import torch
 import yaml
 from packaging import version
+from torch.multiprocessing import ProcessRaisedException
 from torch.optim import SGD
 from torch.optim.lr_scheduler import ReduceLROnPlateau, StepLR
 
@@ -579,7 +580,7 @@ class EarlyExitTestModel(BoringModel):
 @pytest.mark.parametrize("strategy", ("ddp_spawn", "ddp"))
 def test_cli_distributed_save_config_callback(tmpdir, logger, strategy):
     with mock.patch("sys.argv", ["any.py", "fit"]), pytest.raises(
-        MisconfigurationException, match=r"Error on fit start"
+        (MisconfigurationException, ProcessRaisedException), match=r"Error on fit start"
     ):
         LightningCLI(
             EarlyExitTestModel,

--- a/tests/utilities/test_cli.py
+++ b/tests/utilities/test_cli.py
@@ -590,7 +590,7 @@ def test_cli_distributed_save_config_callback(tmpdir, logger, strategy):
                 "max_steps": 1,
                 "max_epochs": 1,
                 "strategy": strategy,
-                "accelerator": "cpu",
+                "accelerator": "auto",
                 "devices": 1,
             },
         )


### PR DESCRIPTION
## What does this PR do?

A CLI test using different strategies (ddp spawn, ddp) was silently broken accidentally in this PR:
https://github.com/PyTorchLightning/pytorch-lightning/pull/9931/files#diff-99e49066f136ed08cfc2c4ed81ff44eb71414ab3e600a62d278e4bd613a67997R584-R585
due to a bug in the `AcceleratorConnector`

Since the test was not working as expected, https://github.com/PyTorchLightning/pytorch-lightning/pull/10896 broke the `SaveConfigCallback` without noticing because now `setup` is called AFTER processes are spawned.

Then, #11448 fixed the `AcceleratorConnector` bug which uncovered the failing CLI test.

This PR fixes the test and uses an internal hook (aka a hack) to support DDP spawn again.
Note that the bug is unreleased.

A longer-term fix will be to make `ArgumentParser` pickleable or to have the parser expose a static save function. @mauvilsa 

### Does your PR introduce any breaking changes? If yes, please list them.

None.

## Before submitting

- [n/a] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified


cc @carmocca @mauvilsa @justusschock @kaushikb11 @awaelchli @akihironitta @rohitgr7