### PR TITLE
Fallback to `CPUAccelerator` when `([], 0, "0")` are passed to the `devices` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Avoid calling `average_parameters` multiple times per optimizer step ([#12452](https://github.com/PyTorchLightning/pytorch-lightning/pull/12452))
 
 
--
+- Fallback to `CPUAccelerator` when `([], 0, "0")` are passed to the `devices` flag and to keep it consistent with the `gpus`, `tpu_cores` and `ipus` flag ([12619](https://github.com/PyTorchLightning/pytorch-lightning/pull/12619))
 
 
 -

--- a/pytorch_lightning/trainer/connectors/accelerator_connector.py
+++ b/pytorch_lightning/trainer/connectors/accelerator_connector.py
@@ -424,6 +424,14 @@ class AcceleratorConnector:
                 " `accelerator=('auto'|'tpu'|'gpu'|'ipu'|'cpu'|'hpu)` for the devices mapping"
             )
 
+        if self._devices_flag in ([], 0, "0"):
+            rank_zero_warn(
+                f"`devices={self._devices_flag}` will be ignored,"
+                " falling back to `CPUAccelerator` with the default `devices='auto'`"
+            )
+            self._accelerator_flag = "cpu"
+            self._devices_flag = "auto"
+
     def _map_deprecated_devices_specfic_info_to_accelerator_and_device_flag(
         self,
         devices: Optional[Union[List[int], str, int]],

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -2256,6 +2256,7 @@ def test_fallback_to_cpu_accelerator_with_devices_auto(monkeypatch, trainer_kwar
     elif trainer_kwargs.get("accelerator") == "tpu":
         monkeypatch.setattr(pytorch_lightning.accelerators.tpu.TPUAccelerator, "is_available", lambda _: True)
 
-    trainer = Trainer(**trainer_kwargs)
+    with pytest.warns(UserWarning, match="falling back to `CPUAccelerator` with the default `devices='auto'`"):
+        trainer = Trainer(**trainer_kwargs)
     assert isinstance(trainer.accelerator, CPUAccelerator)
     assert trainer.num_devices == CPUAccelerator.auto_device_count()


### PR DESCRIPTION

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fallback to `CPUAccelerator` when `([], 0, "0")` are passed to the `devices` flag and to keep it consistent with the `gpus`, `tpu_cores` and `ipus` flag.

Current behavior with `gpus` and other device flags.

```python
## Doesn't fail and falls back to `CPUAccelerator`
Trainer(gpus=0)
```

Without the fix in this PR, the following used to fail
```python
Trainer(accelerator="xpu", devices=0)
```


### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @akihironitta @rohitgr7 @justusschock