### PR TITLE
CLI: resolve jsonargparse deprecation warning

### DIFF
--- a/src/lightning/pytorch/cli.py
+++ b/src/lightning/pytorch/cli.py
@@ -51,9 +51,11 @@ if _JSONARGPARSE_SIGNATURES_AVAILABLE:
 
     try:
         from jsonargparse import set_parsing_settings
+
         set_parsing_settings(config_read_mode_fsspec_enabled=True)
     except ImportError:
         from jsonargparse import set_config_read_mode
+
         set_config_read_mode(fsspec_enabled=True)
 else:
     locals()["ArgumentParser"] = object


### PR DESCRIPTION
## What does this PR do?

The latest [jsonargparse release](https://jsonargparse.readthedocs.io/en/stable/changelog.html#v4-39-0-2025-04-29) deprecates `set_config_read_mode` in favor of `set_parsing_settings`. This results in the following warning message during testing:
```
../../../../../opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/lightning/pytorch/cli.py:52
  /opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/lightning/pytorch/cli.py:52: 
      By default only one JsonargparseDeprecationWarning per type is shown. To see all warnings set environment
      variable JSONARGPARSE_DEPRECATION_WARNINGS=all and to disable the warnings set
      JSONARGPARSE_DEPRECATION_WARNINGS=off.

../../../../../opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/lightning/pytorch/cli.py:52
  /opt/hostedtoolcache/Python/3.13.3/x64/lib/python3.13/site-packages/lightning/pytorch/cli.py:52: 
      set_config_read_mode was deprecated in v4.39.0 and will be removed in v5.0.0. Optional config read modes
      should now be set using function set_parsing_settings.
```
This PR defaults to the new function when available and falls back to the old function for older versions. This makes the code more futureproof and compatible with jsonargparse v5 once it is released. Let me know if you would rather replace the try-except with a version check.

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20802.org.readthedocs.build/en/20802/

<!-- readthedocs-preview pytorch-lightning end -->