### PR TITLE
Remove deprecated `progress_bar_refresh_rate` from Trainer constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
--
+- Removed the `progress_bar_refresh_rate` argument from the Trainer constructor  ([#FIX](https://github.com/PyTorchLightning/pytorch-lightning/pull/FIX))
 
 
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
-- Removed the `progress_bar_refresh_rate` argument from the `Trainer` constructor ([#12514](https://github.com/PyTorchLightning/pytorch-lightning/pull/12514))
+- Removed the deprecated `progress_bar_refresh_rate` argument from the `Trainer` constructor ([#12514](https://github.com/PyTorchLightning/pytorch-lightning/pull/12514))
 
 
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
-- Removed the `progress_bar_refresh_rate` argument from the Trainer constructor  ([#FIX](https://github.com/PyTorchLightning/pytorch-lightning/pull/FIX))
+- Removed the `progress_bar_refresh_rate` argument from the Trainer constructor  ([#12514](https://github.com/PyTorchLightning/pytorch-lightning/pull/12514))
 
 
 -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Removed
 
-- Removed the `progress_bar_refresh_rate` argument from the Trainer constructor  ([#12514](https://github.com/PyTorchLightning/pytorch-lightning/pull/12514))
+- Removed the `progress_bar_refresh_rate` argument from the `Trainer` constructor ([#12514](https://github.com/PyTorchLightning/pytorch-lightning/pull/12514))
 
 
 -

--- a/docs/source/common/trainer.rst
+++ b/docs/source/common/trainer.rst
@@ -1306,36 +1306,6 @@ See the :doc:`profiler documentation <../advanced/profiler>`. for more details.
     # advanced profiler for function-level stats, equivalent to `profiler=AdvancedProfiler()`
     trainer = Trainer(profiler="advanced")
 
-progress_bar_refresh_rate
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. warning:: ``progress_bar_refresh_rate`` has been deprecated in v1.5 and will be removed in v1.7.
-    Please pass :class:`~pytorch_lightning.callbacks.progress.TQDMProgressBar` with ``refresh_rate``
-    directly to the Trainer's ``callbacks`` argument instead. To disable the progress bar,
-    pass ``enable_progress_bar = False`` to the Trainer.
-
-.. raw:: html
-
-    <video width="50%" max-width="400px" controls
-    poster="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/trainer_flags/thumb/progress_bar%E2%80%A8_refresh_rate.jpg"
-    src="https://pl-bolts-doc-images.s3.us-east-2.amazonaws.com/pl_docs/trainer_flags/progress_bar_refresh_rate.mp4"></video>
-
-|
-
-How often to refresh progress bar (in steps).
-
-.. testcode::
-
-    # default used by the Trainer
-    trainer = Trainer(progress_bar_refresh_rate=1)
-
-    # disable progress bar
-    trainer = Trainer(progress_bar_refresh_rate=0)
-
-Note:
-    - In Google Colab notebooks, faster refresh rates (lower number) is known to crash them because of their screen refresh rates.
-      Lightning will set it to 20 in these environments if the user does not provide a value.
-    - This argument is ignored if a custom callback is passed to :paramref:`~Trainer.callbacks`.
 
 enable_progress_bar
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/source/common/trainer.rst
+++ b/docs/source/common/trainer.rst
@@ -1306,7 +1306,6 @@ See the :doc:`profiler documentation <../advanced/profiler>`. for more details.
     # advanced profiler for function-level stats, equivalent to `profiler=AdvancedProfiler()`
     trainer = Trainer(profiler="advanced")
 
-
 enable_progress_bar
 ^^^^^^^^^^^^^^^^^^^
 

--- a/pytorch_lightning/callbacks/progress/tqdm_progress.py
+++ b/pytorch_lightning/callbacks/progress/tqdm_progress.py
@@ -90,10 +90,7 @@ class TQDMProgressBar(ProgressBarBase):
 
     Args:
         refresh_rate: Determines at which rate (in number of batches) the progress bars get updated.
-            Set it to ``0`` to disable the display. By default, the :class:`~pytorch_lightning.trainer.trainer.Trainer`
-            uses this implementation of the progress bar and sets the refresh rate to the value provided to the
-            :paramref:`~pytorch_lightning.trainer.trainer.Trainer.progress_bar_refresh_rate` argument in the
-            :class:`~pytorch_lightning.trainer.trainer.Trainer`.
+            Set it to ``0`` to disable the display.
         process_position: Set this to a value greater than ``0`` to offset the progress bars by this many lines.
             This is useful when you have progress bars defined elsewhere and want to show all of them
             together. This corresponds to

--- a/pytorch_lightning/trainer/connectors/callback_connector.py
+++ b/pytorch_lightning/trainer/connectors/callback_connector.py
@@ -232,12 +232,9 @@ class CallbackConnector:
                 f" but found `{progress_bar_callback.__class__.__name__}` in callbacks list."
             )
 
-        # Return early if the user intends to disable the progress bar callback
-        if not enable_progress_bar:
-            return
-
-        progress_bar_callback = TQDMProgressBar(process_position=process_position)
-        self.trainer.callbacks.append(progress_bar_callback)
+        if enable_progress_bar:
+            progress_bar_callback = TQDMProgressBar(process_position=process_position)
+            self.trainer.callbacks.append(progress_bar_callback)
 
     def _configure_timer_callback(self, max_time: Optional[Union[str, timedelta, Dict[str, int]]] = None) -> None:
         if max_time is None:

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -146,7 +146,6 @@ class Trainer(
         tpu_cores: Optional[Union[List[int], str, int]] = None,
         ipus: Optional[int] = None,
         log_gpu_memory: Optional[str] = None,  # TODO: Remove in 1.7
-        progress_bar_refresh_rate: Optional[int] = None,  # TODO: remove in v1.7
         enable_progress_bar: bool = True,
         overfit_batches: Union[int, float] = 0.0,
         track_grad_norm: Union[int, float, str] = -1,
@@ -330,16 +329,6 @@ class Trainer(
                     ``process_position`` has been deprecated in v1.5 and will be removed in v1.7.
                     Please pass :class:`~pytorch_lightning.callbacks.progress.TQDMProgressBar` with ``process_position``
                     directly to the Trainer's ``callbacks`` argument instead.
-
-            progress_bar_refresh_rate: How often to refresh progress bar (in steps). Value ``0`` disables progress bar.
-                Ignored when a custom progress bar is passed to :paramref:`~Trainer.callbacks`. Default: None, means
-                a suitable value will be chosen based on the environment (terminal, Google COLAB, etc.).
-
-                .. deprecated:: v1.5
-                    ``progress_bar_refresh_rate`` has been deprecated in v1.5 and will be removed in v1.7.
-                    Please pass :class:`~pytorch_lightning.callbacks.progress.TQDMProgressBar` with ``refresh_rate``
-                    directly to the Trainer's ``callbacks`` argument instead. To disable the progress bar,
-                    pass ``enable_progress_bar = False`` to the Trainer.
 
             enable_progress_bar: Whether to enable to progress bar by default.
                 Default: ``False``.
@@ -546,7 +535,6 @@ class Trainer(
             checkpoint_callback,
             enable_checkpointing,
             enable_progress_bar,
-            progress_bar_refresh_rate,
             process_position,
             default_root_dir,
             weights_save_path,

--- a/tests/callbacks/test_tqdm_progress_bar.py
+++ b/tests/callbacks/test_tqdm_progress_bar.py
@@ -76,28 +76,20 @@ class MockTqdm(Tqdm):
         # won't print but is still set
         {"callbacks": TQDMProgressBar(refresh_rate=0)},
         {"callbacks": TQDMProgressBar()},
-        {"progress_bar_refresh_rate": 1},
     ],
 )
 def test_tqdm_progress_bar_on(tmpdir, kwargs):
     """Test different ways the progress bar can be turned on."""
-    if "progress_bar_refresh_rate" in kwargs:
-        with pytest.deprecated_call(match=r"progress_bar_refresh_rate=.*` is deprecated"):
-            trainer = Trainer(default_root_dir=tmpdir, **kwargs)
-    else:
-        trainer = Trainer(default_root_dir=tmpdir, **kwargs)
+    trainer = Trainer(default_root_dir=tmpdir, **kwargs)
 
     progress_bars = [c for c in trainer.callbacks if isinstance(c, ProgressBarBase)]
     assert len(progress_bars) == 1
     assert progress_bars[0] is trainer.progress_bar_callback
 
 
-@pytest.mark.parametrize("kwargs", [{"enable_progress_bar": False}, {"progress_bar_refresh_rate": 0}])
-def test_tqdm_progress_bar_off(tmpdir, kwargs):
-    """Test different ways the progress bar can be turned off."""
-    if "progress_bar_refresh_rate" in kwargs:
-        pytest.deprecated_call(match=r"progress_bar_refresh_rate=.*` is deprecated").__enter__()
-    trainer = Trainer(default_root_dir=tmpdir, **kwargs)
+def test_tqdm_progress_bar_off(tmpdir):
+    """Test turning the progress bar off."""
+    trainer = Trainer(default_root_dir=tmpdir, enable_progress_bar=False)
     progress_bars = [c for c in trainer.callbacks if isinstance(c, ProgressBarBase)]
     assert not len(progress_bars)
 
@@ -263,15 +255,13 @@ def test_tqdm_progress_bar_progress_refresh(tmpdir, refresh_rate: int):
             self.test_batches_seen += 1
 
     pbar = CurrentProgressBar(refresh_rate=refresh_rate)
-    with pytest.deprecated_call(match=r"progress_bar_refresh_rate=101\)` is deprecated"):
-        trainer = Trainer(
-            default_root_dir=tmpdir,
-            callbacks=[pbar],
-            progress_bar_refresh_rate=101,  # should not matter if custom callback provided
-            limit_train_batches=1.0,
-            num_sanity_val_steps=2,
-            max_epochs=3,
-        )
+    trainer = Trainer(
+        default_root_dir=tmpdir,
+        callbacks=[pbar],
+        limit_train_batches=1.0,
+        num_sanity_val_steps=2,
+        max_epochs=3,
+    )
     assert trainer.progress_bar_callback.refresh_rate == refresh_rate
 
     trainer.fit(model)
@@ -348,10 +338,6 @@ def test_tqdm_progress_bar_value_on_colab(tmpdir):
     assert trainer.progress_bar_callback.refresh_rate == 20
 
     trainer = Trainer(default_root_dir=tmpdir, callbacks=TQDMProgressBar(refresh_rate=19))
-    assert trainer.progress_bar_callback.refresh_rate == 19
-
-    with pytest.deprecated_call(match=r"progress_bar_refresh_rate=19\)` is deprecated"):
-        trainer = Trainer(default_root_dir=tmpdir, progress_bar_refresh_rate=19)
     assert trainer.progress_bar_callback.refresh_rate == 19
 
 

--- a/tests/callbacks/test_tqdm_progress_bar.py
+++ b/tests/callbacks/test_tqdm_progress_bar.py
@@ -71,16 +71,16 @@ class MockTqdm(Tqdm):
 
 
 @pytest.mark.parametrize(
-    "kwargs",
+    "pbar",
     [
         # won't print but is still set
-        {"callbacks": TQDMProgressBar(refresh_rate=0)},
-        {"callbacks": TQDMProgressBar()},
+        TQDMProgressBar(refresh_rate=0),
+        TQDMProgressBar(),
     ],
 )
-def test_tqdm_progress_bar_on(tmpdir, kwargs):
+def test_tqdm_progress_bar_on(tmpdir, pbar):
     """Test different ways the progress bar can be turned on."""
-    trainer = Trainer(default_root_dir=tmpdir, **kwargs)
+    trainer = Trainer(default_root_dir=tmpdir, callbacks=pbar)
 
     progress_bars = [c for c in trainer.callbacks if isinstance(c, ProgressBarBase)]
     assert len(progress_bars) == 1

--- a/tests/deprecated_api/test_remove_1-7.py
+++ b/tests/deprecated_api/test_remove_1-7.py
@@ -112,7 +112,6 @@ def test_v1_7_0_moved_get_progress_bar_dict(tmpdir):
 
     trainer = Trainer(
         default_root_dir=tmpdir,
-        progress_bar_refresh_rate=None,
         fast_dev_run=True,
     )
     test_model = TestModel()
@@ -255,11 +254,6 @@ def test_v1_7_0_deprecate_add_get_queue(tmpdir):
 
     with pytest.deprecated_call(match=r"`LightningModule.get_from_queue` method was deprecated in v1.5"):
         trainer.fit(model)
-
-
-def test_v1_7_0_progress_bar_refresh_rate_trainer_constructor(tmpdir):
-    with pytest.deprecated_call(match=r"Setting `Trainer\(progress_bar_refresh_rate=1\)` is deprecated in v1.5"):
-        _ = Trainer(progress_bar_refresh_rate=1)
 
 
 def test_v1_7_0_lightning_logger_base_close(tmpdir):


### PR DESCRIPTION
## What does this PR do?
Part of #12521.

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
