### PR TITLE
Allow self-reviewing to rerun gatekeeper

### DIFF
--- a/.github/workflows/ci_pr-gatekeeper.yml
+++ b/.github/workflows/ci_pr-gatekeeper.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   pr-gatekeeper:
-    if: github.event.review.state == 'approved'
     name: PR Gatekeeper
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What does this PR do?

When a new commit is pushed, the gatekeeper check disappears. This requires a new review event to re-trigger it.

Since the author cannot self-approve, we need to remove the filtering condition.

### Does your PR introduce any breaking changes? If yes, please list them.

None

## Before submitting

- [n/a] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [n/a] Did you make sure to **update the documentation** with your changes? (if necessary)
- [n/a] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [n/a] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

## PR review

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

cc @carmocca @akihironitta @borda @tchaton @rohitgr7