### PR TITLE
Docs: avoid unresolved torch.jit Sphinx refs to fix the CICD doc build failure.

### DIFF
--- a/src/lightning/pytorch/core/module.py
+++ b/src/lightning/pytorch/core/module.py
@@ -1498,11 +1498,10 @@ class LightningModule(
         example_inputs: Optional[Any] = None,
         **kwargs: Any,
     ) -> Union[ScriptModule, dict[str, ScriptModule]]:
-        """By default compiles the whole model to a :class:`~torch.jit.ScriptModule`. If you want to use tracing,
-        please provided the argument ``method='trace'`` and make sure that either the `example_inputs` argument is
-        provided, or the model has :attr:`example_input_array` set. If you would like to customize the modules that are
-        scripted you should override this method. In case you want to return multiple modules, we recommend using a
-        dictionary.
+        """By default compiles the whole model to a ``torch.jit.ScriptModule``. If you want to use tracing, please
+        provided the argument ``method='trace'`` and make sure that either the `example_inputs` argument is provided,
+        or the model has :attr:`example_input_array` set. If you would like to customize the modules that are scripted
+        you should override this method. In case you want to return multiple modules, we recommend using a dictionary.
 
         .. deprecated::
             ``LightningModule.to_torchscript`` has been deprecated in v2.7 and will be removed in v2.8.
@@ -1514,15 +1513,15 @@ class LightningModule(
             method: Whether to use TorchScript's script or trace method. Default: 'script'
             example_inputs: An input to be used to do tracing when method is set to 'trace'.
               Default: None (uses :attr:`example_input_array`)
-            **kwargs: Additional arguments that will be passed to the :func:`torch.jit.script` or
-              :func:`torch.jit.trace` function.
+            **kwargs: Additional arguments that will be passed to the ``torch.jit.script`` or
+              ``torch.jit.trace`` function.
 
         Note:
             - Requires the implementation of the
               :meth:`~lightning.pytorch.core.LightningModule.forward` method.
             - The exported script will be set to evaluation mode.
             - It is recommended that you install the latest supported version of PyTorch
-              to use this feature without limitations. See also the :mod:`torch.jit`
+              to use this feature without limitations. See also the ``torch.jit``
               documentation for supported features.
 
         Example::


### PR DESCRIPTION
## What does this PR do?

Fixes #21620

This PR fixes the docs build failure caused by unresolved Sphinx cross-references in `LightningModule.to_torchscript()`.

The immediate source of the warnings is Lightning's docstring in `src/lightning/pytorch/core/module.py`, which references deprecated `torch.jit` objects with Sphinx roles:
- `torch.jit.ScriptModule`
- `torch.jit.script`
- `torch.jit.trace`
- `torch.jit`

These references appear to have become unresolved after upstream PyTorch documentation / intersphinx changes following TorchScript deprecation.

This change keeps the fix targeted by replacing only those broken external `torch.jit` Sphinx roles with code literals. Other working cross-references remain unchanged.

No breaking changes.

<details>
  <summary><b>Before submitting</b></summary>

- [x] Did you read the contributor guideline, Pull Request section?
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you verify new and existing tests pass locally with your changes? 

Local verification:
- `./.venv/bin/python -m py_compile src/lightning/pytorch/core/module.py`

</details>


<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21621.org.readthedocs.build/en/21621/

<!-- readthedocs-preview pytorch-lightning end -->