### PR TITLE
[WIP] Removal of Deprecated weights_summary argument in Trainer Class

### DIFF
--- a/pytorch_lightning/trainer/connectors/callback_connector.py
+++ b/pytorch_lightning/trainer/connectors/callback_connector.py
@@ -50,7 +50,6 @@ class CallbackConnector:
         default_root_dir: Optional[str],
         weights_save_path: Optional[str],
         enable_model_summary: bool,
-        weights_summary: Optional[str],
         max_time: Optional[Union[str, timedelta, Dict[str, int]]] = None,
         accumulate_grad_batches: Optional[Union[int, Dict[int, int]]] = None,
     ):
@@ -88,7 +87,7 @@ class CallbackConnector:
         self._configure_progress_bar(process_position, enable_progress_bar)
 
         # configure the ModelSummary callback
-        self._configure_model_summary_callback(enable_model_summary, weights_summary)
+        self._configure_model_summary_callback(enable_model_summary)
 
         # accumulated grads
         self._configure_accumulated_gradients(accumulate_grad_batches)
@@ -154,12 +153,6 @@ class CallbackConnector:
     def _configure_model_summary_callback(
         self, enable_model_summary: bool, weights_summary: Optional[str] = None
     ) -> None:
-        if weights_summary is None:
-            rank_zero_deprecation(
-                "Setting `Trainer(weights_summary=None)` is deprecated in v1.5 and will be removed"
-                " in v1.7. Please set `Trainer(enable_model_summary=False)` instead."
-            )
-            return
         if not enable_model_summary:
             return
 
@@ -195,7 +188,6 @@ class CallbackConnector:
         else:
             model_summary = ModelSummary(max_depth=max_depth)
         self.trainer.callbacks.append(model_summary)
-        self.trainer._weights_summary = weights_summary
 
     def _configure_progress_bar(self, process_position: int = 0, enable_progress_bar: bool = True) -> None:
         progress_bars = [c for c in self.trainer.callbacks if isinstance(c, ProgressBarBase)]

--- a/pytorch_lightning/trainer/trainer.py
+++ b/pytorch_lightning/trainer/trainer.py
@@ -169,7 +169,6 @@ class Trainer(
         sync_batchnorm: bool = False,
         precision: Union[int, str] = 32,
         enable_model_summary: bool = True,
-        weights_summary: Optional[str] = "top",
         weights_save_path: Optional[str] = None,  # TODO: Remove in 1.8
         num_sanity_val_steps: int = 2,
         resume_from_checkpoint: Optional[Union[Path, str]] = None,
@@ -417,14 +416,6 @@ class Trainer(
             enable_model_summary: Whether to enable model summarization by default.
                 Default: ``True``.
 
-            weights_summary: Prints a summary of the weights when training begins.
-
-                .. deprecated:: v1.5
-                    ``weights_summary`` has been deprecated in v1.5 and will be removed in v1.7.
-                    To disable the summary, pass ``enable_model_summary = False`` to the Trainer.
-                    To customize the summary, pass :class:`~pytorch_lightning.callbacks.model_summary.ModelSummary`
-                    directly to the Trainer's ``callbacks`` argument.
-
             weights_save_path: Where to save weights if specified. Will override default_root_dir
                 for checkpoints only. Use this if for whatever reason you need the checkpoints
                 stored in a different place than the logs written in `default_root_dir`.
@@ -507,9 +498,6 @@ class Trainer(
         self._tested_ckpt_path: Optional[str] = None  # TODO: remove in v1.8
         self._predicted_ckpt_path: Optional[str] = None  # TODO: remove in v1.8
 
-        # todo: remove in v1.7
-        self._weights_summary: Optional[str] = None
-
         # init callbacks
         # Declare attributes to be set in _callback_connector on_trainer_init
         self._callback_connector.on_trainer_init(
@@ -521,7 +509,6 @@ class Trainer(
             default_root_dir,
             weights_save_path,
             enable_model_summary,
-            weights_summary,
             max_time,
             accumulate_grad_batches,
         )
@@ -2739,16 +2726,6 @@ class Trainer(
     def _should_terminate_gracefully(self) -> bool:
         value = torch.tensor(int(self._terminate_gracefully), device=self.strategy.root_device)
         return self.strategy.reduce(value, reduce_op="sum") > 0
-
-    @property
-    def weights_summary(self) -> Optional[str]:
-        rank_zero_deprecation("`Trainer.weights_summary` is deprecated in v1.5 and will be removed in v1.7.")
-        return self._weights_summary
-
-    @weights_summary.setter
-    def weights_summary(self, val: Optional[str]) -> None:
-        rank_zero_deprecation("Setting `Trainer.weights_summary` is deprecated in v1.5 and will be removed in v1.7.")
-        self._weights_summary = val
 
     """
     Other

--- a/tests/deprecated_api/test_remove_1-7.py
+++ b/tests/deprecated_api/test_remove_1-7.py
@@ -183,21 +183,6 @@ def test_v1_7_0_deprecate_parameter_validation():
         from pytorch_lightning.core.decorators import parameter_validation  # noqa: F401
 
 
-def test_v1_7_0_weights_summary_trainer(tmpdir):
-    with pytest.deprecated_call(match=r"Setting `Trainer\(weights_summary=full\)` is deprecated in v1.5"):
-        t = Trainer(weights_summary="full")
-
-    with pytest.deprecated_call(match=r"Setting `Trainer\(weights_summary=None\)` is deprecated in v1.5"):
-        t = Trainer(weights_summary=None)
-
-    t = Trainer(weights_summary="top")
-    with pytest.deprecated_call(match=r"`Trainer.weights_summary` is deprecated in v1.5"):
-        _ = t.weights_summary
-
-    with pytest.deprecated_call(match=r"Setting `Trainer.weights_summary` is deprecated in v1.5"):
-        t.weights_summary = "blah"
-
-
 def test_v1_7_0_deprecated_slurm_job_id():
     trainer = Trainer()
     with pytest.deprecated_call(match="Method `slurm_job_id` is deprecated in v1.6.0 and will be removed in v1.7.0."):

--- a/tests/utilities/test_model_summary.py
+++ b/tests/utilities/test_model_summary.py
@@ -139,19 +139,6 @@ class DeepNestedModel(LightningModule):
         return self.head(self.branch1(inp), self.branch2(inp))
 
 
-def test_invalid_weights_summary():
-    """Test that invalid value for weights_summary raises an error."""
-    model = LightningModule()
-
-    with pytest.raises(
-        MisconfigurationException, match="`weights_summary` can be None, .* got temp"
-    ), pytest.deprecated_call(match="weights_summary=temp)` is deprecated"):
-        Trainer(weights_summary="temp")
-
-    with pytest.raises(ValueError, match="max_depth` can be .* got temp"):
-        ModelSummary(model, max_depth="temp")
-
-
 @pytest.mark.parametrize("max_depth", [-1, 1])
 def test_empty_model_summary_shapes(max_depth):
     """Test that the summary works for models that have no submodules."""


### PR DESCRIPTION
## What does this PR do?
Part of #12521 

This PR removes the `weights_summary` in the Trainer Class and the corresponding changes. Made the following edits,
- Removed Argument from Trainer Class [[Link](pytorch_lightning/trainer/trainer.py)]
- Removed functionality from Callback_Collector Class ([Link](pytorch_lightning/trainer/connectors/callback_connector.py))
- Removed test in `test_model_summary.py` ([Link](tests/utilities/test_model_summary.py))
- Removed Deprecation tests related to `weights_summary` ([Link](tests/deprecated_api/test_remove_1-7.py))

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

The following links the related issue to the PR (https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
-->


### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [ ] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**? (not for typos and docs)
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃
