### PR TITLE
Docs: add emphasize-lines directive to python code block

### DIFF
--- a/docs/source-pytorch/data/access.rst
+++ b/docs/source-pytorch/data/access.rst
@@ -10,6 +10,7 @@ via the trainer properties :meth:`~lightning.pytorch.trainer.trainer.Trainer.tra
 :meth:`~lightning.pytorch.trainer.trainer.Trainer.predict_dataloaders`.
 
 .. code-block:: python
+   :emphasize-lines: 1
 
     dataloaders = trainer.train_dataloader
     dataloaders = trainer.val_dataloaders


### PR DESCRIPTION
This PR adds the `:emphasize-lines:` directive to a Python code block in `access.rst` to improve documentation clarity and highlight important lines.

Small documentation-only change following issue #12119.


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21536.org.readthedocs.build/en/21536/

<!-- readthedocs-preview pytorch-lightning end -->