### PR TITLE
docs: warning don’t use `torch.profiler.profile` context manager around `Trainer` methods

### DIFF
--- a/docs/source-pytorch/tuning/profiler.rst
+++ b/docs/source-pytorch/tuning/profiler.rst
@@ -4,25 +4,6 @@
 Find bottlenecks in your code
 #############################
 
-.. warning::
-
-    **Do not wrap** ``Trainer.fit()``, ``Trainer.validate()``, or other Trainer methods
-    inside a manual ``torch.profiler.profile`` context manager.
-    This will cause unexpected crashes and cryptic errors due to incompatibility between
-    PyTorch Profiler's context management and Lightning's internal training loop.
-    Instead, always use the ``profiler`` argument in the ``Trainer`` constructor.
-
-    Example (correct usage):
-
-    .. code-block:: python
-
-        import pytorch_lightning as pl
-
-        trainer = pl.Trainer(
-            profiler="pytorch",  # <- This enables built-in profiling safely!
-            ...
-        )
-        trainer.fit(model, train_dataloaders=...)
 .. raw:: html
 
     <div class="display-card-container">

--- a/docs/source-pytorch/tuning/profiler_basic.rst
+++ b/docs/source-pytorch/tuning/profiler_basic.rst
@@ -121,3 +121,22 @@ This can be measured with the :class:`~lightning.pytorch.callbacks.device_stats_
 
 CPU metrics will be tracked by default on the CPU accelerator. To enable it for other accelerators set ``DeviceStatsMonitor(cpu_stats=True)``. To disable logging
 CPU metrics, you can specify ``DeviceStatsMonitor(cpu_stats=False)``.
+
+.. warning::
+
+    **Do not wrap** ``Trainer.fit()``, ``Trainer.validate()``, or other Trainer methods inside a manual
+    ``torch.profiler.profile`` context manager. This will cause unexpected crashes and cryptic errors due to
+    incompatibility between PyTorch Profiler's context management and Lightning's internal training loop.
+    Instead, always use the ``profiler`` argument in the ``Trainer`` constructor or the
+    :class:`~lightning.pytorch.profilers.pytorch.PyTorchProfiler` profiler class if you want to customize the profiling.
+
+    Example:
+
+    .. code-block:: python
+
+        from lightning.pytorch import Trainer
+        from lightning.pytorch.profilers import PytorchProfiler
+
+        trainer = Trainer(profiler="pytorch")
+        # or
+        trainer = Trainer(profiler=PytorchProfiler(dirpath=".", filename="perf_logs"))


### PR DESCRIPTION
What does this PR do?

This PR adds a prominent documentation warning to the Trainer class docstring (and optionally Profiler docs) to alert users not to wrap Trainer.fit(), Trainer.validate(), or similar methods inside a manual torch.profiler.profile context manager.
Instead, users are advised to use the profiler argument in the Trainer constructor, which is the robust and officially supported method for profiling with Lightning.

This change aims to prevent a common source of cryptic internal errors and crashes reported by users who attempt to manually profile the Trainer, and improves developer experience by making the correct usage obvious in the docs.

Fixes #20779
(You can fill in the relevant issue if one exists, such as #16958)
<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

This PR does not introduce any breaking changes.
<details> <summary><b>Before submitting</b></summary>

    Was this discussed/agreed via a GitHub issue?
    Yes, this has been discussed in Lightning issues and user forums (see: #16958 and PyTorch #88472).

Did you read the contributor guideline, Pull Request section?

Did you make sure your PR does only one thing, instead of bundling different changes together?

Did you make sure to update the documentation with your changes? (if necessary)

Did you write any new necessary tests? (not for typos and docs)

Did you verify new and existing tests pass locally with your changes?

Did you list all the breaking changes introduced by this pull request?

    Did you update the CHANGELOG? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions --> </details>
PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the review guidelines. In short, see the following bullet-list:
<details> <summary>Reviewer checklist</summary>

Is this pull request ready for review? (if not, please submit in draft mode)

Check that all items from Before submitting are resolved

Make sure the title is self-explanatory and the description concisely explains the PR

    Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>
References

    PyTorch Issue #88472

    Lightning Issue #16958

    StackOverflow community discussion

Thanks for considering this! This documentation improvement should help prevent many user headaches and support requests.

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--20864.org.readthedocs.build/en/20864/

<!-- readthedocs-preview pytorch-lightning end -->