### PR TITLE
Suggested Change to Wiki Documentation

### DIFF
--- a/docs/source/starter/new-project.rst
+++ b/docs/source/starter/new-project.rst
@@ -148,7 +148,7 @@ Step 1: Define LightningModule
             x = x.view(x.size(0), -1)
             z = self.encoder(x)
             x_hat = self.decoder(z)
-            loss = F.mse_loss(x_hat, x)
+            loss = F.mse_loss(x_hat, y)
             # Logging to TensorBoard by default
             self.log("train_loss", loss)
             return loss


### PR DESCRIPTION
Shouldn't this be `y` not `x`?
