### PR TITLE
Replace PostLocalSGDOptimizer with a dedicated model averaging component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -368,6 +368,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - The strategies that support `sync_batchnorm` now only apply it when fitting ([#11919](https://github.com/PyTorchLightning/pytorch-lightning/pull/11919))
 
 
+- Replaced PostLocalSGDOptimizer with a dedicated model averaging component ([#12378](https://github.com/PyTorchLightning/pytorch-lightning/pull/12378))
 
 ### Deprecated
 

--- a/docs/source/advanced/model_parallel.rst
+++ b/docs/source/advanced/model_parallel.rst
@@ -806,7 +806,7 @@ Combine hooks for accumulated benefit:
     trainer.fit(model)
 
 
-When using Post-localSGD, you must also pass model_averaging_period to allow for model parameter averaging:
+When using Post-localSGD, you must also pass ``model_averaging_period`` to allow for model parameter averaging:
 
 .. note::
     Post-localSGD support requires PyTorch>=1.10.0

--- a/docs/source/advanced/model_parallel.rst
+++ b/docs/source/advanced/model_parallel.rst
@@ -806,7 +806,7 @@ Combine hooks for accumulated benefit:
     trainer.fit(model)
 
 
-When using Post-localSGD, you must also pass ``model_averaging_period`` to allow for model parameter averaging:
+When using Post-localSGD, you must also pass model_averaging_period to allow for model parameter averaging:
 
 .. note::
     Post-localSGD support requires PyTorch>=1.10.0

--- a/docs/source/advanced/model_parallel.rst
+++ b/docs/source/advanced/model_parallel.rst
@@ -743,10 +743,7 @@ Enable `FP16 Compress Hook for multi-node throughput improvement <https://pytorc
 
     from pytorch_lightning import Trainer
     from pytorch_lightning.strategies import DDPStrategy
-    from torch.distributed.algorithms.ddp_comm_hooks import (
-        default_hooks as default,
-        powerSGD_hook as powerSGD,
-    )
+    from torch.distributed.algorithms.ddp_comm_hooks import default_hooks as default
 
     model = MyModel()
     trainer = Trainer(gpus=4, strategy=DDPStrategy(ddp_comm_hook=default.fp16_compress_hook))
@@ -804,6 +801,33 @@ Combine hooks for accumulated benefit:
             ),
             ddp_comm_hook=powerSGD.powerSGD_hook,
             ddp_comm_wrapper=default.fp16_compress_wrapper,
+        ),
+    )
+    trainer.fit(model)
+
+
+When using Post-localSGD, you must also pass ``model_averaging_period`` to allow for model parameter averaging:
+
+.. note::
+    Post-localSGD support requires PyTorch>=1.10.0
+
+.. code-block:: python
+
+    from pytorch_lightning import Trainer
+    from pytorch_lightning.strategies import DDPStrategy
+    from torch.distributed.algorithms.ddp_comm_hooks import post_localSGD_hook as post_localSGD
+
+    model = MyModel()
+    trainer = Trainer(
+        gpus=4,
+        strategy=DDPStrategy(
+            ddp_comm_state=post_localSGD.PostLocalSGDState(
+                process_group=None,
+                subgroup=None,
+                start_localSGD_iter=8,
+            ),
+            ddp_comm_hook=post_localSGD.post_localSGD_hook,
+            model_averaging_period=4,
         ),
     )
     trainer.fit(model)

--- a/pytorch_lightning/strategies/ddp.py
+++ b/pytorch_lightning/strategies/ddp.py
@@ -18,12 +18,13 @@ import signal
 import tempfile
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
 import torch.distributed
 from torch.nn import Module
 from torch.nn.parallel.distributed import DistributedDataParallel
+from torch.optim.optimizer import Optimizer
 
 import pytorch_lightning as pl
 from pytorch_lightning.core.optimizer import LightningOptimizer
@@ -58,6 +59,8 @@ if _FAIRSCALE_AVAILABLE:
     from fairscale.optim import OSS
 if _TORCH_GREATER_EQUAL_1_8:
     from pytorch_lightning.utilities.distributed import register_ddp_comm_hook
+if _TORCH_GREATER_EQUAL_1_10:
+    from torch.distributed.algorithms.model_averaging.averagers import ModelAverager
 
 
 log = logging.getLogger(__name__)
@@ -95,7 +98,9 @@ class DDPStrategy(ParallelStrategy):
         self._ddp_comm_state = ddp_comm_state
         self._ddp_comm_hook = ddp_comm_hook
         self._ddp_comm_wrapper = ddp_comm_wrapper
-        self._model_averaging_period = model_averaging_period
+        if _TORCH_GREATER_EQUAL_1_10:
+            self._model_averaging_period = model_averaging_period
+            self._model_averager: Optional[ModelAverager] = None
         self._pids: Optional[List[int]] = None
         self._sync_dir: Optional[str] = None
         self._rank_0_will_call_children_scripts: bool = False
@@ -231,23 +236,17 @@ class DDPStrategy(ParallelStrategy):
                 import torch.distributed.algorithms.ddp_comm_hooks.post_localSGD_hook as post_localSGD
 
                 if isinstance(self._ddp_comm_state, post_localSGD.PostLocalSGDState):
-                    self._reinit_optimizers_with_post_localSGD(self._ddp_comm_state.start_localSGD_iter)
+                    self._enable_model_averaging()
 
-    def _reinit_optimizers_with_post_localSGD(self, warmup_steps: int):
+    def _enable_model_averaging(self):
         log.detail(f"{self.__class__.__name__}: reinitializing optimizers with post localSGD")
-        optimizers = self.optimizers
         if self._model_averaging_period is None:
             raise ValueError(
                 "Post-localSGD algorithm is used, but model averaging period is not provided to DDP strategy."
             )
-        if _TORCH_GREATER_EQUAL_1_10:
-            if not _IS_WINDOWS:
-                from torch.distributed.optim import DistributedOptimizer
-            import torch.distributed.algorithms.model_averaging.averagers as averagers
-            from torch.distributed.optim import PostLocalSGDOptimizer, ZeroRedundancyOptimizer
+        from torch.distributed.optim import DistributedOptimizer, PostLocalSGDOptimizer, ZeroRedundancyOptimizer
 
-        averager = averagers.PeriodicModelAverager(period=self._model_averaging_period, warmup_steps=warmup_steps)
-        for x, optimizer in enumerate(optimizers):
+        for optimizer in self.optimizers:
             if isinstance(optimizer, LightningOptimizer):
                 optimizer = optimizer._optimizer
 
@@ -256,24 +255,42 @@ class DDPStrategy(ParallelStrategy):
                 is_distributed_optimizer
                 or isinstance(optimizer, ZeroRedundancyOptimizer)
                 or (_FAIRSCALE_AVAILABLE and isinstance(optimizer, OSS))
+                or isinstance(optimizer, PostLocalSGDOptimizer)
             ):
                 raise ValueError(
-                    f"Cannot wrap a distributed optimizer of type {optimizer.__name__} by PostLocalSGDOptimizer."
+                    f"Currently model averaging cannot work with a distributed optimizer of type {optimizer.__name__}."
                 )
 
-            if isinstance(optimizer, PostLocalSGDOptimizer):
-                continue
+        self._model_averager = torch.distributed.algorithms.model_averaging.averagers.PeriodicModelAverager(
+            period=self._model_averaging_period, warmup_steps=self._ddp_comm_state.start_localSGD_iter
+        )
 
-            optim_class = type(optimizer)
-            post_localSGD_optimizer = PostLocalSGDOptimizer(
-                params=optimizer.param_groups,
-                optimizer_class=optim_class,
-                averager=averager,
-                **optimizer.defaults,
-            )
-            optimizers[x] = post_localSGD_optimizer
-            del optimizer
-        self.optimizers = optimizers
+    def optimizer_step(
+        self,
+        optimizer: Optimizer,
+        opt_idx: int,
+        closure: Callable[[], Any],
+        model: Optional[Union["pl.LightningModule", Module]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        """performs the actual optimizer step.
+
+        Args:
+            optimizer: the optimizer performing the step
+            opt_idx: index of the current optimizer
+            closure: closure calculating the loss value
+            model: reference to the model, optionally defining optimizer step related hooks
+            **kwargs: Any extra arguments to ``optimizer.step``
+        """
+        super().optimizer_step(optimizer, opt_idx, closure, model, kwargs)
+
+        if _TORCH_GREATER_EQUAL_1_10 and self._model_averager is not None:
+            for opt in self.optimizers():
+                for group in opt.param_groups:
+                    for param in group["params"]:
+                        if param.grad is None:
+                            continue
+                        self._model_averager.average_parameters(iter(param))
 
     def configure_ddp(self) -> None:
         log.detail(f"{self.__class__.__name__}: configuring DistributedDataParallel")

--- a/pytorch_lightning/strategies/ddp.py
+++ b/pytorch_lightning/strategies/ddp.py
@@ -274,7 +274,7 @@ class DDPStrategy(ParallelStrategy):
         model: Optional[Union["pl.LightningModule", Module]] = None,
         **kwargs: Any,
     ) -> Any:
-        """performs the actual optimizer step.
+        """Performs the actual optimizer step.
 
         Args:
             optimizer: the optimizer performing the step

--- a/pytorch_lightning/strategies/ddp.py
+++ b/pytorch_lightning/strategies/ddp.py
@@ -282,7 +282,7 @@ class DDPStrategy(ParallelStrategy):
             model: reference to the model, optionally defining optimizer step related hooks
             **kwargs: Any extra arguments to ``optimizer.step``
         """
-        super().optimizer_step(optimizer, opt_idx, closure, model, kwargs)
+        super().optimizer_step(optimizer, opt_idx, closure, model, **kwargs)
 
         if _TORCH_GREATER_EQUAL_1_10 and self._model_averager is not None:
             for opt in self.optimizers():

--- a/pytorch_lightning/strategies/ddp.py
+++ b/pytorch_lightning/strategies/ddp.py
@@ -289,12 +289,11 @@ class DDPStrategy(ParallelStrategy):
         if not _TORCH_GREATER_EQUAL_1_10 or self._model_averager is None:
             return optimizer_output
 
-        for opt in self.optimizers:
-            for group in opt.param_groups:
-                for param in group["params"]:
-                    if param.grad is None:
-                        continue
-                    self._model_averager.average_parameters(iter(param))
+        for group in optimizer.param_groups:
+            for param in group["params"]:
+                if param.grad is None:
+                    continue
+                self._model_averager.average_parameters(iter(param))
 
         return optimizer_output
 

--- a/pytorch_lightning/strategies/ddp.py
+++ b/pytorch_lightning/strategies/ddp.py
@@ -258,7 +258,8 @@ class DDPStrategy(ParallelStrategy):
                 or isinstance(optimizer, PostLocalSGDOptimizer)
             ):
                 raise ValueError(
-                    f"Currently model averaging cannot work with a distributed optimizer of type {optimizer.__name__}."
+                    f"Currently model averaging cannot work with a distributed optimizer of type "
+                    f"{optimizer.__class__.__name__}."
                 )
 
         self._model_averager = torch.distributed.algorithms.model_averaging.averagers.PeriodicModelAverager(
@@ -287,7 +288,7 @@ class DDPStrategy(ParallelStrategy):
         if not _TORCH_GREATER_EQUAL_1_10 or self._model_averager is None:
             return optimizer_output
 
-        for opt in self.optimizers():
+        for opt in self.optimizers:
             for group in opt.param_groups:
                 for param in group["params"]:
                     if param.grad is None:

--- a/pytorch_lightning/strategies/strategy.py
+++ b/pytorch_lightning/strategies/strategy.py
@@ -181,7 +181,7 @@ class Strategy(ABC):
         model: Optional[Union["pl.LightningModule", Module]] = None,
         **kwargs: Any,
     ) -> Any:
-        """performs the actual optimizer step.
+        """Performs the actual optimizer step.
 
         Args:
             optimizer: the optimizer performing the step

--- a/pytorch_lightning/utilities/distributed.py
+++ b/pytorch_lightning/utilities/distributed.py
@@ -293,7 +293,7 @@ def register_ddp_comm_hook(
             )
             ddp_comm_hook = ddp_comm_wrapper(ddp_comm_hook)
 
-    rank_zero_debug(f"Registering DDP comm hook: {ddp_comm_hook.__qualname__}.")
+    # rank_zero_debug(f"Registering DDP comm hook: {ddp_comm_hook.__qualname__}.")
     model.register_comm_hook(state=ddp_comm_state, hook=ddp_comm_hook)
 
 

--- a/pytorch_lightning/utilities/distributed.py
+++ b/pytorch_lightning/utilities/distributed.py
@@ -293,7 +293,7 @@ def register_ddp_comm_hook(
             )
             ddp_comm_hook = ddp_comm_wrapper(ddp_comm_hook)
 
-    # rank_zero_debug(f"Registering DDP comm hook: {ddp_comm_hook.__qualname__}.")
+    rank_zero_debug(f"Registering DDP comm hook: {ddp_comm_hook.__qualname__}.")
     model.register_comm_hook(state=ddp_comm_state, hook=ddp_comm_hook)
 
 

--- a/tests/strategies/test_ddp_strategy_with_comm_hook.py
+++ b/tests/strategies/test_ddp_strategy_with_comm_hook.py
@@ -143,38 +143,43 @@ def test_ddp_post_local_sgd_comm_hook(tmpdir):
 
 @RunIf(skip_windows=True, min_torch="1.10.0", min_gpus=2, standalone=True)
 @mock.patch("torch.distributed.algorithms.model_averaging.averagers.PeriodicModelAverager.average_parameters")
-@pytest.mark.parametrize(
-    "strategy",
-    [
-        "ddp",
-        DDPStrategy(
-            ddp_comm_state=post_localSGD.PostLocalSGDState(
-                process_group=None,
-                subgroup=None,
-                start_localSGD_iter=8,
-            ),
-            ddp_comm_hook=post_localSGD.post_localSGD_hook,
-            model_averaging_period=4,
-        ),
-    ],
-)
-def test_post_local_sgd_model_averaging(average_parameters_mock, tmpdir, strategy):
+def test_post_local_sgd_model_averaging(average_parameters_mock, tmpdir):
     """Test that when using DDP with post-localSGD, model averaging is called."""
     model = BoringModel()
 
+    # test regular ddp does not call model averaging
     trainer = Trainer(
         fast_dev_run=True,
         gpus=2,
-        strategy=strategy,
+        strategy="ddp",
         default_root_dir=tmpdir,
         sync_batchnorm=True,
     )
 
     trainer.fit(model)
-    if strategy == "ddp":
-        average_parameters_mock.assert_not_called()
-    else:
-        average_parameters_mock.assert_called()
+    average_parameters_mock.assert_not_called()
+
+    # test ddp with post-localSGD does call model averaging
+    ddp_strategy = DDPStrategy(
+        ddp_comm_state=post_localSGD.PostLocalSGDState(
+            process_group=None,
+            subgroup=None,
+            start_localSGD_iter=8,
+        ),
+        ddp_comm_hook=post_localSGD.post_localSGD_hook,
+        model_averaging_period=4,
+    )
+
+    trainer = Trainer(
+        fast_dev_run=True,
+        gpus=2,
+        strategy=ddp_strategy,
+        default_root_dir=tmpdir,
+        sync_batchnorm=True,
+    )
+
+    trainer.fit(model)
+    average_parameters_mock.assert_called()
 
 
 @RunIf(skip_windows=True, min_torch="1.10.0", min_gpus=2, standalone=True)

--- a/tests/strategies/test_ddp_strategy_with_comm_hook.py
+++ b/tests/strategies/test_ddp_strategy_with_comm_hook.py
@@ -159,10 +159,9 @@ def test_ddp_post_local_sgd_comm_hook(tmpdir):
     ],
 )
 def test_post_local_sgd_model_averaging(average_parameters_mock, tmpdir, strategy):
-    """Test that when using DDP with post-localSGD model averaging is called when it should be."""
+    """Test that when using DDP with post-localSGD, model averaging is called."""
     model = BoringModel()
 
-    # Test that for regular ddp PeriodicModelAverager.average_parameters is not called
     trainer = Trainer(
         fast_dev_run=True,
         gpus=2,

--- a/tests/strategies/test_ddp_strategy_with_comm_hook.py
+++ b/tests/strategies/test_ddp_strategy_with_comm_hook.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from unittest import mock
+
+import pytest
 import torch
 
 from pytorch_lightning import Trainer
@@ -136,3 +139,76 @@ def test_ddp_post_local_sgd_comm_hook(tmpdir):
     expected_comm_hook = post_localSGD.post_localSGD_hook.__qualname__
     assert trainer_comm_hook == expected_comm_hook
     assert trainer.state.finished, f"Training failed with {trainer.state}"
+
+
+@RunIf(skip_windows=True, min_torch="1.10.0", min_gpus=2, standalone=True)
+@mock.patch("torch.distributed.algorithms.model_averaging.averagers.PeriodicModelAverager.average_parameters")
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        "ddp",
+        DDPStrategy(
+            ddp_comm_state=post_localSGD.PostLocalSGDState(
+                process_group=None,
+                subgroup=None,
+                start_localSGD_iter=8,
+            ),
+            ddp_comm_hook=post_localSGD.post_localSGD_hook,
+            model_averaging_period=4,
+        ),
+    ],
+)
+def test_post_local_sgd_model_averaging(average_parameters_mock, tmpdir, strategy):
+    """Test that when using DDP with post-localSGD model averaging is called when it should be."""
+    model = BoringModel()
+
+    # Test that for regular ddp PeriodicModelAverager.average_parameters is not called
+    trainer = Trainer(
+        fast_dev_run=True,
+        gpus=2,
+        strategy=strategy,
+        default_root_dir=tmpdir,
+        sync_batchnorm=True,
+    )
+
+    trainer.fit(model)
+    if strategy == "ddp":
+        average_parameters_mock.assert_not_called()
+    else:
+        average_parameters_mock.assert_called()
+
+
+@RunIf(skip_windows=True, min_torch="1.10.0", min_gpus=2, standalone=True)
+@mock.patch("torch.distributed.algorithms.model_averaging.averagers.PeriodicModelAverager.average_parameters")
+def test_post_local_sgd_model_averaging_value_error(average_parameters_mock, tmpdir):
+    """Test that when using DDP with post-localSGD a ValueError is thrown when the optmizer is
+    ZeroRedundancyOptimizer."""
+    from torch.distributed.optim import ZeroRedundancyOptimizer
+
+    class OptimizerModel(BoringModel):
+        def configure_optimizers(self):
+            return ZeroRedundancyOptimizer(params=self.parameters(), optimizer_class=torch.optim.Adam, lr=0.01)
+
+    model = OptimizerModel()
+    strategy = DDPStrategy(
+        ddp_comm_state=post_localSGD.PostLocalSGDState(
+            process_group=None,
+            subgroup=None,
+            start_localSGD_iter=8,
+        ),
+        ddp_comm_hook=post_localSGD.post_localSGD_hook,
+        model_averaging_period=4,
+    )
+
+    trainer = Trainer(
+        fast_dev_run=True,
+        gpus=2,
+        strategy=strategy,
+        default_root_dir=tmpdir,
+        sync_batchnorm=True,
+    )
+
+    with pytest.raises(ValueError, match="Currently model averaging cannot work with a distributed optimizer"):
+        trainer.fit(model)
+
+    average_parameters_mock.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

_In this PR I am finishing https://github.com/PyTorchLightning/pytorch-lightning/pull/9446 which was created by @wayi1 before the Strategy refactor. The description below is copied from that PR._

This is an improvement of https://github.com/PyTorchLightning/pytorch-lightning/pull/8967.

Replace `PostLocalSGDOptimizer` by a dedicated model averaging component that can run after `optimizer_step`.

The previous implementation can cause data races and fail the training for some cases. For example, if the data loading phase also involves allreduce (e.g., for checking if the input data stream has reached the end), and such allreduce can be kicked off during `optimizer.step()`. Therefore, the implementation in this PR can fix such issue.

Proposal: https://github.com/pytorch/pytorch/issues/59699

There are two options to enable post-local SGD by using vanilla PyTorch:

1. Post-LocalSGD Comm Hook + Periodic Model Averager
https://github.com/pytorch/pytorch/blob/master/torch/distributed/algorithms/model_averaging/averagers.py#L48-L78

    This option requires 1-line addition (such as `averager.average_parameters(model.parameters())`) in the training loop.

2. Post-LocalSGD Comm Hook + Post-LocalSGD Optimizer
https://github.com/pytorch/pytorch/blob/master/torch/distributed/optim/post_localSGD_optimizer.py#L15-L48

    This option does not need any code change in the training loop. I tried this option earlier. However, one limitation is that if there is another phase such as data loading that also runs some communication like allreduce and overlaps with `optimizer_step()`, then this can cause potential data race and fail the training. Since such concurrent phase like data loading is out of the control of model averaging, I didn't choose this implementation.

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
