### PR TITLE
Support optimizers having no `state` property

### DIFF
--- a/pytorch_lightning/utilities/optimizer.py
+++ b/pytorch_lightning/utilities/optimizer.py
@@ -20,7 +20,6 @@ from torch.optim import Optimizer
 from pytorch_lightning.utilities.apply_func import apply_to_collection, move_data_to_device
 from pytorch_lightning.utilities.types import _DEVICE
 
-
 def optimizers_to_device(optimizers: Iterable[Optimizer], device: _DEVICE) -> None:
     """Moves optimizer states for a sequence of optimizers to the device."""
     for opt in optimizers:
@@ -29,5 +28,8 @@ def optimizers_to_device(optimizers: Iterable[Optimizer], device: _DEVICE) -> No
 
 def optimizer_to_device(optimizer: Optimizer, device: _DEVICE) -> None:
     """Moves the state of a single optimizer to the device."""
-    for p, v in optimizer.state.items():
-        optimizer.state[p] = apply_to_collection(v, torch.Tensor, move_data_to_device, device)
+    state, param_groups = optimizer.state_dict().values()
+    for p, v in state.items():
+        state[p] = apply_to_collection(v, torch.Tensor, move_data_to_device, device)
+    optimizer.load_state_dict({'state': state, 'param_groups': param_groups})
+

--- a/pytorch_lightning/utilities/optimizer.py
+++ b/pytorch_lightning/utilities/optimizer.py
@@ -20,6 +20,7 @@ from torch.optim import Optimizer
 from pytorch_lightning.utilities.apply_func import apply_to_collection, move_data_to_device
 from pytorch_lightning.utilities.types import _DEVICE
 
+
 def optimizers_to_device(optimizers: Iterable[Optimizer], device: _DEVICE) -> None:
     """Moves optimizer states for a sequence of optimizers to the device."""
     for opt in optimizers:
@@ -31,5 +32,4 @@ def optimizer_to_device(optimizer: Optimizer, device: _DEVICE) -> None:
     state, param_groups = optimizer.state_dict().values()
     for p, v in state.items():
         state[p] = apply_to_collection(v, torch.Tensor, move_data_to_device, device)
-    optimizer.load_state_dict({'state': state, 'param_groups': param_groups})
-
+    optimizer.load_state_dict({"state": state, "param_groups": param_groups})


### PR DESCRIPTION
Hello, 
Thank you for your great work providing pytorch-lightning. I am doing research and I wanted to use LARS optimizer provided by this repo https://github.com/kakaobrain/torchlars. However, I am getting the following issue:
![image](https://user-images.githubusercontent.com/25345720/161887458-1b0fd04a-32cb-4cca-b01c-9991a03f5bdb.png)
I replaced the direct access to optimizer's state with corresponding methods (state_dict and load_state_dict). I am not sure whether it is a good practice to access the state directly. I believe it still behaves as expected and it allows me to use LARS optimizer. 

