### PR TITLE
fix: avoid AccumulateGrad stream mismatch by using default stream for DDP init

### DIFF
--- a/src/lightning/fabric/strategies/ddp.py
+++ b/src/lightning/fabric/strategies/ddp.py
@@ -124,10 +124,9 @@ class DDPStrategy(ParallelStrategy):
     def setup_module(self, module: Module) -> DistributedDataParallel:
         """Wraps the model into a :class:`~torch.nn.parallel.distributed.DistributedDataParallel` module."""
         device_ids = self._determine_ddp_device_ids()
-        # https://pytorch.org/docs/stable/notes/cuda.html#id5
-        ctx = torch.cuda.stream(torch.cuda.Stream()) if device_ids is not None else nullcontext()
-        with ctx:
-            return DistributedDataParallel(module=module, device_ids=device_ids, **self._ddp_kwargs)
+        # Use default stream for DDP init to match subsequent forwards/backwards and avoid
+        # AccumulateGrad stream mismatch warning (see pytorch/pytorch#input_buffer.cpp)
+        return DistributedDataParallel(module=module, device_ids=device_ids, **self._ddp_kwargs)
 
     @override
     def module_to_device(self, module: Module) -> None:

--- a/src/lightning/pytorch/strategies/ddp.py
+++ b/src/lightning/pytorch/strategies/ddp.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from contextlib import nullcontext
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, Callable, Literal, Optional, Union
 
@@ -190,10 +189,9 @@ class DDPStrategy(ParallelStrategy):
         """Wraps the model into a :class:`~torch.nn.parallel.distributed.DistributedDataParallel` module."""
         device_ids = self.determine_ddp_device_ids()
         log.debug(f"setting up DDP model with device ids: {device_ids}, kwargs: {self._ddp_kwargs}")
-        # https://pytorch.org/docs/stable/notes/cuda.html#id5
-        ctx = torch.cuda.stream(torch.cuda.Stream()) if device_ids is not None else nullcontext()
-        with ctx:
-            return DistributedDataParallel(module=model, device_ids=device_ids, **self._ddp_kwargs)
+        # Use default stream for DDP init to match subsequent forwards/backwards and avoid
+        # AccumulateGrad stream mismatch warning (see pytorch/pytorch#input_buffer.cpp)
+        return DistributedDataParallel(module=model, device_ids=device_ids, **self._ddp_kwargs)
 
     def setup_distributed(self) -> None:
         log.debug(f"{self.__class__.__name__}: setting up distributed...")

--- a/tests/tests_fabric/strategies/test_ddp.py
+++ b/tests/tests_fabric/strategies/test_ddp.py
@@ -145,9 +145,9 @@ def test_module_init_context(precision, expected_dtype):
 
 @mock.patch.dict(os.environ, {"LOCAL_RANK": "0"})
 @mock.patch("lightning.fabric.strategies.ddp.DistributedDataParallel")
-@mock.patch("torch.cuda.Stream")
 @mock.patch("torch.cuda.stream")
-def test_setup_with_cuda_stream(cuda_stream_mock, *_):
+def test_setup_uses_default_stream(cuda_stream_mock, *_):
+    """DDP setup uses default stream to avoid AccumulateGrad stream mismatch warning."""
     model = torch.nn.Linear(2, 2)
     strategy = DDPStrategy(parallel_devices=[torch.device("cpu")], cluster_environment=LightningEnvironment())
     strategy.setup_module(model)
@@ -155,7 +155,7 @@ def test_setup_with_cuda_stream(cuda_stream_mock, *_):
 
     strategy = DDPStrategy(parallel_devices=[torch.device("cuda", 0)], cluster_environment=LightningEnvironment())
     strategy.setup_module(model)
-    cuda_stream_mock.assert_called_once()
+    cuda_stream_mock.assert_not_called()
 
 
 @mock.patch("torch.distributed.init_process_group")


### PR DESCRIPTION
## Summary

Fixes the AccumulateGrad stream mismatch warning when training with Fabric + DDP, especially with gradient accumulation (`no_backward_sync`). The warning occurred because DDP was initialized inside `torch.cuda.stream(torch.cuda.Stream())`, creating AccumulateGrad nodes on a non-default stream that did not match subsequent forwards/backwards.

## Root Cause

DDP setup used a custom CUDA stream context (from PR #17334) when wrapping the model. This caused the AccumulateGrad nodes to be created on a non-default stream. When backward ran on the default stream (or vice versa), PyTorch emitted:

> The AccumulateGrad node's stream does not match the stream of the node that produced the incoming gradient... To resolve the mismatch, ensure that DDP initialization is performed under the same stream as subsequent forwards.

## Fix

Remove the custom stream context so DDP initialization runs on the default stream, matching subsequent forwards/backwards as recommended by PyTorch.

- `lightning_fabric/strategies/ddp.py`: Remove `torch.cuda.stream(torch.cuda.Stream())` context
- `lightning/pytorch/strategies/ddp.py`: Same change
- Update test to assert default stream is used (no custom stream)

Fixes #21567

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21579.org.readthedocs.build/en/21579/

<!-- readthedocs-preview pytorch-lightning end -->