### PR TITLE
Add ability to load checkpoints from cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Include a version suffix for new "last" checkpoints of later runs in the same directory ([#12902](https://github.com/PyTorchLightning/pytorch-lightning/pull/12902))
 
 
+- Add ability to load checkpoints when using the `LightningCLI` by providing `--load_from_checkpoint path/to/checkpoint.ckpt` ([#12940](https://github.com/PyTorchLightning/pytorch-lightning/pull/12940))
+
+
 -
 
 ### Changed

--- a/pytorch_lightning/utilities/cli.py
+++ b/pytorch_lightning/utilities/cli.py
@@ -609,6 +609,12 @@ class LightningCLI:
                 "Set to True to use a random seed."
             ),
         )
+        parser.add_argument(
+            "--load_from_checkpoint",
+            type=Optional[str],
+            default=None,
+            help="Load the lightningmodule from a given checkpoint",
+        )
 
     def add_core_arguments_to_parser(self, parser: LightningArgumentParser) -> None:
         """Adds arguments from the core classes to the parser."""
@@ -712,6 +718,12 @@ class LightningCLI:
         self.config_init = self.parser.instantiate_classes(self.config)
         self.datamodule = self._get(self.config_init, "data")
         self.model = self._get(self.config_init, "model")
+        if "load_from_checkpoint" in self.config and self.config.load_from_checkpoint:
+            self.model = self.model.load_from_checkpoint(
+                self.config.load_from_checkpoint,
+                **{p: getattr(self.model, p) for p in inspect.signature(self.model.__init__).parameters.keys()},
+            )
+
         self._add_configure_optimizers_method_to_model(self.subcommand)
         self.trainer = self.instantiate_trainer()
 


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->

**What does it do?**

This PR adds the ability to load checkpoints from the Lightning CLI. At the moment, checkpoint loading
is limited to the model (trainer, data loader could be added easily if requested).

**Why is this change important?**

I think the lightningcli is a fantastic tool to manage different trainer/model/dataloader configurations.
Especially that the model params are loaded from `yaml` config files.

In my case I would like to export the trained models to `onnx` or `torchscript` with the same hyperparameter config 
(loaded by lightningcli).

```python
# run with --load_from_checkpoint path/to/checkpoint.ckpt
cli = LightningCLI(run=False)
cli.model.to_onnx("model.onnx")
```

In the future it would also be nice to load trainer and dataloaders from checkpoints to continue training ...

### Does your PR introduce any breaking changes? If yes, please list them.

No

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [x] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
