### PR TITLE
Fix a typo in warning message inside Trainer.reset_train_dataloader

### DIFF
--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1885,7 +1885,7 @@ class Trainer(
 
         if self.loggers and self.num_training_batches < self.log_every_n_steps:
             rank_zero_warn(
-                f"The number of training samples ({self.num_training_batches}) is smaller than the logging interval"
+                f"The number of training batches ({self.num_training_batches}) is smaller than the logging interval"
                 f" Trainer(log_every_n_steps={self.log_every_n_steps}). Set a lower value for log_every_n_steps if"
                 " you want to see logs for the training epoch.",
                 category=PossibleUserWarning,

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -702,11 +702,11 @@ def test_warning_with_small_dataloader_and_logging_interval(tmpdir):
     dataloader = DataLoader(RandomDataset(32, length=10))
     model.train_dataloader = lambda: dataloader
 
-    with pytest.warns(UserWarning, match=r"The number of training samples \(10\) is smaller than the logging interval"):
+    with pytest.warns(UserWarning, match=r"The number of training batches \(10\) is smaller than the logging interval"):
         trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, log_every_n_steps=11)
         trainer.fit(model)
 
-    with pytest.warns(UserWarning, match=r"The number of training samples \(1\) is smaller than the logging interval"):
+    with pytest.warns(UserWarning, match=r"The number of training batches \(1\) is smaller than the logging interval"):
         trainer = Trainer(default_root_dir=tmpdir, max_epochs=1, log_every_n_steps=2, limit_train_batches=1)
         trainer.fit(model)
 


### PR DESCRIPTION
## What does this PR do?

Fix a small typo in a warning message.


### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
Yes
Make sure you had fun coding 🙃
