### PR TITLE
Expose deprecated arguments from logger base interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Avoid calling `average_parameters` multiple times per optimizer step ([#12452](https://github.com/PyTorchLightning/pytorch-lightning/pull/12452))
 
 
--
+- Properly pass some Logger's parent's arguments to `super().__init__()` ([#12609](https://github.com/PyTorchLightning/pytorch-lightning/pull/12609))
 
 
 -

--- a/pytorch_lightning/loggers/comet.py
+++ b/pytorch_lightning/loggers/comet.py
@@ -19,7 +19,7 @@ Comet Logger
 import logging
 import os
 from argparse import Namespace
-from typing import Any, Dict, Optional, Union, Mapping, Callable, Sequence
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Union
 
 import torch
 from torch import is_tensor

--- a/pytorch_lightning/loggers/comet.py
+++ b/pytorch_lightning/loggers/comet.py
@@ -19,7 +19,7 @@ Comet Logger
 import logging
 import os
 from argparse import Namespace
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, Mapping, Callable, Sequence
 
 import torch
 from torch import is_tensor
@@ -140,13 +140,15 @@ class CometLogger(LightningLoggerBase):
         experiment_key: Optional[str] = None,
         offline: bool = False,
         prefix: str = "",
+        agg_key_funcs: Optional[Mapping[str, Callable[[Sequence[float]], float]]] = None,
+        agg_default_func: Optional[Callable[[Sequence[float]], float]] = None,
         **kwargs,
     ):
         if comet_ml is None:
             raise ModuleNotFoundError(
                 "You want to use `comet_ml` logger which is not installed yet, install it with `pip install comet-ml`."
             )
-        super().__init__()
+        super().__init__(agg_key_funcs=agg_key_funcs, agg_default_func=agg_default_func)
         self._experiment = None
 
         # Determine online or offline mode based on which arguments were passed to CometLogger

--- a/pytorch_lightning/loggers/neptune.py
+++ b/pytorch_lightning/loggers/neptune.py
@@ -24,7 +24,7 @@ import os
 import warnings
 from argparse import Namespace
 from functools import reduce
-from typing import Any, Dict, Generator, Optional, Set, Union
+from typing import Any, Dict, Generator, Optional, Set, Union, Mapping, Callable, Sequence
 from weakref import ReferenceType
 
 import torch
@@ -265,6 +265,8 @@ class NeptuneLogger(LightningLoggerBase):
         run: Optional["Run"] = None,
         log_model_checkpoints: Optional[bool] = True,
         prefix: str = "training",
+        agg_key_funcs: Optional[Mapping[str, Callable[[Sequence[float]], float]]] = None,
+        agg_default_func: Optional[Callable[[Sequence[float]], float]] = None,
         **neptune_run_kwargs,
     ):
         # verify if user passed proper init arguments
@@ -275,7 +277,7 @@ class NeptuneLogger(LightningLoggerBase):
                 " `pip install neptune-client`."
             )
 
-        super().__init__()
+        super().__init__(agg_key_funcs=agg_key_funcs, agg_default_func=agg_default_func)
         self._log_model_checkpoints = log_model_checkpoints
         self._prefix = prefix
         self._run_name = name

--- a/pytorch_lightning/loggers/neptune.py
+++ b/pytorch_lightning/loggers/neptune.py
@@ -24,7 +24,7 @@ import os
 import warnings
 from argparse import Namespace
 from functools import reduce
-from typing import Any, Dict, Generator, Optional, Set, Union, Mapping, Callable, Sequence
+from typing import Any, Callable, Dict, Generator, Mapping, Optional, Sequence, Set, Union
 from weakref import ReferenceType
 
 import torch

--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -19,7 +19,7 @@ TensorBoard Logger
 import logging
 import os
 from argparse import Namespace
-from typing import Any, Dict, Optional, Union, Sequence, Mapping, Callable
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Union
 
 import numpy as np
 import torch

--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -19,7 +19,7 @@ TensorBoard Logger
 import logging
 import os
 from argparse import Namespace
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, Sequence, Mapping, Callable
 
 import numpy as np
 import torch
@@ -94,9 +94,11 @@ class TensorBoardLogger(LightningLoggerBase):
         default_hp_metric: bool = True,
         prefix: str = "",
         sub_dir: Optional[str] = None,
+        agg_key_funcs: Optional[Mapping[str, Callable[[Sequence[float]], float]]] = None,
+        agg_default_func: Optional[Callable[[Sequence[float]], float]] = None,
         **kwargs,
     ):
-        super().__init__()
+        super().__init__(agg_key_funcs=agg_key_funcs, agg_default_func=agg_default_func)
         self._save_dir = save_dir
         self._name = name or ""
         self._version = version

--- a/pytorch_lightning/loggers/wandb.py
+++ b/pytorch_lightning/loggers/wandb.py
@@ -18,7 +18,7 @@ Weights and Biases Logger
 import os
 from argparse import Namespace
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union, Mapping, Callable, Sequence
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
 from weakref import ReferenceType
 
 import torch.nn as nn

--- a/pytorch_lightning/loggers/wandb.py
+++ b/pytorch_lightning/loggers/wandb.py
@@ -18,7 +18,7 @@ Weights and Biases Logger
 import os
 from argparse import Namespace
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Mapping, Callable, Sequence
 from weakref import ReferenceType
 
 import torch.nn as nn
@@ -259,6 +259,8 @@ class WandbLogger(LightningLoggerBase):
         log_model: Union[str, bool] = False,
         experiment=None,
         prefix: Optional[str] = "",
+        agg_key_funcs: Optional[Mapping[str, Callable[[Sequence[float]], float]]] = None,
+        agg_default_func: Optional[Callable[[Sequence[float]], float]] = None,
         **kwargs,
     ):
         if wandb is None:
@@ -281,7 +283,7 @@ class WandbLogger(LightningLoggerBase):
                 "Hint: Upgrade with `pip install --upgrade wandb`."
             )
 
-        super().__init__()
+        super().__init__(agg_key_funcs=agg_key_funcs, agg_default_func=agg_default_func)
         self._offline = offline
         self._log_model = log_model
         self._prefix = prefix


### PR DESCRIPTION
## What does this PR do?

`jsonargparse` includes the parent's arguments in the config when variadic `**kwargs` are included.

This means we need to explicitly list them so they don't become part of `**kwargs`. Now we pass them to `super().__init__()` so deprecation messages are raised.

I did not update the docstring of these logger classes as these are deprecated and it's already in the parent's docstring.

Fixes #12529 

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @borda @awaelchli @morganmcg1 @AyushExel @borisdayma @scottire @manangoel99 @edward-io @rohitgr7 @kamil-kaczmarek @Raalsky @Blaizzy