### PR TITLE
Print ragged dict of metrics in `EvaluationLoop._print_results` properly

### DIFF
--- a/tests/trainer/logging_/test_eval_loop_logging.py
+++ b/tests/trainer/logging_/test_eval_loop_logging.py
@@ -849,6 +849,35 @@ expected3 = """
 inputs4 = ([{}], "foo")
 expected4 = ""
 
+inputs5 = (
+    [
+        {
+            "test_loss": torch.tensor(0.5),
+            "accuracy": torch.tensor(1.5),
+            "macro avg": {
+                "precision": torch.tensor(2.5),
+                "recall": torch.tensor(3.5),
+                "f1-score": torch.tensor(4.5),
+                "support": torch.tensor(5.5),
+            },
+        }
+    ],
+    RunningStage.TESTING,
+)
+
+expected5 = """
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+       Test metric             DataLoader 0
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+        accuracy                    1.5
+        f1-score                    4.5
+        precision                   2.5
+         recall                     3.5
+         support                    5.5
+        test_loss                   0.5
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+"""
+
 
 @pytest.mark.parametrize(
     ["inputs", "expected"],
@@ -858,6 +887,7 @@ expected4 = ""
         pytest.param(inputs2, expected2, id="case2"),
         pytest.param(inputs3, expected3, id="case3"),
         pytest.param(inputs4, expected4, id="empty case"),
+        pytest.param(inputs5, expected5, id="ragged dict"),
     ],
 )
 def test_native_print_results(monkeypatch, inputs, expected):


### PR DESCRIPTION
## What does this PR do?

Fixes #12799 

`EvaluationLoop._print_results` is now capable to print ragged dicts. In addition, for multilevel dictionaries we concatenate all the keys in order to avoid collisions, so that `sklearn.metrics.classification_report` is fully supported

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
