### PR TITLE
Avoid changing current cudnn benchmark

### DIFF
--- a/docs/source/common/trainer.rst
+++ b/docs/source/common/trainer.rst
@@ -416,7 +416,8 @@ benchmark
 
 |
 
-If true enables cudnn.benchmark.
+The value (``True`` or ``False``) to set ``torch.backends.cudnn.benchmark`` to. If not specified, the value set in
+the current session will be unchanged.
 This flag is likely to increase the speed of your system if your
 input sizes don't change. However, if it does, then it will likely
 make your system slower.

--- a/docs/source/common/trainer.rst
+++ b/docs/source/common/trainer.rst
@@ -416,11 +416,10 @@ benchmark
 
 |
 
-The value (``True`` or ``False``) to set ``torch.backends.cudnn.benchmark`` to. If not specified, the value set in
-the current session will be unchanged.
-This flag is likely to increase the speed of your system if your
-input sizes don't change. However, if it does, then it will likely
-make your system slower.
+The value (``True`` or ``False``) to set ``torch.backends.cudnn.benchmark`` to. If not specified, the value
+set in the current session will be unchanged.
+Setting this flag to ``True`` is likely to increase the speed of your system if your input sizes don't
+change. However, if it does, then it will likely make your system slower.
 
 The speedup comes from allowing the cudnn auto-tuner to find the best
 algorithm for the hardware `[see discussion here]
@@ -428,8 +427,8 @@ algorithm for the hardware `[see discussion here]
 
 Example::
 
-    # default used by the Trainer
-    trainer = Trainer(benchmark=False)
+    # default used by the Trainer (current setting for torch.backends.cudnn.benchmark is unchanged)
+    trainer = Trainer(benchmark=None)
 
 deterministic
 ^^^^^^^^^^^^^

--- a/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -182,7 +182,8 @@ class AcceleratorConnector:
 
         # benchmarking
         # TODO: should this be moved to GPU accelerator?
-        torch.backends.cudnn.benchmark = self.benchmark
+        if self.benchmark is not None:
+            torch.backends.cudnn.benchmark = self.benchmark
 
         self.replace_sampler_ddp = replace_sampler_ddp
 

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -176,7 +176,7 @@ class Trainer(
         num_sanity_val_steps: int = 2,
         resume_from_checkpoint: Optional[Union[Path, str]] = None,
         profiler: Optional[Union[BaseProfiler, str]] = None,
-        benchmark: bool = False,
+        benchmark: Optional[bool] = None,
         deterministic: bool = False,
         reload_dataloaders_every_n_epochs: int = 0,
         auto_lr_find: Union[bool, str] = False,
@@ -227,7 +227,8 @@ class Trainer(
                 GPUs are configured to be in "exclusive mode", such
                 that only one process at a time can access them.
 
-            benchmark: If true enables cudnn.benchmark.
+            benchmark: The value (``True`` or ``False``) to set ``torch.backends.cudnn.benchmark`` to. If not specified,
+                the value set in the current session will be unchanged.
 
             callbacks: Add a callback or list of callbacks.
 


### PR DESCRIPTION
## What does this PR do?

This is a small change that prevents PL from silently overriding `torch.backends.cudnn.benchmark` when constructing a `Trainer` object.

Fixes #12018

With this change, the behaviour can be described by:

For `torch.backends.cudnn.benchmark` to be changed by `Trainer` only when the `benchmark` arg is explicitly set.

| Instantiation | Behaviour |
|-|-|
| `Trainer()` | `torch.backends.cudnn.benchmark` is unchanged from current session value |
| `Trainer(benchmark=None)` | `torch.backends.cudnn.benchmark` is unchanged from current session value |
| `Trainer(benchmark=True)` | `torch.backends.cudnn.benchmark` set to `True` |
| `Trainer(benchmark=False)` | `torch.backends.cudnn.benchmark` set to `False` |

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
