### PR TITLE
fix: add encoding to open() calls + stacklevel to warnings.warn

### DIFF
--- a/src/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/src/lightning/pytorch/callbacks/model_checkpoint.py
@@ -566,7 +566,8 @@ class ModelCheckpoint(Checkpoint):
             warnings.warn(
                 f"The dirpath has changed from {dirpath_from_ckpt!r} to {self.dirpath!r},"
                 " therefore `best_model_score`, `kth_best_model_path`, `kth_value`, `last_model_path` and"
-                " `best_k_models` won't be reloaded. Only `best_model_path` will be reloaded."
+                " `best_k_models` won't be reloaded. Only `best_model_path` will be reloaded.",
+                stacklevel=2,
             )
 
         self.best_model_path = state_dict["best_model_path"]

--- a/src/lightning/pytorch/loggers/mlflow.py
+++ b/src/lightning/pytorch/loggers/mlflow.py
@@ -369,11 +369,11 @@ class MLFlowLogger(Logger):
             # Create a temporary directory to log on mlflow
             with tempfile.TemporaryDirectory() as tmp_dir:
                 # Log the metadata
-                with open(f"{tmp_dir}/metadata.yaml", "w") as tmp_file_metadata:
+                with open(f"{tmp_dir}/metadata.yaml", "w", encoding="utf-8") as tmp_file_metadata:
                     yaml.dump(metadata, tmp_file_metadata, default_flow_style=False)
 
                 # Log the aliases
-                with open(f"{tmp_dir}/aliases.txt", "w") as tmp_file_aliases:
+                with open(f"{tmp_dir}/aliases.txt", "w", encoding="utf-8") as tmp_file_aliases:
                     tmp_file_aliases.write(str(aliases))
 
                 # Log the metadata and aliases

--- a/src/lightning/pytorch/strategies/deepspeed.py
+++ b/src/lightning/pytorch/strategies/deepspeed.py
@@ -818,7 +818,7 @@ class DeepSpeedStrategy(DDPStrategy):
                 raise MisconfigurationException(
                     f"You passed in a path to a DeepSpeed config but the path does not exist: {config}"
                 )
-            with open(config) as f:
+            with open(config, encoding="utf-8") as f:
                 config = json.load(f)
         assert isinstance(config, dict) or config is None
         return config

--- a/src/lightning/pytorch/utilities/migration/utils.py
+++ b/src/lightning/pytorch/utilities/migration/utils.py
@@ -194,7 +194,7 @@ class _RedirectingUnpickler(pickle._Unpickler):
         new_module = _patch_pl_to_mirror_if_necessary(module)
         # this warning won't trigger for standalone as these imports are identical
         if module != new_module:
-            warnings.warn(f"Redirecting import of {module}.{name} to {new_module}.{name}")
+            warnings.warn(f"Redirecting import of {module}.{name} to {new_module}.{name}", stacklevel=2)
         return super().find_class(new_module, name)
 
 


### PR DESCRIPTION
## `encoding='utf-8'` on text-mode `open()` (PEP 597)

3 `open()` calls in text mode don't specify encoding, relying on platform locale. This can cause `UnicodeDecodeError` on non-UTF-8 systems (common on Windows).

| File | Usage |
|------|-------|
| `strategies/deepspeed.py` | Reading DeepSpeed JSON config |
| `loggers/mlflow.py` | Writing metadata YAML |
| `loggers/mlflow.py` | Writing aliases text file |

## `stacklevel=2` on `warnings.warn()`

2 `warnings.warn()` calls lack `stacklevel`, causing the warning to point to Lightning internals instead of the user's code:

| File | Warning |
|------|---------|
| `callbacks/model_checkpoint.py` | Dirpath changed, best model state not reloaded |
| `utilities/migration/utils.py` | Import redirect notification |

<!-- readthedocs-preview pytorch-lightning start -->
----
📚 Documentation preview 📚: https://pytorch-lightning--21656.org.readthedocs.build/en/21656/

<!-- readthedocs-preview pytorch-lightning end -->