### PR TITLE
Update `core/lightning.py` to `core/module.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Raise an error if there are insufficient training batches when using a float value of `limit_train_batches` ([#12885](https://github.com/PyTorchLightning/pytorch-lightning/pull/12885))
 
 
+- Changed `pytorch_lightning.core.lightning` to `pytorch_lightning.core.module` ([#12740](https://github.com/PyTorchLightning/pytorch-lightning/pull/12740))
+
+
 -
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Deprecated setting `LightningCLI(seed_everything_default=None)` in favor of `False` ([#12804](https://github.com/PyTorchLightning/pytorch-lightning/issues/12804)).
 
 
--
+- Deprecated `pytorch_lightning.core.lightning.LightningModule` in favor of `pytorch_lightning.core.module.LightningModule` ([#12740](https://github.com/PyTorchLightning/pytorch-lightning/pull/12740))
 
 
 -

--- a/docs/source/accelerators/accelerator_prepare.rst
+++ b/docs/source/accelerators/accelerator_prepare.rst
@@ -50,7 +50,7 @@ This will make your code scale to any arbitrary number of GPUs or TPUs with Ligh
         z = torch.Tensor(2, 3)
         z = z.type_as(x)
 
-The :class:`~pytorch_lightning.core.lightning.LightningModule` knows what device it is on. You can access the reference via ``self.device``.
+The :class:`~pytorch_lightning.core.module.LightningModule` knows what device it is on. You can access the reference via ``self.device``.
 Sometimes it is necessary to store tensors as module attributes. However, if they are not parameters they will
 remain on the CPU even if the module gets moved to a new device. To prevent that and remain device agnostic,
 register the tensor as a buffer in your modules' ``__init__`` method with :meth:`~torch.nn.Module.register_buffer`.

--- a/docs/source/accelerators/tpu_advanced.rst
+++ b/docs/source/accelerators/tpu_advanced.rst
@@ -26,7 +26,7 @@ Example:
 
 .. code-block:: python
 
-    from pytorch_lightning.core.lightning import LightningModule
+    from pytorch_lightning.core.module import LightningModule
     from torch import nn
     from pytorch_lightning.trainer.trainer import Trainer
 

--- a/docs/source/cli/lightning_cli_advanced_3.rst
+++ b/docs/source/cli/lightning_cli_advanced_3.rst
@@ -73,7 +73,7 @@ To use shorthand notation, the options need to be registered beforehand. This ca
     LightningCLI(auto_registry=True)  # False by default
 
 which will register all subclasses of :class:`torch.optim.Optimizer`, :class:`torch.optim.lr_scheduler._LRScheduler`,
-:class:`~pytorch_lightning.core.lightning.LightningModule`,
+:class:`~pytorch_lightning.core.module.LightningModule`,
 :class:`~pytorch_lightning.core.datamodule.LightningDataModule`, :class:`~pytorch_lightning.callbacks.Callback`, and
 :class:`~pytorch_lightning.loggers.LightningLoggerBase` across all imported modules. This includes those in your own
 code.
@@ -108,7 +108,7 @@ file example that defines a couple of callbacks is the following:
             ...
 
 Similar to the callbacks, any arguments in :class:`~pytorch_lightning.trainer.trainer.Trainer` and user extended
-:class:`~pytorch_lightning.core.lightning.LightningModule` and
+:class:`~pytorch_lightning.core.module.LightningModule` and
 :class:`~pytorch_lightning.core.datamodule.LightningDataModule` classes that have as type hint a class can be configured
 the same way using :code:`class_path` and :code:`init_args`.
 
@@ -209,7 +209,7 @@ A possible config file could be as follows:
         ...
 
 Only model classes that are a subclass of :code:`MyModelBaseClass` would be allowed, and similarly only subclasses of
-:code:`MyDataModuleBaseClass`. If as base classes :class:`~pytorch_lightning.core.lightning.LightningModule` and
+:code:`MyDataModuleBaseClass`. If as base classes :class:`~pytorch_lightning.core.module.LightningModule` and
 :class:`~pytorch_lightning.core.datamodule.LightningDataModule` are given, then the tool would allow any lightning
 module and data module.
 

--- a/docs/source/common/checkpointing_intermediate.rst
+++ b/docs/source/common/checkpointing_intermediate.rst
@@ -120,7 +120,7 @@ What
 Where
 =====
 
-- It gives you the ability to specify the ``dirpath`` and ``filename`` for your checkpoints. Filename can also be dynamic so you can inject the metrics that are being logged using :meth:`~pytorch_lightning.core.lightning.LightningModule.log`.
+- It gives you the ability to specify the ``dirpath`` and ``filename`` for your checkpoints. Filename can also be dynamic so you can inject the metrics that are being logged using :meth:`~pytorch_lightning.core.module.LightningModule.log`.
 
 |
 

--- a/docs/source/common/child_modules.rst
+++ b/docs/source/common/child_modules.rst
@@ -61,7 +61,7 @@ and we can train this using the ``Trainer``:
     trainer = Trainer()
     trainer.fit(lightning_module, train_dataloader, val_dataloader)
 
-And remember that the forward method should define the practical use of a :class:`~pytorch_lightning.core.lightning.LightningModule`.
+And remember that the forward method should define the practical use of a :class:`~pytorch_lightning.core.module.LightningModule`.
 In this case, we want to use the ``LitAutoEncoder`` to extract image representations:
 
 .. code-block:: python

--- a/docs/source/common/early_stopping.rst
+++ b/docs/source/common/early_stopping.rst
@@ -34,7 +34,7 @@ The :class:`~pytorch_lightning.callbacks.early_stopping.EarlyStopping` callback 
 To enable it:
 
 - Import :class:`~pytorch_lightning.callbacks.early_stopping.EarlyStopping` callback.
-- Log the metric you want to monitor using :meth:`~pytorch_lightning.core.lightning.LightningModule.log` method.
+- Log the metric you want to monitor using :meth:`~pytorch_lightning.core.module.LightningModule.log` method.
 - Init the callback, and set ``monitor`` to the logged metric of your choice.
 - Set the ``mode`` based on the metric needs to be monitored.
 - Pass the :class:`~pytorch_lightning.callbacks.early_stopping.EarlyStopping` callback to the :class:`~pytorch_lightning.trainer.trainer.Trainer` callbacks flag.

--- a/docs/source/common/evaluation_intermediate.rst
+++ b/docs/source/common/evaluation_intermediate.rst
@@ -23,7 +23,7 @@ Testing
 
 Lightning allows the user to test their models with any compatible test dataloaders. This can be done before/after training
 and is completely agnostic to :meth:`~pytorch_lightning.trainer.trainer.Trainer.fit` call. The logic used here is defined under
-:meth:`~pytorch_lightning.core.lightning.LightningModule.test_step`.
+:meth:`~pytorch_lightning.core.module.LightningModule.test_step`.
 
 Testing is performed using the ``Trainer`` object's ``.test()`` method.
 
@@ -141,9 +141,9 @@ Validation
 **********
 
 Lightning allows the user to validate their models with any compatible ``val dataloaders``. This can be done before/after training.
-The logic associated to the validation is defined within the :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step`.
+The logic associated to the validation is defined within the :meth:`~pytorch_lightning.core.module.LightningModule.validation_step`.
 
-Apart from this ``.validate`` has same API as ``.test``, but would rely respectively on :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step` and :meth:`~pytorch_lightning.core.lightning.LightningModule.test_step`.
+Apart from this ``.validate`` has same API as ``.test``, but would rely respectively on :meth:`~pytorch_lightning.core.module.LightningModule.validation_step` and :meth:`~pytorch_lightning.core.module.LightningModule.test_step`.
 
 .. note::
     ``.validate`` method uses the same validation logic being used under validation happening within

--- a/docs/source/common/hyperparameters.rst
+++ b/docs/source/common/hyperparameters.rst
@@ -116,8 +116,8 @@ improve readability and reproducibility.
 save_hyperparameters
 """"""""""""""""""""
 
-Use :meth:`~pytorch_lightning.core.lightning.LightningModule.save_hyperparameters` within your
-:class:`~pytorch_lightning.core.lightning.LightningModule`'s ``__init__`` method.
+Use :meth:`~pytorch_lightning.core.module.LightningModule.save_hyperparameters` within your
+:class:`~pytorch_lightning.core.module.LightningModule`'s ``__init__`` method.
 It will enable Lightning to store all the provided arguments under the ``self.hparams`` attribute.
 These hyperparameters will also be stored within the model checkpoint, which simplifies model re-instantiation after training.
 
@@ -164,8 +164,8 @@ In this case, exclude them explicitly:
 load_from_checkpoint
 """"""""""""""""""""
 
-LightningModules that have hyperparameters automatically saved with :meth:`~pytorch_lightning.core.lightning.LightningModule.save_hyperparameters`
-can conveniently be loaded and instantiated directly from a checkpoint with :meth:`~pytorch_lightning.core.lightning.LightningModule.load_from_checkpoint`:
+LightningModules that have hyperparameters automatically saved with :meth:`~pytorch_lightning.core.module.LightningModule.save_hyperparameters`
+can conveniently be loaded and instantiated directly from a checkpoint with :meth:`~pytorch_lightning.core.module.LightningModule.load_from_checkpoint`:
 
 .. code-block:: python
 

--- a/docs/source/common/lightning_module.rst
+++ b/docs/source/common/lightning_module.rst
@@ -159,7 +159,7 @@ Training
 Training Loop
 =============
 
-To activate the training loop, override the :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step` method.
+To activate the training loop, override the :meth:`~pytorch_lightning.core.module.LightningModule.training_step` method.
 
 .. code-block:: python
 
@@ -200,7 +200,7 @@ Under the hood, Lightning does the following (pseudocode):
 Train Epoch-level Metrics
 =========================
 
-If you want to calculate epoch-level metrics and log them, use :meth:`~pytorch_lightning.core.lightning.LightningModule.log`.
+If you want to calculate epoch-level metrics and log them, use :meth:`~pytorch_lightning.core.module.LightningModule.log`.
 
 .. code-block:: python
 
@@ -214,7 +214,7 @@ If you want to calculate epoch-level metrics and log them, use :meth:`~pytorch_l
          self.log("train_loss", loss, on_step=True, on_epoch=True, prog_bar=True, logger=True)
          return loss
 
-The :meth:`~pytorch_lightning.core.lightning.LightningModule.log` object automatically reduces the
+The :meth:`~pytorch_lightning.core.module.LightningModule.log` object automatically reduces the
 requested metrics across a complete epoch and devices. Here's the pseudocode of what it does under the hood:
 
 .. code-block:: python
@@ -239,8 +239,8 @@ requested metrics across a complete epoch and devices. Here's the pseudocode of 
 Train Epoch-level Operations
 ============================
 
-If you need to do something with all the outputs of each :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`,
-override the :meth:`~pytorch_lightning.core.lightning.LightningModule.training_epoch_end` method.
+If you need to do something with all the outputs of each :meth:`~pytorch_lightning.core.module.LightningModule.training_step`,
+override the :meth:`~pytorch_lightning.core.module.LightningModule.training_epoch_end` method.
 
 .. code-block:: python
 
@@ -283,7 +283,7 @@ Training with DataParallel
 When training using a ``strategy`` that splits data from each batch across GPUs, sometimes you might
 need to aggregate them on the main GPU for processing (DP, or DDP2).
 
-In this case, implement the :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step_end`
+In this case, implement the :meth:`~pytorch_lightning.core.module.LightningModule.training_step_end`
 method which will have outputs from all the devices and you can accumulate to get the effective results.
 
 .. code-block:: python
@@ -343,7 +343,7 @@ Validation
 Validation Loop
 ===============
 
-To activate the validation loop while training, override the :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step` method.
+To activate the validation loop while training, override the :meth:`~pytorch_lightning.core.module.LightningModule.validation_step` method.
 
 .. code-block:: python
 
@@ -378,7 +378,7 @@ Under the hood, Lightning does the following (pseudocode):
             torch.set_grad_enabled(True)
             model.train()
 
-You can also run just the validation loop on your validation dataloaders by overriding :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step`
+You can also run just the validation loop on your validation dataloaders by overriding :meth:`~pytorch_lightning.core.module.LightningModule.validation_step`
 and calling :meth:`~pytorch_lightning.trainer.trainer.Trainer.validate`.
 
 .. code-block:: python
@@ -399,8 +399,8 @@ and calling :meth:`~pytorch_lightning.trainer.trainer.Trainer.validate`.
 Validation Epoch-level Metrics
 ==============================
 
-If you need to do something with all the outputs of each :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step`,
-override the :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_epoch_end` method. Note that this method is called before :meth:`~pytorch_lightning.core.lightning.LightningModule.training_epoch_end`.
+If you need to do something with all the outputs of each :meth:`~pytorch_lightning.core.module.LightningModule.validation_step`,
+override the :meth:`~pytorch_lightning.core.module.LightningModule.validation_epoch_end` method. Note that this method is called before :meth:`~pytorch_lightning.core.module.LightningModule.training_epoch_end`.
 
 .. code-block:: python
 
@@ -422,7 +422,7 @@ Validating with DataParallel
 When training using a ``strategy`` that splits data from each batch across GPUs, sometimes you might
 need to aggregate them on the main GPU for processing (DP, or DDP2).
 
-In this case, implement the :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step_end`
+In this case, implement the :meth:`~pytorch_lightning.core.module.LightningModule.validation_step_end`
 method which will have outputs from all the devices and you can accumulate to get the effective results.
 
 .. code-block:: python
@@ -483,7 +483,7 @@ Test Loop
 =========
 
 The process for enabling a test loop is the same as the process for enabling a validation loop. Please refer to
-the section above for details. For this you need to override the :meth:`~pytorch_lightning.core.lightning.LightningModule.test_step` method.
+the section above for details. For this you need to override the :meth:`~pytorch_lightning.core.module.LightningModule.test_step` method.
 
 The only difference is that the test loop is only called when :meth:`~pytorch_lightning.trainer.trainer.Trainer.test` is used.
 
@@ -530,9 +530,9 @@ Inference
 Prediction Loop
 ===============
 
-By default, the :meth:`~pytorch_lightning.core.lightning.LightningModule.predict_step` method runs the
-:meth:`~pytorch_lightning.core.lightning.LightningModule.forward` method. In order to customize this behaviour,
-simply override the :meth:`~pytorch_lightning.core.lightning.LightningModule.predict_step` method.
+By default, the :meth:`~pytorch_lightning.core.module.LightningModule.predict_step` method runs the
+:meth:`~pytorch_lightning.core.module.LightningModule.forward` method. In order to customize this behaviour,
+simply override the :meth:`~pytorch_lightning.core.module.LightningModule.predict_step` method.
 
 For the example let's override ``predict_step`` and try out `Monte Carlo Dropout <https://arxiv.org/pdf/1506.02142.pdf>`_:
 
@@ -616,7 +616,7 @@ such as text generation:
             return decoded
 
 In the case where you want to scale your inference, you should be using
-:meth:`~pytorch_lightning.core.lightning.LightningModule.predict_step`.
+:meth:`~pytorch_lightning.core.module.LightningModule.predict_step`.
 
 .. code-block:: python
 
@@ -748,31 +748,31 @@ Methods
 all_gather
 ~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.all_gather
+.. automethod:: pytorch_lightning.core.module.LightningModule.all_gather
     :noindex:
 
 configure_callbacks
 ~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.configure_callbacks
+.. automethod:: pytorch_lightning.core.module.LightningModule.configure_callbacks
     :noindex:
 
 configure_optimizers
 ~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.configure_optimizers
+.. automethod:: pytorch_lightning.core.module.LightningModule.configure_optimizers
     :noindex:
 
 forward
 ~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.forward
+.. automethod:: pytorch_lightning.core.module.LightningModule.forward
     :noindex:
 
 freeze
 ~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.freeze
+.. automethod:: pytorch_lightning.core.module.LightningModule.freeze
     :noindex:
 
 .. _lm-log:
@@ -780,132 +780,132 @@ freeze
 log
 ~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.log
+.. automethod:: pytorch_lightning.core.module.LightningModule.log
     :noindex:
 
 log_dict
 ~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.log_dict
+.. automethod:: pytorch_lightning.core.module.LightningModule.log_dict
     :noindex:
 
 lr_schedulers
 ~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.lr_schedulers
+.. automethod:: pytorch_lightning.core.module.LightningModule.lr_schedulers
     :noindex:
 
 manual_backward
 ~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.manual_backward
+.. automethod:: pytorch_lightning.core.module.LightningModule.manual_backward
     :noindex:
 
 optimizers
 ~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.optimizers
+.. automethod:: pytorch_lightning.core.module.LightningModule.optimizers
     :noindex:
 
 print
 ~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.print
+.. automethod:: pytorch_lightning.core.module.LightningModule.print
     :noindex:
 
 predict_step
 ~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.predict_step
+.. automethod:: pytorch_lightning.core.module.LightningModule.predict_step
     :noindex:
 
 save_hyperparameters
 ~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.save_hyperparameters
+.. automethod:: pytorch_lightning.core.module.LightningModule.save_hyperparameters
     :noindex:
 
 toggle_optimizer
 ~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.toggle_optimizer
+.. automethod:: pytorch_lightning.core.module.LightningModule.toggle_optimizer
     :noindex:
 
 test_step
 ~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.test_step
+.. automethod:: pytorch_lightning.core.module.LightningModule.test_step
     :noindex:
 
 test_step_end
 ~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.test_step_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.test_step_end
     :noindex:
 
 test_epoch_end
 ~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.test_epoch_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.test_epoch_end
     :noindex:
 
 to_onnx
 ~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.to_onnx
+.. automethod:: pytorch_lightning.core.module.LightningModule.to_onnx
     :noindex:
 
 to_torchscript
 ~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.to_torchscript
+.. automethod:: pytorch_lightning.core.module.LightningModule.to_torchscript
     :noindex:
 
 training_step
 ~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.training_step
+.. automethod:: pytorch_lightning.core.module.LightningModule.training_step
     :noindex:
 
 training_step_end
 ~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.training_step_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.training_step_end
     :noindex:
 
 training_epoch_end
 ~~~~~~~~~~~~~~~~~~
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.training_epoch_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.training_epoch_end
     :noindex:
 
 unfreeze
 ~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.unfreeze
+.. automethod:: pytorch_lightning.core.module.LightningModule.unfreeze
     :noindex:
 
 untoggle_optimizer
 ~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.untoggle_optimizer
+.. automethod:: pytorch_lightning.core.module.LightningModule.untoggle_optimizer
     :noindex:
 
 validation_step
 ~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.validation_step
+.. automethod:: pytorch_lightning.core.module.LightningModule.validation_step
     :noindex:
 
 validation_step_end
 ~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.validation_step_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.validation_step_end
     :noindex:
 
 validation_epoch_end
 ~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.validation_epoch_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.validation_epoch_end
     :noindex:
 
 -----------
@@ -1178,7 +1178,7 @@ example above, we have set ``batch_first=True``.
     sub_batch = batch[0, 0:t, ...]
 
 To modify how the batch is split,
-override the :meth:`pytorch_lightning.core.lightning.LightningModule.tbptt_split_batch` method:
+override the :meth:`pytorch_lightning.core.module.LightningModule.tbptt_split_batch` method:
 
 .. testcode:: python
 
@@ -1294,347 +1294,347 @@ for more information.
 backward
 ~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.backward
+.. automethod:: pytorch_lightning.core.module.LightningModule.backward
     :noindex:
 
 on_before_backward
 ~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_before_backward
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_before_backward
     :noindex:
 
 on_after_backward
 ~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_after_backward
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_after_backward
     :noindex:
 
 on_before_zero_grad
 ~~~~~~~~~~~~~~~~~~~
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_before_zero_grad
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_before_zero_grad
     :noindex:
 
 on_fit_start
 ~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_fit_start
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_fit_start
     :noindex:
 
 on_fit_end
 ~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_fit_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_fit_end
     :noindex:
 
 
 on_load_checkpoint
 ~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_load_checkpoint
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_load_checkpoint
     :noindex:
 
 on_save_checkpoint
 ~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_save_checkpoint
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_save_checkpoint
     :noindex:
 
 load_from_checkpoint
 ~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.load_from_checkpoint
+.. automethod:: pytorch_lightning.core.module.LightningModule.load_from_checkpoint
     :noindex:
 
 on_hpc_save
 ~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_hpc_save
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_hpc_save
     :noindex:
 
 on_hpc_load
 ~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_hpc_load
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_hpc_load
     :noindex:
 
 on_train_start
 ~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_train_start
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_train_start
     :noindex:
 
 on_train_end
 ~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_train_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_train_end
     :noindex:
 
 on_validation_start
 ~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_validation_start
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_validation_start
     :noindex:
 
 on_validation_end
 ~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_validation_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_validation_end
     :noindex:
 
 on_test_batch_start
 ~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_test_batch_start
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_test_batch_start
     :noindex:
 
 on_test_batch_end
 ~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_test_batch_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_test_batch_end
     :noindex:
 
 on_test_epoch_start
 ~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_test_epoch_start
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_test_epoch_start
     :noindex:
 
 on_test_epoch_end
 ~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_test_epoch_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_test_epoch_end
     :noindex:
 
 on_test_start
 ~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_test_start
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_test_start
     :noindex:
 
 on_test_end
 ~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_test_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_test_end
     :noindex:
 
 on_predict_batch_start
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_predict_batch_start
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_predict_batch_start
     :noindex:
 
 on_predict_batch_end
 ~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_predict_batch_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_predict_batch_end
     :noindex:
 
 on_predict_epoch_start
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_predict_epoch_start
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_predict_epoch_start
     :noindex:
 
 on_predict_epoch_end
 ~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_predict_epoch_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_predict_epoch_end
     :noindex:
 
 on_predict_start
 ~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_predict_start
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_predict_start
     :noindex:
 
 on_predict_end
 ~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_predict_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_predict_end
     :noindex:
 
 on_train_batch_start
 ~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_train_batch_start
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_train_batch_start
     :noindex:
 
 on_train_batch_end
 ~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_train_batch_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_train_batch_end
     :noindex:
 
 on_train_epoch_start
 ~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_train_epoch_start
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_train_epoch_start
     :noindex:
 
 on_train_epoch_end
 ~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_train_epoch_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_train_epoch_end
     :noindex:
 
 on_validation_batch_start
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_validation_batch_start
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_validation_batch_start
     :noindex:
 
 on_validation_batch_end
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_validation_batch_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_validation_batch_end
     :noindex:
 
 on_validation_epoch_start
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_validation_epoch_start
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_validation_epoch_start
     :noindex:
 
 on_validation_epoch_end
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_validation_epoch_end
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_validation_epoch_end
     :noindex:
 
 on_post_move_to_device
 ~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_post_move_to_device
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_post_move_to_device
     :noindex:
 
 configure_sharded_model
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.configure_sharded_model
+.. automethod:: pytorch_lightning.core.module.LightningModule.configure_sharded_model
     :noindex:
 
 on_validation_model_eval
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_validation_model_eval
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_validation_model_eval
     :noindex:
 
 on_validation_model_train
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_validation_model_train
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_validation_model_train
     :noindex:
 
 on_test_model_eval
 ~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_test_model_eval
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_test_model_eval
     :noindex:
 
 on_test_model_train
 ~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_test_model_train
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_test_model_train
     :noindex:
 
 on_before_optimizer_step
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_before_optimizer_step
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_before_optimizer_step
     :noindex:
 
 configure_gradient_clipping
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.configure_gradient_clipping
+.. automethod:: pytorch_lightning.core.module.LightningModule.configure_gradient_clipping
     :noindex:
 
 optimizer_step
 ~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.optimizer_step
+.. automethod:: pytorch_lightning.core.module.LightningModule.optimizer_step
     :noindex:
 
 optimizer_zero_grad
 ~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.optimizer_zero_grad
+.. automethod:: pytorch_lightning.core.module.LightningModule.optimizer_zero_grad
     :noindex:
 
 prepare_data
 ~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.prepare_data
+.. automethod:: pytorch_lightning.core.module.LightningModule.prepare_data
     :noindex:
 
 setup
 ~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.setup
+.. automethod:: pytorch_lightning.core.module.LightningModule.setup
     :noindex:
 
 tbptt_split_batch
 ~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.tbptt_split_batch
+.. automethod:: pytorch_lightning.core.module.LightningModule.tbptt_split_batch
     :noindex:
 
 teardown
 ~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.teardown
+.. automethod:: pytorch_lightning.core.module.LightningModule.teardown
     :noindex:
 
 train_dataloader
 ~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.train_dataloader
+.. automethod:: pytorch_lightning.core.module.LightningModule.train_dataloader
     :noindex:
 
 val_dataloader
 ~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.val_dataloader
+.. automethod:: pytorch_lightning.core.module.LightningModule.val_dataloader
     :noindex:
 
 test_dataloader
 ~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.test_dataloader
+.. automethod:: pytorch_lightning.core.module.LightningModule.test_dataloader
     :noindex:
 
 predict_dataloader
 ~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.predict_dataloader
+.. automethod:: pytorch_lightning.core.module.LightningModule.predict_dataloader
     :noindex:
 
 transfer_batch_to_device
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.transfer_batch_to_device
+.. automethod:: pytorch_lightning.core.module.LightningModule.transfer_batch_to_device
     :noindex:
 
 on_before_batch_transfer
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_before_batch_transfer
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_before_batch_transfer
     :noindex:
 
 on_after_batch_transfer
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.on_after_batch_transfer
+.. automethod:: pytorch_lightning.core.module.LightningModule.on_after_batch_transfer
     :noindex:
 
 add_to_queue
 ~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.add_to_queue
+.. automethod:: pytorch_lightning.core.module.LightningModule.add_to_queue
     :noindex:
 
 get_from_queue
 ~~~~~~~~~~~~~~
 
-.. automethod:: pytorch_lightning.core.lightning.LightningModule.get_from_queue
+.. automethod:: pytorch_lightning.core.module.LightningModule.get_from_queue
     :noindex:

--- a/docs/source/common/optimization.rst
+++ b/docs/source/common/optimization.rst
@@ -87,7 +87,7 @@ Use Multiple Optimizers (like GANs)
 ===================================
 
 To use multiple optimizers (optionally with learning rate schedulers), return two or more optimizers from
-:meth:`~pytorch_lightning.core.lightning.LightningModule.configure_optimizers`.
+:meth:`~pytorch_lightning.core.module.LightningModule.configure_optimizers`.
 
 .. testcode:: python
 
@@ -131,7 +131,7 @@ Step Optimizers at Arbitrary Intervals
 =======================================
 
 To do more interesting things with your optimizers such as learning rate warm-up or odd scheduling,
-override the :meth:`~pytorch_lightning.core.lightning.LightningModule.optimizer_step` function.
+override the :meth:`~pytorch_lightning.core.module.LightningModule.optimizer_step` function.
 
 .. warning::
     If you are overriding this method, make sure that you pass the ``optimizer_closure`` parameter to
@@ -200,7 +200,7 @@ Access your Own Optimizer
 =========================
 
 The provided ``optimizer`` is a :class:`~pytorch_lightning.core.optimizer.LightningOptimizer` object wrapping your own optimizer
-configured in your :meth:`~pytorch_lightning.core.lightning.LightningModule.configure_optimizers`.
+configured in your :meth:`~pytorch_lightning.core.module.LightningModule.configure_optimizers`.
 You can access your own optimizer with ``optimizer.optimizer``. However, if you use your own optimizer
 to perform a step, Lightning won't be able to support accelerators, precision and profiling for you.
 
@@ -246,7 +246,7 @@ Bring your own Custom Learning Rate Schedulers
 
 Lightning allows using custom learning rate schedulers that aren't available in `PyTorch natively <https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate>`_.
 One good example is `Timm Schedulers <https://github.com/rwightman/pytorch-image-models/blob/master/timm/scheduler/scheduler.py>`_. When using custom learning rate schedulers
-relying on a different API from Native PyTorch ones, you should override the :meth:`~pytorch_lightning.core.lightning.LightningModule.lr_scheduler_step` with your desired logic.
+relying on a different API from Native PyTorch ones, you should override the :meth:`~pytorch_lightning.core.module.LightningModule.lr_scheduler_step` with your desired logic.
 If you are using native PyTorch schedulers, there is no need to override this hook since Lightning will handle it automatically by default.
 
 .. code-block:: python
@@ -270,17 +270,17 @@ Configure Gradient Clipping
 ===========================
 
 To configure custom gradient clipping, consider overriding
-the :meth:`~pytorch_lightning.core.lightning.LightningModule.configure_gradient_clipping` method.
+the :meth:`~pytorch_lightning.core.module.LightningModule.configure_gradient_clipping` method.
 Attributes ``gradient_clip_val`` and ``gradient_clip_algorithm`` from Trainer will be passed in the
 respective arguments here and Lightning will handle gradient clipping for you. In case you want to set
 different values for your arguments of your choice and let Lightning handle the gradient clipping, you can
-use the inbuilt :meth:`~pytorch_lightning.core.lightning.LightningModule.clip_gradients` method and pass
+use the inbuilt :meth:`~pytorch_lightning.core.module.LightningModule.clip_gradients` method and pass
 the arguments along with your optimizer.
 
 .. warning::
-    Make sure to not override :meth:`~pytorch_lightning.core.lightning.LightningModule.clip_gradients`
+    Make sure to not override :meth:`~pytorch_lightning.core.module.LightningModule.clip_gradients`
     method. If you want to customize gradient clipping, consider using
-    :meth:`~pytorch_lightning.core.lightning.LightningModule.configure_gradient_clipping` method.
+    :meth:`~pytorch_lightning.core.module.LightningModule.configure_gradient_clipping` method.
 
 For example, here we will apply gradient clipping only to the gradients associated with optimizer A.
 

--- a/docs/source/common/trainer.rst
+++ b/docs/source/common/trainer.rst
@@ -5,7 +5,7 @@
 
     import os
     from pytorch_lightning.trainer.trainer import Trainer
-    from pytorch_lightning.core.lightning import LightningModule
+    from pytorch_lightning.core.module import LightningModule
     from pytorch_lightning.utilities.seed import seed_everything
 
 .. _trainer:
@@ -508,7 +508,7 @@ Example::
 
 
 Model-specific callbacks can also be added inside the ``LightningModule`` through
-:meth:`~pytorch_lightning.core.lightning.LightningModule.configure_callbacks`.
+:meth:`~pytorch_lightning.core.module.LightningModule.configure_callbacks`.
 Callbacks returned in this hook will extend the list initially given to the ``Trainer`` argument, and replace
 the trainer callbacks should there be two or more of the same type.
 :class:`~pytorch_lightning.callbacks.model_checkpoint.ModelCheckpoint` callbacks always run last.

--- a/docs/source/deploy/production_advanced.rst
+++ b/docs/source/deploy/production_advanced.rst
@@ -10,7 +10,7 @@ Compile your model to ONNX
 **************************
 `ONNX <https://pytorch.org/docs/stable/onnx.html>`_ is a package developed by Microsoft to optimize inference. ONNX allows the model to be independent of PyTorch and run on any ONNX Runtime.
 
-To export your model to ONNX format call the :meth:`~pytorch_lightning.core.lightning.LightningModule.to_onnx` function on your :class:`~pytorch_lightning.core.lightning.LightningModule` with the ``filepath`` and ``input_sample``.
+To export your model to ONNX format call the :meth:`~pytorch_lightning.core.module.LightningModule.to_onnx` function on your :class:`~pytorch_lightning.core.module.LightningModule` with the ``filepath`` and ``input_sample``.
 
 .. code-block:: python
 
@@ -29,7 +29,7 @@ To export your model to ONNX format call the :meth:`~pytorch_lightning.core.ligh
     input_sample = torch.randn((1, 64))
     model.to_onnx(filepath, input_sample, export_params=True)
 
-You can also skip passing the input sample if the ``example_input_array`` property is specified in your :class:`~pytorch_lightning.core.lightning.LightningModule`.
+You can also skip passing the input sample if the ``example_input_array`` property is specified in your :class:`~pytorch_lightning.core.module.LightningModule`.
 
 .. code-block:: python
 

--- a/docs/source/deploy/production_advanced_2.rst
+++ b/docs/source/deploy/production_advanced_2.rst
@@ -11,7 +11,7 @@ Deploy models into production (advanced)
 Compile your model to TorchScript
 *********************************
 `TorchScript <https://pytorch.org/docs/stable/jit.html>`_ allows you to serialize your models in a way that it can be loaded in non-Python environments.
-The ``LightningModule`` has a handy method :meth:`~pytorch_lightning.core.lightning.LightningModule.to_torchscript` that returns a scripted module which you
+The ``LightningModule`` has a handy method :meth:`~pytorch_lightning.core.module.LightningModule.to_torchscript` that returns a scripted module which you
 can save or directly use.
 
 .. testcode:: python

--- a/docs/source/extensions/callbacks.rst
+++ b/docs/source/extensions/callbacks.rst
@@ -136,7 +136,7 @@ Callback API
 ************
 Here is the full API of methods available in the Callback base class.
 
-The :class:`~pytorch_lightning.callbacks.Callback` class is the base for all the callbacks in Lightning just like the :class:`~pytorch_lightning.core.lightning.LightningModule` is the base for all models.
+The :class:`~pytorch_lightning.callbacks.Callback` class is the base for all the callbacks in Lightning just like the :class:`~pytorch_lightning.core.module.LightningModule` is the base for all models.
 It defines a public interface that each callback implementation must follow, the key ones are:
 
 Properties

--- a/docs/source/extensions/logging.rst
+++ b/docs/source/extensions/logging.rst
@@ -103,7 +103,7 @@ Lightning offers automatic log functionalities for logging scalars, or manual lo
 Automatic Logging
 =================
 
-Use the :meth:`~pytorch_lightning.core.lightning.LightningModule.log` or :meth:`~pytorch_lightning.core.lightning.LightningModule.log_dict`
+Use the :meth:`~pytorch_lightning.core.module.LightningModule.log` or :meth:`~pytorch_lightning.core.module.LightningModule.log_dict`
 methods to log from anywhere in a :doc:`LightningModule <../common/lightning_module>` and :doc:`callbacks <../extensions/callbacks>`.
 
 .. code-block:: python
@@ -122,18 +122,18 @@ methods to log from anywhere in a :doc:`LightningModule <../common/lightning_mod
         self.log_dict({"acc": acc, "recall": recall})
 
 .. note::
-    Everything explained below applies to both :meth:`~pytorch_lightning.core.lightning.LightningModule.log` or :meth:`~pytorch_lightning.core.lightning.LightningModule.log_dict` methods.
+    Everything explained below applies to both :meth:`~pytorch_lightning.core.module.LightningModule.log` or :meth:`~pytorch_lightning.core.module.LightningModule.log_dict` methods.
 
-Depending on where the :meth:`~pytorch_lightning.core.lightning.LightningModule.log` method is called, Lightning auto-determines
+Depending on where the :meth:`~pytorch_lightning.core.module.LightningModule.log` method is called, Lightning auto-determines
 the correct logging mode for you. Of course you can override the default behavior by manually setting the
-:meth:`~pytorch_lightning.core.lightning.LightningModule.log` parameters.
+:meth:`~pytorch_lightning.core.module.LightningModule.log` parameters.
 
 .. code-block:: python
 
     def training_step(self, batch, batch_idx):
         self.log("my_loss", loss, on_step=True, on_epoch=True, prog_bar=True, logger=True)
 
-The :meth:`~pytorch_lightning.core.lightning.LightningModule.log` method has a few options:
+The :meth:`~pytorch_lightning.core.module.LightningModule.log` method has a few options:
 
 * ``on_step``: Logs the metric at the current step.
 * ``on_epoch``: Automatically accumulates and logs at the end of the epoch.
@@ -303,7 +303,7 @@ Individual logger implementations determine their flushing frequency. For exampl
 Progress Bar
 ************
 
-You can add any metric to the progress bar using :meth:`~pytorch_lightning.core.lightning.LightningModule.log`
+You can add any metric to the progress bar using :meth:`~pytorch_lightning.core.module.LightningModule.log`
 method, setting ``prog_bar=True``.
 
 

--- a/docs/source/extensions/loops.rst
+++ b/docs/source/extensions/loops.rst
@@ -66,7 +66,7 @@ The Lightning :class:`~pytorch_lightning.trainer.trainer.Trainer` automates the 
         loss.backward()
         optimizer.step()
 
-The core research logic is simply shifted to the :class:`~pytorch_lightning.core.lightning.LightningModule`:
+The core research logic is simply shifted to the :class:`~pytorch_lightning.core.module.LightningModule`:
 
 .. code-block:: python
 
@@ -222,7 +222,7 @@ Loop API
 --------
 Here is the full API of methods available in the Loop base class.
 
-The :class:`~pytorch_lightning.loops.base.Loop` class is the base of all loops in the same way as the :class:`~pytorch_lightning.core.lightning.LightningModule` is the base of all models.
+The :class:`~pytorch_lightning.loops.base.Loop` class is the base of all loops in the same way as the :class:`~pytorch_lightning.core.module.LightningModule` is the base of all models.
 It defines a public interface that each loop implementation must follow, the key ones are:
 
 Properties
@@ -339,7 +339,7 @@ Each of these :code:`for`-loops represents a class implementing the :class:`~pyt
      - The :class:`~pytorch_lightning.loops.fit_loop.FitLoop` is the top-level loop where training starts.
        It simply counts the epochs and iterates from one to the next by calling :code:`TrainingEpochLoop.run()` in its :code:`advance()` method.
    * - :class:`~pytorch_lightning.loops.epoch.training_epoch_loop.TrainingEpochLoop`
-     - The :class:`~pytorch_lightning.loops.epoch.training_epoch_loop.TrainingEpochLoop` is the one that iterates over the dataloader that the user returns in their :meth:`~pytorch_lightning.core.lightning.LightningModule.train_dataloader` method.
+     - The :class:`~pytorch_lightning.loops.epoch.training_epoch_loop.TrainingEpochLoop` is the one that iterates over the dataloader that the user returns in their :meth:`~pytorch_lightning.core.module.LightningModule.train_dataloader` method.
        Its main responsibilities are calling the :code:`*_epoch_start` and :code:`*_epoch_end` hooks, accumulating outputs if the user request them in one of these hooks, and running validation at the requested interval.
        The validation is carried out by yet another loop, :class:`~pytorch_lightning.loops.epoch.validation_epoch_loop.ValidationEpochLoop`.
 
@@ -352,7 +352,7 @@ Each of these :code:`for`-loops represents a class implementing the :class:`~pyt
        By default, when truncated back-propagation through time (TBPTT) is turned off, this loop does not do anything except redirect the call to the :class:`~pytorch_lightning.loops.optimization.optimizer_loop.OptimizerLoop`.
        Read more about :ref:`TBPTT <sequential-data>`.
    * - :class:`~pytorch_lightning.loops.optimization.optimizer_loop.OptimizerLoop`
-     - The :class:`~pytorch_lightning.loops.optimization.optimizer_loop.OptimizerLoop` iterates over one or multiple optimizers and for each one it calls the :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step` method with the batch, the current batch index and the optimizer index if multiple optimizers are requested.
+     - The :class:`~pytorch_lightning.loops.optimization.optimizer_loop.OptimizerLoop` iterates over one or multiple optimizers and for each one it calls the :meth:`~pytorch_lightning.core.module.LightningModule.training_step` method with the batch, the current batch index and the optimizer index if multiple optimizers are requested.
        It is the leaf node in the tree of loops and performs the actual optimization (forward, zero grad, backward, optimizer step).
    * - :class:`~pytorch_lightning.loops.optimization.manual_loop.ManualOptimization`
      - Substitutes the :class:`~pytorch_lightning.loops.optimization.optimizer_loop.OptimizerLoop` in case of :doc:`manual optimization <../model/manual_optimization>` and implements the manual optimization step.
@@ -447,7 +447,7 @@ Advanced Examples
        To reduce variability, once all rounds are performed using the different folds, the trained models are ensembled and their predictions are
        averaged when estimating the model's predictive performance on the test dataset.
    * - `Yielding Training Step <https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/loop_examples/yielding_training_step.py>`_
-     - This loop enables you to write the :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step` hook
+     - This loop enables you to write the :meth:`~pytorch_lightning.core.module.LightningModule.training_step` hook
        as a Python Generator for automatic optimization with multiple optimizers, i.e., you can :code:`yield` loss
        values from it instead of returning them. This can enable more elegant and expressive implementations, as shown
        shown with a GAN in this example.

--- a/docs/source/extensions/strategy.rst
+++ b/docs/source/extensions/strategy.rst
@@ -10,7 +10,7 @@ The Strategy in PyTorch Lightning handles the following responsibilities:
 * Launch and teardown of training processes (if applicable).
 * Setup communication between processes (NCCL, GLOO, MPI, and so on).
 * Provide a unified communication interface for reduction, broadcast, and so on.
-* Owns the :class:`~pytorch_lightning.core.lightning.LightningModule`
+* Owns the :class:`~pytorch_lightning.core.module.LightningModule`
 * Handles/owns optimizers and schedulers.
 
 

--- a/docs/source/guides/data.rst
+++ b/docs/source/guides/data.rst
@@ -31,7 +31,7 @@ There are a few different data containers used in Lightning:
 Why Use LightningDataModule?
 ============================
 
-The :class:`~pytorch_lightning.core.datamodule.LightningDataModule` was designed as a way of decoupling data-related hooks from the :class:`~pytorch_lightning.core.lightning.LightningModule` so you can develop dataset agnostic models. The :class:`~pytorch_lightning.core.datamodule.LightningDataModule` makes it easy to hot swap different Datasets with your model, so you can test it and benchmark it across domains. It also makes sharing and reusing the exact data splits and transforms across projects possible.
+The :class:`~pytorch_lightning.core.datamodule.LightningDataModule` was designed as a way of decoupling data-related hooks from the :class:`~pytorch_lightning.core.module.LightningModule` so you can develop dataset agnostic models. The :class:`~pytorch_lightning.core.datamodule.LightningDataModule` makes it easy to hot swap different Datasets with your model, so you can test it and benchmark it across domains. It also makes sharing and reusing the exact data splits and transforms across projects possible.
 
 Read :ref:`this <datamodules>` for more details on LightningDataModule.
 
@@ -114,7 +114,7 @@ also works for testing, validation, and prediction Datasets.
 Return Multiple DataLoaders
 ---------------------------
 
-You can set multiple DataLoaders in your :class:`~pytorch_lightning.core.lightning.LightningModule`, and Lightning will take care of batch combination.
+You can set multiple DataLoaders in your :class:`~pytorch_lightning.core.module.LightningModule`, and Lightning will take care of batch combination.
 
 For more details, refer to :paramref:`~pytorch_lightning.trainer.trainer.Trainer.multiple_trainloader_mode`
 
@@ -252,7 +252,7 @@ Evaluate with Additional DataLoaders
 ====================================
 
 You can evaluate your models using additional DataLoaders even if the DataLoader specific hooks haven't been defined within your
-:class:`~pytorch_lightning.core.lightning.LightningModule`. For example, this would be the case if your test data
+:class:`~pytorch_lightning.core.module.LightningModule`. For example, this would be the case if your test data
 set is not available at the time your model was declared. Simply pass the test set to the :meth:`~pytorch_lightning.trainer.trainer.Trainer.test` method:
 
 .. code-block:: python
@@ -372,7 +372,7 @@ Lightning can handle TBPTT automatically via this flag.
             return {"loss": ..., "hiddens": hiddens}
 
 .. note:: If you need to modify how the batch is split,
-    override :func:`~pytorch_lightning.core.lightning.LightningModule.tbptt_split_batch`.
+    override :func:`~pytorch_lightning.core.module.LightningModule.tbptt_split_batch`.
 
 
 Iterable Datasets

--- a/docs/source/guides/speed.rst
+++ b/docs/source/guides/speed.rst
@@ -422,7 +422,7 @@ Here is an example of an advanced use case:
 Set Grads to None
 *****************
 
-In order to improve performance, you can override :meth:`~pytorch_lightning.core.lightning.LightningModule.optimizer_zero_grad`.
+In order to improve performance, you can override :meth:`~pytorch_lightning.core.module.LightningModule.optimizer_zero_grad`.
 
 For a more detailed explanation of the pros / cons of this technique,
 read the documentation for :meth:`~torch.optim.Optimizer.zero_grad` by the PyTorch team.

--- a/docs/source/model/manual_optimization.rst
+++ b/docs/source/model/manual_optimization.rst
@@ -52,7 +52,7 @@ Access your Own Optimizer
 =========================
 
 The provided ``optimizer`` is a :class:`~pytorch_lightning.core.optimizer.LightningOptimizer` object wrapping your own optimizer
-configured in your :meth:`~pytorch_lightning.core.lightning.LightningModule.configure_optimizers`. You can access your own optimizer
+configured in your :meth:`~pytorch_lightning.core.module.LightningModule.configure_optimizers`. You can access your own optimizer
 with ``optimizer.optimizer``. However, if you use your own optimizer to perform a step, Lightning won't be able to
 support accelerators, precision and profiling for you.
 
@@ -179,17 +179,17 @@ Learning Rate Scheduling
 
 Every optimizer you use can be paired with any
 `Learning Rate Scheduler <https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate>`_. Please see the
-documentation of :meth:`~pytorch_lightning.core.lightning.LightningModule.configure_optimizers` for all the available options
+documentation of :meth:`~pytorch_lightning.core.module.LightningModule.configure_optimizers` for all the available options
 
 You can call ``lr_scheduler.step()`` at arbitrary intervals.
-Use ``self.lr_schedulers()`` in  your :class:`~pytorch_lightning.core.lightning.LightningModule` to access any learning rate schedulers
-defined in your :meth:`~pytorch_lightning.core.lightning.LightningModule.configure_optimizers`.
+Use ``self.lr_schedulers()`` in  your :class:`~pytorch_lightning.core.module.LightningModule` to access any learning rate schedulers
+defined in your :meth:`~pytorch_lightning.core.module.LightningModule.configure_optimizers`.
 
 .. warning::
    * Before v1.3, Lightning automatically called ``lr_scheduler.step()`` in both automatic and manual optimization. From
      1.3, ``lr_scheduler.step()`` is now for the user to call at arbitrary intervals.
    * Note that the ``lr_scheduler_config`` keys, such as ``"frequency"`` and ``"interval"``, will be ignored even if they are provided in
-     your :meth:`~pytorch_lightning.core.lightning.LightningModule.configure_optimizers` during manual optimization.
+     your :meth:`~pytorch_lightning.core.module.LightningModule.configure_optimizers` during manual optimization.
 
 Here is an example calling ``lr_scheduler.step()`` every step.
 

--- a/docs/source/starter/converting.rst
+++ b/docs/source/starter/converting.rst
@@ -62,7 +62,7 @@ In the training_step of the LightningModule configure how your training routine 
 ****************************************
 3. Move Optimizer(s) and LR Scheduler(s)
 ****************************************
-Move your optimizers to the :meth:`~pytorch_lightning.core.lightning.LightningModule.configure_optimizers` hook.
+Move your optimizers to the :meth:`~pytorch_lightning.core.module.LightningModule.configure_optimizers` hook.
 
 .. testcode::
 

--- a/docs/source/starter/lightning_lite.rst
+++ b/docs/source/starter/lightning_lite.rst
@@ -199,10 +199,10 @@ utility to move an object to the current device.
 
     If you have hundreds or thousands of lines within your :meth:`~pytorch_lightning.lite.LightningLite.run` function
     and you are feeling unsure about them, then that is the correct feeling.
-    In 2019, our :class:`~pytorch_lightning.core.lightning.LightningModule` was getting larger
+    In 2019, our :class:`~pytorch_lightning.core.module.LightningModule` was getting larger
     and we got the same feeling, so we started to organize our code for simplicity, interoperability and standardization.
     This is definitely a good sign that you should consider refactoring your code and / or switching to
-    :class:`~pytorch_lightning.core.lightning.LightningModule` ultimately.
+    :class:`~pytorch_lightning.core.module.LightningModule` ultimately.
 
 
 ----------
@@ -245,9 +245,9 @@ Convert to Lightning
 from its hundreds of features.
 
 You can see our :class:`~pytorch_lightning.lite.LightningLite` class as a
-future :class:`~pytorch_lightning.core.lightning.LightningModule`, and slowly refactor your code into its API.
-Below, the :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`, :meth:`~pytorch_lightning.core.lightning.LightningModule.forward`,
-:meth:`~pytorch_lightning.core.lightning.LightningModule.configure_optimizers`, :meth:`~pytorch_lightning.core.lightning.LightningModule.train_dataloader` methods
+future :class:`~pytorch_lightning.core.module.LightningModule`, and slowly refactor your code into its API.
+Below, the :meth:`~pytorch_lightning.core.module.LightningModule.training_step`, :meth:`~pytorch_lightning.core.module.LightningModule.forward`,
+:meth:`~pytorch_lightning.core.module.LightningModule.configure_optimizers`, :meth:`~pytorch_lightning.core.module.LightningModule.train_dataloader` methods
 are implemented.
 
 
@@ -299,7 +299,7 @@ are implemented.
 
 
 Finally, change the :meth:`~pytorch_lightning.lite.LightningLite.run` into a
-:meth:`~pytorch_lightning.core.lightning.LightningModule.__init__` and drop the ``fit`` call from inside.
+:meth:`~pytorch_lightning.core.module.LightningModule.__init__` and drop the ``fit`` call from inside.
 
 .. code-block:: python
 

--- a/docs/source/starter/style_guide.rst
+++ b/docs/source/starter/style_guide.rst
@@ -2,7 +2,7 @@
 Style Guide
 ###########
 The main goal of PyTorch Lightning is to improve readability and reproducibility. Imagine looking into any GitHub repo or a research project,
-finding a :class:`~pytorch_lightning.core.lightning.LightningModule`, and knowing exactly where to look to find the things you care about.
+finding a :class:`~pytorch_lightning.core.module.LightningModule`, and knowing exactly where to look to find the things you care about.
 
 The goal of this style guide is to encourage Lightning code to be structured similarly.
 
@@ -12,7 +12,7 @@ The goal of this style guide is to encourage Lightning code to be structured sim
 LightningModule
 ***************
 
-These are best practices for structuring your :class:`~pytorch_lightning.core.lightning.LightningModule` class:
+These are best practices for structuring your :class:`~pytorch_lightning.core.module.LightningModule` class:
 
 Systems vs Models
 =================
@@ -171,8 +171,8 @@ In practice, the code looks like this:
 Forward vs training_step
 ========================
 
-We recommend using :meth:`~pytorch_lightning.core.lightning.LightningModule.forward` for inference/predictions and keeping
-:meth:`~pytorch_lightning.core.lightning.LightningModule.training_step` independent.
+We recommend using :meth:`~pytorch_lightning.core.module.LightningModule.forward` for inference/predictions and keeping
+:meth:`~pytorch_lightning.core.module.LightningModule.training_step` independent.
 
 .. code-block:: python
 
@@ -208,7 +208,7 @@ DataModules
 ===========
 
 The :class:`~pytorch_lightning.core.datamodule.LightningDataModule` is designed as a way of decoupling data-related
-hooks from the :class:`~pytorch_lightning.core.lightning.LightningModule` so you can develop dataset agnostic models. It makes it easy to hot swap different
+hooks from the :class:`~pytorch_lightning.core.module.LightningModule` so you can develop dataset agnostic models. It makes it easy to hot swap different
 datasets with your model, so you can test it and benchmark it across domains. It also makes sharing and reusing the exact data splits and transforms across projects possible.
 
 Check out :ref:`data` document to understand data management within Lightning and its best practices.

--- a/pl_examples/loop_examples/kfold.py
+++ b/pl_examples/loop_examples/kfold.py
@@ -30,7 +30,7 @@ from pl_examples import _DATASETS_PATH
 from pl_examples.basic_examples.mnist_datamodule import MNIST
 from pl_examples.basic_examples.mnist_examples.image_classifier_4_lightning_module import ImageClassifier
 from pytorch_lightning import LightningDataModule, seed_everything, Trainer
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.core.module import LightningModule
 from pytorch_lightning.loops.base import Loop
 from pytorch_lightning.loops.fit_loop import FitLoop
 from pytorch_lightning.trainer.states import TrainerFn

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ module = [
     "pytorch_lightning.callbacks.stochastic_weight_avg",
     "pytorch_lightning.core.datamodule",
     "pytorch_lightning.core.decorators",
-    "pytorch_lightning.core.lightning",
+    "pytorch_lightning.core.module",
     "pytorch_lightning.core.mixins.device_dtype_mixin",
     "pytorch_lightning.core.saving",
     "pytorch_lightning.demos.boring_classes",

--- a/pytorch_lightning/callbacks/base.py
+++ b/pytorch_lightning/callbacks/base.py
@@ -307,7 +307,7 @@ class Callback:
 
         Args:
             trainer: the current :class:`~pytorch_lightning.trainer.Trainer` instance.
-            pl_module: the current :class:`~pytorch_lightning.core.lightning.LightningModule` instance.
+            pl_module: the current :class:`~pytorch_lightning.core.module.LightningModule` instance.
             checkpoint: the checkpoint dictionary that will be saved.
 
         Returns:
@@ -327,7 +327,7 @@ class Callback:
 
         Args:
             trainer: the current :class:`~pytorch_lightning.trainer.Trainer` instance.
-            pl_module: the current :class:`~pytorch_lightning.core.lightning.LightningModule` instance.
+            pl_module: the current :class:`~pytorch_lightning.core.module.LightningModule` instance.
             callback_state: the callback state returned by ``on_save_checkpoint``.
 
         Note:

--- a/pytorch_lightning/callbacks/model_checkpoint.py
+++ b/pytorch_lightning/callbacks/model_checkpoint.py
@@ -48,7 +48,7 @@ warning_cache = WarningCache()
 class ModelCheckpoint(Callback):
     r"""
     Save the model periodically by monitoring a quantity. Every metric logged with
-    :meth:`~pytorch_lightning.core.lightning.log` or :meth:`~pytorch_lightning.core.lightning.log_dict` in
+    :meth:`~pytorch_lightning.core.module.log` or :meth:`~pytorch_lightning.core.module.log_dict` in
     LightningModule is a candidate for the monitor key. For more information, see
     :ref:`checkpointing`.
 

--- a/pytorch_lightning/callbacks/model_summary.py
+++ b/pytorch_lightning/callbacks/model_summary.py
@@ -15,7 +15,7 @@
 Model Summary
 =============
 
-Generates a summary of all layers in a :class:`~pytorch_lightning.core.lightning.LightningModule`.
+Generates a summary of all layers in a :class:`~pytorch_lightning.core.module.LightningModule`.
 
 The string representation of this summary prints a table with columns containing
 the name, type and number of parameters for each layer.
@@ -33,7 +33,7 @@ log = logging.getLogger(__name__)
 
 class ModelSummary(Callback):
     r"""
-    Generates a summary of all layers in a :class:`~pytorch_lightning.core.lightning.LightningModule`.
+    Generates a summary of all layers in a :class:`~pytorch_lightning.core.module.LightningModule`.
 
     Args:
         max_depth: The maximum depth of layer nesting that the summary will include. A value of 0 turns the

--- a/pytorch_lightning/callbacks/pruning.py
+++ b/pytorch_lightning/callbacks/pruning.py
@@ -28,7 +28,7 @@ from typing_extensions import TypedDict
 
 import pytorch_lightning as pl
 from pytorch_lightning.callbacks.base import Callback
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.core.module import LightningModule
 from pytorch_lightning.utilities.apply_func import apply_to_collection
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.rank_zero import rank_zero_debug, rank_zero_only

--- a/pytorch_lightning/callbacks/rich_model_summary.py
+++ b/pytorch_lightning/callbacks/rich_model_summary.py
@@ -24,7 +24,7 @@ if _RICH_AVAILABLE:
 
 class RichModelSummary(ModelSummary):
     r"""
-    Generates a summary of all layers in a :class:`~pytorch_lightning.core.lightning.LightningModule`
+    Generates a summary of all layers in a :class:`~pytorch_lightning.core.module.LightningModule`
     with `rich text formatting <https://github.com/Textualize/rich>`_.
 
     Install it with pip:

--- a/pytorch_lightning/core/__init__.py
+++ b/pytorch_lightning/core/__init__.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 from pytorch_lightning.core.datamodule import LightningDataModule
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.core.module import LightningModule
 
 __all__ = ["LightningDataModule", "LightningModule"]

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -1,0 +1,27 @@
+# Copyright The PyTorch Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Any
+
+from pytorch_lightning.core.module import LightningModule as NewLightningModule
+from pytorch_lightning.utilities import rank_zero_deprecation
+
+
+class LightningModule(NewLightningModule):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        rank_zero_deprecation(
+            "pytorch_lightning.core.lightning.LightningModule has been deprecated in v1.7"
+            " and will be removed in v1.9."
+            " Use the equivalent class from the pytorch_lightning.core.module.LightningModule class instead."
+        )
+        super().__init__(*args, **kwargs)

--- a/pytorch_lightning/core/module.py
+++ b/pytorch_lightning/core/module.py
@@ -593,7 +593,7 @@ class LightningModule(
             batch_idx (``int``): Integer displaying index of this batch
             optimizer_idx (``int``): When using multiple optimizers, this argument will also be present.
             hiddens (``Any``): Passed in if
-                :paramref:`~pytorch_lightning.core.lightning.LightningModule.truncated_bptt_steps` > 0.
+                :paramref:`~pytorch_lightning.core.module.LightningModule.truncated_bptt_steps` > 0.
 
         Return:
             Any of.
@@ -1112,10 +1112,9 @@ class LightningModule(
 
     def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> Any:
         """Step function called during :meth:`~pytorch_lightning.trainer.trainer.Trainer.predict`. By default, it
-        calls :meth:`~pytorch_lightning.core.lightning.LightningModule.forward`. Override to add any processing
-        logic.
+        calls :meth:`~pytorch_lightning.core.module.LightningModule.forward`. Override to add any processing logic.
 
-        The :meth:`~pytorch_lightning.core.lightning.LightningModule.predict_step` is used
+        The :meth:`~pytorch_lightning.core.module.LightningModule.predict_step` is used
         to scale inference on multi-devices.
 
         To prevent an OOM error, it is possible to use :class:`~pytorch_lightning.callbacks.BasePredictionWriter`
@@ -1257,7 +1256,7 @@ class LightningModule(
                 )
 
         Metrics can be made available to monitor by simply logging it using
-        ``self.log('metric_to_track', metric_val)`` in your :class:`~pytorch_lightning.core.lightning.LightningModule`.
+        ``self.log('metric_to_track', metric_val)`` in your :class:`~pytorch_lightning.core.module.LightningModule`.
 
         Note:
             The ``frequency`` value specified in a dict along with the ``optimizer`` key is an int corresponding
@@ -1699,7 +1698,7 @@ class LightningModule(
         Note:
             Called in the training loop after
             :meth:`~pytorch_lightning.callbacks.base.Callback.on_train_batch_start`
-            if :paramref:`~pytorch_lightning.core.lightning.LightningModule.truncated_bptt_steps` > 0.
+            if :paramref:`~pytorch_lightning.core.module.LightningModule.truncated_bptt_steps` > 0.
             Each returned batch split is passed separately to :meth:`training_step`.
         """
         time_dims = [len(x[0]) for x in batch if isinstance(x, (torch.Tensor, collections.Sequence))]
@@ -1857,7 +1856,7 @@ class LightningModule(
 
         Note:
             - Requires the implementation of the
-              :meth:`~pytorch_lightning.core.lightning.LightningModule.forward` method.
+              :meth:`~pytorch_lightning.core.module.LightningModule.forward` method.
             - The exported script will be set to evaluation mode.
             - It is recommended that you install the latest supported version of PyTorch
               to use this feature without limitations. See also the :mod:`torch.jit`

--- a/pytorch_lightning/loggers/comet.py
+++ b/pytorch_lightning/loggers/comet.py
@@ -193,7 +193,7 @@ class CometLogger(Logger):
     def experiment(self) -> Union[CometExperiment, CometExistingExperiment, CometOfflineExperiment]:
         r"""
         Actual Comet object. To use Comet features in your
-        :class:`~pytorch_lightning.core.lightning.LightningModule` do the following.
+        :class:`~pytorch_lightning.core.module.LightningModule` do the following.
 
         Example::
 

--- a/pytorch_lightning/loggers/csv_logs.py
+++ b/pytorch_lightning/loggers/csv_logs.py
@@ -175,7 +175,7 @@ class CSVLogger(Logger):
         r"""
 
         Actual ExperimentWriter object. To use ExperimentWriter features in your
-        :class:`~pytorch_lightning.core.lightning.LightningModule` do the following.
+        :class:`~pytorch_lightning.core.module.LightningModule` do the following.
 
         Example::
 

--- a/pytorch_lightning/loggers/mlflow.py
+++ b/pytorch_lightning/loggers/mlflow.py
@@ -71,7 +71,7 @@ class MLFlowLogger(Logger):
         mlf_logger = MLFlowLogger(experiment_name="lightning_logs", tracking_uri="file:./ml-runs")
         trainer = Trainer(logger=mlf_logger)
 
-    Use the logger anywhere in your :class:`~pytorch_lightning.core.lightning.LightningModule` as follows:
+    Use the logger anywhere in your :class:`~pytorch_lightning.core.module.LightningModule` as follows:
 
     .. code-block:: python
 
@@ -146,7 +146,7 @@ class MLFlowLogger(Logger):
     def experiment(self) -> MlflowClient:
         r"""
         Actual MLflow object. To use MLflow features in your
-        :class:`~pytorch_lightning.core.lightning.LightningModule` do the following.
+        :class:`~pytorch_lightning.core.module.LightningModule` do the following.
 
         Example::
 

--- a/pytorch_lightning/loggers/neptune.py
+++ b/pytorch_lightning/loggers/neptune.py
@@ -120,7 +120,7 @@ class NeptuneLogger(Logger):
 
     **How to use NeptuneLogger?**
 
-    Use the logger anywhere in your :class:`~pytorch_lightning.core.lightning.LightningModule` as follows:
+    Use the logger anywhere in your :class:`~pytorch_lightning.core.module.LightningModule` as follows:
 
     .. code-block:: python
 
@@ -403,7 +403,7 @@ class NeptuneLogger(Logger):
     def experiment(self) -> Run:
         r"""
         Actual Neptune run object. Allows you to use neptune logging features in your
-        :class:`~pytorch_lightning.core.lightning.LightningModule`.
+        :class:`~pytorch_lightning.core.module.LightningModule`.
 
         Example::
 

--- a/pytorch_lightning/loggers/tensorboard.py
+++ b/pytorch_lightning/loggers/tensorboard.py
@@ -160,7 +160,7 @@ class TensorBoardLogger(Logger):
     def experiment(self) -> SummaryWriter:
         r"""
         Actual tensorboard object. To use TensorBoard features in your
-        :class:`~pytorch_lightning.core.lightning.LightningModule` do the following.
+        :class:`~pytorch_lightning.core.module.LightningModule` do the following.
 
         Example::
 

--- a/pytorch_lightning/loggers/wandb.py
+++ b/pytorch_lightning/loggers/wandb.py
@@ -68,7 +68,7 @@ class WandbLogger(Logger):
 
     **Log metrics**
 
-    Log from :class:`~pytorch_lightning.core.lightning.LightningModule`:
+    Log from :class:`~pytorch_lightning.core.module.LightningModule`:
 
     .. code-block:: python
 
@@ -84,7 +84,7 @@ class WandbLogger(Logger):
 
     **Log hyper-parameters**
 
-    Save :class:`~pytorch_lightning.core.lightning.LightningModule` parameters:
+    Save :class:`~pytorch_lightning.core.module.LightningModule` parameters:
 
     .. code-block:: python
 
@@ -328,7 +328,7 @@ class WandbLogger(Logger):
         r"""
 
         Actual wandb object. To use wandb features in your
-        :class:`~pytorch_lightning.core.lightning.LightningModule` do the following.
+        :class:`~pytorch_lightning.core.module.LightningModule` do the following.
 
         Example::
 

--- a/pytorch_lightning/loops/optimization/manual_loop.py
+++ b/pytorch_lightning/loops/optimization/manual_loop.py
@@ -30,7 +30,7 @@ from pytorch_lightning.utilities.types import STEP_OUTPUT
 class ManualResult(OutputResult):
     """A container to hold the result returned by the ``ManualLoop``.
 
-    It is created from the output of :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`.
+    It is created from the output of :meth:`~pytorch_lightning.core.module.LightningModule.training_step`.
 
     Attributes:
         extra: Anything returned by the ``training_step``.
@@ -66,11 +66,11 @@ _OUTPUTS_TYPE = Dict[str, Any]
 
 class ManualOptimization(Loop[_OUTPUTS_TYPE]):
     """A special loop implementing what is known in Lightning as Manual Optimization where the optimization happens
-    entirely in the :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step` and therefore the user
-    is responsible for back-propagating gradients and making calls to the optimizers.
+    entirely in the :meth:`~pytorch_lightning.core.module.LightningModule.training_step` and therefore the user is
+    responsible for back-propagating gradients and making calls to the optimizers.
 
     This loop is a trivial case because it performs only a single iteration (calling directly into the module's
-    :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`) and passing through the output(s).
+    :meth:`~pytorch_lightning.core.module.LightningModule.training_step`) and passing through the output(s).
     """
 
     output_result_cls = ManualResult

--- a/pytorch_lightning/loops/optimization/optimizer_loop.py
+++ b/pytorch_lightning/loops/optimization/optimizer_loop.py
@@ -39,7 +39,7 @@ from pytorch_lightning.utilities.warnings import WarningCache
 class ClosureResult(OutputResult):
     """A container to hold the result of a :class:`Closure` call.
 
-    It is created from the output of :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step`.
+    It is created from the output of :meth:`~pytorch_lightning.core.module.LightningModule.training_step`.
 
     Attributes:
         closure_loss: The loss with a graph attached.
@@ -101,7 +101,7 @@ class Closure(AbstractClosure[ClosureResult]):
     do something with the output.
 
     Args:
-        step_fn: This is typically the :meth:`pytorch_lightning.core.lightning.LightningModule.training_step
+        step_fn: This is typically the :meth:`pytorch_lightning.core.module.LightningModule.training_step
             wrapped with processing for its outputs
         backward_fn: A function that takes a loss value as input, performs back-propagation and returns the loss value.
             Can be set to ``None`` to skip the backward operation.

--- a/pytorch_lightning/overrides/base.py
+++ b/pytorch_lightning/overrides/base.py
@@ -100,8 +100,8 @@ class _LightningModuleWrapperBase(DeviceDtypeModuleMixin, torch.nn.Module):
 
 
 def unwrap_lightning_module(wrapped_model: nn.Module) -> "pl.LightningModule":
-    """Recursively unwraps a :class:`~pytorch_lightning.core.lightning.LightningModule` by following the
-    ``.module`` attributes on the wrapper.
+    """Recursively unwraps a :class:`~pytorch_lightning.core.module.LightningModule` by following the ``.module``
+    attributes on the wrapper.
 
     Raises:
         TypeError: If the unwrapping leads to a module that is not a LightningModule and that cannot be unwrapped

--- a/pytorch_lightning/profiler/pytorch.py
+++ b/pytorch_lightning/profiler/pytorch.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from torch.autograd.profiler import EventList
     from torch.utils.hooks import RemovableHandle
 
-    from pytorch_lightning.core.lightning import LightningModule
+    from pytorch_lightning.core.module import LightningModule
 
 if _KINETO_AVAILABLE:
     from torch.profiler import ProfilerAction, ProfilerActivity, tensorboard_trace_handler

--- a/pytorch_lightning/strategies/strategy.py
+++ b/pytorch_lightning/strategies/strategy.py
@@ -327,7 +327,7 @@ class Strategy(ABC):
     def training_step(self, *args, **kwargs) -> STEP_OUTPUT:
         """The actual training step.
 
-        See :meth:`~pytorch_lightning.core.lightning.LightningModule.training_step` for more details
+        See :meth:`~pytorch_lightning.core.module.LightningModule.training_step` for more details
         """
         with self.precision_plugin.train_step_context():
             return self.model.training_step(*args, **kwargs)
@@ -338,7 +338,7 @@ class Strategy(ABC):
     def validation_step(self, *args, **kwargs) -> Optional[STEP_OUTPUT]:
         """The actual validation step.
 
-        See :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step` for more details
+        See :meth:`~pytorch_lightning.core.module.LightningModule.validation_step` for more details
         """
         with self.precision_plugin.val_step_context():
             return self.model.validation_step(*args, **kwargs)
@@ -346,7 +346,7 @@ class Strategy(ABC):
     def test_step(self, *args, **kwargs) -> Optional[STEP_OUTPUT]:
         """The actual test step.
 
-        See :meth:`~pytorch_lightning.core.lightning.LightningModule.test_step` for more details
+        See :meth:`~pytorch_lightning.core.module.LightningModule.test_step` for more details
         """
         with self.precision_plugin.test_step_context():
             return self.model.test_step(*args, **kwargs)
@@ -354,7 +354,7 @@ class Strategy(ABC):
     def predict_step(self, *args, **kwargs) -> STEP_OUTPUT:
         """The actual predict step.
 
-        See :meth:`~pytorch_lightning.core.lightning.LightningModule.predict_step` for more details
+        See :meth:`~pytorch_lightning.core.module.LightningModule.predict_step` for more details
         """
         with self.precision_plugin.predict_step_context():
             return self.model.predict_step(*args, **kwargs)

--- a/pytorch_lightning/trainer/connectors/data_connector.py
+++ b/pytorch_lightning/trainer/connectors/data_connector.py
@@ -483,7 +483,7 @@ class _DataLoaderSource:
 
     The source can be
 
-    1. from a ``*_datalaoder()`` method on the :class:`~pytorch_lightning.core.lightning.LightningModule`,
+    1. from a ``*_datalaoder()`` method on the :class:`~pytorch_lightning.core.module.LightningModule`,
     2. from a ``*_datalaoder()`` method on the :class:`~pytorch_lightning.core.datamodule.LightningDataModule`,
     3. a direct instance of a :class:`~torch.utils.data.DataLoader` or supported collections thereof.
 
@@ -538,7 +538,7 @@ class _DataHookSelector:
 
     The hook source can be
 
-    1. a method from the :class:`~pytorch_lightning.core.lightning.LightningModule`,
+    1. a method from the :class:`~pytorch_lightning.core.module.LightningModule`,
     2. a method from the :class:`~pytorch_lightning.core.datamodule.LightningDataModule`,
 
     Arguments:

--- a/pytorch_lightning/trainer/connectors/logger_connector/result.py
+++ b/pytorch_lightning/trainer/connectors/logger_connector/result.py
@@ -199,7 +199,7 @@ class _Metadata:
 
 
 class _ResultMetric(Metric, DeviceDtypeModuleMixin):
-    """Wraps the value provided to `:meth:`~pytorch_lightning.core.lightning.LightningModule.log`"""
+    """Wraps the value provided to `:meth:`~pytorch_lightning.core.module.LightningModule.log`"""
 
     def __init__(self, metadata: _Metadata, is_tensor: bool) -> None:
         super().__init__()
@@ -449,7 +449,7 @@ class _ResultCollection(dict):
         metric_attribute: Optional[str] = None,
         rank_zero_only: bool = False,
     ) -> None:
-        """See :meth:`~pytorch_lightning.core.lightning.LightningModule.log`"""
+        """See :meth:`~pytorch_lightning.core.module.LightningModule.log`"""
         # no metrics should be logged with graphs
         if not enable_graph:
             value = recursive_detach(value)

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -791,8 +791,8 @@ class Trainer(
 
         Returns:
             List of dictionaries with metrics logged during the validation phase, e.g., in model- or callback hooks
-            like :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_step`,
-            :meth:`~pytorch_lightning.core.lightning.LightningModule.validation_epoch_end`, etc.
+            like :meth:`~pytorch_lightning.core.module.LightningModule.validation_step`,
+            :meth:`~pytorch_lightning.core.module.LightningModule.validation_epoch_end`, etc.
             The length of the list corresponds to the number of validation dataloaders used.
         """
         self.strategy.model = model or self.lightning_module
@@ -879,8 +879,8 @@ class Trainer(
 
         Returns:
             List of dictionaries with metrics logged during the test phase, e.g., in model- or callback hooks
-            like :meth:`~pytorch_lightning.core.lightning.LightningModule.test_step`,
-            :meth:`~pytorch_lightning.core.lightning.LightningModule.test_epoch_end`, etc.
+            like :meth:`~pytorch_lightning.core.module.LightningModule.test_step`,
+            :meth:`~pytorch_lightning.core.module.LightningModule.test_epoch_end`, etc.
             The length of the list corresponds to the number of test dataloaders used.
         """
         self.strategy.model = model or self.lightning_module

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -416,8 +416,8 @@ class LightningCLI:
         .. warning:: ``LightningCLI`` is in beta and subject to change.
 
         Args:
-            model_class: An optional :class:`~pytorch_lightning.core.lightning.LightningModule` class to train on or a
-                callable which returns a :class:`~pytorch_lightning.core.lightning.LightningModule` instance when
+            model_class: An optional :class:`~pytorch_lightning.core.module.LightningModule` class to train on or a
+                callable which returns a :class:`~pytorch_lightning.core.module.LightningModule` instance when
                 called. If ``None``, you can pass a registered model with ``--model=MyModel``.
             datamodule_class: An optional :class:`~pytorch_lightning.core.datamodule.LightningDataModule` class or a
                 callable which returns a :class:`~pytorch_lightning.core.datamodule.LightningDataModule` instance when
@@ -670,7 +670,7 @@ class LightningCLI:
     def configure_optimizers(
         lightning_module: LightningModule, optimizer: Optimizer, lr_scheduler: Optional[LRSchedulerTypeUnion] = None
     ) -> Any:
-        """Override to customize the :meth:`~pytorch_lightning.core.lightning.LightningModule.configure_optimizers`
+        """Override to customize the :meth:`~pytorch_lightning.core.module.LightningModule.configure_optimizers`
         method.
 
         Args:
@@ -688,9 +688,8 @@ class LightningCLI:
         return [optimizer], [lr_scheduler]
 
     def _add_configure_optimizers_method_to_model(self, subcommand: Optional[str]) -> None:
-        """Overrides the model's :meth:`~pytorch_lightning.core.lightning.LightningModule.configure_optimizers`
-        method if a single optimizer and optionally a scheduler argument groups are added to the parser as
-        'AUTOMATIC'."""
+        """Overrides the model's :meth:`~pytorch_lightning.core.module.LightningModule.configure_optimizers` method
+        if a single optimizer and optionally a scheduler argument groups are added to the parser as 'AUTOMATIC'."""
         parser = self._parser(subcommand)
 
         def get_automatic(

--- a/pytorch_lightning/utilities/model_summary.py
+++ b/pytorch_lightning/utilities/model_summary.py
@@ -34,8 +34,8 @@ UNKNOWN_SIZE = "?"
 
 
 class LayerSummary:
-    """Summary class for a single layer in a :class:`~pytorch_lightning.core.lightning.LightningModule`. It
-    collects the following information:
+    """Summary class for a single layer in a :class:`~pytorch_lightning.core.module.LightningModule`. It collects
+    the following information:
 
     - Type of the layer (e.g. Linear, BatchNorm1d, ...)
     - Input shape
@@ -124,7 +124,7 @@ class LayerSummary:
 
 
 class ModelSummary:
-    """Generates a summary of all layers in a :class:`~pytorch_lightning.core.lightning.LightningModule`.
+    """Generates a summary of all layers in a :class:`~pytorch_lightning.core.module.LightningModule`.
 
     Args:
         model: The model to summarize (also referred to as the root module).

--- a/tests/accelerators/test_ipu.py
+++ b/tests/accelerators/test_ipu.py
@@ -22,7 +22,7 @@ from torch.utils.data import DistributedSampler
 
 from pytorch_lightning import Callback, seed_everything, Trainer
 from pytorch_lightning.accelerators import IPUAccelerator
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.core.module import LightningModule
 from pytorch_lightning.plugins import IPUPrecisionPlugin
 from pytorch_lightning.strategies.ipu import IPUStrategy
 from pytorch_lightning.trainer.states import RunningStage, TrainerFn

--- a/tests/callbacks/test_tqdm_progress_bar.py
+++ b/tests/callbacks/test_tqdm_progress_bar.py
@@ -27,7 +27,7 @@ from torch.utils.data.dataloader import DataLoader
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint, ProgressBarBase, TQDMProgressBar
 from pytorch_lightning.callbacks.progress.tqdm_progress import Tqdm
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.core.module import LightningModule
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.helpers.boring_model import BoringModel, RandomDataset
 from tests.helpers.runif import RunIf

--- a/tests/deprecated_api/test_remove_1-9.py
+++ b/tests/deprecated_api/test_remove_1-9.py
@@ -17,7 +17,7 @@ from unittest import mock
 import pytest
 
 import pytorch_lightning.loggers.base as logger_base
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.core.module import LightningModule
 from pytorch_lightning.utilities.cli import LightningCLI
 from pytorch_lightning.utilities.rank_zero import rank_zero_only
 

--- a/tests/deprecated_api/test_remove_1-9.py
+++ b/tests/deprecated_api/test_remove_1-9.py
@@ -84,6 +84,16 @@ def test_lightning_logger_base_merge_dicts_deprecation_warning():
         logger_base.merge_dicts([d1, d2, d3], agg_funcs, dflt_func)
 
 
+def test_old_lightningmodule_path():
+    from pytorch_lightning.core.lightning import LightningModule
+
+    with pytest.deprecated_call(
+        match="pytorch_lightning.core.lightning.LightningModule has been deprecated in v1.7"
+        " and will be removed in v1.9."
+    ):
+        LightningModule()
+
+
 def test_lightningCLI_seed_everything_default_to_None_deprecation_warning():
     with mock.patch("sys.argv", ["any.py"]), pytest.deprecated_call(
         match="Setting `LightningCLI.seed_everything_default` to `None` is deprecated in v1.7 "

--- a/tests/helpers/advanced_models.py
+++ b/tests/helpers/advanced_models.py
@@ -18,7 +18,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.core.module import LightningModule
 from pytorch_lightning.utilities.imports import _TORCHVISION_AVAILABLE
 from tests import _PATH_DATASETS
 from tests.helpers.datasets import AverageDataset, MNIST, TrialMNIST

--- a/tests/helpers/deterministic_model.py
+++ b/tests/helpers/deterministic_model.py
@@ -15,7 +15,7 @@ import torch
 from torch import nn
 from torch.utils.data import DataLoader, Dataset
 
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.core.module import LightningModule
 
 
 class DeterministicModel(LightningModule):

--- a/tests/loops/test_evaluation_loop_flow.py
+++ b/tests/loops/test_evaluation_loop_flow.py
@@ -16,7 +16,7 @@
 import torch
 
 from pytorch_lightning import Trainer
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.core.module import LightningModule
 from pytorch_lightning.trainer.states import RunningStage
 from tests.helpers.deterministic_model import DeterministicModel
 

--- a/tests/loops/test_training_loop_flow_dict.py
+++ b/tests/loops/test_training_loop_flow_dict.py
@@ -16,7 +16,7 @@
 import torch
 
 from pytorch_lightning import Trainer
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.core.module import LightningModule
 from tests.helpers.deterministic_model import DeterministicModel
 
 

--- a/tests/loops/test_training_loop_flow_scalar.py
+++ b/tests/loops/test_training_loop_flow_scalar.py
@@ -17,7 +17,7 @@ from torch.utils.data import DataLoader
 from torch.utils.data._utils.collate import default_collate
 
 from pytorch_lightning import Trainer
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.core.module import LightningModule
 from pytorch_lightning.loops.optimization.optimizer_loop import Closure
 from pytorch_lightning.trainer.states import RunningStage
 from tests.helpers.boring_model import BoringModel, RandomDataset

--- a/tests/trainer/logging_/test_train_loop_logging.py
+++ b/tests/trainer/logging_/test_train_loop_logging.py
@@ -25,7 +25,7 @@ from torchmetrics import Accuracy
 
 from pytorch_lightning import callbacks, Trainer
 from pytorch_lightning.callbacks import EarlyStopping, ModelCheckpoint, TQDMProgressBar
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.core.module import LightningModule
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from tests.helpers.boring_model import BoringModel, RandomDataset, RandomDictDataset
 from tests.helpers.runif import RunIf

--- a/tests/utilities/test_meta.py
+++ b/tests/utilities/test_meta.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from torch import nn
 
-from pytorch_lightning.core.lightning import LightningModule
+from pytorch_lightning.core.module import LightningModule
 from pytorch_lightning.utilities.meta import init_meta_context, is_on_meta_device, materialize_module
 from tests.helpers.runif import RunIf
 


### PR DESCRIPTION
## What does this PR do?

<!--
Migration of `core/lightning.py` to `core/module.py` as discussed in the following issue.
-->

Fixes https://github.com/PyTorchLightning/pytorch-lightning/issues/10499

### Does your PR introduce any breaking changes? If yes, please list them.
While running `make test` I got some CUDA errors, I think that's issue from my side and some of the tests need `nvidia/apex`, `deepspeed` etc which I don't have in my system. 

result:
```
220 failed, 2509 passed, 335 skipped, 12 xfailed, 4996 warnings, 3 rerun
```

some of the errors I got
```
FAILED tests/trainer/optimization/test_manual_optimization.py::test_multiple_optimizers_step - RuntimeError: CUDA error: invalid device function
FAILED tests/trainer/optimization/test_manual_optimization.py::test_step_with_optimizer_closure_with_different_frequencies_ddp_spawn - torch.multiprocessing.spawn.ProcessRaise...
FAILED tests/trainer/optimization/test_manual_optimization.py::test_multiple_optimizers_logging[16] - RuntimeError: CUDA error: invalid device function
FAILED tests/trainer/optimization/test_manual_optimization.py::test_multiple_optimizers_logging[32] - RuntimeError: CUDA error: invalid device function
FAILED tests/trainer/properties/test_get_model.py::test_get_model_gpu - RuntimeError: CUDA error: invalid device function
FAILED tests/tuner/test_scale_batch_size.py::test_auto_scale_batch_size_trainer_arg[power] - RuntimeError: CUDA error: invalid device function
FAILED tests/tuner/test_scale_batch_size.py::test_auto_scale_batch_size_trainer_arg[binsearch] - RuntimeError: CUDA error: invalid device function
FAILED tests/tuner/test_scale_batch_size.py::test_auto_scale_batch_size_trainer_arg[True] - RuntimeError: CUDA error: invalid device function
FAILED tests/tuner/test_scale_batch_size.py::test_auto_scale_batch_size_set_model_attribute[True] - RuntimeError: CUDA error: invalid device function
FAILED tests/tuner/test_scale_batch_size.py::test_auto_scale_batch_size_set_model_attribute[False] - RuntimeError: CUDA error: invalid device function
FAILED tests/tuner/test_scale_batch_size.py::test_auto_scale_batch_size_with_amp - RuntimeError: CUDA error: invalid device function
FAILED tests/utilities/test_cli.py::test_cli_distributed_save_config_callback[ddp_spawn-False] - AssertionError: Regex pattern 'Error on fit start' does not match '\n\n-- Proc...
FAILED tests/utilities/test_cli.py::test_cli_distributed_save_config_callback[ddp_spawn-True] - AssertionError: Regex pattern 'Error on fit start' does not match '\n\n-- Proce...
FAILED tests/utilities/test_cli.py::test_cli_distributed_save_config_callback[ddp-False] - RuntimeError: CUDA error: invalid device function
FAILED tests/utilities/test_cli.py::test_cli_distributed_save_config_callback[ddp-True] - RuntimeError: CUDA error: invalid device function
FAILED tests/utilities/test_distributed.py::test_collect_states - torch.multiprocessing.spawn.ProcessRaisedException:
FAILED tests/utilities/test_dtype_device_mixin.py::test_submodules_multi_gpu_dp - RuntimeError: CUDA error: invalid device function
FAILED tests/utilities/test_dtype_device_mixin.py::test_submodules_multi_gpu_ddp_spawn - torch.multiprocessing.spawn.ProcessRaisedException:
FAILED tests/utilities/test_fetching.py::test_trainer_num_prefetch_batches - RuntimeError: CUDA error: invalid device function
FAILED tests/utilities/test_model_summary.py::test_linear_model_summary_shapes[device1--1] - RuntimeError: CUDA error: invalid device function
FAILED tests/utilities/test_model_summary.py::test_linear_model_summary_shapes[device1-1] - RuntimeError: CUDA error: invalid device function
FAILED tests/utilities/test_model_summary.py::test_model_size_precision - RuntimeError: CUDA error: invalid device function
```

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or minor internal changes/refactors)

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
