### PR TITLE
Update type hint for log_model

### DIFF
--- a/pytorch_lightning/loggers/wandb.py
+++ b/pytorch_lightning/loggers/wandb.py
@@ -256,7 +256,7 @@ class WandbLogger(LightningLoggerBase):
         anonymous: Optional[bool] = None,
         version: Optional[str] = None,
         project: Optional[str] = None,
-        log_model: Optional[bool] = False,
+        log_model: Union[str, bool] = False,
         experiment=None,
         prefix: Optional[str] = "",
         **kwargs,


### PR DESCRIPTION
According to the documentation, `log_model` should either be boolean or the string "all".
Updated type hint to reflect that: `Union[str, bool]`