### PR TITLE
Revert "ci(Mergify): configuration update (#12599)"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,4 +58,3 @@
 /README.md                       @williamfalcon @edenlightning @borda
 /setup.py                        @williamfalcon @borda
 /pytorch_lightning/__about__.py  @williamfalcon @borda
-/.github/mergify.yml             @williamfalcon @borda

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -68,29 +68,3 @@ pull_request_rules:
       request_reviews:
         teams:
           - "@PyTorchLightning/core-lightning"
-
-  - name: Grid.ai employee approval
-    conditions:
-      - or:
-        - approved-reviews-by=awaelchli
-        - approved-reviews-by=Borda
-        - approved-reviews-by=carmocca
-        - approved-reviews-by=edenlightning
-        - approved-reviews-by=ethanwharris
-        - approved-reviews-by=kaushikb11
-        - approved-reviews-by=krshrimali
-        - approved-reviews-by=rohitgr7
-        - approved-reviews-by=tchaton
-        - approved-reviews-by=williamFalcon
-    actions:
-      post_check:
-        title: |
-          {% if check_succeed %}
-          This PR has Grid.ai approval.
-          {% else %}
-          This PR is waiting for approval from a Grid.ai team member.
-          {% endif %}
-        summary: |
-          {% if not check_succeed %}
-          Each pull request must be approved by at least one Grid.ai team member.
-          {% endif %}


### PR DESCRIPTION
This reverts commit 184518c2fab188a9679a5b9d73ba95e3a8097280.

## What does this PR do?

turned out is it paid feature and the subscription is not reasonable for this small improvement

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @carmocca @akihironitta @borda