### PR TITLE
Fix zero division error for empty dataloaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Make positional arguments required for classes passed into the `add_argparse_args` function. ([#12504](https://github.com/PyTorchLightning/pytorch-lightning/pull/12504))
 
 
+- Raise an error if there are insufficient training batches when using a float value of `limit_train_batches` ([#12885](https://github.com/PyTorchLightning/pytorch-lightning/pull/12885))
+
+
 -
 
 ### Deprecated
@@ -179,6 +182,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Enable mixed precision in `DDPFullyShardedStrategy` when `precision=16` ([#12965](https://github.com/PyTorchLightning/pytorch-lightning/pull/12965))
 
 
+- Fixed `TQDMProgressBar` reset and update to show correct time estimation ([#12889](https://github.com/PyTorchLightning/pytorch-lightning/pull/12889))
+
+
+- Fixed an issue causing zero-division error for empty dataloaders ([#12885](https://github.com/PyTorchLightning/pytorch-lightning/pull/12885))
+
+
 ## [1.6.2] - 2022-04-27
 
 ### Fixed
@@ -187,9 +196,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - When using custom DataLoaders in LightningDataModule, multiple inheritance is resolved properly ([#12716](https://github.com/PyTorchLightning/pytorch-lightning/pull/12716))
 - Fixed encoding issues on terminals that do not support unicode characters ([#12828](https://github.com/PyTorchLightning/pytorch-lightning/pull/12828))
 - Fixed support for `ModelCheckpoint` monitors with dots ([#12783](https://github.com/PyTorchLightning/pytorch-lightning/pull/12783))
-
-
-- Fixed `TQDMProgressBar` reset and update to show correct time estimation ([#12889](https://github.com/PyTorchLightning/pytorch-lightning/pull/12889))
 
 
 ## [1.6.1] - 2022-04-13

--- a/pytorch_lightning/trainer/connectors/data_connector.py
+++ b/pytorch_lightning/trainer/connectors/data_connector.py
@@ -388,10 +388,10 @@ class DataConnector:
                 orig_num_batches = num_batches = (
                     len(dataloader) if has_len_all_ranks(dataloader, self.trainer.strategy, module) else float("inf")
                 )
+
                 if orig_num_batches == 0:
-                    raise MisconfigurationException(
-                        f"You have provided an empty `DataLoader` inside `{mode.dataloader_prefix}_dataloader`."
-                    )
+                    loader_num_batches.append(num_batches)
+                    continue
 
                 self._worker_check(dataloader, f"{mode.dataloader_prefix}_dataloader {i}")
 

--- a/pytorch_lightning/trainer/connectors/data_connector.py
+++ b/pytorch_lightning/trainer/connectors/data_connector.py
@@ -381,7 +381,6 @@ class DataConnector:
         loader_num_batches = []
 
         # determine number of batches
-        # datasets could be none, 1 or 2+
         module = model or self.trainer.lightning_module or self.datamodule
         if len(dataloaders) != 0:
             for i, dataloader in enumerate(dataloaders):
@@ -390,7 +389,7 @@ class DataConnector:
                 )
 
                 if orig_num_batches == 0:
-                    loader_num_batches.append(num_batches)
+                    loader_num_batches.append(orig_num_batches)
                     continue
 
                 self._worker_check(dataloader, f"{mode.dataloader_prefix}_dataloader {i}")
@@ -400,14 +399,13 @@ class DataConnector:
 
                 # limit num batches either as a percent or num steps
                 if isinstance(limit_eval_batches, int):
-                    num_batches = min(num_batches, int(limit_eval_batches))
-                elif num_batches != float("inf"):
-                    num_batches = int(num_batches * limit_eval_batches)
+                    num_batches = min(orig_num_batches, limit_eval_batches)
+                elif isinstance(limit_eval_batches, float) and orig_num_batches != float("inf"):
+                    num_batches = int(orig_num_batches * limit_eval_batches)
                 elif limit_eval_batches != 1.0:
                     raise MisconfigurationException(
-                        f"When using an IterableDataset for `limit_{mode}_batches`,"
-                        f" `Trainer(limit_{mode.dataloader_prefix}_batches)` must be `1.0` or an int. An int k"
-                        f" specifies `num_{mode.dataloader_prefix}_batches` to use."
+                        f"When using an `IterableDataset`, `Trainer(limit_{mode.dataloader_prefix}_batches)` must be"
+                        f"`1.0` or an int. An int specifies `num_{mode.dataloader_prefix}_batches` to use."
                     )
 
                 if (

--- a/pytorch_lightning/trainer/connectors/data_connector.py
+++ b/pytorch_lightning/trainer/connectors/data_connector.py
@@ -414,12 +414,12 @@ class DataConnector:
                     and isinstance(limit_eval_batches, float)
                     and orig_num_batches != float("inf")
                 ):
-                    min_pct = 1.0 / orig_num_batches
+                    min_percentage = 1.0 / orig_num_batches
                     raise MisconfigurationException(
                         f"You requested to check {limit_eval_batches} of the `{mode.dataloader_prefix}_dataloader` but"
                         f" {limit_eval_batches} * {orig_num_batches} < 1. Please increase the"
                         f" `limit_{mode.dataloader_prefix}_batches` argument. Try at least"
-                        f" `limit_{mode.dataloader_prefix}_batches={min_pct}`"
+                        f" `limit_{mode.dataloader_prefix}_batches={min_percentage}`"
                     )
 
                 loader_num_batches.append(num_batches)

--- a/pytorch_lightning/trainer/connectors/data_connector.py
+++ b/pytorch_lightning/trainer/connectors/data_connector.py
@@ -405,7 +405,7 @@ class DataConnector:
                 elif limit_eval_batches != 1.0:
                     raise MisconfigurationException(
                         f"When using an `IterableDataset`, `Trainer(limit_{mode.dataloader_prefix}_batches)` must be"
-                        f"`1.0` or an int. An int specifies `num_{mode.dataloader_prefix}_batches` to use."
+                        f" `1.0` or an int. An int specifies `num_{mode.dataloader_prefix}_batches` to use."
                     )
 
                 if (

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1821,7 +1821,10 @@ class Trainer(
         )
 
         if orig_train_batches == 0:
-            raise MisconfigurationException("You have provided an empty `DataLoader` inside `train_dataloader`.")
+            return
+
+        # store epoch of dataloader reset for reload_dataloaders_every_n_epochs
+        self._last_train_dl_reload_epoch = self.current_epoch
 
         if isinstance(self.limit_train_batches, int):
             self.num_training_batches = min(self.num_training_batches, int(self.limit_train_batches))
@@ -1878,9 +1881,6 @@ class Trainer(
                 f" `limit_train_batches` argument. Try at least"
                 f" `limit_train_batches={min_pct}`"
             )
-
-        # store epoch of dataloader reset for reload_dataloaders_every_n_epochs
-        self._last_train_dl_reload_epoch = self.current_epoch
 
     def reset_val_dataloader(self, model: Optional["pl.LightningModule"] = None) -> None:
         """Resets the validation dataloader and determines the number of batches.

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1819,7 +1819,6 @@ class Trainer(
             if has_len_all_ranks(self.train_dataloader, self.strategy, module)
             else float("inf")
         )
-
         if orig_train_batches == 0:
             return
 
@@ -1827,14 +1826,13 @@ class Trainer(
         self._last_train_dl_reload_epoch = self.current_epoch
 
         if isinstance(self.limit_train_batches, int):
-            self.num_training_batches = min(self.num_training_batches, int(self.limit_train_batches))
+            self.num_training_batches = min(orig_train_batches, self.limit_train_batches)
         elif self.num_training_batches != float("inf"):
-            self.num_training_batches = int(self.num_training_batches * self.limit_train_batches)
+            self.num_training_batches = int(orig_train_batches * self.limit_train_batches)
         elif self.limit_train_batches != 1.0:
             raise MisconfigurationException(
-                "When using an IterableDataset for `limit_train_batches`,"
-                " `Trainer(limit_train_batches)` must be `1.0` or an int. An int k specifies"
-                " `num_training_batches` to use."
+                "When using an `IterableDataset`, `Trainer(limit_train_batches)` must be `1.0` or an int."
+                "An int specifies `num_training_batches` to use."
             )
 
         if isinstance(self.val_check_interval, int):

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -1872,12 +1872,12 @@ class Trainer(
             and isinstance(self.limit_train_batches, float)
             and orig_train_batches != float("inf")
         ):
-            min_pct = 1.0 / orig_train_batches
+            min_percentage = 1.0 / orig_train_batches
             raise MisconfigurationException(
                 f"You requested to check {self.limit_train_batches} of the `train_dataloader` but"
                 f" {self.limit_train_batches} * {orig_train_batches} < 1. Please increase the"
                 f" `limit_train_batches` argument. Try at least"
-                f" `limit_train_batches={min_pct}`"
+                f" `limit_train_batches={min_percentage}`"
             )
 
     def reset_val_dataloader(self, model: Optional["pl.LightningModule"] = None) -> None:

--- a/tests/trainer/connectors/test_data_connector.py
+++ b/tests/trainer/connectors/test_data_connector.py
@@ -25,7 +25,6 @@ from pytorch_lightning.trainer.connectors.data_connector import _DataHookSelecto
 from pytorch_lightning.trainer.states import RunningStage, TrainerFn
 from pytorch_lightning.trainer.supporters import CombinedLoader
 from pytorch_lightning.utilities.data import _update_dataloader
-from pytorch_lightning.trainer.states import TrainerFn
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.warnings import PossibleUserWarning
 from tests.helpers.boring_model import BoringDataModule, BoringModel, RandomDataset

--- a/tests/trainer/connectors/test_data_connector.py
+++ b/tests/trainer/connectors/test_data_connector.py
@@ -542,7 +542,7 @@ def test_eval_shuffle_with_distributed_sampler_replacement(shuffle):
     assert trainer.val_dataloaders[0].sampler.shuffle == shuffle
 
 
-def test_error_raised_with_float_limit_train_dataloader():
+def test_error_raised_with_insufficient_float_limit_train_dataloader():
     batch_size = 16
     dl = DataLoader(RandomDataset(32, batch_size * 9), batch_size=batch_size)
     trainer = Trainer(limit_train_batches=0.1, limit_val_batches=0.1)

--- a/tests/trainer/connectors/test_data_connector.py
+++ b/tests/trainer/connectors/test_data_connector.py
@@ -545,7 +545,7 @@ def test_eval_shuffle_with_distributed_sampler_replacement(shuffle):
 def test_error_raised_with_insufficient_float_limit_train_dataloader():
     batch_size = 16
     dl = DataLoader(RandomDataset(32, batch_size * 9), batch_size=batch_size)
-    trainer = Trainer(limit_train_batches=0.1, limit_val_batches=0.1)
+    trainer = Trainer(limit_train_batches=0.1)
     model = BoringModel()
 
     trainer._data_connector.attach_data(model=model, train_dataloaders=dl)

--- a/tests/trainer/connectors/test_data_connector.py
+++ b/tests/trainer/connectors/test_data_connector.py
@@ -542,26 +542,6 @@ def test_eval_shuffle_with_distributed_sampler_replacement(shuffle):
     assert trainer.val_dataloaders[0].sampler.shuffle == shuffle
 
 
-def test_empty_dataloader():
-    """Test that a `MisconfigurationException` is raised with dataloader with no data is provided."""
-    batch_size = 16
-    dl = DataLoader(RandomDataset(32, batch_size - 1), batch_size=batch_size, drop_last=True)
-    trainer = Trainer()
-    model = BoringModel()
-
-    trainer._data_connector.attach_data(model=model, train_dataloaders=dl)
-    with pytest.raises(
-        MisconfigurationException, match="You have provided an empty `DataLoader` inside `train_dataloader`"
-    ):
-        trainer.reset_train_dataloader(model)
-
-    trainer._data_connector.attach_data(model=model, val_dataloaders=dl)
-    with pytest.raises(
-        MisconfigurationException, match="You have provided an empty `DataLoader` inside `val_dataloader`"
-    ):
-        trainer.reset_val_dataloader(model)
-
-
 def test_error_raised_with_float_limit_train_dataloader():
     batch_size = 16
     dl = DataLoader(RandomDataset(32, batch_size * 9), batch_size=batch_size)

--- a/tests/trainer/connectors/test_data_connector.py
+++ b/tests/trainer/connectors/test_data_connector.py
@@ -25,6 +25,7 @@ from pytorch_lightning.trainer.connectors.data_connector import _DataHookSelecto
 from pytorch_lightning.trainer.states import RunningStage, TrainerFn
 from pytorch_lightning.trainer.supporters import CombinedLoader
 from pytorch_lightning.utilities.data import _update_dataloader
+from pytorch_lightning.trainer.states import TrainerFn
 from pytorch_lightning.utilities.exceptions import MisconfigurationException
 from pytorch_lightning.utilities.warnings import PossibleUserWarning
 from tests.helpers.boring_model import BoringDataModule, BoringModel, RandomDataset
@@ -539,3 +540,37 @@ def test_eval_shuffle_with_distributed_sampler_replacement(shuffle):
     trainer._data_connector.attach_data(model)
     trainer.reset_val_dataloader(model)
     assert trainer.val_dataloaders[0].sampler.shuffle == shuffle
+
+
+def test_empty_dataloader():
+    """Test that a `MisconfigurationException` is raised with dataloader with no data is provided."""
+    batch_size = 16
+    dl = DataLoader(RandomDataset(32, batch_size - 1), batch_size=batch_size, drop_last=True)
+    trainer = Trainer()
+    model = BoringModel()
+
+    trainer._data_connector.attach_data(model=model, train_dataloaders=dl)
+    with pytest.raises(
+        MisconfigurationException, match="You have provided an empty `DataLoader` inside `train_dataloader`"
+    ):
+        trainer.reset_train_dataloader(model)
+
+    trainer._data_connector.attach_data(model=model, val_dataloaders=dl)
+    with pytest.raises(
+        MisconfigurationException, match="You have provided an empty `DataLoader` inside `val_dataloader`"
+    ):
+        trainer.reset_val_dataloader(model)
+
+
+def test_error_raised_with_float_limit_train_dataloader():
+    batch_size = 16
+    dl = DataLoader(RandomDataset(32, batch_size * 9), batch_size=batch_size)
+    trainer = Trainer(limit_train_batches=0.1, limit_val_batches=0.1)
+    model = BoringModel()
+
+    trainer._data_connector.attach_data(model=model, train_dataloaders=dl)
+    with pytest.raises(
+        MisconfigurationException,
+        match="Please increase the `limit_train_batches` argument. Try at least",
+    ):
+        trainer.reset_train_dataloader(model)

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -523,6 +523,7 @@ def test_warning_on_zero_len_dataloader(tmpdir):
     train_dataloader = DataLoader(RandomDataset(32, 0))
     val_dataloader = DataLoader(RandomDataset(32, 0))
     trainer._data_connector.attach_data(model, train_dataloaders=train_dataloader, val_dataloaders=val_dataloader)
+
     with pytest.warns(UserWarning, match="Total length of `CombinedLoader` across ranks is zero"):
         trainer.reset_train_dataloader(model)
     assert trainer.num_training_batches == 0

--- a/tests/trainer/test_dataloaders.py
+++ b/tests/trainer/test_dataloaders.py
@@ -967,7 +967,7 @@ def test_inf_dataloader_raise_error_with_partial_batch_limits(tmpdir, stage, dat
     trainer = Trainer(**trainer_kwargs)
     trainer_fn = "fit" if stage == RunningStage.TRAINING else stage.value
 
-    with pytest.raises(MisconfigurationException, match=r"using an IterableDataset .* must be `1.0` or an int"):
+    with pytest.raises(MisconfigurationException, match=r"IterableDataset`.*limit_.*_batches\)`.*`1.0` or an int"):
         getattr(trainer, trainer_fn)(model)
 
 

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -1416,58 +1416,6 @@ def test_predict_return_predictions_cpu(return_predictions, precision, tmpdir):
         assert preds[0].dtype == (torch.float64 if precision == 64 else torch.float32)
 
 
-@pytest.mark.parametrize(
-    ["limit_train_batches", "global_step", "num_training_batches", "current_epoch", "should_train"],
-    [(0.2, 0, 0, 0, False), (0.5, 10, 2, 5, True)],
-)
-def test_disabled_training_for_insufficient_limit_train_batches(
-    tmpdir, limit_train_batches, global_step, num_training_batches, current_epoch, should_train
-):
-    """Verify when `limit_train_batches` is float & between [0.0, 1.0] and.
-
-    `int(self.num_training_batches * self.limit_train_batches) == 0`, the training loop is disabled.
-    """
-
-    class CurrentModel(BoringModel):
-
-        training_step_invoked = False
-        training_epoch_end_invoked = False
-
-        def training_step(self, *args, **kwargs):
-            self.training_step_invoked = True
-            return super().training_step(*args, **kwargs)
-
-        def training_epoch_end(self, *args, **kwargs):
-            self.training_epoch_end_invoked = True
-            return super().training_epoch_end(*args, **kwargs)
-
-    dataset_len = 100
-    batch_size = 25
-
-    train = RandomDataset(32, length=dataset_len)
-    train_loader = DataLoader(train, batch_size=batch_size)
-
-    model = CurrentModel()
-
-    trainer = Trainer(default_root_dir=tmpdir, max_epochs=5, limit_train_batches=limit_train_batches)
-    trainer.fit(model, train_loader)
-
-    params_string = f"""`limit_train_batches={limit_train_batches}`, `dataset_len={dataset_len}`
-                        & `batch_size={batch_size}` as
-                        `num_training_batches={num_training_batches}`"""
-    if should_train:
-        error_string = f"should run with {params_string}"
-    else:
-        error_string = f"should not run with {params_string}"
-
-    assert trainer.state.finished, f"Training failed with {trainer.state}"
-    assert trainer.global_step == global_step
-    assert trainer.num_training_batches == num_training_batches
-    assert trainer.current_epoch == current_epoch
-    assert model.training_step_invoked == should_train, f"`training_step` {error_string}"
-    assert model.training_epoch_end_invoked == should_train, f"`training_epoch_end` {error_string}"
-
-
 @pytest.mark.parametrize(["max_steps", "max_epochs", "global_step"], [(10, 5, 10), (20, None, 20)])
 def test_repeated_fit_calls_with_max_epochs_and_steps(tmpdir, max_steps, max_epochs, global_step):
     """Ensure that the training loop is bound by `max_steps` and `max_epochs` for repeated calls of `trainer.fit`,


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

Fixes #12830

Also if there are insufficient batches when using `limi_train_batches=float` (for eg, `total batches=9 and limit_train_batches=0.1`), it is used to silently disable the training. Ideally, it should raise an error just like it does with eval dataloaders.

Also, it is weird that when the input dataloaders have no batches, it just raises a warning and doesn't do anything but for the above case, it raises an exception. IMO we should start raising an exception in this case too?

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [x] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @justusschock @awaelchli @ninginthecloud @rohitgr7 @borda