### PR TITLE
feat: add __len__ support to LightningDataModule

### DIFF
--- a/src/lightning/pytorch/core/datamodule.py
+++ b/src/lightning/pytorch/core/datamodule.py
@@ -253,6 +253,37 @@ class LightningDataModule(DataHooks, HyperparametersMixin):
         )
         return cast(Self, loaded)
 
+    def __len__(self) -> int:
+        """Return the number of samples in the training dataset.
+
+        Override this method in your subclass to return the total number of
+        training samples. By default, this method attempts to determine the
+        length from the training dataloader's dataset.
+
+        Returns:
+            The number of samples in the training dataset.
+
+        Raises:
+            TypeError: If ``train_dataloader`` is not configured or the dataset
+                does not implement ``__len__``.
+
+        Example::
+
+            class MyDataModule(LightningDataModule):
+                def __len__(self) -> int:
+                    return len(self.train_dataset)
+
+        """
+        try:
+            loader = self.train_dataloader()
+            dataset = loader.dataset
+            return len(dataset)  # type: ignore[arg-type]
+        except Exception as ex:
+            raise TypeError(
+                f"'{type(self).__name__}' object has no len(). "
+                "Override `__len__` in your LightningDataModule subclass to return the number of training samples."
+            ) from ex
+
     def __str__(self) -> str:
         """Return a string representation of the datasets that are set up.
 


### PR DESCRIPTION
Closes #5965.

Adds `__len__` support to `LightningDataModule` so users can call `len(datamodule)`.

**Default implementation:** Attempts to return the length from `train_dataloader().dataset`. If the training dataloader is not configured or the dataset doesn't implement `__len__`, raises a `TypeError` with a helpful message directing users to override `__len__` in their subclass.

**Usage:**
```python
# Use the default implementation (returns train dataset length)
datamodule = MyDataModule()
datamodule.setup("fit")
print(len(datamodule))  # e.g., 50000

# Or override for custom behavior
class MyDataModule(LightningDataModule):
    def __len__(self) -> int:
        return len(self.train_dataset)
```

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21546.org.readthedocs.build/en/21546/

<!-- readthedocs-preview pytorch-lightning end -->