### PR TITLE
remove deprecated `model_size` from LightningModule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed the deprecated `summarize` method from the `LightningModule` ([#12559](https://github.com/PyTorchLightning/pytorch-lightning/pull/12559))
 
 
+- Removed the deprecated `model_size` property from the `LightningModule` class ([#PR_ID](https://github.com/PyTorchLightning/pytorch-lightning/pull/PR_ID))
+
+
 - Removed the deprecated `stochastic_weight_avg` argument from the `Trainer` constructor ([#12535](https://github.com/PyTorchLightning/pytorch-lightning/pull/12535))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Removed the deprecated `summarize` method from the `LightningModule` ([#12559](https://github.com/PyTorchLightning/pytorch-lightning/pull/12559))
 
 
-- Removed the deprecated `model_size` property from the `LightningModule` class ([#PR_ID](https://github.com/PyTorchLightning/pytorch-lightning/pull/PR_ID))
+- Removed the deprecated `model_size` property from the `LightningModule` class ([#12641](https://github.com/PyTorchLightning/pytorch-lightning/pull/12641))
 
 
 - Removed the deprecated `stochastic_weight_avg` argument from the `Trainer` constructor ([#12535](https://github.com/PyTorchLightning/pytorch-lightning/pull/12535))

--- a/docs/source/common/lightning_module.rst
+++ b/docs/source/common/lightning_module.rst
@@ -1112,11 +1112,6 @@ Set and access example_input_array, which basically represents a single batch.
         # generate some images using the example_input_array
         gen_images = self.generator(self.example_input_array)
 
-model_size
-~~~~~~~~~~
-
-Get the model file size (in megabytes) using ``self.model_size`` inside LightningModule.
-
 truncated_bptt_steps
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -45,7 +45,6 @@ from pytorch_lightning.utilities.apply_func import apply_to_collection, convert_
 from pytorch_lightning.utilities.cloud_io import get_filesystem
 from pytorch_lightning.utilities.distributed import distributed_available, sync_ddp
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
-from pytorch_lightning.utilities.memory import get_model_size_mb
 from pytorch_lightning.utilities.parsing import collect_init_args
 from pytorch_lightning.utilities.rank_zero import rank_zero_debug, rank_zero_deprecation, rank_zero_warn
 from pytorch_lightning.utilities.signature_utils import is_param_in_hook_signature
@@ -77,7 +76,6 @@ class LightningModule(
             "local_rank",
             "logger",
             "loggers",
-            "model_size",
             "automatic_optimization",
             "truncated_bptt_steps",
             "use_amp",
@@ -1927,21 +1925,6 @@ class LightningModule(
         self._running_torchscript = False
 
         return torchscript_module
-
-    @property
-    def model_size(self) -> float:
-        """Returns the model size in MegaBytes (MB)
-
-        Note:
-            This property will not return correct value for Deepspeed (stage 3) and fully-sharded training.
-        """
-        if not self._running_torchscript:  # remove with the deprecation removal
-            rank_zero_deprecation(
-                "The `LightningModule.model_size` property was deprecated in v1.5 and will be removed in v1.7."
-                " Please use the `pytorch_lightning.utilities.memory.get_model_size_mb`.",
-                stacklevel=5,
-            )
-        return get_model_size_mb(self)
 
     @property
     def use_amp(self) -> bool:

--- a/tests/deprecated_api/test_remove_1-7.py
+++ b/tests/deprecated_api/test_remove_1-7.py
@@ -57,14 +57,6 @@ def test_v1_7_0_moved_get_memory_profile_and_get_gpu_memory_map(tmpdir):
         from pytorch_lightning.core.memory import get_gpu_memory_map, get_memory_profile  # noqa: F401
 
 
-def test_v1_7_0_deprecated_model_size():
-    model = BoringModel()
-    with pytest.deprecated_call(
-        match="LightningModule.model_size` property was deprecated in v1.5 and will be removed in v1.7"
-    ):
-        _ = model.model_size
-
-
 def test_v1_7_0_datamodule_transform_properties(tmpdir):
     dm = MNISTDataModule()
     with pytest.deprecated_call(match=r"DataModule property `train_transforms` was deprecated in v1.5"):


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Part of #12521 

Primary change:

- removed the deprecated `model_size` property/method from the `LightningModule` class

Associated edits:

- removed "model_size" from an internal list of `__jit_unused_properties__`
- removed an import made redundant by the above edits
- removed a unit test associated with the removed method
- removed a few lines of documentation describing the removed method 
- updated the changelog

Notes:

Following a suggestion from @kaushikb11 in one of the comments in #12521, a search for ".model_size" on grep.app gave 438 hits. This pattern is quite generic, so it is not surprising there are many hits not related to lightning or to this PR. I browsed through them, quickly omitting cases attempting to assign a model size rather than retrieve it and cases where a model size was compared to strings. I investigated the others for signs of importing lightning or including lightning in the repo requirements file. The only proper hit I found was a repository intel-analytics/BigDL. The authors seem to be already aware that the `model_size` property is deprecated (see [here](https://github.com/intel-analytics/BigDL/issues/4071)), so no further action taken.



### Does your PR introduce any breaking changes? If yes, please list them.

- removed property `model_size` in the LightningModule class


## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
