### PR TITLE
Feature/12804 Automatic Seeding of the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Marked `swa_lrs` argument in `StochasticWeightAveraging` callback as required ([#12556](https://github.com/PyTorchLightning/pytorch-lightning/pull/12556))
 
 
--
+- Changed `seed_default_value` argument in the `LightningCLI` to type `Union[bool, int]`. If set to `True` a seed is automatically generated for the parser argument `--seed_everything`. Setting it to `None` raises a `LightningDeprecationWarning` ([#12804](https://github.com/PyTorchLightning/pytorch-lightning/issues/12804)). 
 
 
 -

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -512,7 +512,7 @@ class LightningCLI:
                 this particular CLI. Alternatively, configurable callbacks can be added as explained in
                 :ref:`the CLI docs <lightning-cli>`.
             seed_everything_default: Value for the :func:`~pytorch_lightning.utilities.seed.seed_everything`
-                seed argument. Set to True to automatically choose a valid seed.
+                seed argument. Set to True to automatically choose a valid seed. Set to False if you want to set your seeds manually.
             description: Description of the tool shown when running ``--help``.
             env_prefix: Prefix for environment variables.
             env_parse: Whether environment variable parsing is enabled.


### PR DESCRIPTION
## What does this PR do?

The argument `seed_default_value` of the `LightningCLI` is changed to the type `Optional[Union[bool,int]] = True` (from `Optional[int] = None`). The `Optional` flag is set for backwards compatibility. Setting it to `None` has the same effect as setting it to `False`, but raises a `rankzero - LightningDeprecationWarning`.

If the value is set to `True` a valid (range `np.iiinfo(np.int32).min` to `np.iiinfo(np.int32).max` ) seed is drawn at random and added as default to the `seed_everything` argument. 

The issue was discussed and approved in [12804](https://github.com/PyTorchLightning/pytorch-lightning/issues/12804). The type of `--seed_everything` is set to `Optional[int32]`, as I do not think, that setting it to `Optional[Union[bool,int]]` is required. By default the CLI now chooses a new seed with every instantiation, which can of course be overwritten with `--seed_everything` from the CLI or a config file. The only time, one would like to set it to `False`, would be if somewhere in the code the seed is already set, but in this case the automatic seeding should be disabled in the code (by setting `seed_default_value` to False) and not in a config file with `--seed_everything`.

Choosing a seed outside of the valid seed range, raises and error and avoids unnoticed accidental mistakes.

The version in the deprecation warning still needs to be set.

Fixes #\<[12804](https://github.com/PyTorchLightning/pytorch-lightning/issues/12804)>
For a motivation and discussion, have a look at the issue. 

### Does your PR introduce any breaking changes? If yes, please list them.

No.

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
