### PR TITLE
Update `validation_epoch_end` docs

### DIFF
--- a/docs/source/common/lightning_module.rst
+++ b/docs/source/common/lightning_module.rst
@@ -398,7 +398,7 @@ Validation Epoch-level Metrics
 ==============================
 
 If you need to do something with all the outputs of each :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step`,
-override the :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_epoch_end` method.
+override the :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_epoch_end` method. Note that this method is called before  :meth:`~pytorch_lightning.core.lightning.LightningModule.training_epoch_end`.
 
 .. code-block:: python
 

--- a/docs/source/common/lightning_module.rst
+++ b/docs/source/common/lightning_module.rst
@@ -398,7 +398,7 @@ Validation Epoch-level Metrics
 ==============================
 
 If you need to do something with all the outputs of each :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step`,
-override the :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_epoch_end` method. Note that this method is called before  :meth:`~pytorch_lightning.core.lightning.LightningModule.training_epoch_end`.
+override the :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_epoch_end` method. Note that this method is called before :meth:`~pytorch_lightning.core.lightning.LightningModule.training_epoch_end`.
 
 .. code-block:: python
 


### PR DESCRIPTION
It took me time to understand that validation_epoch_end is called before training_epoch_end. This behavior is expected (see https://github.com/PyTorchLightning/pytorch-lightning/issues/3832), but not obvious, so I think that the documentation could be clearer