### PR TITLE
Rudimentary support for weight averaging (EMA) with FSDP

### DIFF
--- a/docs/source-pytorch/advanced/training_tricks.rst
+++ b/docs/source-pytorch/advanced/training_tricks.rst
@@ -62,7 +62,7 @@ Lightning provides two callbacks to facilitate weight averaging. :class:`~lightn
 is a generic callback that wraps the
 `AveragedModel <https://pytorch.org/docs/stable/generated/torch.optim.swa_utils.AveragedModel.html>`__ class from
 PyTorch. It allows SWA, EMA, or a custom averaging strategy to be used. By default, it updates the weights after every
-step, but it can be customized to update at specific steps or epochs by overriding the `should_update()` method.
+step, but it can be customized to update at specific steps or epochs by overriding the ``should_update()`` method.
 
 The older :class:`~lightning.pytorch.callbacks.StochasticWeightAveraging` callback is specific to SWA. It starts the SWA
 procedure after a certain number of epochs and always runs on every epoch. Additionally, it switches to a constant
@@ -75,7 +75,7 @@ procedure starts.
 
 .. seealso::
     The :class:`~lightning.pytorch.callbacks.WeightAveraging` callback and
-    :class:`~lightning.pytorch.callbacks.StochasticWeightAveraging` callback
+    :class:`~lightning.pytorch.callbacks.StochasticWeightAveraging` callback.
 
 .. testcode::
 

--- a/src/lightning/pytorch/CHANGELOG.md
+++ b/src/lightning/pytorch/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
--
+- Added support for FSDP with `WeightAveraging`, by summoning full parameters before averaged model update ([#21414](https://github.com/Lightning-AI/pytorch-lightning/pull/21414))
 
 ### Changed
 


### PR DESCRIPTION
## What does this PR do?

The `WeightAveraging` callback doesn't support sharded models. The reason is that either the averaged model should be sharded too, or the full model parameters are needed when creating and updating the averaged model. There was a lot of interest in using EMA with FSDP, but this was left out from the [original PR](https://github.com/Lightning-AI/pytorch-lightning/pull/20545), because it's not obvious how to implement it.

@amorehead noticed that SimpleFold uses Lightning, AveragedModel, and FSDP. They simply [summon full parameters](https://github.com/apple/ml-simplefold/blob/ff4b91daca2ef8cafe83e3e80140bcce6a3136d1/src/simplefold/model/simplefold.py#L718-L723) before updating the averaged model. That's what this PR does.

The full parameters are also needed when creating the averaged model and when swapping the current and the averaged model for validation. I call `pl_module.configure_model()` in `setup()`, meaning that the full parameters are initialized in CPU memory. SimpleFold doesn't define `configure_model()` at all, so I believe the result is the same. When updating the averaged model, SimpleFold doesn't use `offload_to_cpu`, so I don't use it either. If the entire model doesn't fit in the GPU memory, you'll run out of memory at this point.

This is probably the best we can do without massive changes. Is this good enough? I don't know, I've never used FSDP. Maybe someone who has an actual use case could check if this is useful. Tagging people who asked about this in the original PR @amorehead @kzrpg @npuichigo

<details>
  <summary><b>Before submitting</b></summary>

- Was this **discussed/agreed** via a GitHub issue? -- Not agreed, but there was a lot of interest in the original PR.
- Did you make sure to **update the documentation** with your changes? -- Updated the documentation of the WeightAveraging class.
- Did you write any **new necessary tests**? (not for typos and docs) -- Added one test for EMA with FSDP. Feel free to suggest more.

</details>

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>

<!--

Did you have fun?

Make sure you had fun coding 🙃

-->


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21414.org.readthedocs.build/en/21414/

<!-- readthedocs-preview pytorch-lightning end -->