### PR TITLE
Set a less strict pre-commit Python version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 default_language_version:
-  python: python3.8
+  python: python3
 
 ci:
   autofix_prs: true


### PR DESCRIPTION
## What does this PR do?

Pre-commit currently requires Python 3.8 to run. This should be relaxed for local development.

Fixes the error described in https://github.com/pre-commit/pre-commit/issues/1375

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [n/a] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [n/a] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [n/a] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @carmocca @akihironitta @borda