### PR TITLE
Make the default SLURM requeue signal configurable

### DIFF
--- a/src/lightning/fabric/plugins/environments/slurm.py
+++ b/src/lightning/fabric/plugins/environments/slurm.py
@@ -44,11 +44,13 @@ class SLURMEnvironment(ClusterEnvironment):
 
     """
 
+    DEFAULT_REQUEUE_SIGNAL = signal.SIGUSR1 if not _IS_WINDOWS else None
+
     def __init__(self, auto_requeue: bool = True, requeue_signal: Optional[signal.Signals] = None) -> None:
         super().__init__()
         self.auto_requeue = auto_requeue
-        if requeue_signal is None and not _IS_WINDOWS:
-            requeue_signal = signal.SIGUSR1
+        if requeue_signal is None:
+            requeue_signal = self.DEFAULT_REQUEUE_SIGNAL
         self.requeue_signal = requeue_signal
         self._validate_srun_used()
         self._validate_srun_variables()


### PR DESCRIPTION
## What does this PR do?

It moves the hardcoded default for `requeue_signal` in `SLURMEnvironment` into a class constant. This lets users change the default for SLURM environments without having to leave lightning's environment detection behind to instantiate the environment themselves.

Fixes #21404

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- Did you make sure to **update the documentation** with your changes? (if necessary)
- Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- Did you list all the **breaking changes** introduced by this pull request?
- Did you **update the CHANGELOG**? (not for typos, docs, test updates, or minor internal changes/refactors)

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21405.org.readthedocs.build/en/21405/

<!-- readthedocs-preview pytorch-lightning end -->