### PR TITLE
fix import failed

### DIFF
--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -54,7 +54,7 @@ def _module_available(module_path: str) -> bool:
         return False
     try:
         importlib.import_module(module_path)
-    except (ImportError, ModuleNotFoundError):
+    except ImportError:
         return False
     return True
 
@@ -67,7 +67,7 @@ def _compare_version(package: str, op: Callable, version: str, use_base_version:
     """
     try:
         pkg = importlib.import_module(package)
-    except (ImportError, ModuleNotFoundError, DistributionNotFound):
+    except (ImportError, DistributionNotFound):
         return False
     try:
         if hasattr(pkg, "__version__"):

--- a/pytorch_lightning/utilities/imports.py
+++ b/pytorch_lightning/utilities/imports.py
@@ -54,7 +54,7 @@ def _module_available(module_path: str) -> bool:
         return False
     try:
         importlib.import_module(module_path)
-    except ModuleNotFoundError:
+    except (ImportError, ModuleNotFoundError):
         return False
     return True
 
@@ -67,7 +67,7 @@ def _compare_version(package: str, op: Callable, version: str, use_base_version:
     """
     try:
         pkg = importlib.import_module(package)
-    except (ModuleNotFoundError, DistributionNotFound):
+    except (ImportError, ModuleNotFoundError, DistributionNotFound):
         return False
     try:
         if hasattr(pkg, "__version__"):


### PR DESCRIPTION
## What does this PR do?

there is a potential issue when your `torchtext is not build correctly`

```
ImportError                               Traceback (most recent call last)
Input In [2], in <cell line: 8>()
      6 import numpy as np
      7 import torch
----> 8 from pytorch_lightning import LightningModule, Trainer
      9 from pytorch_lightning.utilities import DistributedType
     10 from torch import Tensor, nn

File ~/.local/lib/python3.9/site-packages/pytorch_lightning/__init__.py:30, in <module>
     27     _logger.addHandler(logging.StreamHandler())
     28     _logger.propagate = False
---> 30 from pytorch_lightning.callbacks import Callback  # noqa: E402
     31 from pytorch_lightning.core import LightningDataModule, LightningModule  # noqa: E402
     32 from pytorch_lightning.trainer import Trainer  # noqa: E402

File ~/.local/lib/python3.9/site-packages/pytorch_lightning/callbacks/__init__.py:14, in <module>
      1 # Copyright The PyTorch Lightning team.
      2 #
      3 # Licensed under the Apache License, Version 2.0 (the "License");
   (...)
     12 # See the License for the specific language governing permissions and
     13 # limitations under the License.
---> 14 from pytorch_lightning.callbacks.base import Callback
     15 from pytorch_lightning.callbacks.device_stats_monitor import DeviceStatsMonitor
     16 from pytorch_lightning.callbacks.early_stopping import EarlyStopping

File ~/.local/lib/python3.9/site-packages/pytorch_lightning/callbacks/base.py:25, in <module>
     22 from torch.optim import Optimizer
     24 import pytorch_lightning as pl
---> 25 from pytorch_lightning.utilities.types import STEP_OUTPUT
     28 class Callback:
     29     r"""
     30     Abstract base class used to build new callbacks.
     31 
     32     Subclass this class and override any of the relevant hooks
     33     """

File ~/.local/lib/python3.9/site-packages/pytorch_lightning/utilities/__init__.py:18, in <module>
     14 """General utilities."""
     16 import numpy
---> 18 from pytorch_lightning.utilities.apply_func import move_data_to_device  # noqa: F401
     19 from pytorch_lightning.utilities.distributed import AllGatherGrad  # noqa: F401
     20 from pytorch_lightning.utilities.enums import (  # noqa: F401
     21     _AcceleratorType,
     22     _StrategyType,
   (...)
     27     ModelSummaryMode,
     28 )

File ~/.local/lib/python3.9/site-packages/pytorch_lightning/utilities/apply_func.py:29, in <module>
     26 import torch
     28 from pytorch_lightning.utilities.exceptions import MisconfigurationException
---> 29 from pytorch_lightning.utilities.imports import _compare_version, _TORCHTEXT_LEGACY
     30 from pytorch_lightning.utilities.warnings import rank_zero_deprecation
     32 if _TORCHTEXT_LEGACY:

File ~/.local/lib/python3.9/site-packages/pytorch_lightning/utilities/imports.py:116, in <module>
    114 _TORCH_QUANTIZE_AVAILABLE = bool([eg for eg in torch.backends.quantized.supported_engines if eg != "none"])
    115 _TORCHTEXT_AVAILABLE = _package_available("torchtext")
--> 116 _TORCHTEXT_LEGACY: bool = _TORCHTEXT_AVAILABLE and _compare_version("torchtext", operator.lt, "0.11.0")
    117 _TORCHVISION_AVAILABLE = _package_available("torchvision")
    118 _WANDB_AVAILABLE = _package_available("wandb")

File ~/.local/lib/python3.9/site-packages/pytorch_lightning/utilities/imports.py:69, in _compare_version(package, op, version, use_base_version)
     63 """Compare package version with some requirements.
     64 
     65 >>> _compare_version("torch", operator.ge, "0.1")
     66 True
     67 """
     68 try:
---> 69     pkg = importlib.import_module(package)
     70 except (ModuleNotFoundError, DistributionNotFound):
     71     return False

File /usr/lib/python3.9/importlib/__init__.py:127, in import_module(name, package)
    125             break
    126         level += 1
--> 127 return _bootstrap._gcd_import(name[level:], package, level)

File /usr/local/lib/python3.9/dist-packages/torchtext/__init__.py:5, in <module>
      3 from . import datasets
      4 from . import utils
----> 5 from . import vocab
      6 from . import legacy
      7 from ._extension import _init_extension

File /usr/local/lib/python3.9/dist-packages/torchtext/vocab/__init__.py:11, in <module>
      1 from .vocab import Vocab
      3 from .vectors import (
      4     GloVe,
      5     FastText,
   (...)
      8     Vectors,
      9 )
---> 11 from .vocab_factory import (
     12     vocab,
     13     build_vocab_from_iterator,
     14 )
     16 __all__ = ["Vocab",
     17            "vocab",
     18            "build_vocab_from_iterator",
   (...)
     22            "pretrained_aliases",
     23            "Vectors"]

File /usr/local/lib/python3.9/dist-packages/torchtext/vocab/vocab_factory.py:4, in <module>
      2 from typing import Dict, Iterable, Optional, List
      3 from collections import Counter, OrderedDict
----> 4 from torchtext._torchtext import (
      5     Vocab as VocabPybind,
      6 )
      9 def vocab(ordered_dict: Dict, min_freq: int = 1) -> Vocab:
     10     r"""Factory method for creating a vocab object which maps tokens to indices.
     11 
     12     Note that the ordering in which key value pairs were inserted in the `ordered_dict` will be respected when building the vocab.
   (...)
     42         >>> v2['out of vocab'] is v2[unk_token] #prints True
     43     """

ImportError: /usr/local/lib/python3.9/dist-packages/torchtext/_torchtext.so: undefined symbol: _ZTVN5torch3jit6MethodE
```
see: https://dev.azure.com/PytorchLightning/Tutorials/_build/results?buildId=66516&view=logs&j=4d809e3c-18a0-5a8d-e0ac-4c5682e3f11b&t=ccd228a0-6bb7-550f-2646-371fba78c5ec

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda @tchaton @rohitgr7