### PR TITLE
Fix `LightningModule.trainer` reference error when state dict hooks are called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Support `auto_select_gpus` with the accelerator and devices API ([#12608](https://github.com/PyTorchLightning/pytorch-lightning/pull/12608))
 
 
+- Fixed an issue with `LightningModule.{load_}state_dict()` raising a `ReferenceError` when the trainer weak reference count is zero ([#12785](https://github.com/PyTorchLightning/pytorch-lightning/pull/12785))
+
+
 ## [1.6.0] - 2022-03-29
 
 ### Added

--- a/pytorch_lightning/core/lightning.py
+++ b/pytorch_lightning/core/lightning.py
@@ -20,10 +20,10 @@ import numbers
 import os
 import tempfile
 import weakref
-from weakref import ReferenceType
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, overload, Sequence, Tuple, Union
+from weakref import ReferenceType
 
 import torch
 from torch import ScriptModule, Tensor

--- a/tests/core/test_lightning_module.py
+++ b/tests/core/test_lightning_module.py
@@ -406,6 +406,8 @@ def test_lightning_module_configure_gradient_clipping_different_argument_values(
 @RunIf(min_torch="1.10", skip_windows=True)
 @pytest.mark.skipif(not torch.distributed.is_available(), reason="Requires torch.distributed to be available")
 def test_lightning_module_state_dict_hook_trainer_weakref(monkeypatch):
+    """Regression test for issue #12233: Test that state dict hooks execute without raising a reference error on the
+    trainer attribute."""
     from torch.distributed._sharded_tensor import pre_load_state_dict_hook, state_dict_hook
 
     monkeypatch.setattr(torch.distributed._sharded_tensor, "pre_load_state_dict_hook", Mock(wraps=pre_load_state_dict_hook))

--- a/tests/core/test_lightning_module.py
+++ b/tests/core/test_lightning_module.py
@@ -410,7 +410,9 @@ def test_lightning_module_state_dict_hook_trainer_weakref(monkeypatch):
     trainer attribute."""
     from torch.distributed._sharded_tensor import pre_load_state_dict_hook, state_dict_hook
 
-    monkeypatch.setattr(torch.distributed._sharded_tensor, "pre_load_state_dict_hook", Mock(wraps=pre_load_state_dict_hook))
+    monkeypatch.setattr(
+        torch.distributed._sharded_tensor, "pre_load_state_dict_hook", Mock(wraps=pre_load_state_dict_hook)
+    )
     monkeypatch.setattr(torch.distributed._sharded_tensor, "state_dict_hook", Mock(wraps=state_dict_hook))
 
     def set_trainer(m):

--- a/tests/core/test_lightning_module.py
+++ b/tests/core/test_lightning_module.py
@@ -406,8 +406,8 @@ def test_lightning_module_configure_gradient_clipping_different_argument_values(
 @RunIf(min_torch="1.10", skip_windows=True)
 @pytest.mark.skipif(not torch.distributed.is_available(), reason="Requires torch.distributed to be available")
 def test_lightning_module_state_dict_hook_trainer_weakref(monkeypatch):
-    """Regression test for issue #12233: Test that state dict hooks execute without raising a reference error on the
-    trainer attribute."""
+    """Regression test for issue #12233: Test that state dict hooks execute without raising a reference error on
+    the trainer attribute."""
     from torch.distributed._sharded_tensor import pre_load_state_dict_hook, state_dict_hook
 
     monkeypatch.setattr(


### PR DESCRIPTION
## What does this PR do?

Fixes #12233

Test fails on master.

TODO: fix typehints for state dict methods.


## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] Did you update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)? (not for typos, docs, test updates, or internal minor changes/refactorings)

<!-- For CHANGELOG separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review
Anyone in the community is free to review the PR once the tests have passed.
Before you start reviewing make sure you have read [Review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

 - [x] Is this pull request ready for review? (if not, please submit in draft mode)
 - [x] Check that all items from **Before submitting** are resolved
 - [x] Make sure the title is self-explanatory and the description concisely explains the PR
 - [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?
I made sure I had fun coding 🙃


