### PR TITLE
docs: fix broken Neptune documentation URLs

### DIFF
--- a/src/lightning/pytorch/loggers/neptune.py
+++ b/src/lightning/pytorch/loggers/neptune.py
@@ -64,7 +64,7 @@ def _catch_inactive(func: Callable) -> Callable:
 
 
 class NeptuneLogger(Logger):
-    r"""Log using `Neptune <https://docs.neptune.ai/integrations/lightning/>`_.
+    r"""Log using `Neptune <https://docs-legacy.neptune.ai/integrations/lightning/>`_.
 
     Install it with pip:
 
@@ -124,7 +124,7 @@ class NeptuneLogger(Logger):
     Note that the syntax ``self.logger.experiment["your/metadata/structure"].append(metadata)`` is specific to
     Neptune and extends the logger capabilities. It lets you log various types of metadata, such as
     scores, files, images, interactive visuals, and CSVs.
-    Refer to the `Neptune docs <https://docs.neptune.ai/logging/methods>`_
+    Refer to the `Neptune docs <https://docs-legacy.neptune.ai/logging/methods>`_
     for details.
     You can also use the regular logger methods ``log_metrics()``, and ``log_hyperparams()`` with NeptuneLogger.
 
@@ -179,7 +179,7 @@ class NeptuneLogger(Logger):
         )
         trainer = Trainer(max_epochs=3, logger=neptune_logger)
 
-    Check `run documentation <https://docs.neptune.ai/api/neptune/#init_run>`_
+    Check `run documentation <https://docs-legacy.neptune.ai/api/neptune/#init_run>`_
     for more info about additional run parameters.
 
     **Details about Neptune run structure**
@@ -191,18 +191,18 @@ class NeptuneLogger(Logger):
 
     See also:
         - Read about
-          `what objects you can log to Neptune <https://docs.neptune.ai/logging/what_you_can_log/>`_.
+          `what objects you can log to Neptune <https://docs-legacy.neptune.ai/logging/what_you_can_log/>`_.
         - Check out an `example run <https://app.neptune.ai/o/common/org/pytorch-lightning-integration/e/PTL-1/all>`_
           with multiple types of metadata logged.
         - For more detailed examples, see the
-          `user guide <https://docs.neptune.ai/integrations/lightning/>`_.
+          `user guide <https://docs-legacy.neptune.ai/integrations/lightning/>`_.
 
     Args:
         api_key: Optional.
             Neptune API token, found on https://www.neptune.ai upon registration.
             You should save your token to the `NEPTUNE_API_TOKEN`
             environment variable and leave the api_key argument out of your code.
-            Instructions: `Setting your API token <https://docs.neptune.ai/setup/setting_api_token/>`_.
+            Instructions: `Setting your API token <https://docs-legacy.neptune.ai/setup/setting_api_token/>`_.
         project: Optional.
             Name of a project in the form "workspace-name/project-name", for example "tom/mask-rcnn".
             If ``None``, the value of `NEPTUNE_PROJECT` environment variable is used.
@@ -372,7 +372,7 @@ class NeptuneLogger(Logger):
         is specific to Neptune and extends the logger capabilities.
         It lets you log various types of metadata, such as scores, files,
         images, interactive visuals, and CSVs. Refer to the
-        `Neptune docs <https://docs.neptune.ai/logging/methods>`_
+        `Neptune docs <https://docs-legacy.neptune.ai/logging/methods>`_
         for more detailed explanations.
         You can also use the regular logger methods ``log_metrics()``, and ``log_hyperparams()``
         with NeptuneLogger.


### PR DESCRIPTION
## What does this PR do?

Fixes #21371

Neptune changed their API and documentation to v3.x, which broke the existing URLs in the NeptuneLogger docstrings. This PR updates all `docs.neptune.ai` URLs to point to `docs-legacy.neptune.ai` where the v2.x documentation is hosted.

## Changes

Updated 7 URLs in `src/lightning/pytorch/loggers/neptune.py`:
- `https://docs.neptune.ai/integrations/lightning/` → `https://docs-legacy.neptune.ai/integrations/lightning/`
- `https://docs.neptune.ai/logging/methods` → `https://docs-legacy.neptune.ai/logging/methods`
- `https://docs.neptune.ai/api/neptune/#init_run` → `https://docs-legacy.neptune.ai/api/neptune/#init_run`
- `https://docs.neptune.ai/logging/what_you_can_log/` → `https://docs-legacy.neptune.ai/logging/what_you_can_log/`
- `https://docs.neptune.ai/setup/setting_api_token/` → `https://docs-legacy.neptune.ai/setup/setting_api_token/`

All legacy URLs have been verified to be working.

## Testing

- Verified that all new URLs resolve correctly
- No code changes, only documentation URLs updated

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21452.org.readthedocs.build/en/21452/

<!-- readthedocs-preview pytorch-lightning end -->