### PR TITLE
Fix device section in PyTorch To Lightning docs

### DIFF
--- a/docs/source/starter/converting.rst
+++ b/docs/source/starter/converting.rst
@@ -185,17 +185,7 @@ Your :doc:`LightningModule <../common/lightning_module>` can automatically run o
 
 If you have any explicit calls to ``.cuda()`` or ``.to(device)``, you can remove them since Lightning makes sure that the data coming from :class:`~torch.utils.data.DataLoader`
 and all the :class:`~torch.nn.Module` instances initialized inside ``LightningModule.__init__`` are moved to the respective devices automatically.
-
-.. testcode::
-
-    class LitModel(LightningModule):
-        def __init__(self):
-            super().__init__()
-            self.register_buffer("running_mean", torch.zeros(num_features))
-
-If you still need to access the current device, you can use ``self.device`` anywhere in ``LightningModule`` except ``__init__`` and ``setup`` methods.
-You are initializing a :class:`~torch.Tensor` within ``LightningModule.__init__`` method and want it to be moved to the device automatically you must
-:meth:`~torch.nn.Module.register_buffer` to register it as a parameter.
+If you still need to access the current device, you can use ``self.device`` anywhere in your ``LightningModule`` except in the ``__init__`` and ``setup`` methods.
 
 .. testcode::
 
@@ -203,6 +193,16 @@ You are initializing a :class:`~torch.Tensor` within ``LightningModule.__init__`
         def training_step(self, batch, batch_idx):
             z = torch.randn(4, 5, device=self.device)
             ...
+
+Hint: If you are initializing a :class:`~torch.Tensor` within the ``LightningModule.__init__`` method and want it to be moved to the device automatically you should call
+:meth:`~torch.nn.Module.register_buffer` to register it as a parameter.
+
+.. testcode::
+
+    class LitModel(LightningModule):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("running_mean", torch.zeros(num_features))
 
 --------
 


### PR DESCRIPTION
## What does this PR do?

Fixes the section **Remove any .cuda() or .to(device) Calls** in the converting docs. 
This section was completely scrambled.
The order of examples was mixed up with the text and the text had grammatical errors.


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃





cc @borda @rohitgr7