### PR TITLE
Changelog after 2.5.6 Release

### DIFF
--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -32,11 +32,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 - Add MPS accelerator support for mixed precision ([#21209](https://github.com/Lightning-AI/pytorch-lightning/pull/21209))
 
-- 
+-
 
 ### Removed
 
-- 
+-
 
 ### Fixed
 


### PR DESCRIPTION
Updates the changelog after 2.5.6 release

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21337.org.readthedocs.build/en/21337/

<!-- readthedocs-preview pytorch-lightning end -->