### PR TITLE
Fix LightningCLI tests with invalid subclass arguments order

### DIFF
--- a/tests/utilities/test_cli.py
+++ b/tests/utilities/test_cli.py
@@ -737,7 +737,7 @@ def test_lightning_cli_optimizers_and_lr_scheduler_with_link_to(use_registries, 
             self.optim2 = instantiate_class(self.parameters(), optim2)
             self.scheduler = instantiate_class(self.optim1, scheduler)
 
-    cli_args = ["fit", f"--trainer.default_root_dir={tmpdir}", "--trainer.max_epochs=1", "--lr_scheduler.gamma=0.2"]
+    cli_args = ["fit", f"--trainer.default_root_dir={tmpdir}", "--trainer.max_epochs=1"]
     if use_registries:
         cli_args += [
             "--optim1",
@@ -750,6 +750,7 @@ def test_lightning_cli_optimizers_and_lr_scheduler_with_link_to(use_registries, 
         ]
     else:
         cli_args += ["--optim2.class_path=torch.optim.SGD", "--optim2.init_args.lr=0.01"]
+    cli_args += ["--lr_scheduler.gamma=0.2"]
 
     with mock.patch("sys.argv", ["any.py"] + cli_args):
         cli = MyLightningCLI(TestModel)
@@ -1249,9 +1250,8 @@ def test_optimizers_and_lr_schedulers_add_arguments_to_parser_implemented_reload
         "--lr_scheduler.max_lr=1",
         "--opt1",
         "Adam",
+        "--opt2=ASGD",
         "--opt2.lr=0.1",
-        "--opt2",
-        "ASGD",
         "--lr_scheduler.anneal_strategy=linear",
         "--something",
         "a",


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes two unit tests that have invalid argument order in specifying parameters for subclasses. I have been looking into implementing [jsonargparse#84](https://github.com/omni-us/jsonargparse/issues/84) with the aim of eventually removing https://github.com/PyTorchLightning/pytorch-lightning/blob/3e808b8a7002f13970c9d6f449fb2bb1042b9b98/pytorch_lightning/utilities/cli.py#L280-L341

While doing this I noticed the inconsistencies in the tests. With the implemented placeholder it works, but this does not conform with how jsonargparse works. The order of the arguments is important. And for subclasses it is always necessary to first specify the `class_path` and then its `init_args`. If an init arg is given before the `class_path` it gives as error `f'Found {opt_str} but not yet known to which class_path this corresponds.'`.

Relates to #12464 and [jsonargparse#84](https://github.com/omni-us/jsonargparse/issues/84)

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->
None

## Before submitting

- [n/a] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [n/a] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
