### PR TITLE
Clean loop fetching usage

### DIFF
--- a/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/evaluation_epoch_loop.py
@@ -14,7 +14,7 @@
 
 from collections import OrderedDict
 from functools import lru_cache
-from typing import Any, Dict, Iterator, Optional
+from typing import Any, cast, Dict, Optional
 
 from deprecate import void
 from torch.utils.data import DataLoader
@@ -47,7 +47,6 @@ class EvaluationEpochLoop(Loop):
 
         self._outputs: EPOCH_OUTPUT = []
         self._dl_max_batches = 0
-        self._dataloader_iter: Optional[Iterator] = None
         self._data_fetcher: Optional[AbstractDataFetcher] = None
         self._dataloader_state_dict: Dict[str, Any] = {}
 
@@ -83,10 +82,9 @@ class EvaluationEpochLoop(Loop):
         """
         void(kwargs)
         self._dl_max_batches = dl_max_batches
-        self._data_fetcher = data_fetcher
-
         self._reload_dataloader_state_dict(data_fetcher)
-        self._dataloader_iter = iter(data_fetcher)
+        # creates the iterator inside the fetcher but returns `self`
+        self._data_fetcher = cast(AbstractDataFetcher, iter(data_fetcher))
 
     def advance(  # type: ignore[override]
         self,
@@ -106,12 +104,12 @@ class EvaluationEpochLoop(Loop):
         """
         void(dl_max_batches)
 
-        assert self._dataloader_iter is not None
         if not isinstance(data_fetcher, DataLoaderIterDataFetcher):
             batch_idx = self.batch_progress.current.ready
-            batch, self.batch_progress.is_last_batch = next(self._dataloader_iter)
+            batch = next(data_fetcher)
         else:
-            batch_idx, (batch, self.batch_progress.is_last_batch) = next(self._dataloader_iter)
+            batch_idx, batch = next(data_fetcher)
+        self.batch_progress.is_last_batch = data_fetcher.done
 
         # configure step_kwargs
         kwargs = self._build_kwargs(kwargs, batch, batch_idx)
@@ -153,7 +151,6 @@ class EvaluationEpochLoop(Loop):
     def on_run_end(self) -> EPOCH_OUTPUT:
         """Returns the outputs of the whole run."""
         outputs, self._outputs = self._outputs, []  # free memory
-        self._dataloader_iter = None
         self._data_fetcher = None
         return outputs
 

--- a/pytorch_lightning/loops/epoch/training_epoch_loop.py
+++ b/pytorch_lightning/loops/epoch/training_epoch_loop.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import math
 from collections import defaultdict
-from typing import Any, Dict, Generator, Iterator, List, Optional, overload, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, overload, Tuple, Union
 
 import numpy as np
 import torch
@@ -70,7 +70,6 @@ class TrainingEpochLoop(loops.Loop[_OUTPUTS_TYPE]):
         self._results = _ResultCollection(training=True)
         self._outputs: _OUTPUTS_TYPE = []
         self._warning_cache = WarningCache()
-        self._dataloader_iter: Optional[Iterator] = None
         # caches the loaded dataloader state until dataloader objects are available
         self._dataloader_state_dict: Dict[str, Any] = {}
 
@@ -143,7 +142,7 @@ class TrainingEpochLoop(loops.Loop[_OUTPUTS_TYPE]):
 
     def on_run_start(self, data_fetcher: AbstractDataFetcher) -> None:  # type: ignore[override]
         self._reload_dataloader_state_dict(data_fetcher)
-        self._dataloader_iter = iter(data_fetcher)
+        iter(data_fetcher)  # creates the iterator inside the fetcher
 
     def advance(self, data_fetcher: AbstractDataFetcher) -> None:  # type: ignore[override]
         """Runs a single training batch.
@@ -157,12 +156,12 @@ class TrainingEpochLoop(loops.Loop[_OUTPUTS_TYPE]):
         # we are going to train first so the val loop does not need to restart
         self.val_loop.restarting = False
 
-        assert self._dataloader_iter is not None
         if not isinstance(data_fetcher, DataLoaderIterDataFetcher):
             batch_idx = self.batch_idx + 1
-            batch, self.batch_progress.is_last_batch = next(self._dataloader_iter)
+            batch = next(data_fetcher)
         else:
-            batch_idx, (batch, self.batch_progress.is_last_batch) = next(self._dataloader_iter)
+            batch_idx, batch = next(data_fetcher)
+        self.batch_progress.is_last_batch = data_fetcher.done
 
         self.batch_progress.increment_ready()
 

--- a/pytorch_lightning/utilities/fetching.py
+++ b/pytorch_lightning/utilities/fetching.py
@@ -235,7 +235,7 @@ class DataFetcher(AbstractDataFetcher):
             except StopIteration:
                 break
 
-    def fetching_function(self) -> Tuple[Any, bool]:
+    def fetching_function(self) -> Any:
         assert self.dataloader_iter is not None
         if self.batches:
             # there are pre-fetched batches already from a previous `prefetching` call.
@@ -260,7 +260,7 @@ class DataFetcher(AbstractDataFetcher):
             # the iterator is empty
             raise StopIteration
         self.wait()
-        return self.move_to_device(batch), self.done
+        return self.move_to_device(batch)
 
     def _fetch_next_batch(self, iterator: Iterator) -> None:
         start_output = self.on_fetch_start()
@@ -369,7 +369,7 @@ class DataLoaderIterDataFetcher(AbstractDataFetcher):
         assert iterator is not None
         self.iterator = iter(StepFuncDataLoaderIter(iterator, self))
 
-    def fetching_function(self) -> Tuple[int, Tuple[Iterator, bool]]:
+    def fetching_function(self) -> Tuple[int, Iterator]:
         if not self.done:
-            return self.fetched, (self.iterator, self.done)
+            return self.fetched, self.iterator
         raise StopIteration

--- a/tests/utilities/test_auto_restart.py
+++ b/tests/utilities/test_auto_restart.py
@@ -786,7 +786,7 @@ def test_dataset_rng_states_restart(dataset_class, num_workers, batch_size):
         return dl, sampler
 
     def fetch(fetcher, prefetch_iter, num_batches_fetched):
-        batch, _ = next(prefetch_iter)
+        _ = next(prefetch_iter)
 
         state: List[MergedIteratorState] = fetcher.state
         assert len(state) == 1
@@ -814,8 +814,8 @@ def test_dataset_rng_states_restart(dataset_class, num_workers, batch_size):
     state = deepcopy(state[0])
 
     # (B) simulate 2 additional batches
-    batch05, _ = next(prefetch_iter)
-    batch06, _ = next(prefetch_iter)
+    batch05 = next(prefetch_iter)
+    batch06 = next(prefetch_iter)
 
     # start reloading
     dataset, random_sampler = create_dataset_sampler()
@@ -830,8 +830,8 @@ def test_dataset_rng_states_restart(dataset_class, num_workers, batch_size):
     prefetch_iter = iter(prefetcher)
 
     # fetch 2 random batches, these should match exactly the batches seen at (B)
-    batch05_restart, _ = next(prefetch_iter)
-    batch06_restart, _ = next(prefetch_iter)
+    batch05_restart = next(prefetch_iter)
+    batch06_restart = next(prefetch_iter)
 
     assert torch.equal(batch05, batch05_restart)
     assert torch.equal(batch06, batch06_restart)

--- a/tests/utilities/test_fetching.py
+++ b/tests/utilities/test_fetching.py
@@ -51,7 +51,9 @@ def test_prefetch_iterator(use_combined_loader):
         iterator.setup(loader)
 
         def generate():
-            generated = [(iterator.fetched, *data) for i, data in enumerate(iterator, prefetch_batches + 1)]
+            generated = [
+                (iterator.fetched, data, iterator.done) for i, data in enumerate(iterator, prefetch_batches + 1)
+            ]
             assert iterator.fetched == 3
             assert iterator.done
             return generated


### PR DESCRIPTION
## What does this PR do?

Minor clean-up:
- Remove `self._dataloader_iter` reference as it actually points to the `data_fetcher`
- Simplify return by accessing `done` manually. This should make testing easier and is more in-line with generic iterators.

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @borda @justusschock @awaelchli @rohitgr7 @ninginthecloud @carmocca @ananthsub