### PR TITLE
Fix `LightningLite.run` signature for arbitrary arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Avoid calling `average_parameters` multiple times per optimizer step ([#12452](https://github.com/PyTorchLightning/pytorch-lightning/pull/12452))
 
 
--
+- Fixed an issue where incorrect type warnings appear when the overridden `LightningLite.run` method accepts user-defined arguments ([#12629](https://github.com/PyTorchLightning/pytorch-lightning/pull/12629))
 
 
 -

--- a/pytorch_lightning/lite/lite.py
+++ b/pytorch_lightning/lite/lite.py
@@ -142,7 +142,7 @@ class LightningLite(ABC):
         return self._strategy.is_global_zero
 
     @abstractmethod
-    def run(self) -> Any:
+    def run(self, *args: Any, **kargs: Any) -> Any:
         """All the code inside this run method gets accelerated by Lite.
 
         You can pass arbitrary arguments to this function when overriding it.

--- a/pytorch_lightning/lite/lite.py
+++ b/pytorch_lightning/lite/lite.py
@@ -142,7 +142,7 @@ class LightningLite(ABC):
         return self._strategy.is_global_zero
 
     @abstractmethod
-    def run(self, *args: Any, **kargs: Any) -> Any:
+    def run(self, *args: Any, **kwargs: Any) -> Any:
         """All the code inside this run method gets accelerated by Lite.
 
         You can pass arbitrary arguments to this function when overriding it.


### PR DESCRIPTION
## What does this PR do?

The LightningLite.run method can accept arbitrary arguments. This PR fixes the signature and avoids linting errors with static type checkers in IDEs:

<img width="892" alt="image" src="https://user-images.githubusercontent.com/5495193/161891620-d6a5e86e-5012-48ed-907e-b11d2ab83e40.png">


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


cc @borda @carmocca @justusschock @awaelchli