### PR TITLE
Fix `RichProgressBar` loading when using `LightningCLI`

### DIFF
--- a/src/lightning/pytorch/callbacks/progress/rich_progress.py
+++ b/src/lightning/pytorch/callbacks/progress/rich_progress.py
@@ -221,7 +221,6 @@ class RichProgressBarTheme:
     metrics_text_delimiter: str = " "
     metrics_format: str = ".3f"
 
-
     def __init__(self) -> None:
         pass
 


### PR DESCRIPTION


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21340.org.readthedocs.build/en/21340/

<!-- readthedocs-preview pytorch-lightning end -->