### PR TITLE
Avoid annoying firewall message from `find_free_network_port`

### DIFF
--- a/pytorch_lightning/plugins/environments/lightning_environment.py
+++ b/pytorch_lightning/plugins/environments/lightning_environment.py
@@ -96,7 +96,6 @@ def find_free_network_port() -> int:
     """
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.bind(("", 0))
-    s.listen(1)
     port = s.getsockname()[1]
     s.close()
     return port


### PR DESCRIPTION
## What does this PR do?

For years, we have learned to ignored the annoying firewall message that pops up when we run for example ddp, tests locally on CPU. **No more.** The `sock.listen(1)` call in the `find_free_network_port` utility function is causing this, but the call itself seems to be redundant after all. 

<img width="553" alt="image" src="https://user-images.githubusercontent.com/5495193/169448422-e6957c63-c6b5-4117-b1ed-6017b803b832.png">

### Does your PR introduce any breaking changes? If yes, please list them.

No.

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **update the [CHANGELOG](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/CHANGELOG.md)**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/PyTorchLightning/pytorch-lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones (and optionally projects) to the PR so it can be classified

## Did you have fun?

Make sure you had fun coding 🙃


cc @borda @awaelchli @ananthsub